### PR TITLE
fix fetcher not finding some URLs

### DIFF
--- a/crates/gosub_net/src/http/fetcher.rs
+++ b/crates/gosub_net/src/http/fetcher.rs
@@ -25,7 +25,8 @@ impl Fetcher {
 
             response.try_into()?
         } else if scheme == "file" {
-            let path = url.path();
+            let path = &url.as_str()[7..];
+
             let body = std::fs::read(path)?;
 
             Response::from(body)


### PR DESCRIPTION
When using relative file paths as an `URL`, the current fetcher removes the first directory. 

So from
`resources/files/image.png`
it makes
`/files/image.png`