### PR TITLE
Add `Fetcher` which automatically expands urls

### DIFF
--- a/crates/gosub_net/src/http.rs
+++ b/crates/gosub_net/src/http.rs
@@ -1,5 +1,6 @@
 pub use ureq;
 
+pub mod fetcher;
 pub mod headers;
 pub mod request;
 pub mod response;

--- a/crates/gosub_net/src/http/fetcher.rs
+++ b/crates/gosub_net/src/http/fetcher.rs
@@ -1,0 +1,58 @@
+use super::response::Response;
+use crate::http::request::Request;
+use anyhow::bail;
+use gosub_shared::types::Result;
+use url::{ParseError, Url};
+
+pub struct Fetcher {
+    base_url: Url,
+    client: ureq::Agent,
+}
+
+impl Fetcher {
+    pub fn new(base: Url) -> Self {
+        Self {
+            base_url: base,
+            client: ureq::Agent::new(),
+        }
+    }
+
+    pub fn get_url(&self, url: &Url) -> Result<Response> {
+        let scheme = url.scheme();
+
+        let resp = if scheme == "http" || scheme == "https" {
+            let response = self.client.get(url.as_str()).call()?;
+
+            response.try_into()?
+        } else if scheme == "file" {
+            let path = url.path();
+            let body = std::fs::read(path)?;
+
+            Response::from(body)
+        } else {
+            bail!("Unsupported scheme")
+        };
+
+        Ok(resp)
+    }
+
+    pub fn get(&self, url: &str) -> Result<Response> {
+        let url = self.parse_url(url)?;
+
+        self.get_url(&url)
+    }
+
+    pub fn get_req(&self, _url: &Request) {
+        todo!()
+    }
+
+    fn parse_url(&self, url: &str) -> Result<Url> {
+        let mut parsed_url = Url::parse(url);
+
+        if parsed_url == Err(ParseError::RelativeUrlWithoutBase) {
+            parsed_url = self.base_url.join(url);
+        }
+
+        Ok(parsed_url?)
+    }
+}

--- a/crates/gosub_net/src/http/headers.rs
+++ b/crates/gosub_net/src/http/headers.rs
@@ -12,8 +12,18 @@ impl Headers {
         }
     }
 
