### PR TITLE
add tab keybindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,6 +1642,7 @@ dependencies = [
  "log",
  "raw-window-handle",
  "smallvec",
+ "url",
 ]
 
 [[package]]

--- a/crates/gosub_render_backend/Cargo.toml
+++ b/crates/gosub_render_backend/Cargo.toml
@@ -15,4 +15,5 @@ image = "0.25.2"
 raw-window-handle = "0.6.2"
 log = "0.4.14"
 anyhow = "1.0.91"
+url = "2.5.2"
 

--- a/crates/gosub_render_backend/src/lib.rs
+++ b/crates/gosub_render_backend/src/lib.rs
@@ -10,6 +10,7 @@ use gosub_shared::traits::render_tree::RenderTree;
 use gosub_shared::types::Result;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use smallvec::SmallVec;
+use url::Url;
 
 pub mod geo;
 pub mod layout;
@@ -27,6 +28,8 @@ pub trait WindowedEventLoop<B: RenderBackend, RT: RenderTree<C>, C: CssSystem>:
     fn add_img_cache(&mut self, url: String, buf: ImageBuffer<B>, size: Option<SizeU32>);
 
     fn reload_from(&mut self, rt: RT);
+
+    fn open_tab(&mut self, url: Url);
 }
 
 pub trait RenderBackend: Sized + Debug + 'static {

--- a/crates/gosub_renderer/src/draw.rs
+++ b/crates/gosub_renderer/src/draw.rs
@@ -100,11 +100,7 @@ where
         size: SizeU32,
         el: &impl WindowedEventLoop<B, RenderTree<L, C>, C>,
     ) -> bool {
-        if !self.dirty && self.size == Some(size) {
-            return false;
-        }
-
-        if self.tree_scene.is_none() || self.size != Some(size) {
+        if self.tree_scene.is_none() || self.size != Some(size) || !self.dirty {
             self.size = Some(size);
 
             let mut scene = B::Scene::new();

--- a/crates/gosub_useragent/src/event_loop.rs
+++ b/crates/gosub_useragent/src/event_loop.rs
@@ -1,17 +1,17 @@
+use url::Url;
 use winit::event::{ElementState, MouseScrollDelta, WindowEvent};
 use winit::event_loop::ActiveEventLoop;
-use winit::keyboard::{KeyCode, PhysicalKey};
+use winit::keyboard::{KeyCode, ModifiersState, PhysicalKey};
 
+use crate::window::{Window, WindowState};
 use gosub_render_backend::layout::{LayoutTree, Layouter};
-use gosub_render_backend::{Point, RenderBackend, SizeU32, FP};
+use gosub_render_backend::{Point, RenderBackend, SizeU32, WindowedEventLoop, FP};
 use gosub_renderer::draw::SceneDrawer;
 use gosub_shared::traits::css3::CssSystem;
 use gosub_shared::traits::document::Document;
 use gosub_shared::traits::html5::Html5Parser;
 use gosub_shared::traits::render_tree::RenderTree;
 use gosub_shared::types::Result;
-
-use crate::window::{Window, WindowState};
 
 impl<
         'a,
@@ -118,9 +118,90 @@ impl<
                         KeyCode::F5 => {
                             tab.reload::<P>(self.el.clone());
                         }
+                        KeyCode::ArrowRight => {
+                            if self.mods.state().contains(ModifiersState::CONTROL) {
+                                self.tabs.next_tab();
+                                self.window.request_redraw();
+                            }
+                        }
+                        KeyCode::ArrowLeft => {
+                            if self.mods.state().contains(ModifiersState::CONTROL) {
+                                self.tabs.previous_tab();
+                                self.window.request_redraw();
+                            }
+                        }
+                        KeyCode::Digit0 => {
+                            if self.mods.state().contains(ModifiersState::CONTROL) {
+                                self.tabs.activate_idx(0);
+                                self.window.request_redraw();
+                            }
+                        }
+                        KeyCode::Digit1 => {
+                            if self.mods.state().contains(ModifiersState::CONTROL) {
+                                self.tabs.activate_idx(1);
+                                self.window.request_redraw();
+                            }
+                        }
+                        KeyCode::Digit2 => {
+                            if self.mods.state().contains(ModifiersState::CONTROL) {
+                                self.tabs.activate_idx(2);
+                                self.window.request_redraw();
+                            }
+                        }
+                        KeyCode::Digit3 => {
+                            if self.mods.state().contains(ModifiersState::CONTROL) {
+                                self.tabs.activate_idx(3);
+                                self.window.request_redraw();
+                            }
+                        }
+                        KeyCode::Digit4 => {
+                            if self.mods.state().contains(ModifiersState::CONTROL) {
+                                self.tabs.activate_idx(4);
+                                self.window.request_redraw();
+                            }
+                        }
+                        KeyCode::Digit5 => {
+                            if self.mods.state().contains(ModifiersState::CONTROL) {
+                                self.tabs.activate_idx(5);
+                                self.window.request_redraw();
+                            }
+                        }
+                        KeyCode::Digit6 => {
+                            if self.mods.state().contains(ModifiersState::CONTROL) {
+                                self.tabs.activate_idx(6);
+                                self.window.request_redraw();
+                            }
+                        }
+                        KeyCode::Digit7 => {
+                            if self.mods.state().contains(ModifiersState::CONTROL) {
+                                self.tabs.activate_idx(7);
+                                self.window.request_redraw();
+                            }
+                        }
+                        KeyCode::Digit8 => {
+                            if self.mods.state().contains(ModifiersState::CONTROL) {
+                                self.tabs.activate_idx(8);
+                                self.window.request_redraw();
+                            }
+                        }
+                        KeyCode::Digit9 => {
+                            if self.mods.state().contains(ModifiersState::CONTROL) {
+                                self.tabs.activate_idx(9);
+                                self.window.request_redraw();
+                            }
+                        }
+
+                        KeyCode::F6 => self.el.open_tab(Url::parse("https://news.ycombinator.com")?),
+                        KeyCode::F7 => self.el.open_tab(Url::parse("https://archlinux.org")?),
+                        KeyCode::F8 => self.el.open_tab(Url::parse("file://resources/test.html")?),
+
                         _ => {}
                     }
                 }
+            }
+
+            WindowEvent::ModifiersChanged(mods) => {
+                self.mods = mods;
             }
 
             _ => {}

