### PR TITLE
fix `width` and `height` not being taken into account in block layout.

### DIFF
--- a/crates/gosub_render_backend/src/layout.rs
+++ b/crates/gosub_render_backend/src/layout.rs
@@ -39,11 +39,11 @@ pub trait Layouter: Sized + Clone + Send + 'static {
     fn layout<LT: LayoutTree<Self>>(&self, tree: &mut LT, root: LT::NodeId, space: SizeU32) -> Result<()>;
 }
 
-pub trait LayoutCache: Default + Send {
+pub trait LayoutCache: Default + Send + Debug {
     fn invalidate(&mut self);
 }
 
-pub trait Layout: Default {
+pub trait Layout: Default + Debug {
     /// Returns the relative upper left pos of the content box
     fn rel_pos(&self) -> Point;
 


### PR DESCRIPTION
This makes the layout of our old website slightly better. I still don't know why the text is on such a wrong position

After:
![image](https://github.com/user-attachments/assets/b19caf18-c9fe-4843-81b8-f182d17f4b5c)

Before:

![image](https://github.com/user-attachments/assets/2d44727e-5b27-4f83-9fa7-6d3af9c90a9e)
