### PR TITLE
disable padding for inline elements, only inline-block elements get padding

### DIFF
--- a/crates/gosub_taffy/src/lib.rs
+++ b/crates/gosub_taffy/src/lib.rs
@@ -70,7 +70,9 @@ pub struct TaffyLayouter;
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 #[allow(unused)]
 pub enum Display {
-    Text,
+    Inline,
+    InlineBlock,
+    Table,
     #[default]
     Taffy,
 }
@@ -240,17 +242,6 @@ impl<LT: LayoutTree<TaffyLayouter>> LayoutPartialTree for LayoutDocument<'_, LT>
             if let Some(node) = tree.0.get_node(node_id) {
                 if node.is_anon_inline_parent() {
                     return compute_inline_layout(tree, node_id, inputs);
-                }
-            }
-
-            if let Some(cache) = tree.0.get_cache(node_id) {
-                match cache.display {
-                    Display::Text => {
-                        // We should implement a new way of layouting text. Currently, we just measure how long the text is and don't insert any linebreaks,
-                        // which is obviously not correct. So, if we encounter Display::Text, we need to ask our text-layouter and tell him how much space we have, and it will insert linebreaks
-                        todo!()
-                    }
-                    Display::Taffy => {}
                 }
             }
 

--- a/crates/gosub_taffy/src/style/parse_properties.rs
+++ b/crates/gosub_taffy/src/style/parse_properties.rs
@@ -25,6 +25,9 @@ pub fn parse_display(node: &mut impl Node) -> (Display, crate::Display) {
         "block" => (Display::Block, crate::Display::Taffy),
         "flex" => (Display::Flex, crate::Display::Taffy),
         "grid" => (Display::Grid, crate::Display::Taffy),
+        "inline-block" => (Display::Block, crate::Display::InlineBlock),
+        "inline" => (Display::Block, crate::Display::Inline),
+        "table" => (Display::Block, crate::Display::Table),
         _ => (Display::Block, crate::Display::Taffy),
     }
 }


### PR DESCRIPTION
Many (nested) inline elements got too large because they got padding from somehwere, this is wrong. Inline elements aren't affected by margin, padding, width and height properties. This PR fixes some of those issues with padding.



Note: This is more of a temporary fix, since the current implementation still lays out inline elements with the block algorithm