### PR TITLE
remove empty text nodes from tree in `remove_unrenderable_nodes`

### DIFF
--- a/crates/gosub_styling/src/render_tree.rs
+++ b/crates/gosub_styling/src/render_tree.rs
@@ -248,6 +248,21 @@ impl<B: RenderBackend> RenderTree<B> {
                 }
             }
 
+            if let RenderNodeData::Text(t) = &node.data {
+                let mut remove = true;
+                for c in t.prerender.value().chars() {
+                    if !c.is_ascii_whitespace() {
+                        remove = false;
+                        break;
+                    }
+                }
+
+                if remove {
+                    delete_list.push(*id);
+                    continue;
+                }
+            }
+
             // Check CSS styles and remove if not renderable
             if let Some(mut prop) = self.get_property(*id, "display") {
                 if prop.compute_value().to_string() == "none" {


### PR DESCRIPTION
This PR lets `remove_unrenderable_nodes` remove also text nodes that are only whitespaces.
This reduces the tree size on `src/bin/resources/gosub.html` from 40 to 27, which is nice I guess...

Also great for debugging with `print_tree` because you don't need to search through so much text...