### PR TITLE
#393 Cleaning up some methods in color.rs and getting rid of more unwraps

### DIFF
--- a/crates/gosub_config/src/storage/json.rs
+++ b/crates/gosub_config/src/storage/json.rs
@@ -48,19 +48,19 @@ impl TryFrom<&String> for JsonStorageAdapter {
 
 impl StorageAdapter for JsonStorageAdapter {
     fn get(&self, key: &str) -> Option<Setting> {
-        let lock = self.elements.lock().unwrap();
+        let lock = self.elements.lock().expect("Poisoned");
         lock.get(key).cloned()
     }
 
     fn set(&self, key: &str, value: Setting) {
-        let mut lock = self.elements.lock().unwrap();
+        let mut lock = self.elements.lock().expect("Poisoned");
         lock.insert(key.to_owned(), value);
 
         // self.write_file()
     }
 
     fn all(&self) -> Result<HashMap<String, Setting>> {
-        let lock = self.elements.lock().unwrap();
+        let lock = self.elements.lock().expect("Poisoned");
 
         Ok(lock.clone())
     }
@@ -73,14 +73,14 @@ impl JsonStorageAdapter {
         let mut file = File::open(&self.path).expect("failed to open json file");
 
         let mut buf = String::new();
-        _ = file.read_to_string(&mut buf);
+        let _ = file.read_to_string(&mut buf);
 
         let parsed_json: Value = serde_json::from_str(&buf).expect("Failed to parse json");
 
         if let Value::Object(settings) = parsed_json {
             self.elements = Mutex::new(HashMap::new());
 
-            let mut lock = self.elements.lock().unwrap();
+            let mut lock = self.elements.lock().expect("Poisoned");
             for (key, value) in &settings {
                 match serde_json::from_value(value.clone()) {
                     Ok(setting) => {

--- a/crates/gosub_config/src/storage/memory.rs
+++ b/crates/gosub_config/src/storage/memory.rs
@@ -20,18 +20,18 @@ impl MemoryStorageAdapter {
 
 impl StorageAdapter for MemoryStorageAdapter {
     fn get(&self, key: &str) -> Option<Setting> {
-        let lock = self.settings.lock().unwrap();
+        let lock = self.settings.lock().expect("Poisoned");
         let v = lock.get(key);
         v.cloned()
     }
 
     fn set(&self, key: &str, value: Setting) {
-        let mut lock = self.settings.lock().unwrap();
+        let mut lock = self.settings.lock().expect("Poisoned");
         lock.insert(key.to_owned(), value);
     }
 
     fn all(&self) -> Result<HashMap<String, Setting>> {
-        let lock = self.settings.lock().unwrap();
+        let lock = self.settings.lock().expect("Poisoned");
         Ok(lock.clone())
     }
 }

--- a/crates/gosub_config/src/storage/sqlite.rs
+++ b/crates/gosub_config/src/storage/sqlite.rs
@@ -31,42 +31,62 @@ impl TryFrom<&String> for SqliteStorageAdapter {
 
 impl StorageAdapter for SqliteStorageAdapter {
     fn get(&self, key: &str) -> Option<Setting> {
-        let db_lock = self.connection.lock().unwrap();
+        let db_lock = match self.connection.lock() {
+            Ok(l) => {l}
+            Err(e) => {
+                warn!("Poisoned mutex {e}");
+                return None
+            }
+        };
 
         let query = "SELECT * FROM settings WHERE key = :key";
-        let mut statement = db_lock.prepare(query).unwrap();
-        statement.bind((":key", key)).unwrap();
+        // If any of these sqlite commands fail at any point,
+        // Then we return a None
+        let mut statement = match db_lock.prepare(query) {
+            Ok(s) => {s}
+            Err(e) => {
+                warn!("problem preparing statement: {e}");
+                return None
+            }
+        };
+        match statement.bind((":key", key)) {
+            Ok(_) => {}
+            Err(e) => {
+                warn!("problem binding statement: {e}");
+                return None
+            }
+        };
 
         match Setting::from_str(key) {
             Ok(setting) => Some(setting),
-            Err(err) => {
-                warn!("problem reading from sqlite: {err}");
+            Err(e) => {
+                warn!("problem reading from sqlite: {e}");
                 None
             }
         }
     }
 
     fn set(&self, key: &str, value: Setting) {
-        let db_lock = self.connection.lock().unwrap();
+        let db_lock = self.connection.lock().expect("Poisoned");
 
         let query = "INSERT OR REPLACE INTO settings (key, value) VALUES (:key, :value)";
-        let mut statement = db_lock.prepare(query).unwrap();
-        statement.bind((":key", key)).unwrap();
-        statement.bind((":value", value.to_string().as_str())).unwrap();
+        let mut statement = db_lock.prepare(query).expect("Poisoned");
+        statement.bind((":key", key)).expect("Failed to bind");
+        statement.bind((":value", value.to_string().as_str())).expect("Failed to bind");
 
-        statement.next().unwrap();
+        statement.next().expect("Failed to execute the set");
     }
 
     fn all(&self) -> Result<HashMap<String, Setting>> {
-        let db_lock = self.connection.lock().unwrap();
+        let db_lock = self.connection.lock().expect("Poisoned");
 
         let query = "SELECT * FROM settings";
-        let mut statement = db_lock.prepare(query).unwrap();
+        let mut statement = db_lock.prepare(query)?;
 
         let mut settings = HashMap::new();
-        while let sqlite::State::Row = statement.next().unwrap() {
-            let key = statement.read::<String, _>(1).unwrap();
-            let value = statement.read::<String, _>(2).unwrap();
+        while let sqlite::State::Row = statement.next()? {
+            let key = statement.read::<String, _>(1)?;
+            let value = statement.read::<String, _>(2)?;
             settings.insert(key, Setting::from_str(&value)?);
         }
 

--- a/crates/gosub_css3/src/colors.rs
+++ b/crates/gosub_css3/src/colors.rs
@@ -2,7 +2,7 @@ use std::convert::From;
 use std::fmt::Debug;
 use std::str::FromStr;
 
-use colors_transform::Color;
+use colors_transform::{Color};
 use colors_transform::{AlphaColor, Hsl, Rgb};
 use lazy_static::lazy_static;
 
@@ -49,55 +49,57 @@ impl Default for RgbColor {
 
 impl From<&str> for RgbColor {
     fn from(value: &str) -> Self {
-        if value.is_empty() {
-            return RgbColor::default();
-        }
-        if value == "currentcolor" {
-            // @todo: implement currentcolor
-            return RgbColor::default();
-        }
-
-        if value.starts_with('#') {
-            return parse_hex(value);
-        }
-        if value.starts_with("rgb(") {
-            // Rgb function
-            let rgb = Rgb::from_str(value);
-            if rgb.is_err() {
-                return RgbColor::default();
+        match value {
+            value if value.is_empty() => {
+                RgbColor::default()
             }
-            let rgb = rgb.unwrap();
-            return RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), 255.0);
-        }
-        if value.starts_with("rgba(") {
-            // Rgba function
-            let rgb = Rgb::from_str(value);
-            if rgb.is_err() {
-                return RgbColor::default();
+            "currentcolor" => {
+                // @todo: implement currentcolor
+                RgbColor::default()
             }
-            let rgb = rgb.unwrap();
-            return RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), rgb.get_alpha());
-        }
-        if value.starts_with("hsl(") {
-            let hsl = Hsl::from_str(value);
-            if hsl.is_err() {
-                return RgbColor::default();
+            value if value.starts_with('#') => {
+                parse_hex(value)
             }
-            let rgb: Rgb = hsl.unwrap().to_rgb();
-            return RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), 255.0);
-        }
-        if value.starts_with("hsla(") {
-            // @TODO: hsla() does not work properly
-            // HSLA function
-            let hsl = Hsl::from_str(value);
-            if hsl.is_err() {
-                return RgbColor::default();
+            value if value.starts_with("rgb(") => {
+                // Rgb function
+                let rgb_result = Rgb::from_str(value);
+                let rgb = match rgb_result {
+                    Ok(r) => {r}
+                    Err(_) => {return RgbColor::default()}
+                };
+                RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), 255.0)
             }
-            let rgb: Rgb = hsl.unwrap().to_rgb();
-            return RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), rgb.get_alpha());
+            value if value.starts_with("rgba(") => {
+                // Rgb function
+                let rgb_result = Rgb::from_str(value);
+                let rgb = match rgb_result {
+                    Ok(r) => {r}
+                    Err(_) => {return RgbColor::default()}
+                };
+                RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), rgb.get_alpha())
+            }
+            value if value.starts_with("hsl(") => {
+                let hsl_result = Hsl::from_str(value);
+                let rgb = match hsl_result {
+                    Ok(h) => {h.to_rgb()}
+                    Err(_) => {return RgbColor::default()}
+                };
+                RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), 255.0)
+            }
+            value if value.starts_with("hsla(") => {
+                // @TODO: hsla() does not work properly
+                // HSLA function
+                let hsl_result = Hsl::from_str(value);
+                let rgb = match hsl_result {
+                    Ok(h) => {h.to_rgb()}
+                    Err(_) => {return RgbColor::default()}
+                };
+                RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), rgb.get_alpha())
+            }
+            &_ => {
+                get_hex_color_from_name(value).map_or(RgbColor::default(), parse_hex)
+            }
         }
-
-        return get_hex_color_from_name(value).map_or(RgbColor::default(), parse_hex);
     }
 }
 

--- a/crates/gosub_shared/src/timing.rs
+++ b/crates/gosub_shared/src/timing.rs
@@ -202,7 +202,7 @@ macro_rules! timing_start {
 #[macro_export]
 macro_rules! timing_stop {
     ($timer_id:expr) => {{
-        $crate::timing::TIMING_TABLE.lock().unwrap().stop_timer($timer_id);
+        $crate::timing::TIMING_TABLE.lock().expect("Poisoned").stop_timer($timer_id);
     }};
 }
 
@@ -353,7 +353,7 @@ mod tests {
         sleep(Duration::from_millis(20));
         timing_stop!(t);
 
-        TIMING_TABLE.lock().unwrap().print_timings(true, Scale::Auto);
+        TIMING_TABLE.lock().expect("Poisoned").print_timings(true, Scale::Auto);
     }
 
     #[wasm_bindgen_test]
@@ -387,7 +387,7 @@ mod tests {
         sleep(window, Duration::from_millis(20));
         timing_stop!(t);
 
-        TIMING_TABLE.lock().unwrap().print_timings(true, Scale::Auto);
+        TIMING_TABLE.lock().expect("Poisoned").print_timings(true, Scale::Auto);
     }
 
     //This should only be used for testing purposes


### PR DESCRIPTION
Slowly clanking out a lot of the unwraps used in the codebase. Decided to ignore all unwraps used in tests since that's fine.

a lot of these were `.lock().unwrap()` which i just changed to an `.expect("Poisoned")` since that's the only possible error. Just think it's a little clearer what is going on. But of course always open to feeback