### PR TITLE
Reimplment selector matching, fix descendant combinator & implement next & subsequent child combinator

### DIFF
--- a/crates/gosub_styling/src/render_tree.rs
+++ b/crates/gosub_styling/src/render_tree.rs
@@ -253,7 +253,7 @@ impl<L: Layouter> RenderTree<L> {
         for current_node_id in tree_iterator {
             let mut css_map_entry = CssProperties::new();
 
-            let mut doc = document.get();
+            let doc = document.get();
             let node = doc.get_node_by_id(current_node_id).expect("node not found");
 
             if node_is_undernderable(node) {
@@ -425,11 +425,9 @@ impl<L: Layouter> RenderTree<L> {
     /// Removes all unrenderable nodes from the render tree
     fn remove_unrenderable_nodes(&mut self) {
         // There are more elements that are not renderable, but for now we only remove the most common ones
-
-        const REMOVABLE_ELEMENTS: [&str; 5] = ["head", "script", "style", "svg", "noscript"];
         let mut delete_list = Vec::new();
 
-        for (id, node) in &self.nodes {
+        for id in self.nodes.keys() {
             // Check CSS styles and remove if not renderable
             if let Some(mut prop) = self.get_property(*id, "display") {
                 if prop.compute_value().to_string() == "none" {

--- a/crates/gosub_styling/src/render_tree.rs
+++ b/crates/gosub_styling/src/render_tree.rs
@@ -235,7 +235,7 @@ impl<L: Layouter> RenderTree<L> {
         render_tree
     }
 
-    fn generate_from(&mut self, document: DocumentHandle) {
+    fn generate_from(&mut self, mut document: DocumentHandle) {
         // Iterate the complete document tree
         let tree_iterator = TreeIterator::new(&document);
 
@@ -253,10 +253,26 @@ impl<L: Layouter> RenderTree<L> {
         for current_node_id in tree_iterator {
             let mut css_map_entry = CssProperties::new();
 
-            let binding = document.get();
-            let node = binding
-                .get_node_by_id(current_node_id)
-                .expect("node not found");
+            let mut doc = document.get();
+            let node = doc.get_node_by_id(current_node_id).expect("node not found");
+
+            if node_is_undernderable(node) {
+                if let Some(parent) = node.parent {
+                    if let Some(parent) = self.get_node_mut(parent) {
+                        parent.children.retain(|id| *id != current_node_id);
+                        // continue
+                        //TODO: somehow we still can't continue here, I don't know why
+                    }
+                }
+
+                drop(doc);
+
+                let mut doc = document.get_mut();
+
+                doc.detach_node_from_parent(current_node_id);
+
+                continue;
+            }
 
             let definitions = get_css_definitions();
 
@@ -409,20 +425,11 @@ impl<L: Layouter> RenderTree<L> {
     /// Removes all unrenderable nodes from the render tree
     fn remove_unrenderable_nodes(&mut self) {
         // There are more elements that are not renderable, but for now we only remove the most common ones
-        let removable_elements = ["head", "script", "style", "svg", "noscript"];
 
+        const REMOVABLE_ELEMENTS: [&str; 5] = ["head", "script", "style", "svg", "noscript"];
         let mut delete_list = Vec::new();
 
         for (id, node) in &self.nodes {
-            if let RenderNodeData::Element(element) = &node.data {
-                if removable_elements.contains(&element.name.as_str()) {
-                    println!("removing: {:?}({id})", element.name);
-                    delete_list.append(&mut self.get_child_node_ids(*id));
-                    delete_list.push(*id);
-                    continue;
-                }
-            }
-
             // Check CSS styles and remove if not renderable
             if let Some(mut prop) = self.get_property(*id, "display") {
                 if prop.compute_value().to_string() == "none" {
@@ -834,6 +841,26 @@ pub fn generate_render_tree<L: Layouter>(document: DocumentHandle) -> Result<Ren
     let render_tree = RenderTree::from_document(document);
 
     Ok(render_tree)
+}
+
+pub fn node_is_undernderable(node: &gosub_html5::node::Node) -> bool {
+    // There are more elements that are not renderable, but for now we only remove the most common ones
+
+    const REMOVABLE_ELEMENTS: [&str; 5] = ["head", "script", "style", "svg", "noscript"];
+
+    if let NodeData::Element(element) = &node.data {
+        if REMOVABLE_ELEMENTS.contains(&element.name.as_str()) {
+            return true;
+        }
+    }
+
+    if let NodeData::Text(text) = &node.data {
+        if text.value.chars().all(|c| c.is_whitespace()) {
+            return true;
+        }
+    }
+
+    false
 }
 
 // pub fn walk_render_tree(tree: &RenderTree, visitor: &mut Box<dyn TreeVisitor<RenderTreeNode>>) {

--- a/crates/gosub_styling/src/styling.rs
+++ b/crates/gosub_styling/src/styling.rs
@@ -222,17 +222,6 @@ fn match_selector_part<'a>(
                     match_selector_part(&last, parent, doc, next_node, parts)
                 }
                 Combinator::NextSibling => {
-                    // let Some(parent) = current_node.parent else {
-                    //     return false;
-                    // };
-                    //
-
-                    let is_debug = u64::from(current_node.id) == 32;
-
-                    if is_debug {
-                        println!("current_node: {:?}", current_node);
-                    }
-
                     let Some(children) = doc.parent_node(current_node).map(|p| &p.children) else {
                         return false;
                     };
@@ -263,18 +252,30 @@ fn match_selector_part<'a>(
 
                     *next_node = Some(prev);
 
-                    if is_debug {
-                        dbg!(prev);
-                        dbg!(last);
-                        dbg!(&parts);
-
-                        println!("DEBUG 3333");
-                    }
-
                     match_selector_part(last, prev, doc, next_node, parts)
                 }
                 Combinator::SubsequentSibling => {
-                    // We need to match the previous siblings of the current node
+                    let Some(children) = doc.parent_node(current_node).map(|p| &p.children) else {
+                        return false;
+                    };
+
+                    let Some(last) = consume(parts) else {
+                        return false;
+                    };
+
+                    for child in children {
+                        if *child == current_node.id {
+                            break;
+                        }
+
+                        let Some(child) = doc.get_node_by_id(*child) else {
+                            continue;
+                        };
+
+                        if match_selector_part(&last, child, doc, next_node, parts) {
+                            return true;
+                        }
+                    }
 
                     false
                 }

--- a/crates/gosub_styling/src/styling.rs
+++ b/crates/gosub_styling/src/styling.rs
@@ -50,7 +50,7 @@ fn match_selector_parts(
         }
 
         if !match_selector_part(
-            &part,
+            part,
             current_node,
             &binding,
             &mut next_current_node,
@@ -90,7 +90,7 @@ fn match_selector_part<'a>(
             if !current_node.is_element() {
                 return false;
             }
-            current_node.as_element().classes.contains(&name)
+            current_node.as_element().classes.contains(name)
         }
         CssSelectorPart::Id(name) => {
             if !current_node.is_element() {
@@ -106,25 +106,25 @@ fn match_selector_part<'a>(
         CssSelectorPart::Attribute(attr) => {
             let wanted_attr_name = &attr.name;
 
-            if !current_node.has_attribute(&wanted_attr_name) {
+            if !current_node.has_attribute(wanted_attr_name) {
                 return false;
             }
 
             let mut wanted_attr_value = &attr.value;
             let mut got_attr_value = current_node
-                .get_attribute(&wanted_attr_name)
+                .get_attribute(wanted_attr_name)
                 .map(|v| v.as_str())
                 .unwrap_or("");
 
-            let mut wanted_buf = String::new(); //Two buffers, so we don't need to clone the value if we match case-sensitive
-            let mut got_buf = String::new();
+            let mut _wanted_buf = String::new(); //Two buffers, so we don't need to clone the value if we match case-sensitive
+            let mut _got_buf = String::new();
             // If we need to match case-insensitive, just convert everything to lowercase for comparison
             if attr.case_insensitive {
-                wanted_buf = wanted_attr_name.to_lowercase();
-                got_buf = got_attr_value.to_lowercase();
+                _wanted_buf = wanted_attr_name.to_lowercase();
+                _got_buf = got_attr_value.to_lowercase();
 
-                wanted_attr_value = &wanted_buf;
-                got_attr_value = &got_buf;
+                wanted_attr_value = &_wanted_buf;
+                got_attr_value = &_got_buf;
             };
 
             match attr.matcher {
@@ -161,11 +161,11 @@ fn match_selector_part<'a>(
                 }
             }
         }
-        CssSelectorPart::PseudoClass(name) => {
+        CssSelectorPart::PseudoClass(_name) => {
             // @Todo: implement pseudo classes
             false
         }
-        CssSelectorPart::PseudoElement(name) => {
+        CssSelectorPart::PseudoElement(_name) => {
             // @Todo: implement pseudo elements
             false
         }
@@ -190,7 +190,7 @@ fn match_selector_part<'a>(
 
                         *next_node = Some(parent);
 
-                        if match_selector_part(&last, parent, doc, next_node, parts) {
+                        if match_selector_part(last, parent, doc, next_node, parts) {
                             return true;
                         }
 
@@ -219,7 +219,7 @@ fn match_selector_part<'a>(
 
                     *next_node = Some(parent);
 
-                    match_selector_part(&last, parent, doc, next_node, parts)
+                    match_selector_part(last, parent, doc, next_node, parts)
                 }
                 Combinator::NextSibling => {
                     let Some(children) = doc.parent_node(current_node).map(|p| &p.children) else {
@@ -272,7 +272,7 @@ fn match_selector_part<'a>(
                             continue;
                         };
 
-                        if match_selector_part(&last, child, doc, next_node, parts) {
+                        if match_selector_part(last, child, doc, next_node, parts) {
                             return true;
                         }
                     }
@@ -298,7 +298,7 @@ fn match_selector_part<'a>(
                         return false;
                     };
 
-                    current_node.is_namespace(&namespace)
+                    current_node.is_namespace(namespace)
                 }
                 Combinator::Column => {
                     //TODO

--- a/crates/gosub_styling/src/styling.rs
+++ b/crates/gosub_styling/src/styling.rs
@@ -4,10 +4,10 @@ use std::collections::HashMap;
 
 use crate::property_definitions::{get_css_definitions, CSS_DEFINITIONS};
 use gosub_css3::stylesheet::{
-    CssOrigin, CssSelector, CssSelectorPart, CssSelectorType, CssValue, MatcherType, Specificity,
+    Combinator, CssOrigin, CssSelector, CssSelectorPart, CssValue, MatcherType, Specificity,
 };
-use gosub_html5::node::NodeId;
-use gosub_html5::parser::document::DocumentHandle;
+use gosub_html5::node::{Node, NodeId};
+use gosub_html5::parser::document::{Document, DocumentHandle};
 
 // Matches a complete selector (all parts) against the given node(id)
 pub(crate) fn match_selector(
@@ -15,178 +15,251 @@ pub(crate) fn match_selector(
     node_id: NodeId,
     selector: &CssSelector,
 ) -> bool {
-    let mut parts = selector.parts.clone();
-    parts.reverse();
-    match_selector_part(document, node_id, &mut parts)
+    match_selector_parts(document, node_id, &selector.parts)
+}
+
+fn consume<'a, T>(this: &mut &'a [T]) -> Option<&'a T> {
+    let last = this.last()?;
+
+    if let Some(parts) = this.get(..this.len() - 1) {
+        *this = parts;
+    }
+
+    Some(last)
 }
 
 /// Returns true when the given node matches the part(s)
-fn match_selector_part(
+fn match_selector_parts(
     document: DocumentHandle,
     node_id: NodeId,
-    selector_parts: &mut Vec<CssSelectorPart>,
+    mut parts: &[CssSelectorPart],
 ) -> bool {
     let binding = document.get();
-    let mut next_current_node = Some(binding.get_node_by_id(node_id).expect("node not found"));
+    let mut next_current_node = binding.get_node_by_id(node_id);
+    if next_current_node.is_none() {
+        return false;
+    }
 
-    while !selector_parts.is_empty() {
-        if next_current_node.is_none() {
+    while let Some(part) = consume(&mut parts) {
+        let Some(current_node) = next_current_node else {
             return false;
-        }
-        let current_node = next_current_node.expect("current_node not found");
+        };
+
         if current_node.is_root() {
             return false;
         }
 
-        let part = selector_parts.remove(0);
-
-        match part.type_ {
-            CssSelectorType::Universal => {
-                // '*' always matches any selector
-            }
-            CssSelectorType::Type => {
-                if !current_node.is_element() {
-                    return false;
-                }
-                if part.value != current_node.as_element().name {
-                    return false;
-                }
-            }
-            CssSelectorType::Class => {
-                if !current_node.is_element() {
-                    return false;
-                }
-                if !current_node.as_element().classes.contains(&part.value) {
-                    return false;
-                }
-            }
-            CssSelectorType::Id => {
-                if !current_node.is_element() {
-                    return false;
-                }
-                if current_node
-                    .as_element()
-                    .attributes
-                    .get("id")
-                    .unwrap_or(&"".to_string())
-                    != &part.value
-                {
-                    return false;
-                }
-            }
-            CssSelectorType::Attribute => {
-                let wanted_attr_name = part.name.clone();
-
-                if !current_node.has_attribute(&wanted_attr_name) {
-                    return false;
-                }
-
-                let mut wanted_attr_value = part.value.clone();
-                let mut got_attr_value = current_node
-                    .get_attribute(&wanted_attr_name)
-                    .unwrap_or(&"".to_string())
-                    .to_string();
-
-                // If we need to match case-insensitive, just convert everything to lowercase for comparison
-                if part.flags.eq_ignore_ascii_case("i") {
-                    wanted_attr_value = wanted_attr_value.to_lowercase();
-                    got_attr_value = got_attr_value.to_lowercase();
-                };
-
-                return match part.matcher {
-                    MatcherType::None => {
-                        // Just the presence of the attribute is enough
-                        true
-                    }
-                    MatcherType::Equals => {
-                        // Exact match
-                        wanted_attr_value == got_attr_value
-                    }
-                    MatcherType::Includes => {
-                        // Contains word
-                        wanted_attr_value
-                            .split_whitespace()
-                            .any(|s| s == got_attr_value)
-                    }
-                    MatcherType::DashMatch => {
-                        // Exact value or value followed by a hyphen
-                        got_attr_value == wanted_attr_value
-                            || got_attr_value.starts_with(&format!("{}-", wanted_attr_value))
-                    }
-                    MatcherType::PrefixMatch => {
-                        // Starts with
-                        got_attr_value.starts_with(&wanted_attr_value)
-                    }
-                    MatcherType::SuffixMatch => {
-                        // Ends with
-                        got_attr_value.ends_with(&wanted_attr_value)
-                    }
-                    MatcherType::SubstringMatch => {
-                        // Contains
-                        got_attr_value.contains(&wanted_attr_value)
-                    }
-                };
-            }
-            CssSelectorType::PseudoClass => {
-                // @Todo: implement pseudo classes
-                if part.value == "link" {
-                    return false;
-                }
-                return false;
-            }
-            CssSelectorType::PseudoElement => {
-                // @Todo: implement pseudo elements
-                if part.value == "first-child" {
-                    return false;
-                }
-                return false;
-            }
-            CssSelectorType::Combinator => {
-                // We don't have the descendant combinator (space), as this is the default behaviour
-                match part.value.as_str() {
-                    // @todo: We also should do: column combinator ('||' experimental)
-                    // @todo: Namespace combinator ('|')
-                    " " => {
-                        // Descendant combinator, any parent that matches the previous selector will do
-                        if !match_selector_part(
-                            DocumentHandle::clone(&document),
-                            current_node.id,
-                            selector_parts,
-                        ) {
-                            // we insert the combinator back so we the next loop will match against the parent node
-                            selector_parts.insert(0, part);
-                        }
-                    }
-                    ">" => {
-                        // Child combinator. Only matches the direct child
-                        if !match_selector_part(
-                            DocumentHandle::clone(&document),
-                            current_node.id,
-                            selector_parts,
-                        ) {
-                            return false;
-                        }
-                    }
-                    "+" => {
-                        // We need to match the previous sibling of the current node
-                    }
-                    "~" => {
-                        // We need to match the previous siblings of the current node
-                    }
-                    _ => {
-                        panic!("Unknown combinator: {}", part.value);
-                    }
-                }
-            }
+        if !match_selector_part(
+            &part,
+            current_node,
+            &binding,
+            &mut next_current_node,
+            &mut parts,
+        ) {
+            return false;
         }
 
         // We have matched this part, so we move up the chain
         // let binding = document.get();
-        next_current_node = binding.parent_node(current_node);
+        // next_current_node = binding.parent_node(current_node);
     }
 
     // All parts of the selector have matched
     true
+}
+
+fn match_selector_part<'a>(
+    part: &CssSelectorPart,
+    current_node: &Node,
+    doc: &'a Document,
+    next_node: &mut Option<&'a Node>,
+    parts: &mut &[CssSelectorPart],
+) -> bool {
+    match part {
+        CssSelectorPart::Universal => {
+            // '*' always matches any selector
+            true
+        }
+        CssSelectorPart::Type(name) => {
+            if !current_node.is_element() {
+                return false;
+            }
+            *name == current_node.as_element().name
+        }
+        CssSelectorPart::Class(name) => {
+            if !current_node.is_element() {
+                return false;
+            }
+            current_node.as_element().classes.contains(&name)
+        }
+        CssSelectorPart::Id(name) => {
+            if !current_node.is_element() {
+                return false;
+            }
+            current_node
+                .as_element()
+                .attributes
+                .get("id")
+                .unwrap_or(&"".to_string())
+                == name
+        }
+        CssSelectorPart::Attribute(attr) => {
+            let wanted_attr_name = &attr.name;
+
+            if !current_node.has_attribute(&wanted_attr_name) {
+                return false;
+            }
+
+            let mut wanted_attr_value = &attr.value;
+            let mut got_attr_value = current_node
+                .get_attribute(&wanted_attr_name)
+                .map(|v| v.as_str())
+                .unwrap_or("");
+
+            let mut wanted_buf = String::new(); //Two buffers, so we don't need to clone the value if we match case-sensitive
+            let mut got_buf = String::new();
+            // If we need to match case-insensitive, just convert everything to lowercase for comparison
+            if attr.case_insensitive {
+                wanted_buf = wanted_attr_name.to_lowercase();
+                got_buf = got_attr_value.to_lowercase();
+
+                wanted_attr_value = &wanted_buf;
+                got_attr_value = &got_buf;
+            };
+
+            match attr.matcher {
+                MatcherType::None => {
+                    // Just the presence of the attribute is enough
+                    true
+                }
+                MatcherType::Equals => {
+                    // Exact match
+                    wanted_attr_value == got_attr_value
+                }
+                MatcherType::Includes => {
+                    // Contains word
+                    wanted_attr_value
+                        .split_whitespace()
+                        .any(|s| s == got_attr_value)
+                }
+                MatcherType::DashMatch => {
+                    // Exact value or value followed by a hyphen
+                    got_attr_value == wanted_attr_value
+                        || got_attr_value.starts_with(&format!("{}-", wanted_attr_value))
+                }
+                MatcherType::PrefixMatch => {
+                    // Starts with
+                    got_attr_value.starts_with(wanted_attr_value)
+                }
+                MatcherType::SuffixMatch => {
+                    // Ends with
+                    got_attr_value.ends_with(wanted_attr_value)
+                }
+                MatcherType::SubstringMatch => {
+                    // Contains
+                    got_attr_value.contains(wanted_attr_value)
+                }
+            }
+        }
+        CssSelectorPart::PseudoClass(name) => {
+            // @Todo: implement pseudo classes
+            false
+        }
+        CssSelectorPart::PseudoElement(name) => {
+            // @Todo: implement pseudo elements
+            false
+        }
+        CssSelectorPart::Combinator(combinator) => {
+            // We don't have the descendant combinator (space), as this is the default behaviour
+            match combinator {
+                Combinator::Descendant => {
+                    let Some(mut parent_id) = current_node.parent else {
+                        return false;
+                    };
+
+                    let last = consume(parts);
+
+                    let Some(last) = last else {
+                        return false;
+                    };
+
+                    loop {
+                        let Some(parent) = doc.get_node_by_id(parent_id) else {
+                            return false;
+                        };
+
+                        *next_node = Some(parent);
+
+                        if match_selector_part(&last, parent, doc, next_node, parts) {
+                            return true;
+                        }
+
+                        let Some(p) = parent.parent else {
+                            return false;
+                        };
+
+                        parent_id = p;
+                    }
+                }
+                Combinator::Child => {
+                    // Child combinator. Only matches the direct child
+                    let Some(parent) = current_node.parent else {
+                        return false;
+                    };
+
+                    let last = consume(parts);
+
+                    let Some(last) = last else {
+                        return false;
+                    };
+
+                    let Some(parent) = doc.get_node_by_id(parent) else {
+                        return false;
+                    };
+
+                    *next_node = Some(parent);
+
+                    match_selector_part(&last, parent, doc, next_node, parts)
+                }
+                Combinator::NextSibling => {
+                    // We need to match the previous sibling of the current node
+
+                    false
+                }
+                Combinator::SubsequentSibling => {
+                    // We need to match the previous siblings of the current node
+
+                    false
+                }
+                Combinator::Namespace => {
+                    let namespace = consume(parts);
+
+                    let Some(namespace) = namespace else {
+                        if current_node.namespace.is_none() {
+                            return true;
+                        }
+
+                        return false;
+                    };
+
+                    if *namespace == CssSelectorPart::Universal {
+                        return true;
+                    }
+
+                    let CssSelectorPart::Type(namespace) = namespace else {
+                        return false;
+                    };
+
+                    current_node.is_namespace(&namespace)
+                }
+                Combinator::Column => {
+                    //TODO
+
+                    false
+                }
+            }
+        }
+    }
 }
 
 /// A declarationProperty defines a single value for a property (color: red;). It consists of the value,


### PR DESCRIPTION
Gosub:
![Screenshot_20240908_222741](https://github.com/user-attachments/assets/f56739ee-0f1f-4782-b79f-be72ffaff7d9)


Firefox:
![image](https://github.com/user-attachments/assets/4ba690e4-c039-42aa-9ec9-3beb4d026d7a)