### PR TITLE
fix "," in css selectors

### DIFF
--- a/crates/gosub_css3/src/convert/ast_converter.rs
+++ b/crates/gosub_css3/src/convert/ast_converter.rs
@@ -90,7 +90,9 @@ pub fn convert_ast_to_stylesheet(
                 continue;
             }
 
-            let mut selector = CssSelector { parts: vec![] };
+            let mut selector = CssSelector {
+                parts: vec![vec![]],
+            };
             for node in node.as_selector_list().iter() {
                 if !node.is_selector() {
                     continue;
@@ -134,11 +136,19 @@ pub fn convert_ast_to_stylesheet(
                             value: value.clone(),
                             case_insensitive: flags.eq_ignore_ascii_case("i"),
                         })),
+                        NodeType::Comma => {
+                            selector.parts.push(vec![]);
+                            continue;
+                        }
                         _ => {
                             return Err(anyhow!("Unsupported selector part: {:?}", node.node_type))
                         }
                     };
-                    selector.parts.push(part);
+                    if let Some(x) = selector.parts.last_mut() {
+                        x.push(part)
+                    } else {
+                        selector.parts.push(vec![part]); //unreachable, but still, we handle it
+                    }
                 }
             }
             rule.selectors.push(selector);

--- a/crates/gosub_css3/src/parser/selector.rs
+++ b/crates/gosub_css3/src/parser/selector.rs
@@ -255,11 +255,22 @@ impl Css3<'_> {
         let mut space = false;
         let mut whitespace_location = loc.clone();
 
+        let mut skip_space = false;
+
         while !self.tokenizer.eof() {
             let t = self.consume_any()?;
             if t.is_comment() {
                 continue;
             }
+
+            if skip_space {
+                if t.is_whitespace() {
+                    continue;
+                } else {
+                    skip_space = false;
+                }
+            }
+
             if t.is_whitespace() {
                 // on whitespace for selector
                 whitespace_location = t.location.clone();
@@ -323,6 +334,11 @@ impl Css3<'_> {
                 TokenType::Delim('&') => {
                     self.tokenizer.reconsume();
                     self.parse_nesting_selector()?
+                }
+                TokenType::Comma => {
+                    skip_space = true;
+
+                    Node::new(NodeType::Comma, t.location)
                 }
                 _ => {
                     self.tokenizer.reconsume();

--- a/crates/gosub_styling/src/render_tree.rs
+++ b/crates/gosub_styling/src/render_tree.rs
@@ -1,22 +1,21 @@
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 
-use crate::property_definitions::get_css_definitions;
-use crate::shorthands::FixList;
-use crate::styling::{
-    match_selector, prop_is_inherit, CssProperties, CssProperty, DeclarationProperty,
-};
 use log::warn;
 
-use gosub_css3::stylesheet::{
-    CssDeclaration, CssOrigin, CssSelector, CssStylesheet, CssValue, Specificity,
-};
+use gosub_css3::stylesheet::{CssDeclaration, CssOrigin, CssStylesheet, CssValue, Specificity};
 use gosub_html5::node::data::element::ElementData;
 use gosub_html5::node::{NodeData, NodeId};
 use gosub_html5::parser::document::{DocumentHandle, TreeIterator};
 use gosub_render_backend::geo::Size;
 use gosub_render_backend::layout::{HasTextLayout, Layout, LayoutTree, Layouter, Node, TextLayout};
 use gosub_shared::types::Result;
+
+use crate::property_definitions::get_css_definitions;
+use crate::shorthands::FixList;
+use crate::styling::{
+    match_selector, prop_is_inherit, CssProperties, CssProperty, DeclarationProperty,
+};
 
 mod desc;
 

--- a/crates/gosub_styling/src/styling.rs
+++ b/crates/gosub_styling/src/styling.rs
@@ -14,8 +14,14 @@ pub(crate) fn match_selector(
     document: DocumentHandle,
     node_id: NodeId,
     selector: &CssSelector,
-) -> bool {
-    match_selector_parts(document, node_id, &selector.parts)
+) -> (bool, Specificity) {
+    for part in &selector.parts {
+        if match_selector_parts(DocumentHandle::clone(&document), node_id, part) {
+            return (true, Specificity::from(part.as_slice()));
+        }
+    }
+
+    (false, Specificity::new(0, 0, 0))
 }
 
 fn consume<'a, T>(this: &mut &'a [T]) -> Option<&'a T> {


### PR DESCRIPTION
Previously, we could not use the "," (or "or" combinator) in a css selector, this is now implemented, so selectors like

```css
div, span {}
```

work now