### PR TITLE
#521 - Updated FIXTURE_ROOT path

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,6 +5,7 @@
 
 Ahmed Ibrahim <me@ahmedibrahim.dev>
 DynamiteC <shethshails@gmail.com>
+Emre AYDIN <aeaydin1@gmail.com>
 Joshua Thijssen <jthijssen@noxlogic.nl>
 Nicholas Nguyen <nicholas.nguyen@chargeitspot.com>
 Niklas Scheerhoorn <sinner1991@gmail.com>

--- a/crates/gosub_testing/src/testing.rs
+++ b/crates/gosub_testing/src/testing.rs
@@ -2,5 +2,5 @@
 pub mod tokenizer;
 pub mod tree_construction;
 
-pub const FIXTURE_ROOT: &str = "./tests/data/html5lib-tests";
+pub const FIXTURE_ROOT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../gosub_html5/tests/data/html5lib-tests",);
 pub const TREE_CONSTRUCTION_PATH: &str = "tree-construction";


### PR DESCRIPTION
This change makes the test fixture path resolution more robust by using Cargo's manifest directory environment variable instead of a relative path. This ensures tests can be run from any directory while correctly locating the test data files.