### PR TITLE
fix elements always stuck in center

### DIFF
--- a/crates/gosub_taffy/src/style/parse.rs
+++ b/crates/gosub_taffy/src/style/parse.rs
@@ -23,7 +23,7 @@ pub fn parse_len(node: &mut impl Node, name: &str) -> LengthPercentage {
 
 pub fn parse_len_auto(node: &mut impl Node, name: &str) -> LengthPercentageAuto {
     let Some(property) = node.get_property(name) else {
-        return LengthPercentageAuto::Auto;
+        return LengthPercentageAuto::Length(0.0);
     };
 
     property.compute_value();


### PR DESCRIPTION
Fixes elements being stuck in the middle because of wrong margin defaults.

Now, #588 should look like firefox.