-    pub fn set(&mut self, key: &str, value: &str) {
+    pub fn with_capacity(capacity: usize) -> Headers {
+        Headers {
+            headers: HashMap::with_capacity(capacity),
+        }
+    }
+
+    pub fn set_str(&mut self, key: &str, value: &str) {
         self.headers.insert(key.to_string(), value.to_string());
+    }
+
+    pub fn set(&mut self, key: String, value: String) {
+        self.headers.insert(key, value);
     }
 
     pub fn get(&self, key: &str) -> Option<&String> {
@@ -40,10 +50,10 @@ mod tests {
     fn test_headers() {
         let mut headers = Headers::new();
 
-        headers.set("Content-Type", "application/json");
+        headers.set_str("Content-Type", "application/json");
         assert_eq!(headers.get("Content-Type").unwrap(), "application/json");
 
-        headers.set("Content-Type", "text/html");
+        headers.set_str("Content-Type", "text/html");
         assert_eq!(headers.get("Content-Type").unwrap(), "text/html");
         assert_eq!(headers.all().len(), 1);
     }

--- a/crates/gosub_net/src/http/request.rs
+++ b/crates/gosub_net/src/http/request.rs
@@ -62,11 +62,11 @@ mod tests {
         req.headers(Headers::new());
         req.cookies(CookieJar::new());
 
-        req.headers.set("Content-Type", "application/json");
+        req.headers.set_str("Content-Type", "application/json");
         req.cookies.add(Cookie::new("qux", "wok"));
         req.cookies.add(Cookie::new("foo", "bar"));
-        req.headers.set("Accept", "text/html");
-        req.headers.set("Accept-Encoding", "gzip, deflate, br");
+        req.headers.set_str("Accept", "text/html");
+        req.headers.set_str("Accept-Encoding", "gzip, deflate, br");
 
         assert_eq!(req.method, "GET");
         assert_eq!(req.uri, "/");
@@ -83,9 +83,9 @@ mod tests {
 
         req.cookies.add(Cookie::new("foo", "bar"));
         req.cookies.add(Cookie::new("qux", "wok"));
-        req.headers.set("Content-Type", "application/json");
-        req.headers.set("Accept", "text/html");
-        req.headers.set("Accept-Encoding", "gzip, deflate, br");
+        req.headers.set_str("Content-Type", "application/json");
+        req.headers.set_str("Accept", "text/html");
+        req.headers.set_str("Accept-Encoding", "gzip, deflate, br");
 
         let s = format!("{}", req);
         assert_eq!(s, "GET / HTTP/1.1\nHeaders:\n  Accept: text/html\n  Accept-Encoding: gzip, deflate, br\n  Content-Type: application/json\nCookies:\n  foo=bar\n  qux=wok\nBody: 0 bytes\n");

--- a/crates/gosub_net/src/http/response.rs
+++ b/crates/gosub_net/src/http/response.rs
@@ -1,6 +1,7 @@
 use crate::http::headers::Headers;
 use core::fmt::{Display, Formatter};
 use std::collections::HashMap;
+use std::io::Read;
 
 #[derive(Debug)]
 pub struct Response {
@@ -23,6 +24,63 @@ impl Response {
             body: vec![],
         }
     }
+
+    pub fn is_ok(&self) -> bool {
+        self.status >= 200 && self.status < 300
+    }
+}
+
+impl TryFrom<ureq::Response> for Response {
+    type Error = anyhow::Error;
+
+    fn try_from(value: ureq::Response) -> std::result::Result<Self, Self::Error> {
+        let body = Vec::with_capacity(
+            value
+                .header("Content-Length")
+                .map(|s| s.parse().unwrap_or(0))
+                .unwrap_or(0),
+        );
+
+        let mut this = Self {
+            status: value.status(),
+            status_text: value.status_text().to_string(),
+            version: value.http_version().to_string(),
+            headers: get_headers(&value),
+            body,
+            cookies: Default::default(),
+        };
+
+        value.into_reader().read_to_end(&mut this.body)?;
+
+        Ok(this)
+    }
+}
+
+impl From<Vec<u8>> for Response {
+    fn from(body: Vec<u8>) -> Self {
+        Self {
+            status: 200,
+            status_text: "OK".to_string(),
+            version: "HTTP/1.1".to_string(),
+            headers: Default::default(),
+            cookies: Default::default(),
+            body,
+        }
+    }
+}
+
+fn get_headers(response: &ureq::Response) -> Headers {
+    let names = response.headers_names();
+
+    let mut headers = Headers::with_capacity(names.len());
+
+    for name in names {
+        let header = response.header(&name).unwrap_or_default().to_string();
+
+        headers.set(name, header);
+    }
+
+    headers
 }
 
 impl Default for Response {
@@ -60,7 +118,7 @@ mod tests {
         assert_eq!(s, "HTTP/1.1 0\nHeaders:\nCookies:\nBody: 0 bytes\n");
 
         response.status = 200;
-        response.headers.set("Content-Type", "application/json");
+        response.headers.set_str("Content-Type", "application/json");
         response
             .cookies
             .insert("session".to_string(), "1234567890".to_string());

--- a/crates/gosub_render_backend/src/svg.rs
+++ b/crates/gosub_render_backend/src/svg.rs
@@ -1,6 +1,6 @@
 use gosub_html5::node::NodeId;
 use gosub_html5::parser::document::DocumentHandle;
-use gosub_shared::types::Result;
+use gosub_shared::types::{Result, Size};
 
 use crate::{ImageBuffer, RenderBackend};
 
@@ -13,4 +13,9 @@ pub trait SvgRenderer<B: RenderBackend> {
     fn parse_internal(tree: DocumentHandle, id: NodeId) -> Result<Self::SvgDocument>;
 
     fn render(&mut self, doc: &Self::SvgDocument) -> Result<ImageBuffer<B>>;
+    fn render_with_size(
+        &mut self,
+        doc: &Self::SvgDocument,
+        size: Size<u32>,
+    ) -> Result<ImageBuffer<B>>;
 }

--- a/crates/gosub_renderer/src/render_tree.rs
+++ b/crates/gosub_renderer/src/render_tree.rs
@@ -6,6 +6,7 @@ use url::Url;
 use gosub_html5::node::NodeId;
 use gosub_html5::parser::document::{Document, DocumentBuilder};
 use gosub_html5::parser::Html5Parser;
+use gosub_net::http::fetcher::Fetcher;
 use gosub_net::http::ureq;
 use gosub_render_backend::geo::SizeU32;
 use gosub_render_backend::layout::Layouter;
@@ -16,10 +17,10 @@ use gosub_styling::render_tree::{generate_render_tree, RenderNodeData, RenderTre
 use gosub_styling::styling::CssProperties;
 
 pub struct TreeDrawer<B: RenderBackend, L: Layouter> {
+    pub(crate) fetcher: Fetcher,
     pub(crate) tree: RenderTree<B, L>,
     pub(crate) layouter: L,
     pub(crate) size: Option<SizeU32>,
-    pub(crate) url: Url,
     pub(crate) position: PositionTree,
     pub(crate) last_hover: Option<NodeId>,
     pub(crate) debug: bool,
@@ -36,7 +37,6 @@ impl<B: RenderBackend, L: Layouter> TreeDrawer<B, L> {
             tree,
             layouter,
             size: None,
-            url,
             position: PositionTree::default(),
             last_hover: None,
             debug,
@@ -45,6 +45,7 @@ impl<B: RenderBackend, L: Layouter> TreeDrawer<B, L> {
             tree_scene: None,
             selected_element: None,
             scene_transform: None,
+            fetcher: Fetcher::new(url),
         }
     }
 }

--- a/crates/gosub_svg/src/resvg.rs
+++ b/crates/gosub_svg/src/resvg.rs
@@ -6,7 +6,7 @@ use gosub_html5::parser::document::DocumentHandle;
 use gosub_render_backend::geo::FP;
 use gosub_render_backend::svg::SvgRenderer;
 use gosub_render_backend::{Image, ImageBuffer, RenderBackend};
-use gosub_shared::types::Result;
+use gosub_shared::types::{Result, Size};
 
 use crate::SVGDocument;
 
@@ -28,17 +28,30 @@ impl<B: RenderBackend> SvgRenderer<B> for Resvg {
     }
 
     fn render(&mut self, doc: &SVGDocument) -> Result<ImageBuffer<B>> {
-        let img: B::Image = Self::render_to_image::<B>(self, doc)?;
+        let size = doc.tree.size().to_int_size();
+        let size = Size::new(size.width(), size.height());
+
+        self.render_with_size(doc, size)
+    }
+
+    fn render_with_size(
+        &mut self,
+        doc: &Self::SvgDocument,
+        size: Size<u32>,
+    ) -> Result<ImageBuffer<B>> {
+        let img: B::Image = Self::render_to_image::<B>(self, doc, size)?;
 
         Ok(ImageBuffer::Image(img))
     }
 }
 
 impl Resvg {
-    pub fn render_to_image<B: RenderBackend>(&mut self, doc: &SVGDocument) -> Result<B::Image> {
-        let size = doc.tree.size().to_int_size();
-
-        let mut pixmap = Pixmap::new(size.width(), size.height())
+    pub fn render_to_image<B: RenderBackend>(
+        &mut self,
+        doc: &SVGDocument,
+        size: Size<u32>,
+    ) -> Result<B::Image> {
+        let mut pixmap = Pixmap::new(size.width, size.height)
             .ok_or_else(|| anyhow!("Failed to create pixmap"))?;
 
         resvg::render(

--- a/crates/gosub_vello/src/vello_svg.rs
+++ b/crates/gosub_vello/src/vello_svg.rs
@@ -2,7 +2,7 @@ use gosub_html5::node::NodeId;
 use gosub_html5::parser::document::DocumentHandle;
 use gosub_render_backend::svg::SvgRenderer;
 use gosub_render_backend::ImageBuffer;
-use gosub_shared::types::Result;
+use gosub_shared::types::{Result, Size};
 
 use crate::render::window::WindowData;
 use crate::VelloBackend;
@@ -29,5 +29,13 @@ impl SvgRenderer<VelloBackend> for VelloSVG {
         // vello_svg::render_tree(scene.inner(), &doc.tree); //TODO: too old versions that vello_svg uses
 
         todo!();
+    }
+
+    fn render_with_size(
+        &mut self,
+        _doc: &Self::SvgDocument,
+        _size: Size<u32>,
+    ) -> gosub_shared::types::Result<ImageBuffer<VelloBackend>> {
+        todo!()
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -110,7 +110,7 @@ fn fetch_url(
             fetch_response.response.version = format!("{:?}", resp.http_version());
             for key in &resp.headers_names() {
                 for value in resp.all(key) {
-                    fetch_response.response.headers.set(key.as_str(), value);
+                    fetch_response.response.headers.set_str(key.as_str(), value);
                 }
             }
             // TODO: cookies
@@ -167,7 +167,7 @@ mod tests {
     fn test_fetch_url() {
         let url = "https://gosub.io/";
         let mut headers = Headers::new();
-        headers.set("User-Agent", USER_AGENT);
+        headers.set_str("User-Agent", USER_AGENT);
         let cookies = CookieJar::new();
 
         let resp = fetch_url("GET", url, headers, cookies);


### PR DESCRIPTION
The Fetcher automatically handles URLs expanding and requesting, so when it encounters a relative URL, it will make use of the base URL and "expands" the URL.

It also handles different schemes, like `https`, `http` and `file` we can add more later on.

For now, I only make use of it in the image requesting. I guess in the future, we want to build a fetcher, when we download the HTML and pass it to the different subcomponents, like drawing and so on.

The fetcher can then also make some caching, but only for the lifetime of the page, so if we have for example the same image twice on the page, it doesn't try to download it two times but only once.