### PR TITLE
Add more tests for V8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,7 @@ dependencies = [
  "derive_more",
  "gosub_shared",
  "lazy_static",
+ "serde_json",
  "thiserror",
  "v8",
 ]

--- a/crates/gosub_webexecutor/Cargo.toml
+++ b/crates/gosub_webexecutor/Cargo.toml
@@ -13,3 +13,6 @@ lazy_static = "1.4"
 thiserror = "1.0.57"
 v8 = "0.84.0"
 anyhow = "1.0.80"
+
+[dev-dependencies]
+serde_json = "1.0.114"

--- a/crates/gosub_webexecutor/src/js.rs
+++ b/crates/gosub_webexecutor/src/js.rs
@@ -52,14 +52,14 @@ lazy_static! {
 pub trait JSArray {
     type RT: JSRuntime;
 
-    fn get<T: Into<<Self::RT as JSRuntime>::ArrayIndex>>(
+    fn get(
         &self,
-        index: T,
+        index: <Self::RT as JSRuntime>::ArrayIndex,
     ) -> Result<<Self::RT as JSRuntime>::Value>;
 
-    fn set<T: Into<<Self::RT as JSRuntime>::ArrayIndex>>(
+    fn set(
         &self,
-        index: T,
+        index: <Self::RT as JSRuntime>::ArrayIndex,
         value: &<Self::RT as JSRuntime>::Value,
     ) -> Result<()>;
 
@@ -74,6 +74,7 @@ pub trait JSArray {
     //TODO: implement other things when needed. Maybe also `Iterator`?
 }
 
+#[derive(Debug, Clone, PartialEq)]
 pub enum JSType {
     Undefined,
     Null,

--- a/crates/gosub_webexecutor/src/js.rs
+++ b/crates/gosub_webexecutor/src/js.rs
@@ -1,18 +1,19 @@
-use lazy_static::lazy_static;
 use std::sync::Mutex;
+
+use lazy_static::lazy_static;
 use thiserror::Error;
 
-use crate::js::v8::V8Engine;
 pub use compile::*;
 pub use context::*;
 pub use function::*;
+use gosub_shared::types::Result;
 pub use interop::*;
 pub use object::*;
 pub use runtime::*;
 pub use value::*;
 pub use value_conversion::*;
 
-use gosub_shared::types::Result;
+use crate::js::v8::V8Engine;
 
 mod compile;
 mod context;

--- a/crates/gosub_webexecutor/src/js/compile.rs
+++ b/crates/gosub_webexecutor/src/js/compile.rs
@@ -1,5 +1,6 @@
-use crate::js::{JSContext, JSRuntime, JSValue};
 use gosub_shared::types::Result;
+
+use crate::js::{JSContext, JSRuntime, JSValue};
 
 //compiled code will be stored with this trait for later execution (e.g HTML parsing not done yet)
 pub trait JSCompiled {

--- a/crates/gosub_webexecutor/src/js/context.rs
+++ b/crates/gosub_webexecutor/src/js/context.rs
@@ -1,5 +1,6 @@
-use crate::js::{JSArray, JSCompiled, JSFunction, JSObject, JSRuntime, JSValue};
 use gosub_shared::types::Result;
+
+use crate::js::{JSArray, JSCompiled, JSFunction, JSObject, JSRuntime, JSValue};
 
 //main trait for JS context (can be implemented for different JS engines like V8, SpiderMonkey, JSC, etc.)
 pub trait JSContext: Clone {

--- a/crates/gosub_webexecutor/src/js/function.rs
+++ b/crates/gosub_webexecutor/src/js/function.rs
@@ -1,6 +1,8 @@
-use crate::js::{JSContext, JSError, JSObject, JSRuntime, JSValue};
 use core::fmt::Display;
+
 use gosub_shared::types::Result;
+
+use crate::js::{JSContext, JSObject, JSRuntime, JSValue};
 
 struct Function<T: JSFunction>(pub T);
 

--- a/crates/gosub_webexecutor/src/js/function.rs
+++ b/crates/gosub_webexecutor/src/js/function.rs
@@ -15,7 +15,10 @@ pub trait JSFunction {
     where
         Self: Sized;
 
-    fn call(&mut self, callback: &mut <Self::RT as JSRuntime>::FunctionCallBack);
+    fn call(
+        &mut self,
+        args: &[<Self::RT as JSRuntime>::Value],
+    ) -> Result<<Self::RT as JSRuntime>::Value>;
 }
 
 pub trait JSFunctionCallBack {
@@ -64,7 +67,10 @@ pub trait JSFunctionVariadic {
     where
         Self: Sized;
 
-    fn call(&mut self, callback: &mut <Self::RT as JSRuntime>::FunctionCallBackVariadic);
+    fn call(
+        &mut self,
+        args: &[<Self::RT as JSRuntime>::Value],
+    ) -> Result<<Self::RT as JSRuntime>::Value>;
 }
 
 pub trait JSFunctionCallBackVariadic {

--- a/crates/gosub_webexecutor/src/js/interop.rs
+++ b/crates/gosub_webexecutor/src/js/interop.rs
@@ -1,7 +1,9 @@
-use crate::js::JSRuntime;
-use gosub_shared::types::Result;
 use std::cell::RefCell;
 use std::rc::Rc;
+
+use gosub_shared::types::Result;
+
+use crate::js::JSRuntime;
 
 pub trait JSInterop {
     fn implement<RT: JSRuntime>(s: Rc<RefCell<Self>>, ctx: RT::Context) -> Result<()>;

--- a/crates/gosub_webexecutor/src/js/object.rs
+++ b/crates/gosub_webexecutor/src/js/object.rs
@@ -1,6 +1,8 @@
-use crate::js::{JSContext, JSFunction, JSFunctionVariadic, JSRuntime, JSValue};
 use core::fmt::Display;
+
 use gosub_shared::types::Result;
+
+use crate::js::{JSContext, JSFunction, JSFunctionVariadic, JSRuntime, JSValue};
 
 pub trait JSObject {
     type RT: JSRuntime;

--- a/crates/gosub_webexecutor/src/js/runtime.rs
+++ b/crates/gosub_webexecutor/src/js/runtime.rs
@@ -1,9 +1,10 @@
+use gosub_shared::types::Result;
+
 use crate::js::{
     Args, JSArray, JSCompiled, JSContext, JSFunction, JSFunctionCallBack,
     JSFunctionCallBackVariadic, JSFunctionVariadic, JSGetterCallback, JSObject, JSSetterCallback,
-    JSValue, ValueConversion, VariadicArgs, VariadicArgsInternal,
+    JSValue, VariadicArgs, VariadicArgsInternal,
 };
-use gosub_shared::types::Result;
 
 //trait around the main JS engine (e.g V8, SpiderMonkey, JSC, etc.)
 pub trait JSRuntime {

--- a/crates/gosub_webexecutor/src/js/v8.rs
+++ b/crates/gosub_webexecutor/src/js/v8.rs
@@ -61,7 +61,6 @@ impl V8Engine<'_> {
             return;
         }
 
-
         V8_INITIALIZED.call_once(|| {
             V8_INITIALIZING.store(true, Ordering::SeqCst);
             //https://github.com/denoland/rusty_v8/issues/1381

--- a/crates/gosub_webexecutor/src/js/v8.rs
+++ b/crates/gosub_webexecutor/src/js/v8.rs
@@ -9,11 +9,11 @@ pub use array::*;
 pub use compile::*;
 pub use context::*;
 pub use function::*;
+use gosub_shared::types::Result;
 pub use object::*;
 pub use value::*;
 
 use crate::js::{JSArray, JSContext, JSFunction, JSObject, JSRuntime, JSValue, ValueConversion};
-use gosub_shared::types::Result;
 
 mod array;
 mod compile;
@@ -111,15 +111,10 @@ impl<'a> JSRuntime for V8Engine<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::Ordering;
-
     use anyhow;
-    use colored::Colorize;
 
     use crate::js::v8::V8_INITIALIZED;
-    use crate::js::{JSContext, JSError, JSRuntime, JSValue};
-    use crate::Error;
-    use crate::Error::JS;
+    use crate::js::{JSContext, JSRuntime, JSValue};
 
     #[test]
     fn v8_engine_initialization() {
@@ -147,6 +142,7 @@ mod tests {
     }
 
     #[test]
+    #[should_panic = "called `Result::unwrap()` on an `Err` value: js: compile error: SyntaxError: missing ) after argument list\n\nCaused by:\n    compile error: SyntaxError: missing ) after argument list"]
     fn v8_run_invalid_syntax() {
         let mut engine = crate::js::v8::V8Engine::new();
 
@@ -160,11 +156,7 @@ mod tests {
         );
 
         assert!(result.is_err());
-        // This assertion fails because the error type is not correct
-        // assert!(matches!(
-        //     result,
-        //     Err(anyhow::Error::new(JSError::Compile(_)))
-        // ));
+        result.unwrap();
     }
 
     #[test]

--- a/crates/gosub_webexecutor/src/js/v8/array.rs
+++ b/crates/gosub_webexecutor/src/js/v8/array.rs
@@ -10,13 +10,24 @@ pub struct V8Array<'a> {
     ctx: V8Context<'a>,
 }
 
+impl<'a> V8Array<'a> {
+    pub fn new(ctx: &V8Context<'a>, len: u32) -> Result<Self> {
+        let value = Array::new(ctx.borrow_mut().scope(), len as i32);
+
+        Ok(Self {
+            value,
+            ctx: ctx.clone(),
+        })
+    }
+}
+
 impl<'a> JSArray for V8Array<'a> {
     type RT = V8Engine<'a>;
 
-    fn get<T: Into<u32>>(&self, index: T) -> Result<<Self::RT as JSRuntime>::Value> {
+    fn get(&self, index: u32) -> Result<<Self::RT as JSRuntime>::Value> {
         let Some(value) = self
             .value
-            .get_index(self.ctx.borrow_mut().scope(), index.into())
+            .get_index(self.ctx.borrow_mut().scope(), index)
         else {
             return Err(Error::JS(JSError::Generic(
                 "failed to get a value from an array".to_owned(),
@@ -27,10 +38,10 @@ impl<'a> JSArray for V8Array<'a> {
         Ok(V8Value::from_value(self.ctx.clone(), value))
     }
 
-    fn set<T: Into<u32>>(&self, index: T, value: &V8Value) -> Result<()> {
+    fn set(&self, index: u32, value: &V8Value) -> Result<()> {
         match self
             .value
-            .set_index(self.ctx.borrow_mut().scope(), index.into(), value.value)
+            .set_index(self.ctx.borrow_mut().scope(), index, value.value)
         {
             Some(_) => Ok(()),
             None => Err(Error::JS(JSError::Conversion(
@@ -95,5 +106,124 @@ impl<'a> JSArray for V8Array<'a> {
 
     fn length(&self) -> Result<u32> {
         Ok(self.value.length())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::web_executor::js::v8::{V8Array, V8Engine};
+    use crate::web_executor::js::{JSArray, JSRuntime, JSValue, ValueConversion};
+
+    #[test]
+    fn set() {
+        let mut engine = V8Engine::new();
+        let mut context = engine.new_context().unwrap();
+
+        let array = V8Array::new(&context, 2).unwrap();
+        array
+            .set(0, &1234.0.to_js_value(context.clone()).unwrap())
+            .unwrap();
+        array
+            .set(1, &"Hello World!".to_js_value(context).unwrap())
+            .unwrap();
+
+        assert_eq!(array.length().unwrap(), 2);
+    }
+
+    #[test]
+    fn get() {
+        let mut engine = V8Engine::new();
+        let mut context = engine.new_context().unwrap();
+
+        let array = V8Array::new(&context, 2).unwrap();
+
+        array
+            .set(0, &1234.0.to_js_value(context.clone()).unwrap())
+            .unwrap();
+        array
+            .set(1, &"Hello World!".to_js_value(context).unwrap())
+            .unwrap();
+
+        assert_eq!(array.get(0).unwrap().as_number().unwrap(), 1234.0);
+        assert_eq!(
+            array.get(1).unwrap().as_string().unwrap(),
+            "Hello World!"
+        );
+    }
+
+    #[test]
+    fn push() {
+        let mut engine = V8Engine::new();
+        let mut context = engine.new_context().unwrap();
+
+        let array = V8Array::new(&context, 2).unwrap();
+
+        array
+            .push(1234.0.to_js_value(context.clone()).unwrap())
+            .unwrap();
+        array
+            .push("Hello World!".to_js_value(context).unwrap())
+            .unwrap();
+
+        assert_eq!(array.length().unwrap(), 4);
+    }
+
+    #[test]
+    fn out_of_bounds() {
+        let mut engine = V8Engine::new();
+        let mut context = engine.new_context().unwrap();
+
+        let array = V8Array::new(&context, 2).unwrap();
+
+        array
+            .set(0, &1234.0.to_js_value(context.clone()).unwrap())
+            .unwrap();
+        array
+            .set(1, &"Hello World!".to_js_value(context).unwrap())
+            .unwrap();
+
+        assert!(array.get(2).unwrap().is_undefined());
+    }
+
+    #[test]
+    fn pop() {
+        let mut engine = V8Engine::new();
+        let mut context = engine.new_context().unwrap();
+
+        let array = V8Array::new(&context, 2).unwrap();
+
+        array
+            .set(0, &1234.0.to_js_value(context.clone()).unwrap())
+            .unwrap();
+        array
+            .set(1, &"Hello World!".to_js_value(context).unwrap())
+            .unwrap();
+
+        assert_eq!(array.pop().unwrap().as_string().unwrap(), "Hello World!");
+        assert_eq!(array.get(0u32).unwrap().as_number().unwrap(), 1234.0);
+        assert!(array.get(1u32).unwrap().is_undefined());
+    }
+
+    #[test]
+    fn dynamic_resize() {
+        let mut engine = V8Engine::new();
+        let mut context = engine.new_context().unwrap();
+
+        let array = V8Array::new(&context, 2).unwrap();
+
+        array
+            .set(0, &1234.0.to_js_value(context.clone()).unwrap())
+            .unwrap();
+        array
+            .set(1, &"Hello World!".to_js_value(context.clone()).unwrap())
+            .unwrap();
+        array
+            .set(2, &1234.0.to_js_value(context.clone()).unwrap())
+            .unwrap();
+        array
+            .set(3, &"Hello World!".to_js_value(context.clone()).unwrap())
+            .unwrap();
+
+        assert_eq!(array.length().unwrap(), 4);
     }
 }

--- a/crates/gosub_webexecutor/src/js/v8/array.rs
+++ b/crates/gosub_webexecutor/src/js/v8/array.rs
@@ -1,9 +1,10 @@
 use v8::{Array, Local};
 
+use gosub_shared::types::Result;
+
 use crate::js::v8::{V8Context, V8Engine, V8Value};
 use crate::js::{JSArray, JSError, JSRuntime};
 use crate::Error;
-use gosub_shared::types::Result;
 
 pub struct V8Array<'a> {
     value: Local<'a, Array>,
@@ -25,10 +26,7 @@ impl<'a> JSArray for V8Array<'a> {
     type RT = V8Engine<'a>;
 
     fn get(&self, index: u32) -> Result<<Self::RT as JSRuntime>::Value> {
-        let Some(value) = self
-            .value
-            .get_index(self.ctx.borrow_mut().scope(), index)
-        else {
+        let Some(value) = self.value.get_index(self.ctx.borrow_mut().scope(), index) else {
             return Err(Error::JS(JSError::Generic(
                 "failed to get a value from an array".to_owned(),
             ))
@@ -111,8 +109,8 @@ impl<'a> JSArray for V8Array<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::web_executor::js::v8::{V8Array, V8Engine};
-    use crate::web_executor::js::{JSArray, JSRuntime, JSValue, ValueConversion};
+    use crate::js::v8::{V8Array, V8Engine};
+    use crate::js::{JSArray, JSRuntime, JSValue, ValueConversion};
 
     #[test]
     fn set() {
@@ -145,10 +143,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(array.get(0).unwrap().as_number().unwrap(), 1234.0);
-        assert_eq!(
-            array.get(1).unwrap().as_string().unwrap(),
-            "Hello World!"
-        );
+        assert_eq!(array.get(1).unwrap().as_string().unwrap(), "Hello World!");
     }
 
     #[test]

--- a/crates/gosub_webexecutor/src/js/v8/compile.rs
+++ b/crates/gosub_webexecutor/src/js/v8/compile.rs
@@ -1,8 +1,12 @@
+use std::rc::Rc;
+
+use v8::{Local, Script};
+
+use gosub_shared::types::Result;
+
 use crate::js::v8::{FromContext, V8Context, V8Ctx, V8Engine, V8Value};
 use crate::js::{JSCompiled, JSRuntime};
-use gosub_shared::types::Result;
-use std::rc::Rc;
-use v8::{Local, Script};
+
 pub struct V8Compiled<'a> {
     compiled: Local<'a, Script>,
     context: V8Context<'a>,

--- a/crates/gosub_webexecutor/src/js/v8/context.rs
+++ b/crates/gosub_webexecutor/src/js/v8/context.rs
@@ -7,12 +7,13 @@ use v8::{
     TryCatch,
 };
 
+use gosub_shared::types::Result;
+
 use crate::js::compile::JSCompiled;
 use crate::js::v8::compile::V8Compiled;
-use crate::js::v8::{FromContext, V8Context, V8Engine, V8Object, V8Value};
+use crate::js::v8::{FromContext, V8Context, V8Engine, V8Object};
 use crate::js::{JSContext, JSError, JSRuntime};
 use crate::Error;
-use gosub_shared::types::Result;
 
 /// SAFETY: This is NOT thread safe, as the rest of the engine is not thread safe.
 /// This struct uses `NonNull` internally to store pointers to the V8Context "values" in one struct.

--- a/crates/gosub_webexecutor/src/js/v8/function.rs
+++ b/crates/gosub_webexecutor/src/js/v8/function.rs
@@ -6,6 +6,8 @@ use v8::{
     FunctionCallbackInfo, Local, ReturnValue, TryCatch,
 };
 
+use gosub_shared::types::Result;
+
 use crate::js::function::{JSFunctionCallBack, JSFunctionCallBackVariadic};
 use crate::js::v8::{ctx_from_function_callback_info, V8Context, V8Engine, V8Value};
 use crate::js::{
@@ -13,7 +15,6 @@ use crate::js::{
     VariadicArgsInternal,
 };
 use crate::Error;
-use gosub_shared::types::Result;
 
 pub struct V8Function<'a> {
     pub(super) ctx: V8Context<'a>,
@@ -31,9 +32,7 @@ impl<'a> V8FunctionCallBack<'a> {
         Ok(Self {
             ctx,
             args,
-            ret: Err(Error::JS(JSError::Execution(
-                "function was not called".to_owned(),
-            ))),
+            ret: Err(Error::JS(JSError::Execution("function was not called".to_owned())).into()),
         })
     }
 }
@@ -283,8 +282,7 @@ impl<'a> JSFunction for V8Function<'a> {
                 value,
             })
         } else {
-            Err(Error::JS(JSError::Execution(
-                "failed to call a function".to_owned())).into())
+            Err(Error::JS(JSError::Execution("failed to call a function".to_owned())).into())
         }
     }
 }
@@ -566,17 +564,16 @@ impl<'a> JSFunctionVariadic for V8FunctionVariadic<'a> {
                 value,
             })
         } else {
-            Err(Error::JS(JSError::Execution(
-                "failed to call a function".to_owned())).into())
+            Err(Error::JS(JSError::Execution("failed to call a function".to_owned())).into())
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::web_executor::js::v8::{V8Engine, V8Function, V8FunctionVariadic, V8Value};
-    use crate::web_executor::js::{
-        Args, JSContext, JSFunction, JSFunctionCallBack, JSFunctionVariadic, JSRuntime, JSValue,
+    use crate::js::v8::{V8Engine, V8Function, V8FunctionVariadic};
+    use crate::js::{
+        Args, JSFunction, JSFunctionCallBack, JSFunctionVariadic, JSRuntime, JSValue,
         ValueConversion,
     };
 

--- a/crates/gosub_webexecutor/src/js/v8/object.rs
+++ b/crates/gosub_webexecutor/src/js/v8/object.rs
@@ -6,6 +6,8 @@ use v8::{
     ReturnValue, Value,
 };
 
+use gosub_shared::types::Result;
+
 use crate::js::v8::{
     ctx_from, FromContext, V8Context, V8Ctx, V8Engine, V8Function, V8FunctionCallBack,
     V8FunctionVariadic, V8Value,
@@ -14,7 +16,6 @@ use crate::js::{
     JSArray, JSError, JSGetterCallback, JSObject, JSRuntime, JSSetterCallback, JSValue,
 };
 use crate::Error;
-use gosub_shared::types::Result;
 
 pub struct V8Object<'a> {
     ctx: V8Context<'a>,
@@ -115,7 +116,7 @@ impl<'a> JSObject for V8Object<'a> {
         let Some(name) = v8::String::new(self.ctx.borrow_mut().scope(), name) else {
             return Err(Error::JS(JSError::Generic("failed to create a string".to_owned())).into());
         };
-        
+
         let scope = self.ctx.borrow_mut().scope();
 
         self.value
@@ -253,7 +254,7 @@ impl<'a> JSObject for V8Object<'a> {
                 };
 
                 let gs = unsafe { &*(external.value() as *const GetterSetter) };
-                
+
                 let isolate = gs.ctx.borrow().isolate;
 
                 let ctx = match ctx_from(scope, isolate) {
@@ -351,13 +352,13 @@ impl<'a> FromContext<'a, Local<'a, Object>> for V8Object<'a> {
 
 #[cfg(test)]
 mod tests {
-    use alloc::rc::Rc;
     use std::cell::RefCell;
+    use std::rc::Rc;
 
     use serde_json::to_string;
 
-    use crate::web_executor::js::v8::V8FunctionCallBackVariadic;
-    use crate::web_executor::js::{
+    use crate::js::v8::V8FunctionCallBackVariadic;
+    use crate::js::{
         JSFunction, JSFunctionCallBack, JSFunctionCallBackVariadic, JSFunctionVariadic,
         ValueConversion, VariadicArgsInternal,
     };

--- a/crates/gosub_webexecutor/src/js/v8/object.rs
+++ b/crates/gosub_webexecutor/src/js/v8/object.rs
@@ -26,6 +26,14 @@ pub struct GetterCallback<'a, 'r> {
     ret: &'r mut V8Value<'a>,
 }
 
+impl V8Object<'_> {
+    pub fn new(ctx: V8Context) -> Result<V8Object> {
+        let scope = ctx.borrow_mut().scope();
+        let value = Object::new(scope);
+        Ok(V8Object { ctx, value })
+    }
+}
+
 impl<'a> JSGetterCallback for GetterCallback<'a, '_> {
     type RT = V8Engine<'a>;
 
@@ -107,9 +115,11 @@ impl<'a> JSObject for V8Object<'a> {
         let Some(name) = v8::String::new(self.ctx.borrow_mut().scope(), name) else {
             return Err(Error::JS(JSError::Generic("failed to create a string".to_owned())).into());
         };
+        
+        let scope = self.ctx.borrow_mut().scope();
 
         self.value
-            .get(self.ctx.borrow_mut().scope(), name.into())
+            .get(scope, name.into())
             .ok_or_else(|| {
                 Error::JS(JSError::Generic(
                     "failed to get a property from an object".to_owned(),
@@ -243,10 +253,10 @@ impl<'a> JSObject for V8Object<'a> {
                 };
 
                 let gs = unsafe { &*(external.value() as *const GetterSetter) };
+                
+                let isolate = gs.ctx.borrow().isolate;
 
-                let ctx = scope.get_current_context();
-
-                let ctx = match ctx_from(scope, gs.ctx.borrow().isolate) {
+                let ctx = match ctx_from(scope, isolate) {
                     Ok(ctx) => ctx,
                     Err((mut st, e)) => {
                         let scope = st.get();
@@ -336,5 +346,132 @@ impl<'a> JSObject for V8Object<'a> {
 impl<'a> FromContext<'a, Local<'a, Object>> for V8Object<'a> {
     fn from_ctx(ctx: V8Context<'a>, object: Local<'a, Object>) -> Self {
         Self { ctx, value: object }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::rc::Rc;
+    use std::cell::RefCell;
+
+    use serde_json::to_string;
+
+    use crate::web_executor::js::v8::V8FunctionCallBackVariadic;
+    use crate::web_executor::js::{
+        JSFunction, JSFunctionCallBack, JSFunctionCallBackVariadic, JSFunctionVariadic,
+        ValueConversion, VariadicArgsInternal,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_object() {
+        let mut engine = V8Engine::new();
+        let mut ctx = engine.new_context().unwrap();
+
+        let obj = V8Object::new(ctx.clone()).unwrap();
+
+        let value = V8Value::new_string(ctx.clone(), "value").unwrap();
+        obj.set_property("key", &value).unwrap();
+
+        let value = obj.get_property("key").unwrap();
+        assert_eq!(value.as_string().unwrap(), "value");
+    }
+
+    #[test]
+    fn test_object_accessor() {
+        let mut engine = V8Engine::new();
+        let mut ctx = engine.new_context().unwrap();
+
+        let mut string = Rc::new(RefCell::new("value".to_string()));
+
+        let getter = {
+            let string = Rc::clone(&string);
+            Box::new(move |cb: &mut GetterCallback| {
+                let value = string.borrow().to_js_value(cb.context().clone()).unwrap();
+                cb.ret(value);
+            })
+        };
+
+        let setter = {
+            let string = Rc::clone(&string);
+            Box::new(move |cb: &mut SetterCallback| {
+                let value = cb.value().as_string().unwrap();
+                *string.borrow_mut() = value;
+            })
+        };
+
+        let obj = V8Object::new(ctx.clone()).unwrap();
+        obj.set_property_accessor("key", getter, setter).unwrap();
+
+        let value = obj.get_property("key").unwrap();
+        assert_eq!(value.as_string().unwrap(), "value");
+        //TODO modify value and test
+    }
+
+    #[test]
+    fn test_object_method() {
+        let mut engine = V8Engine::new();
+        let mut ctx = engine.new_context().unwrap();
+
+        let obj = V8Object::new(ctx.clone()).unwrap();
+
+        let called = Rc::new(RefCell::new(false));
+        let mut func = V8Function::new(ctx.clone(), |cb: &mut V8FunctionCallBack| {
+            let value = V8Value::new_string(cb.context().clone(), "value").unwrap();
+            cb.ret(value);
+        })
+        .unwrap();
+
+        func.call(&[]).unwrap();
+
+        obj.set_method("key", &func).unwrap();
+
+        let value = obj.call_method("key", &[]).unwrap();
+        assert_eq!(value.as_string().unwrap(), "value");
+    }
+
+    #[test]
+    fn test_object_method_variadic() {
+        let mut engine = V8Engine::new();
+        let mut ctx = engine.new_context().unwrap();
+
+        let obj = V8Object::new(ctx.clone()).unwrap();
+
+        let called = Rc::new(RefCell::new(false));
+        let func = V8FunctionVariadic::new(ctx.clone(), |cb: &mut V8FunctionCallBackVariadic| {
+            let ctx = cb.context().clone();
+
+            let args_str = cb
+                .args()
+                .as_vec(ctx.clone())
+                .iter()
+                .map(|v| v.as_string().unwrap())
+                .collect::<Vec<_>>();
+
+            let value = V8Value::new_string(ctx, &to_string(&args_str).unwrap()).unwrap();
+
+            cb.ret(value);
+        })
+        .unwrap();
+
+        obj.set_method_variadic("key", &func).unwrap();
+
+        let value = obj
+            .call_method(
+                "key",
+                &[
+                    &V8Value::new_string(ctx.clone(), "value1").unwrap(),
+                    &V8Value::new_string(ctx.clone(), "value2").unwrap(),
+                    &V8Value::new_undefined(ctx.clone()).unwrap(),
+                    &V8Value::new_null(ctx.clone()).unwrap(),
+                    &V8Value::new_number(ctx.clone(), 42).unwrap(),
+                ],
+            )
+            .unwrap();
+        assert_eq!(
+            value.as_string().unwrap(),
+            "[\"value1\",\"value2\",\"undefined\",\"null\",\"42\"]"
+        );
     }
 }

--- a/crates/gosub_webexecutor/src/js/v8/value.rs
+++ b/crates/gosub_webexecutor/src/js/v8/value.rs
@@ -2,10 +2,11 @@ use std::rc::Rc;
 
 use v8::{Local, Value};
 
+use gosub_shared::types::Result;
+
 use crate::js::v8::{FromContext, V8Context, V8Engine, V8Object};
 use crate::js::{JSError, JSRuntime, JSType, JSValue, ValueConversion};
 use crate::Error;
-use gosub_shared::types::Result;
 
 pub struct V8Value<'a> {
     pub(crate) context: V8Context<'a>,
@@ -154,7 +155,7 @@ impl<'a> JSValue for V8Value<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::web_executor::js::JSContext;
+    use crate::js::JSContext;
 
     use super::*;
 

--- a/crates/gosub_webexecutor/src/js/value.rs
+++ b/crates/gosub_webexecutor/src/js/value.rs
@@ -1,5 +1,6 @@
-use crate::js::{JSArray, JSContext, JSObject, JSRuntime, JSType};
 use gosub_shared::types::Result;
+
+use crate::js::{JSArray, JSContext, JSObject, JSRuntime, JSType};
 
 pub trait JSValue
 where

--- a/crates/gosub_webexecutor/src/js/value_conversion.rs
+++ b/crates/gosub_webexecutor/src/js/value_conversion.rs
@@ -1,5 +1,6 @@
-use crate::js::{JSContext, JSRuntime, JSValue};
 use gosub_shared::types::Result;
+
+use crate::js::{JSContext, JSRuntime, JSValue};
 
 //trait to easily convert Rust types to JS values (just call .to_js_value() on the type)
 pub trait ValueConversion<V: JSValue> {


### PR DESCRIPTION
This PR adds more tests for V8.
Maybe we should also have tests that aren't specific to V8, so they can be reused.
During writing those, I noticed some things I can still improve about the JS API:

<details>
<summary>
Next Steps
</summary>

- [Better way to modify JSValues in Rust](https://github.com/orgs/gosub-browser/projects/1?pane=issue&itemId=54107346)
- [Better way to modify Rust values from JS Functions](https://github.com/orgs/gosub-browser/projects/1?pane=issue&itemId=54107684)
- [Better interop for arrays](https://github.com/orgs/gosub-browser/projects/1?pane=issue&itemId=54237233)
- [JS interop macro](https://github.com/orgs/gosub-browser/projects/1?pane=issue&itemId=48671672)
</details>

- [x] Fix merge conflicts - Since PR #379 has also moved the JS API and this PR uses still the old layout, it has merge conflicts