### PR TITLE
also load external stylesheets with file://

### DIFF
--- a/crates/gosub_renderer/src/draw/img.rs
+++ b/crates/gosub_renderer/src/draw/img.rs
@@ -11,11 +11,7 @@ pub fn request_img<B: RenderBackend>(
     url: &str,
     size: SizeU32,
 ) -> Result<ImageBuffer<B>> {
-    println!("getting image from url: {}", url);
-
     let res = fetcher.get(url)?;
-
-    println!("got response from url: {}", res.status);
 
     if !res.is_ok() {
         return Err(anyhow!("Could not get url. Status code {}", res.status));


### PR DESCRIPTION
We weren't loading stylesheets that were stored on the disk before, now it is implemented.

In the future, we probably want to fetch the stylesheets with the `Fetcher` added in #558 