### PR TITLE
Fixes scrolling behavior for short pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ settings.db
 
 # C API tests (ignore everything but source files)
 *.dSYM
+
+#ignore jetbrains ide folders
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,3 @@ settings.db
 
 # C API tests (ignore everything but source files)
 *.dSYM
-
-#ignore jetbrains ide folders
-.idea

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,6 +4,7 @@
 # Please keep this list sorted alphabetically or run `python scripts/sort_authors.py` to auto-sort the authors list.
 
 Ahmed Ibrahim <me@ahmedibrahim.dev>
+DynamiteC <shethshails@gmail.com>
 Joshua Thijssen <jthijssen@noxlogic.nl>
 Niklas Scheerhoorn <sinner1991@gmail.com>
 Shark <sharktheone@proton.me>

--- a/crates/gosub_renderer/src/draw.rs
+++ b/crates/gosub_renderer/src/draw.rs
@@ -100,8 +100,9 @@ where
             // Apply new maximums to the scene transform
             if let Some(scene_transform) = self.scene_transform.as_mut() {
                 let root_size = self.tree.get_root().layout.content();
-                let max_x = root_size.width - size.width as f32;
-                let max_y = root_size.height - size.height as f32;
+                // Calculate max_x and max_y, ensuring they are not negative cause if the root size is smaller than the size, max_x/max_y should be 0
+                let max_x = (root_size.width - size.width as f32).max(0.0);
+                let max_y = (root_size.height - size.height as f32).max(0.0);
 
                 let x = scene_transform.tx().min(0.0).max(-max_x);
                 let y = scene_transform.ty().min(0.0).max(-max_y);


### PR DESCRIPTION
Fixes #618 

Addressed an issue where scrolling a page shorter than 100vh would cause it to get stuck at the bottom after the first scroll. Thanks to the maintainers for guiding me to the correct rendering logic where adjustments were needed to calculate scroll limits properly.

- Updated scroll handling logic in draw function.
- I added .idea to .gitignore to avoid adding JetBrains files to commits.