### PR TITLE
fix percentages being off by factor 100

### DIFF
--- a/crates/gosub_styling/src/syntax_matcher.rs
+++ b/crates/gosub_styling/src/syntax_matcher.rs
@@ -306,7 +306,7 @@ fn match_component_single<'a>(
                 _ => {}
             },
             _ => {
-                println!("unknown datatype: {datatype:?}");
+                // println!("unknown datatype: {datatype:?}");
 
                 return first_match(input);
             } // _ => panic!("Unknown built-in datatype: {:?}", datatype),

--- a/crates/gosub_taffy/src/lib.rs
+++ b/crates/gosub_taffy/src/lib.rs
@@ -218,10 +218,6 @@ impl<LT: LayoutTree<TaffyLayouter>> LayoutPartialTree for LayoutDocument<'_, LT>
 
         let node_id = LT::NodeId::from(node_id.into());
 
-        if self.0.child_count(node_id) == 0 {
-            println!("Setting layout for leaf node: {:?}", layout);
-        }
-
         self.0.set_layout(node_id, layout);
     }
 

--- a/crates/gosub_taffy/src/style/parse.rs
+++ b/crates/gosub_taffy/src/style/parse.rs
@@ -15,7 +15,7 @@ pub fn parse_len(node: &mut impl Node, name: &str) -> LengthPercentage {
     property.compute_value();
 
     if let Some(percent) = property.as_percentage() {
-        return LengthPercentage::Percent(percent);
+        return LengthPercentage::Percent(percent / 100.0);
     }
 
     LengthPercentage::Length(property.unit_to_px())
@@ -35,7 +35,7 @@ pub fn parse_len_auto(node: &mut impl Node, name: &str) -> LengthPercentageAuto 
     }
 
     if let Some(percent) = property.as_percentage() {
-        return LengthPercentageAuto::Percent(percent);
+        return LengthPercentageAuto::Percent(percent / 100.0);
     }
 
     LengthPercentageAuto::Length(property.unit_to_px())
@@ -55,7 +55,7 @@ pub fn parse_dimension(node: &mut impl Node, name: &str) -> Dimension {
     }
 
     if let Some(percent) = property.as_percentage() {
-        return Dimension::Percent(percent);
+        return Dimension::Percent(percent / 100.0);
     }
 
     Dimension::Length(property.unit_to_px())


### PR DESCRIPTION
Percentages were off by factor 100. 

This is because taffy expects a percentage from 0-1 as the full range, however we gave it 0-100 as full range.

This resulted in some "fairly" large sites, like ~20Mio px wide... 
(~2000px viewport width, *100² = 20Mio)