### PR TITLE
Rendering/performance

### DIFF
--- a/crates/gosub_render_backend/src/lib.rs
+++ b/crates/gosub_render_backend/src/lib.rs
@@ -7,6 +7,7 @@ pub use geo::*;
 use gosub_shared::types::Result;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use smallvec::SmallVec;
+use gosub_shared::async_executor::WasmNotSendSync;
 
 pub mod geo;
 pub mod layout;
@@ -15,6 +16,16 @@ pub mod svg;
 pub trait WindowHandle: HasDisplayHandle + HasWindowHandle + Send + Sync + Clone {}
 
 impl<T> WindowHandle for T where T: HasDisplayHandle + HasWindowHandle + Send + Sync + Clone {}
+
+
+
+
+pub trait WindowedEventLoop<B: RenderBackend>: WasmNotSendSync + Clone  + 'static {
+    fn redraw(&mut self);
+    
+    fn add_img_cache(&mut self, url: String, buf: ImageBuffer<B>, size: Option<SizeU32>);
+}
+
 
 pub trait RenderBackend: Sized + Debug + 'static {
     type Rect: Rect;

--- a/crates/gosub_render_backend/src/lib.rs
+++ b/crates/gosub_render_backend/src/lib.rs
@@ -4,10 +4,10 @@ use std::ops::{Div, Mul, MulAssign};
 use crate::layout::TextLayout;
 use crate::svg::SvgRenderer;
 pub use geo::*;
+use gosub_shared::async_executor::WasmNotSendSync;
 use gosub_shared::types::Result;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use smallvec::SmallVec;
-use gosub_shared::async_executor::WasmNotSendSync;
 
 pub mod geo;
 pub mod layout;
@@ -17,15 +17,11 @@ pub trait WindowHandle: HasDisplayHandle + HasWindowHandle + Send + Sync + Clone
 
 impl<T> WindowHandle for T where T: HasDisplayHandle + HasWindowHandle + Send + Sync + Clone {}
 
-
-
-
-pub trait WindowedEventLoop<B: RenderBackend>: WasmNotSendSync + Clone  + 'static {
+pub trait WindowedEventLoop<B: RenderBackend>: WasmNotSendSync + Clone + 'static {
     fn redraw(&mut self);
-    
+
     fn add_img_cache(&mut self, url: String, buf: ImageBuffer<B>, size: Option<SizeU32>);
 }
-
 
 pub trait RenderBackend: Sized + Debug + 'static {
     type Rect: Rect;

--- a/crates/gosub_renderer/src/draw.rs
+++ b/crates/gosub_renderer/src/draw.rs
@@ -4,17 +4,11 @@ use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 
 use anyhow::anyhow;
-use log::warn;
-use url::Url;
-
 use gosub_net::http::fetcher::Fetcher;
 use gosub_render_backend::geo::{Size, SizeU32, FP};
 use gosub_render_backend::layout::{Layout, LayoutTree, Layouter, TextLayout};
 use gosub_render_backend::svg::SvgRenderer;
-use gosub_render_backend::{
-    Border, BorderSide, BorderStyle, Brush, Color, ImageBuffer, ImgCache, NodeDesc, Rect, RenderBackend, RenderBorder,
-    RenderRect, RenderText, Scene as TScene, Text, Transform,
-};
+use gosub_render_backend::{Border, BorderSide, BorderStyle, Brush, Color, WindowedEventLoop, ImageBuffer, ImgCache, NodeDesc, Rect, RenderBackend, RenderBorder, RenderRect, RenderText, Scene as TScene, Text, Transform};
 use gosub_rendering::position::PositionTree;
 use gosub_rendering::render_tree::{RenderNodeData, RenderTree, RenderTreeNode};
 use gosub_shared::async_executor::WasmNotSend;
@@ -23,6 +17,8 @@ use gosub_shared::traits::css3::{CssProperty, CssPropertyMap, CssSystem};
 use gosub_shared::traits::document::Document;
 use gosub_shared::traits::html5::Html5Parser;
 use gosub_shared::types::Result;
+use log::warn;
+use url::Url;
 
 use crate::debug::scale::px_scale;
 use crate::draw::img::request_img;
@@ -33,7 +29,7 @@ mod img;
 pub mod img_cache;
 
 pub trait SceneDrawer<B: RenderBackend, L: Layouter, LT: LayoutTree<L>, D: Document<C>, C: CssSystem>:
-    WasmNotSend + 'static
+WasmNotSend + 'static
 {
     type ImgCache: ImgCache<B>;
 
@@ -42,15 +38,15 @@ pub trait SceneDrawer<B: RenderBackend, L: Layouter, LT: LayoutTree<L>, D: Docum
         backend: &mut B,
         data: &mut B::WindowData<'_>,
         size: SizeU32,
-        rerender: impl Fn() + Send + Sync + 'static,
+        el: &impl WindowedEventLoop<B>,
     ) -> bool;
     fn mouse_move(&mut self, backend: &mut B, x: FP, y: FP) -> bool;
 
     fn scroll(&mut self, point: Point);
-    fn from_url<P>(url: Url, layouter: L, debug: bool) -> impl Future<Output = Result<Self>> + WasmNotSend
+    fn from_url<P>(url: Url, layouter: L, debug: bool) -> impl Future<Output=Result<Self>> + WasmNotSend
     where
         Self: Sized,
-        P: Html5Parser<C, Document = D>;
+        P: Html5Parser<C, Document=D>;
 
     fn clear_buffers(&mut self);
     fn toggle_debug(&mut self);
