### PR TITLE
Added bencher

### DIFF
--- a/.github/workflows/bencher.yaml
+++ b/.github/workflows/bencher.yaml
@@ -1,0 +1,25 @@
+name: Bencher.dev benchmarks
+
+on:
+  push:
+    branches:
+      - * # All branches
+
+jobs:
+  benchmark_with_bencher:
+    name: Continuous Benchmarking with Bencher
+    runs-on: ubuntu-latest
+    env:
+      BENCHER_PROJECT: gosub-engine
+      BENCHER_TESTBED: ubuntu-latest
+      BENCHER_ADAPTER: json
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bencherdev/bencher@main
+      - name: Track Benchmarks with Bencher
+        run: |
+          bencher run \
+          --branch "$GITHUB_REF_NAME" \
+          --token "${{ secrets.BENCHER_API_TOKEN }}" \
+          --err \
+          cargo bench --all


### PR DESCRIPTION
Added bencher.dev so we can display benchmarks over a long period. We currently have bench.developer.gosub.io, but this only uses the last benchmarks. 

We could also add triggers on regressions with this tool. 