### PR TITLE
fix declarations using only the first value

### DIFF
--- a/crates/gosub_css3/src/ast.rs
+++ b/crates/gosub_css3/src/ast.rs
@@ -1,3 +1,5 @@
+use log::warn;
+
 use crate::node::{Node as CssNode, NodeType};
 use crate::stylesheet::{
     AttributeSelector, Combinator, CssDeclaration, CssRule, CssSelector, CssSelectorPart, CssStylesheet, CssValue,
@@ -5,7 +7,6 @@ use crate::stylesheet::{
 };
 use gosub_shared::errors::{CssError, CssResult};
 use gosub_shared::traits::css3::CssOrigin;
-use log::warn;
 
 /*
 
@@ -199,9 +200,15 @@ pub fn convert_ast_to_stylesheet(css_ast: &CssNode, origin: CssOrigin, url: &str
                     continue;
                 }
 
+                let value = if css_values.len() == 1 {
+                    css_values.pop().expect("unreachable")
+                } else {
+                    CssValue::List(css_values)
+                };
+
                 rule.declarations.push(CssDeclaration {
                     property: property.clone(),
-                    value: css_values.to_vec(),
+                    value,
                     important: *important,
                 });
             }
@@ -259,7 +266,7 @@ mod tests {
         );
         assert_eq!(
             stylesheet.rules.first().unwrap().declarations.first().unwrap().value,
-            vec![CssValue::String("red".into())]
+            CssValue::String("red".into())
         );
 
         assert_eq!(
@@ -268,11 +275,11 @@ mod tests {
         );
         assert_eq!(
             stylesheet.rules.get(1).unwrap().declarations.first().unwrap().value,
-            vec![
+            CssValue::List(vec![
                 CssValue::Unit(1.0, "px".into()),
                 CssValue::String("solid".into()),
                 CssValue::String("black".into())
-            ]
+            ])
         );
     }
 }

--- a/crates/gosub_css3/src/matcher/property_definitions.rs
+++ b/crates/gosub_css3/src/matcher/property_definitions.rs
@@ -858,4 +858,22 @@ mod tests {
             .clone()
             .matches(&[unit!(1.0, "px"), unit!(2.0, "px"), unit!(3.0, "px"), unit!(4.0, "px"),]));
     }
+
+    #[test]
+    fn test_font_var() {
+        let definitions = get_css_definitions();
+        let def = definitions.find_property("font-variation-settings").unwrap();
+
+        assert_true!(def.matches(&[str!("normal")]));
+
+        assert_true!(def.matches(&[str!("wgth"), CssValue::Number(100.0)]));
+
+        assert_true!(def.matches(&[
+            str!("wgth"),
+            CssValue::Number(100.0),
+            CssValue::Comma,
+            str!("ital"),
+            CssValue::Number(100.0)
+        ]));
+    }
 }

--- a/crates/gosub_css3/src/stylesheet.rs
+++ b/crates/gosub_css3/src/stylesheet.rs
@@ -143,7 +143,7 @@ pub struct CssDeclaration {
     pub property: String,
     // Raw values of the declaration. It is not calculated or converted in any way (ie: "red", "50px" etc.)
     // There can be multiple values  (ie:   "1px solid black" are split into 3 values)
-    pub value: Vec<CssValue>,
+    pub value: CssValue,
     // ie: !important
     pub important: bool,
 }
@@ -613,7 +613,7 @@ mod test {
             }],
             declarations: vec![CssDeclaration {
                 property: "color".to_string(),
-                value: vec![CssValue::String("red".to_string())],
+                value: CssValue::String("red".to_string()),
                 important: false,
             }],
         };

--- a/crates/gosub_html5/Cargo.toml
+++ b/crates/gosub_html5/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 [dependencies]
 gosub_shared = { path = "../gosub_shared", features = [] }
 gosub_css3 = { path = "../gosub_css3", features = [] }
-derive_more = { version = "1", features = ["from"] }
+derive_more = { version = "1", features = ["from", "display"] }
 phf = { version = "0.11.2", features = ["macros"] }
 lazy_static = "1.5"
 thiserror = "1.0.64"

--- a/crates/gosub_shared/Cargo.toml
+++ b/crates/gosub_shared/Cargo.toml
@@ -15,7 +15,7 @@ uuid = { version = "1.10.0", features = ["v4"] }
 rand = "0.9.0-alpha.1"
 chardetng = "0.1.17"
 encoding_rs = "0.8.34"
-derive_more = "1.0"
+derive_more = {version = "1.0.0", features = ["display"]}
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
Previously we only copied over the first value of a declaration to the `CssProperties`, now if we have multiple, it will be converted to a `CssValue::List`

This PR is blocked by #582 