--- a/crates/gosub_useragent/src/lib.rs
+++ b/crates/gosub_useragent/src/lib.rs
@@ -2,3 +2,5 @@ pub mod application;
 pub mod event_loop;
 pub mod tabs;
 pub mod window;
+
+pub use winit;

--- a/crates/gosub_useragent/src/tabs.rs
+++ b/crates/gosub_useragent/src/tabs.rs
@@ -109,6 +109,32 @@ impl<
             tab.data.unselect_element();
         }
     }
+
+    pub fn next_tab(&mut self) {
+        if let Some(next_tab_id) = self.tabs.keys().skip_while(|key| *key != self.active.0).nth(1) {
+            self.active = TabID(next_tab_id);
+        }
+    }
+
+    pub fn previous_tab(&mut self) {
+        if let Some(prev_tab_id) = self
+            .tabs
+            .keys()
+            .collect::<Vec<_>>()
+            .iter()
+            .rev()
+            .skip_while(|key| **key != self.active.0)
+            .nth(1)
+        {
+            self.active = TabID(*prev_tab_id);
+        }
+    }
+
+    pub fn activate_idx(&mut self, idx: usize) {
+        if let Some(id) = self.tabs.keys().nth(idx) {
+            self.active = TabID(id);
+        }
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Tabs can now be changed with CTRL+ArrowLeft or CTRL+ArrowRight or CTRL+DigitX
There are some default tabs you can open with F6, F7 and F8.

You can also open new tabs by setting a WindowID in the terminal with the "window" command followed by the WindowID. It prints the ID of the window when it gets created. That isn't pretty, but it works for now. Then you can open tabs with the "open" command.