@@ -62,18 +58,20 @@ pub trait SceneDrawer<B: RenderBackend, L: Layouter, LT: LayoutTree<L>, D: Docum
 
     fn set_needs_redraw(&mut self);
 
-    fn get_img_cache(&self) -> Arc<Mutex<Self::ImgCache>>;
+    fn get_img_cache(&mut self) -> &mut Self::ImgCache;
+    
+    fn make_dirty(&mut self);
 }
 
 const DEBUG_CONTENT_COLOR: (u8, u8, u8) = (0, 192, 255); //rgb(0, 192, 255)
 const DEBUG_PADDING_COLOR: (u8, u8, u8) = (0, 255, 192); //rgb(0, 255, 192)
 const DEBUG_BORDER_COLOR: (u8, u8, u8) = (255, 72, 72); //rgb(255, 72, 72)
-                                                        // const DEBUG_MARGIN_COLOR: (u8, u8, u8) = (255, 192, 0);
+// const DEBUG_MARGIN_COLOR: (u8, u8, u8) = (255, 192, 0);
 
 type Point = gosub_shared::types::Point<FP>;
 
 impl<B: RenderBackend, L: Layouter, D: Document<C>, C: CssSystem> SceneDrawer<B, L, RenderTree<L, C>, D, C>
-    for TreeDrawer<B, L, D, C>
+for TreeDrawer<B, L, D, C>
 where
     <<B as RenderBackend>::Text as Text>::Font: From<<<L as Layouter>::TextLayout as TextLayout>::Font>,
 {
@@ -84,15 +82,13 @@ where
         backend: &mut B,
         data: &mut B::WindowData<'_>,
         size: SizeU32,
-        rerender: impl Fn() + Send + Sync + 'static,
+        el: &impl WindowedEventLoop<B>,
     ) -> bool {
-        let dirty = self.dirty.load(Ordering::Relaxed);
-
-        if !dirty && self.size == Some(size) {
+        if !self.dirty && self.size == Some(size) {
             return false;
         }
 
-        if self.tree_scene.is_none() || self.size != Some(size) || dirty {
+        if self.tree_scene.is_none() || self.size != Some(size) || self.dirty {
             self.size = Some(size);
 
             let mut scene = B::Scene::new();
@@ -110,20 +106,12 @@ where
                 scene_transform.set_xy(x, y);
             }
 
-            let image_cache = self.img_cache.clone();
-
-            let dirty = self.dirty.clone();
 
             let mut drawer = Drawer {
                 scene: &mut scene,
                 drawer: self,
                 svg: Arc::new(Mutex::new(B::SVGRenderer::new())),
-                rerender: Arc::new(move || {
-                    dirty.store(true, Ordering::Relaxed);
-
-                    rerender();
-                }),
-                image_cache,
+                el,
             };
 
             drawer.render(size);
@@ -152,14 +140,14 @@ where
             backend.apply_scene(data, scene, self.scene_transform.clone());
         }
 
-        if self.dirty.load(Ordering::Relaxed) {
+        if self.dirty {
             if let Some(id) = self.selected_element {
                 self.debug_annotate(id);
             }
         }
 
         if let Some(scene) = &self.debugger_scene {
-            self.dirty.store(false, Ordering::Relaxed);
+            self.dirty = false;
             backend.apply_scene(data, scene, self.scene_transform.clone());
         }
 
@@ -175,8 +163,8 @@ where
             backend.apply_scene(data, &scale, None);
         }
 
-        if self.dirty.load(Ordering::Relaxed) {
-            self.dirty.store(false, Ordering::Relaxed);
+        if self.dirty {
+            self.dirty = false;
 
             return true;
         }
@@ -219,12 +207,12 @@ where
 
         self.scene_transform = Some(transform);
 
-        self.dirty.store(true, Ordering::Relaxed);
+        self.dirty = true;
     }
 
     async fn from_url<P>(url: Url, layouter: L, debug: bool) -> Result<Self>
     where
-        P: Html5Parser<C, Document = D>,
+        P: Html5Parser<C, Document=D>,
     {
         let (rt, fetcher) = load_html_rendertree::<L, P, C>(url.clone()).await?;
 
@@ -235,25 +223,25 @@ where
         self.tree_scene = None;
         self.debugger_scene = None;
         self.last_hover = None;
-        self.dirty.store(true, Ordering::Relaxed);
+        self.dirty = true;
     }
 
     fn toggle_debug(&mut self) {
         self.debug = !self.debug;
-        self.dirty.store(true, Ordering::Relaxed);
+        self.dirty = true;
         self.last_hover = None;
         self.debugger_scene = None;
     }
 
     fn select_element(&mut self, id: NodeId) {
         self.selected_element = Some(id);
-        self.dirty.store(true, Ordering::Relaxed);
+        self.dirty = true;
     }
 
     fn unselect_element(&mut self) {
         self.selected_element = None;
         self.debugger_scene = None;
-        self.dirty.store(true, Ordering::Relaxed);
+        self.dirty = true
     }
 
     fn send_nodes(&mut self, sender: Sender<NodeDesc>) {
@@ -261,23 +249,26 @@ where
     }
 
     fn set_needs_redraw(&mut self) {
-        self.dirty.store(true, Ordering::Relaxed);
+        self.dirty = true;
     }
 
-    fn get_img_cache(&self) -> Arc<Mutex<Self::ImgCache>> {
-        self.img_cache.clone()
+    fn get_img_cache(&mut self) -> &mut Self::ImgCache {
+        &mut self.img_cache
+    }
+
+    fn make_dirty(&mut self) {
+        self.dirty = true;
     }
 }
 
-struct Drawer<'s, 't, B: RenderBackend, L: Layouter, D: Document<C>, C: CssSystem> {
+struct Drawer<'s, 't, B: RenderBackend, L: Layouter, D: Document<C>, C: CssSystem, EL: WindowedEventLoop<B>> {
     scene: &'s mut B::Scene,
     drawer: &'t mut TreeDrawer<B, L, D, C>,
     svg: Arc<Mutex<B::SVGRenderer>>,
-    rerender: Arc<dyn Fn() + Send + Sync>,
-    image_cache: Arc<Mutex<ImageCache<B>>>,
+    el: &'t EL,
 }
 
-impl<B: RenderBackend, L: Layouter, D: Document<C>, C: CssSystem> Drawer<'_, '_, B, L, D, C>
+impl<B: RenderBackend, L: Layouter, D: Document<C>, C: CssSystem, EL: WindowedEventLoop<B>> Drawer<'_, '_, B, L, D, C, EL>
 where
     <<B as RenderBackend>::Text as Text>::Font: From<<<L as Layouter>::TextLayout as TextLayout>::Font>,
 {
@@ -292,7 +283,7 @@ where
 
         self.drawer.position = PositionTree::from_tree::<B, L, D, C>(&self.drawer.tree);
 
-        self.render_node_with_children(self.drawer.tree.root, Point::ZERO);
+        self.render_node_with_children(self.drawer.tree.root, Point::ZERO, );
     }
 
     fn render_node_with_children(&mut self, id: NodeId, mut pos: Point) {
@@ -324,8 +315,8 @@ where
             pos,
             self.svg.clone(),
             self.drawer.fetcher.clone(),
-            self.image_cache.clone(),
-            self.rerender.clone(),
+            &mut self.drawer.img_cache,
+            self.el,
         );
 
         let mut size_change = new_size;
@@ -343,8 +334,8 @@ where
                     self.svg.clone(),
                     url,
                     size,
-                    self.image_cache.clone(),
-                    self.rerender.clone(),
+                    &mut self.drawer.img_cache,
+                    self.el,
                 )?;
 
                 if size.is_none() {
@@ -359,11 +350,11 @@ where
 
                 let size = size.unwrap_or(img.size()).f32();
 
-                render_image::<B>(img, self.scene, *pos, size, border_radius, fit)?;
+                render_image::<B, L, C>(img, *pos, size, border_radius, fit, self.scene)?;
             }
         }
 
-        render_text::<B, L, C>(node, self.scene, pos);
+        render_text::<B, L, C>(node, pos, self.scene);
 
         if let Some(new) = size_change {
             let node = self
@@ -383,8 +374,8 @@ where
 
 fn render_text<B: RenderBackend, L: Layouter, C: CssSystem>(
     node: &RenderTreeNode<L, C>,
-    scene: &mut B::Scene,
     pos: &Point,
+    scene: &mut B::Scene,
 ) where
     <<B as RenderBackend>::Text as Text>::Font: From<<<L as Layouter>::TextLayout as TextLayout>::Font>,
 {
@@ -427,141 +418,13 @@ fn render_text<B: RenderBackend, L: Layouter, C: CssSystem>(
     }
 }
 
-fn render_bg<B: RenderBackend, L: Layouter, C: CssSystem>(
-    node: &RenderTreeNode<L, C>,
-    scene: &mut B::Scene,
-    pos: &Point,
-    svg: Arc<Mutex<B::SVGRenderer>>,
-    fetcher: Arc<Fetcher>,
-    img_cache: Arc<Mutex<ImageCache<B>>>,
-    rerender: Arc<dyn Fn() + Send + Sync>,
-) -> ((FP, FP, FP, FP), Option<SizeU32>) {
-    let bg_color = node
-        .properties
-        .get("background-color")
-        .and_then(|prop| prop.parse_color())
-        .map(|color| Color::rgba(color.0 as u8, color.1 as u8, color.2 as u8, color.3 as u8));
-
-    let border_radius_left = node
-        .properties
-        .get("border-radius-left")
-        .map(|prop| prop.unit_to_px() as f64)
-        .unwrap_or(0.0);
-
-    let border_radius_right = node
-        .properties
-        .get("border-radius-right")
-        .map(|prop| prop.unit_to_px() as f64)
-        .unwrap_or(0.0);
-
-    let border_radius_top = node
-        .properties
-        .get("border-radius-top")
-        .map(|prop| prop.unit_to_px() as f64)
-        .unwrap_or(0.0);
-
-    let border_radius_bottom = node
-        .properties
-        .get("border-radius-bottom")
-        .map(|prop| prop.unit_to_px() as f64)
-        .unwrap_or(0.0);
-
-    let border_radius = (
-        border_radius_top as FP,
-        border_radius_right as FP,
-        border_radius_bottom as FP,
-        border_radius_left as FP,
-    );
-
-    let border = get_border::<B, L, C>(node).map(|border| RenderBorder::new(border));
-
-    if let Some(bg_color) = bg_color {
-        let size = node.layout.size();
-
-        let rect = Rect::new(pos.x as FP, pos.y as FP, size.width as FP, size.height as FP);
-
-        let rect = RenderRect {
-            rect,
-            transform: None,
-            radius: Some(B::BorderRadius::from(border_radius)),
-            brush: Brush::color(bg_color),
-            brush_transform: None,
-            border,
-        };
-
-        scene.draw_rect(&rect);
-    } else if let Some(border) = border {
-        let size = node.layout.size();
-
-        let rect = Rect::new(pos.x as FP, pos.y as FP, size.width as FP, size.height as FP);
-
-        let rect = RenderRect {
-            rect,
-            transform: None,
-            radius: Some(B::BorderRadius::from(border_radius)),
-            brush: Brush::color(Color::TRANSPARENT),
-            brush_transform: None,
-            border: Some(border),
-        };
-
-        scene.draw_rect(&rect);
-    }
-
-    let background_image = node
-        .properties
-        .get("background-image")
-        .and_then(|prop| prop.as_string());
-
-    let mut img_size = None;
-
-    if let Some(url) = background_image {
-        let size = node.layout.size_or().map(|x| x.u32());
-
-        let img = match request_img::<B>(fetcher.clone(), svg.clone(), url, size, img_cache, rerender) {
-            Ok(img) => img,
-            Err(e) => {
-                eprintln!("Error loading image: {:?}", e);
-                return (border_radius, None);
-            }
-        };
-
-        if size.is_none() {
-            img_size = Some(img.size());
-        }
-
-        let _ = render_image::<B>(img, scene, *pos, node.layout.size(), border_radius, "fill").map_err(|e| {
-            eprintln!("Error rendering image: {:?}", e);
-        });
-    }
-
-    (border_radius, img_size)
-}
-
-enum Side {
-    Top,
-    Right,
-    Bottom,
-    Left,
-}
-
-impl Side {
-    fn to_str(&self) -> &'static str {
-        match self {
-            Side::Top => "top",
-            Side::Right => "right",
-            Side::Bottom => "bottom",
-            Side::Left => "left",
-        }
-    }
-}
-
-fn render_image<B: RenderBackend>(
+fn render_image<B: RenderBackend, L: Layouter, C: CssSystem>(
     img: ImageBuffer<B>,
-    scene: &mut B::Scene,
     pos: Point,
     size: Size,
     radii: (FP, FP, FP, FP),
     fit: &str,
+    scene: &mut B::Scene,
 ) -> anyhow::Result<()> {
     let width = size.width as FP;
     let height = size.height as FP;
@@ -700,6 +563,117 @@ pub fn print_tree<B: RenderBackend, L: Layouter>(
 }
 */
 
+fn render_bg<B: RenderBackend, L: Layouter, C: CssSystem>(
+    node: &RenderTreeNode<L, C>,
+    scene: &mut B::Scene,
+    pos: &Point,
+    svg: Arc<Mutex<B::SVGRenderer>>,
+    fetcher: Arc<Fetcher>,
+    img_cache: &mut ImageCache<B>,
+    el: &impl WindowedEventLoop<B>,
+) -> ((FP, FP, FP, FP), Option<SizeU32>) {
+    let bg_color = node
+        .properties
+        .get("background-color")
+        .and_then(|prop| prop.parse_color())
+        .map(|color| Color::rgba(color.0 as u8, color.1 as u8, color.2 as u8, color.3 as u8));
+
+    let border_radius_left = node
+        .properties
+        .get("border-radius-left")
+        .map(|prop| prop.unit_to_px() as f64)
+        .unwrap_or(0.0);
+
+    let border_radius_right = node
+        .properties
+        .get("border-radius-right")
+        .map(|prop| prop.unit_to_px() as f64)
+        .unwrap_or(0.0);
+
+    let border_radius_top = node
+        .properties
+        .get("border-radius-top")
+        .map(|prop| prop.unit_to_px() as f64)
+        .unwrap_or(0.0);
+
+    let border_radius_bottom = node
+        .properties
+        .get("border-radius-bottom")
+        .map(|prop| prop.unit_to_px() as f64)
+        .unwrap_or(0.0);
+
+    let border_radius = (
+        border_radius_top as FP,
+        border_radius_right as FP,
+        border_radius_bottom as FP,
+        border_radius_left as FP,
+    );
+
+    let border = get_border::<B, L, C>(node).map(|border| RenderBorder::new(border));
+
+    if let Some(bg_color) = bg_color {
+        let size = node.layout.size();
+
+        let rect = Rect::new(pos.x as FP, pos.y as FP, size.width as FP, size.height as FP);
+
+        let rect = RenderRect {
+            rect,
+            transform: None,
+            radius: Some(B::BorderRadius::from(border_radius)),
+            brush: Brush::color(bg_color),
+            brush_transform: None,
+            border,
+        };
+
+        scene.draw_rect(&rect);
+    } else if let Some(border) = border {
+        let size = node.layout.size();
+
+        let rect = Rect::new(pos.x as FP, pos.y as FP, size.width as FP, size.height as FP);
+
+        let rect = RenderRect {
+            rect,
+            transform: None,
+            radius: Some(B::BorderRadius::from(border_radius)),
+            brush: Brush::color(Color::TRANSPARENT),
+            brush_transform: None,
+            border: Some(border),
+        };
+
+        scene.draw_rect(&rect);
+    }
+
+    let background_image = node
+        .properties
+        .get("background-image")
+        .and_then(|prop| prop.as_string());
+
+    let mut img_size = None;
+
+    if let Some(url) = background_image {
+        let size = node.layout.size_or().map(|x| x.u32());
+
+        let img = match request_img::<B>(fetcher.clone(), svg.clone(), url, size, img_cache, el) {
+            Ok(img) => img,
+            Err(e) => {
+                eprintln!("Error loading image: {:?}", e);
+                return (border_radius, None);
+            }
+        };
+
+        if size.is_none() {
+            img_size = Some(img.size());
+        }
+
+        let _ = render_image::<B, L, C>(img, *pos, node.layout.size(), border_radius, "fill", scene).map_err(|e| {
+            eprintln!("Error rendering image: {:?}", e);
+        });
+    }
+
+    (border_radius, img_size)
+}
+
+
 fn get_border<B: RenderBackend, L: Layouter, C: CssSystem>(node: &RenderTreeNode<L, C>) -> Option<B::Border> {
     let left = get_border_side::<B, L, C>(node, Side::Left);
     let right = get_border_side::<B, L, C>(node, Side::Right);
@@ -756,6 +730,24 @@ fn get_border_side<B: RenderBackend, L: Layouter, C: CssSystem>(
     let brush = Brush::color(Color::rgba(color.0 as u8, color.1 as u8, color.2 as u8, color.3 as u8));
 
     Some(BorderSide::new(width as FP, style, brush))
+}
+
+enum Side {
+    Top,
+    Right,
+    Bottom,
+    Left,
+}
+
+impl Side {
+    fn to_str(&self) -> &'static str {
+        match self {
+            Side::Top => "top",
+            Side::Right => "right",
+            Side::Bottom => "bottom",
+            Side::Left => "left",
+        }
+    }
 }
 
 impl<B: RenderBackend, L: Layouter, D: Document<C>, C: CssSystem> TreeDrawer<B, L, D, C> {
@@ -866,7 +858,7 @@ impl<B: RenderBackend, L: Layouter, D: Document<C>, C: CssSystem> TreeDrawer<B, 
         scene.draw_rect(&render_rect);
 
         self.debugger_scene = Some(scene);
-        self.dirty.store(true, Ordering::Relaxed);
+        self.dirty = true;
 
         true
     }

--- a/crates/gosub_renderer/src/draw/img.rs
+++ b/crates/gosub_renderer/src/draw/img.rs
@@ -3,15 +3,14 @@ use std::sync::{Arc, LazyLock, Mutex};
 
 use anyhow::anyhow;
 use image::DynamicImage;
-use log::error;
 
 use crate::draw::img_cache::ImageCache;
 use gosub_net::http::fetcher::Fetcher;
 use gosub_render_backend::svg::SvgRenderer;
-use gosub_render_backend::{WindowedEventLoop, Image as _, ImageBuffer, ImageCacheEntry, ImgCache, RenderBackend, SizeU32};
+use gosub_render_backend::{
+    Image as _, ImageBuffer, ImageCacheEntry, ImgCache, RenderBackend, SizeU32, WindowedEventLoop,
+};
 use gosub_shared::types::Result;
-
-
 
 pub fn request_img<B: RenderBackend>(
     fetcher: Arc<Fetcher>,
@@ -21,7 +20,6 @@ pub fn request_img<B: RenderBackend>(
     img_cache: &mut ImageCache<B>,
     el: &impl WindowedEventLoop<B>,
 ) -> Result<ImageBuffer<B>> {
-
     let img = img_cache.get(url);
 
     Ok(match img {
@@ -30,18 +28,13 @@ pub fn request_img<B: RenderBackend>(
         ImageCacheEntry::None => {
             img_cache.add_pending(url.to_string());
 
-
             let url = url.to_string();
-            
+
             let mut el = el.clone();
 
             gosub_shared::async_executor::spawn(async move {
                 if let Ok(img) = load_img::<B>(&url, fetcher, svg_renderer, size).await {
-                    
-                    
-                    
                     el.add_img_cache(url.to_string(), img, size);
-                    
                 } else {
                     el.add_img_cache(
                         url.to_string(),

--- a/crates/gosub_renderer/src/draw/img.rs
+++ b/crates/gosub_renderer/src/draw/img.rs
@@ -8,54 +8,42 @@ use log::error;
 use crate::draw::img_cache::ImageCache;
 use gosub_net::http::fetcher::Fetcher;
 use gosub_render_backend::svg::SvgRenderer;
-use gosub_render_backend::{Image as _, ImageBuffer, ImageCacheEntry, ImgCache, RenderBackend, SizeU32};
+use gosub_render_backend::{WindowedEventLoop, Image as _, ImageBuffer, ImageCacheEntry, ImgCache, RenderBackend, SizeU32};
 use gosub_shared::types::Result;
+
+
 
 pub fn request_img<B: RenderBackend>(
     fetcher: Arc<Fetcher>,
     svg_renderer: Arc<Mutex<B::SVGRenderer>>,
     url: &str,
     size: Option<SizeU32>,
-    img_cache: Arc<Mutex<ImageCache<B>>>,
-    rerender: Arc<dyn Fn() + Send + Sync>,
+    img_cache: &mut ImageCache<B>,
+    el: &impl WindowedEventLoop<B>,
 ) -> Result<ImageBuffer<B>> {
-    let mut cache = img_cache.lock().map_err(|_| anyhow!("Could not lock img cache"))?;
 
-    let img = cache.get(url);
+    let img = img_cache.get(url);
 
     Ok(match img {
         ImageCacheEntry::Image(img) => img.clone(),
         ImageCacheEntry::Pending => ImageBuffer::Image(B::Image::from_img(image::DynamicImage::new_rgba8(0, 0))),
         ImageCacheEntry::None => {
-            cache.add_pending(url.to_string());
+            img_cache.add_pending(url.to_string());
 
-            drop(cache);
 
             let url = url.to_string();
+            
+            let mut el = el.clone();
 
             gosub_shared::async_executor::spawn(async move {
                 if let Ok(img) = load_img::<B>(&url, fetcher, svg_renderer, size).await {
-                    let mut cache = match img_cache.lock() {
-                        Ok(cache) => cache,
-                        Err(e) => {
-                            error!("Could not lock img cache: {}", e);
-                            return;
-                        }
-                    };
-
-                    cache.add(url.to_string(), img.clone(), size);
-
-                    rerender();
+                    
+                    
+                    
+                    el.add_img_cache(url.to_string(), img, size);
+                    
                 } else {
-                    let mut cache = match img_cache.lock() {
-                        Ok(cache) => cache,
-                        Err(e) => {
-                            error!("Could not lock img cache: {}", e);
-                            return;
-                        }
-                    };
-
-                    cache.add(
+                    el.add_img_cache(
                         url.to_string(),
                         ImageBuffer::Image(B::Image::from_img(INVALID_IMG.clone())),
                         size,

--- a/crates/gosub_renderer/src/render_tree.rs
+++ b/crates/gosub_renderer/src/render_tree.rs
@@ -27,12 +27,12 @@ pub struct TreeDrawer<B: RenderBackend, L: Layouter, D: Document<C>, C: CssSyste
     pub(crate) position: PositionTree,
     pub(crate) last_hover: Option<NodeId>,
     pub(crate) debug: bool,
-    pub(crate) dirty: Arc<AtomicBool>,
+    pub(crate) dirty: bool,
     pub(crate) debugger_scene: Option<B::Scene>,
     pub(crate) tree_scene: Option<B::Scene>,
     pub(crate) selected_element: Option<NodeId>,
     pub(crate) scene_transform: Option<B::Transform>,
-    pub(crate) img_cache: Arc<Mutex<ImageCache<B>>>,
+    pub(crate) img_cache: ImageCache<B>,
     _marker: PhantomData<fn(D)>,
 }
 
@@ -47,11 +47,11 @@ impl<B: RenderBackend, L: Layouter, D: Document<C>, C: CssSystem> TreeDrawer<B, 
             last_hover: None,
             debug,
             debugger_scene: None,
-            dirty: Arc::new(AtomicBool::new(false)),
+            dirty: false,
             tree_scene: None,
             selected_element: None,
             scene_transform: None,
-            img_cache: Arc::new(Mutex::new(ImageCache::new())),
+            img_cache: ImageCache::new(),
             _marker: PhantomData,
         }
     }

--- a/crates/gosub_renderer/src/render_tree.rs
+++ b/crates/gosub_renderer/src/render_tree.rs
@@ -14,8 +14,7 @@ use gosub_shared::traits::document::{Document, DocumentBuilder};
 use gosub_shared::traits::html5::Html5Parser;
 use std::fs;
 use std::marker::PhantomData;
-use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use url::Url;
 
 #[derive(Debug)]

--- a/crates/gosub_shared/src/async_executor.rs
+++ b/crates/gosub_shared/src/async_executor.rs
@@ -26,7 +26,6 @@ impl<T> WasmNotSync for T {}
 
 pub trait WasmNotSendSync: WasmNotSend + WasmNotSync {}
 
-
 impl<T: WasmNotSync + WasmNotSend> WasmNotSendSync for T {}
 
 pub fn spawn<F: Future<Output = ()> + WasmNotSend + 'static>(f: F) {

--- a/crates/gosub_shared/src/async_executor.rs
+++ b/crates/gosub_shared/src/async_executor.rs
@@ -26,6 +26,9 @@ impl<T> WasmNotSync for T {}
 
 pub trait WasmNotSendSync: WasmNotSend + WasmNotSync {}
 
+
+impl<T: WasmNotSync + WasmNotSend> WasmNotSendSync for T {}
+
 pub fn spawn<F: Future<Output = ()> + WasmNotSend + 'static>(f: F) {
     #[cfg(target_arch = "wasm32")]
     {

--- a/crates/gosub_useragent/Cargo.toml
+++ b/crates/gosub_useragent/Cargo.toml
@@ -17,6 +17,7 @@ url = "2.5.2"
 image = "0.25.2"
 
 
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = "0.3.72"
 wasm-bindgen-futures = "0.4.43"

--- a/crates/gosub_useragent/src/event_loop.rs
+++ b/crates/gosub_useragent/src/event_loop.rs
@@ -52,8 +52,6 @@ impl<
                     return Ok(());
                 };
 
-                let w = window.clone();
-
                 let redraw = tab.data.draw(backend, &mut self.renderer_data, size, &self.el);
 
                 backend.render(&mut self.renderer_data, active_window_data)?;

--- a/crates/gosub_useragent/src/event_loop.rs
+++ b/crates/gosub_useragent/src/event_loop.rs
@@ -54,9 +54,7 @@ impl<
 
                 let w = window.clone();
 
-                let redraw = tab.data.draw(backend, &mut self.renderer_data, size, move || {
-                    w.request_redraw();
-                });
+                let redraw = tab.data.draw(backend, &mut self.renderer_data, size, &self.el);
 
                 backend.render(&mut self.renderer_data, active_window_data)?;
 

--- a/crates/gosub_useragent/src/window.rs
+++ b/crates/gosub_useragent/src/window.rs
@@ -66,18 +66,17 @@ pub struct Window<
     pub(crate) el: WindowEventLoop<D, B, L, LT, Doc, C>,
 }
 
-
 impl<
-    'a,
-    D: SceneDrawer<B, L, LT, Doc, C>,
-    B: RenderBackend,
-    L: Layouter,
-    LT: LayoutTree<L>,
-    Doc: Document<C>,
-    C: CssSystem,
-> Window<'a, D, B, L, LT, Doc, C>
+        'a,
+        D: SceneDrawer<B, L, LT, Doc, C>,
+        B: RenderBackend,
+        L: Layouter,
+        LT: LayoutTree<L>,
+        Doc: Document<C>,
+        C: CssSystem,
+    > Window<'a, D, B, L, LT, Doc, C>
 {
-    pub fn new<P: Html5Parser<C, Document=Doc>>(
+    pub fn new<P: Html5Parser<C, Document = Doc>>(
         event_loop: &ActiveEventLoop,
         backend: &mut B,
         opts: WindowOptions,
@@ -118,7 +117,6 @@ impl<
             id: window.id(),
         };
 
-
         Ok(Self {
             state: WindowState::Suspended,
             window,
@@ -128,7 +126,7 @@ impl<
         })
     }
 
-    pub async fn open_tab<P: Html5Parser<C, Document=Doc>>(
+    pub async fn open_tab<P: Html5Parser<C, Document = Doc>>(
         &mut self,
         url: Url,
         layouter: L,
@@ -219,7 +217,6 @@ fn create_window(event_loop: &ActiveEventLoop) -> Result<Arc<WinitWindow>> {
         .map(Arc::new)
 }
 
-
 pub(crate) struct WindowEventLoop<
     D: SceneDrawer<B, L, LT, Doc, C>,
     B: RenderBackend,
@@ -232,15 +229,15 @@ pub(crate) struct WindowEventLoop<
     id: WindowId,
 }
 
-
 impl<
-    D: SceneDrawer<B, L, LT, Doc, C>,
-    B: RenderBackend,
-    L: Layouter,
-    LT: LayoutTree<L>,
-    Doc: Document<C>,
-    C: CssSystem,
-> Clone for WindowEventLoop<D, B, L, LT, Doc, C> {
+        D: SceneDrawer<B, L, LT, Doc, C>,
+        B: RenderBackend,
+        L: Layouter,
+        LT: LayoutTree<L>,
+        Doc: Document<C>,
+        C: CssSystem,
+    > Clone for WindowEventLoop<D, B, L, LT, Doc, C>
+{
     fn clone(&self) -> Self {
         Self {
             proxy: self.proxy.clone(),
@@ -249,15 +246,15 @@ impl<
     }
 }
 
-
 impl<
-    D: SceneDrawer<B, L, LT, Doc, C>,
-    B: RenderBackend,
-    L: Layouter,
-    LT: LayoutTree<L>,
-    Doc: Document<C>,
-    C: CssSystem,
-> WindowedEventLoop<B> for WindowEventLoop<D, B, L, LT, Doc, C> {
+        D: SceneDrawer<B, L, LT, Doc, C>,
+        B: RenderBackend,
+        L: Layouter,
+        LT: LayoutTree<L>,
+        Doc: Document<C>,
+        C: CssSystem,
+    > WindowedEventLoop<B> for WindowEventLoop<D, B, L, LT, Doc, C>
+{
     fn redraw(&mut self) {
         if let Err(e) = self.proxy.send_event(CustomEventInternal::Redraw(self.id)) {
             error!("Failed to send event {e}"); // only will error if the event loop was closed
@@ -265,7 +262,10 @@ impl<
     }
 
     fn add_img_cache(&mut self, url: String, buf: ImageBuffer<B>, size: Option<SizeU32>) {
-        if let Err(e) = self.proxy.send_event(CustomEventInternal::AddImg(url, buf, size, self.id)) {
+        if let Err(e) = self
+            .proxy
+            .send_event(CustomEventInternal::AddImg(url, buf, size, self.id))
+        {
             error!("Failed to send event {e}");
         }
     }

--- a/crates/gosub_useragent/src/window.rs
+++ b/crates/gosub_useragent/src/window.rs
@@ -5,22 +5,22 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use image::imageops::FilterType;
-use log::warn;
+use log::{error, warn};
 use url::Url;
 use winit::dpi::LogicalSize;
-use winit::event_loop::ActiveEventLoop;
+use winit::event_loop::{ActiveEventLoop, EventLoopProxy};
 use winit::window::{Icon, Window as WinitWindow, WindowId};
 
 use gosub_render_backend::geo::SizeU32;
 use gosub_render_backend::layout::{LayoutTree, Layouter};
-use gosub_render_backend::{NodeDesc, RenderBackend};
+use gosub_render_backend::{ImageBuffer, NodeDesc, RenderBackend, WindowedEventLoop};
 use gosub_renderer::draw::SceneDrawer;
 use gosub_shared::traits::css3::CssSystem;
 use gosub_shared::traits::document::Document;
 use gosub_shared::traits::html5::Html5Parser;
 use gosub_shared::types::Result;
 
-use crate::application::WindowOptions;
+use crate::application::{CustomEventInternal, WindowOptions};
 use crate::tabs::{Tab, TabID, Tabs};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -63,22 +63,25 @@ pub struct Window<
     pub(crate) window: Arc<WinitWindow>,
     pub(crate) renderer_data: B::WindowData<'a>,
     pub(crate) tabs: Tabs<D, B, L, LT, Doc, C>,
+    pub(crate) el: WindowEventLoop<D, B, L, LT, Doc, C>,
 }
 
+
 impl<
-        'a,
-        D: SceneDrawer<B, L, LT, Doc, C>,
-        B: RenderBackend,
-        L: Layouter,
-        LT: LayoutTree<L>,
-        Doc: Document<C>,
-        C: CssSystem,
-    > Window<'a, D, B, L, LT, Doc, C>
+    'a,
+    D: SceneDrawer<B, L, LT, Doc, C>,
+    B: RenderBackend,
+    L: Layouter,
+    LT: LayoutTree<L>,
+    Doc: Document<C>,
+    C: CssSystem,
+> Window<'a, D, B, L, LT, Doc, C>
 {
-    pub fn new<P: Html5Parser<C, Document = Doc>>(
+    pub fn new<P: Html5Parser<C, Document=Doc>>(
         event_loop: &ActiveEventLoop,
         backend: &mut B,
         opts: WindowOptions,
+        el: EventLoopProxy<CustomEventInternal<D, B, L, LT, Doc, C>>,
     ) -> Result<Self> {
         let window = create_window(event_loop)?;
 
@@ -110,15 +113,22 @@ impl<
 
         let renderer_data = backend.create_window_data(window.clone())?;
 
+        let el = WindowEventLoop {
+            proxy: el,
+            id: window.id(),
+        };
+
+
         Ok(Self {
             state: WindowState::Suspended,
             window,
             renderer_data,
             tabs: Tabs::default(),
+            el,
         })
     }
 
-    pub async fn open_tab<P: Html5Parser<C, Document = Doc>>(
+    pub async fn open_tab<P: Html5Parser<C, Document=Doc>>(
         &mut self,
         url: Url,
         layouter: L,
@@ -207,4 +217,56 @@ fn create_window(event_loop: &ActiveEventLoop) -> Result<Arc<WinitWindow>> {
         .create_window(attributes)
         .map_err(|e| anyhow!(e.to_string()))
         .map(Arc::new)
+}
+
+
+pub(crate) struct WindowEventLoop<
+    D: SceneDrawer<B, L, LT, Doc, C>,
+    B: RenderBackend,
+    L: Layouter,
+    LT: LayoutTree<L>,
+    Doc: Document<C>,
+    C: CssSystem,
+> {
+    proxy: EventLoopProxy<CustomEventInternal<D, B, L, LT, Doc, C>>,
+    id: WindowId,
+}
+
+
+impl<
+    D: SceneDrawer<B, L, LT, Doc, C>,
+    B: RenderBackend,
+    L: Layouter,
+    LT: LayoutTree<L>,
+    Doc: Document<C>,
+    C: CssSystem,
+> Clone for WindowEventLoop<D, B, L, LT, Doc, C> {
+    fn clone(&self) -> Self {
+        Self {
+            proxy: self.proxy.clone(),
+            id: self.id,
+        }
+    }
+}
+
+
+impl<
+    D: SceneDrawer<B, L, LT, Doc, C>,
+    B: RenderBackend,
+    L: Layouter,
+    LT: LayoutTree<L>,
+    Doc: Document<C>,
+    C: CssSystem,
+> WindowedEventLoop<B> for WindowEventLoop<D, B, L, LT, Doc, C> {
+    fn redraw(&mut self) {
+        if let Err(e) = self.proxy.send_event(CustomEventInternal::Redraw(self.id)) {
+            error!("Failed to send event {e}"); // only will error if the event loop was closed
+        }
+    }
+
+    fn add_img_cache(&mut self, url: String, buf: ImageBuffer<B>, size: Option<SizeU32>) {
+        if let Err(e) = self.proxy.send_event(CustomEventInternal::AddImg(url, buf, size, self.id)) {
+            error!("Failed to send event {e}");
+        }
+    }
 }

--- a/crates/gosub_vello/src/scene.rs
+++ b/crates/gosub_vello/src/scene.rs
@@ -1,9 +1,8 @@
+use gosub_render_backend::{Point, RenderBackend, RenderRect, RenderText, Scene as TScene, FP};
 use std::fmt::{Debug, Formatter};
 use vello::kurbo::RoundedRect;
 use vello::peniko::Fill;
 use vello::Scene as VelloScene;
-
-use gosub_render_backend::{Point, RenderBackend, RenderRect, RenderText, Scene as TScene, FP};
 
 use crate::debug::text::render_text_simple;
 use crate::{Border, BorderRenderOptions, Text, Transform, VelloBackend};

--- a/src/bin/renderer.rs
+++ b/src/bin/renderer.rs
@@ -26,7 +26,7 @@ type Drawer = TreeDrawer<Backend, Layouter, Document, CssSystem>;
 type Tree = RenderTree<Layouter, CssSystem>;
 
 fn main() -> Result<()> {
-    // simple_logger::init_with_level(log::Level::Info)?;
+    simple_logger::init_with_level(log::Level::Info)?;
 
     let matches = clap::Command::new("Gosub Renderer")
         .arg(

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -5,7 +5,7 @@
     <title>Title</title>
 
     <script type="module">
-        import init, {renderer, RendererOptions} from "../pkg";
+        import init, {renderer, RendererOptions} from "../pkg/gosub_engine.js";
 
         
         await init()


### PR DESCRIPTION
Make image rendering more performant, for instance, by removing atomic operations in the draw function.

For some reason on Wasm this is still quite slow with images, even if they are very very tiny and even if we are only applying the previous scene. Probably, this is a bug in vello or wgpu.