### PR TITLE
Fix scrolling behavior for short pages

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,6 +4,7 @@
 # Please keep this list sorted alphabetically or run `python scripts/sort_authors.py` to auto-sort the authors list.
 
 Ahmed Ibrahim <me@ahmedibrahim.dev>
+DynamiteC <shethshails@gmail.com>
 Joshua Thijssen <jthijssen@noxlogic.nl>
 Niklas Scheerhoorn <sinner1991@gmail.com>
 Shark <sharktheone@proton.me>

--- a/crates/gosub_renderer/src/draw.rs
+++ b/crates/gosub_renderer/src/draw.rs
@@ -103,6 +103,10 @@ where
                 let max_x = root_size.width - size.width as f32;
                 let max_y = root_size.height - size.height as f32;
 
+                // If the root size is smaller than the size, max_x/max_y should be 0
+                let max_x = if max_x < 0.0 { 0.0 } else { max_x };
+                let max_y = if max_y < 0.0 { 0.0 } else { max_y };
+
                 let x = scene_transform.tx().min(0.0).max(-max_x);
                 let y = scene_transform.ty().min(0.0).max(-max_y);
 


### PR DESCRIPTION
Fixes #618 

Addressed an issue where scrolling a page shorter than 100vh would cause it to get stuck at the bottom after the first scroll. Thanks to the maintainers for guiding me to the correct rendering logic where adjustments were needed to properly calculate scroll limits. 

- Updated scroll handling logic in `draw` function.