### PR TITLE
Added alias table for deprecated css properties

### DIFF
--- a/crates/gosub_styling/tools/generate_definitions/.gitignore
+++ b/crates/gosub_styling/tools/generate_definitions/.gitignore
@@ -1,0 +1,2 @@
+.cache
+.output

--- a/crates/gosub_styling/tools/generate_definitions/main.go
+++ b/crates/gosub_styling/tools/generate_definitions/main.go
@@ -47,23 +47,9 @@ func main() {
 	})
 
 	for _, property := range webrefData.Properties {
-
 		if property.Syntax == "" {
-			alias, err := webref.GetAlias(property.Name)
-			if err != nil {
-				log.Panic("failed to get alias syntax for property: " + property.Name)
-			}
-
-			for wdp := range webrefData.Properties {
-				if webrefData.Properties[wdp].Name == alias {
-					property.Syntax = webrefData.Properties[wdp].Syntax
-					break
-				}
-			}
-
-			if property.Syntax == "" {
-				log.Panic("failed to get alias syntax for property: " + property.Name)
-			}
+			// Skip any empty syntax, as they will be filled later with alias table
+			continue
 		}
 
 		prop := utils.Property{
@@ -124,6 +110,23 @@ func main() {
 			Descriptors: descriptors,
 			Values:      atRule.Values,
 		})
+
+		for _, property := range webrefData.Properties {
+			if property.Syntax != "" {
+				// Skip properties with syntax
+				continue
+			}
+
+			alias, err := webref.GetAlias(property.Name)
+			if err != nil {
+				log.Panic("failed to get alias syntax for property: " + property.Name)
+			}
+
+			data.PropAliases = append(data.PropAliases, utils.PropAlias{
+				Name: property.Name,
+				For:  alias,
+			})
+		}
 	}
 
 	data.Selectors = webrefData.Selectors
@@ -164,6 +167,7 @@ func ExportMultiFile(data *utils.Data) {
 	ExportData(data.Values, path.Join(MultiFileDir, MultiFilePrefix+"values.json"))
 	ExportData(data.AtRules, path.Join(MultiFileDir, MultiFilePrefix+"at-rules.json"))
 	ExportData(data.Selectors, path.Join(MultiFileDir, MultiFilePrefix+"selectors.json"))
+	ExportData(data.PropAliases, path.Join(MultiFileDir, MultiFilePrefix+"prop-aliases.json"))
 
 }
 

--- a/crates/gosub_styling/tools/generate_definitions/main.go
+++ b/crates/gosub_styling/tools/generate_definitions/main.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"sort"
 )
 
 type ExportType int
@@ -21,7 +22,7 @@ const (
 
 const (
 	exportType      = Both
-	ResourcePath    = "crates/gosub_styling/resources/definitions"
+	ResourcePath    = ".output"
 	SingleFilePath  = ResourcePath + "/definitions.json"
 	MultiFileDir    = ResourcePath
 	MultiFilePrefix = "definitions_"
@@ -41,7 +42,30 @@ func main() {
 		len(webrefData.Properties), len(webrefData.Values), len(webrefData.AtRules), len(webrefData.Selectors),
 	)
 
+	sort.Slice(webrefData.Properties, func(i, j int) bool {
+		return webrefData.Properties[i].Name < webrefData.Properties[j].Name
+	})
+
 	for _, property := range webrefData.Properties {
+
+		if property.Syntax == "" {
+			alias, err := webref.GetAlias(property.Name)
+			if err != nil {
+				log.Panic("failed to get alias syntax for property: " + property.Name)
+			}
+
+			for wdp := range webrefData.Properties {
+				if webrefData.Properties[wdp].Name == alias {
+					property.Syntax = webrefData.Properties[wdp].Syntax
+					break
+				}
+			}
+
+			if property.Syntax == "" {
+				log.Panic("failed to get alias syntax for property: " + property.Name)
+			}
+		}
+
 		prop := utils.Property{
 			Name:      property.Name,
 			Syntax:    property.Syntax,

--- a/crates/gosub_styling/tools/generate_definitions/utils/types.go
+++ b/crates/gosub_styling/tools/generate_definitions/utils/types.go
@@ -1,10 +1,16 @@
 package utils
 
 type Data struct {
-	Properties []Property `json:"properties"`
-	Values     []Value    `json:"values"`
-	AtRules    []AtRule   `json:"atrules"`
-	Selectors  []Selector `json:"selectors"`
+	Properties  []Property  `json:"properties"`
+	Values      []Value     `json:"values"`
+	AtRules     []AtRule    `json:"atrules"`
+	Selectors   []Selector  `json:"selectors"`
+	PropAliases []PropAlias `json:"propAliases"`
+}
+
+type PropAlias struct {
+	Name string `json:"name"`
+	For  string `json:"for"`
 }
 
 type Value struct {

--- a/crates/gosub_styling/tools/generate_definitions/utils/utils.go
+++ b/crates/gosub_styling/tools/generate_definitions/utils/utils.go
@@ -10,7 +10,7 @@ const (
 	REPO             = "w3c/webref"
 	LOCATION         = "ed/css"
 	PATCH_LOCATION   = "ed/csspatches"
-	CACHE_DIR        = "crates/gosub_styling/resources/cache"
+	CACHE_DIR        = ".cache"
 	CACHE_INDEX_FILE = CACHE_DIR + "/index/cache_index.json"
 	CUSTOM_PATCH_DIR = "crates/gosub_styling/resources/patches"
 	BRANCH           = "curated"


### PR DESCRIPTION
Fixes #551 

- sorting properties alfabetically,
- added an alias table so we can fetch the syntax from the deprecated properties
- hardcoded skipping some properties (stop-color, stop-opacity)
- 