### PR TITLE
issue 393: Use less unwrap and for loops in `colors.rs`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,6 +5,7 @@
 
 Ahmed Ibrahim <me@ahmedibrahim.dev>
 Joshua Thijssen <jthijssen@noxlogic.nl>
+Nicholas Nguyen <nicholas.nguyen@chargeitspot.com>
 Niklas Scheerhoorn <sinner1991@gmail.com>
 Shark <sharktheone@proton.me>
 Zach Weaver <zachlweaver00@gmail.com>


### PR DESCRIPTION
Hi there! This is my first PR so please let me know if I need to improve anything.

This PR changes a lot of the `.unwrap()` called in `colors.rs`. It instead puts everything together in a method and called `expect()` with an error message (hopefully the expect shouldn't fail either!).

It also gets rid of some of the for loops in the code for iters. Just cleaner and easier to understand I think.

This is part of issue 393 about getting rid of the unwraps in the codebase. This is a step in that process!

Always open to feedback!