### PR TITLE
Added functionality to render tree from html-source instead of url

### DIFF
--- a/crates/gosub_interface/src/draw.rs
+++ b/crates/gosub_interface/src/draw.rs
@@ -36,7 +36,7 @@ pub trait TreeDrawer<C: HasDrawComponents> {
         layouter: C::Layouter,
         // Debug flag
         debug: bool,
-    ) -> impl Future<Output = gosub_shared::types::Result<Self>>
+    ) -> gosub_shared::types::Result<Self>
     where
         Self: Sized;
 

--- a/crates/gosub_interface/src/draw.rs
+++ b/crates/gosub_interface/src/draw.rs
@@ -27,6 +27,19 @@ pub trait TreeDrawer<C: HasDrawComponents> {
     where
         Self: Sized;
 
+    fn from_source(
+        // The initial url that the source was loaded from
+        url: Url,
+        // Actual loaded source HTML
+        source_html: &str,
+        // Layouter that renders the tree
+        layouter: C::Layouter,
+        // Debug flag
+        debug: bool,
+    ) -> impl Future<Output = gosub_shared::types::Result<Self>>
+    where
+        Self: Sized;
+
     fn clear_buffers(&mut self);
     fn toggle_debug(&mut self);
 

--- a/crates/gosub_renderer/src/draw.rs
+++ b/crates/gosub_renderer/src/draw.rs
@@ -212,7 +212,13 @@ where
     }
 
     async fn from_url(url: Url, layouter: C::Layouter, debug: bool) -> Result<Self> {
-        let (rt, fetcher) = load_html_rendertree::<C>(url.clone()).await?;
+        let (rt, fetcher) = load_html_rendertree::<C>(url.clone(), None).await?;
+
+        Ok(Self::new(rt, layouter, fetcher, debug))
+    }
+
+    async fn from_source(url: Url, source_html: &str, layouter: C::Layouter, debug: bool) -> Result<Self> {
+        let (rt, fetcher) = load_html_rendertree::<C>(url, Some(source_html)).await?;
 
         Ok(Self::new(rt, layouter, fetcher, debug))
     }

--- a/crates/gosub_renderer/src/draw.rs
+++ b/crates/gosub_renderer/src/draw.rs
@@ -2,7 +2,7 @@ use crate::debug::scale::px_scale;
 use crate::draw::img::request_img;
 use crate::draw::img_cache::ImageCache;
 use crate::draw::testing::{test_add_element, test_restyle_element};
-use crate::render_tree::{load_html_rendertree, load_html_rendertree_fetcher};
+use crate::render_tree::{load_html_rendertree, load_html_rendertree_fetcher, load_html_rendertree_source};
 use anyhow::anyhow;
 use gosub_interface::config::{HasDrawComponents, HasHtmlParser};
 use gosub_interface::css3::{CssProperty, CssPropertyMap, CssValue};
@@ -217,8 +217,9 @@ where
         Ok(Self::new(rt, layouter, fetcher, debug))
     }
 
-    async fn from_source(url: Url, source_html: &str, layouter: C::Layouter, debug: bool) -> Result<Self> {
-        let (rt, fetcher) = load_html_rendertree::<C>(url, Some(source_html)).await?;
+    fn from_source(url: Url, source_html: &str, layouter: C::Layouter, debug: bool) -> Result<Self> {
+        let fetcher = Fetcher::new(url.clone());
+        let rt = load_html_rendertree_source::<C>(url, source_html)?;
 
         Ok(Self::new(rt, layouter, fetcher, debug))
     }

--- a/crates/gosub_renderer/src/render_tree.rs
+++ b/crates/gosub_renderer/src/render_tree.rs
@@ -20,14 +20,16 @@ pub(crate) async fn load_html_rendertree<
     let fetcher = Fetcher::new(url.clone());
 
     let rt = match source {
-        Some(source) => load_html_rendertree_source::<C>(url, source).await?,
+        Some(source) => load_html_rendertree_source::<C>(url, source)?,
         None => load_html_rendertree_fetcher::<C>(url, &fetcher).await?,
     };
 
     Ok((rt, fetcher))
 }
 
-pub(crate) async fn load_html_rendertree_source<
+// Generate a render tree from the given source HTML. THe URL is needed to resolve relative URLs
+// and also to set the base URL for the document.
+pub(crate) fn load_html_rendertree_source<
     C: HasRenderTree<LayoutTree = RenderTree<C>, RenderTree = RenderTree<C>> + HasHtmlParser,
 >(
     url: Url,
@@ -53,6 +55,7 @@ pub(crate) async fn load_html_rendertree_source<
     generate_render_tree(DocumentHandle::clone(&doc_handle))
 }
 
+/// Generates a render tree from the given URL. The complete HTML source is fetched from the URL async.
 pub(crate) async fn load_html_rendertree_fetcher<
     C: HasRenderTree<LayoutTree = RenderTree<C>, RenderTree = RenderTree<C>> + HasHtmlParser,
 >(
@@ -73,5 +76,5 @@ pub(crate) async fn load_html_rendertree_fetcher<
         bail!("Unsupported url scheme: {}", url.scheme());
     };
 
-    load_html_rendertree_source(url, &html).await
+    load_html_rendertree_source(url, &html)
 }

--- a/crates/gosub_renderer/src/render_tree.rs
+++ b/crates/gosub_renderer/src/render_tree.rs
@@ -10,16 +10,47 @@ use gosub_shared::byte_stream::{ByteStream, Encoding};
 use std::fs;
 use url::Url;
 
+/// Generates a render tree from the given URL.. if the source is given, the URL is not loaded, but the source HTML is used instead
 pub(crate) async fn load_html_rendertree<
     C: HasRenderTree<LayoutTree = RenderTree<C>, RenderTree = RenderTree<C>> + HasHtmlParser,
 >(
     url: Url,
+    source: Option<&str>,
 ) -> gosub_shared::types::Result<(RenderTree<C>, Fetcher)> {
     let fetcher = Fetcher::new(url.clone());
 
-    let rt = load_html_rendertree_fetcher::<C>(url, &fetcher).await?;
+    let rt = match source {
+        Some(source) => load_html_rendertree_source::<C>(url, source).await?,
+        None => load_html_rendertree_fetcher::<C>(url, &fetcher).await?,
+    };
 
     Ok((rt, fetcher))
+}
+
+pub(crate) async fn load_html_rendertree_source<
+    C: HasRenderTree<LayoutTree = RenderTree<C>, RenderTree = RenderTree<C>> + HasHtmlParser,
+>(
+    url: Url,
+    source_html: &str,
+) -> gosub_shared::types::Result<RenderTree<C>> {
+    let mut stream = ByteStream::new(Encoding::UTF8, None);
+    stream.read_from_str(source_html, Some(Encoding::UTF8));
+    stream.close();
+
+    let mut doc_handle = C::DocumentBuilder::new_document(Some(url));
+    let parse_errors = C::HtmlParser::parse(&mut stream, DocumentHandle::clone(&doc_handle), None)?;
+
+    for error in parse_errors {
+        eprintln!("Parse error: {:?}", error);
+    }
+
+    let mut doc = doc_handle.get_mut();
+
+    doc.add_stylesheet(C::CssSystem::load_default_useragent_stylesheet());
+
+    drop(doc);
+
+    generate_render_tree(DocumentHandle::clone(&doc_handle))
 }
 
 pub(crate) async fn load_html_rendertree_fetcher<
@@ -42,22 +73,5 @@ pub(crate) async fn load_html_rendertree_fetcher<
         bail!("Unsupported url scheme: {}", url.scheme());
     };
 
-    let mut stream = ByteStream::new(Encoding::UTF8, None);
-    stream.read_from_str(&html, Some(Encoding::UTF8));
-    stream.close();
-
-    let mut doc_handle = C::DocumentBuilder::new_document(Some(url));
-    let parse_errors = C::HtmlParser::parse(&mut stream, DocumentHandle::clone(&doc_handle), None)?;
-
-    for error in parse_errors {
-        eprintln!("Parse error: {:?}", error);
-    }
-
-    let mut doc = doc_handle.get_mut();
-
-    doc.add_stylesheet(C::CssSystem::load_default_useragent_stylesheet());
-
-    drop(doc);
-
-    generate_render_tree(DocumentHandle::clone(&doc_handle))
+    load_html_rendertree_source(url, &html).await
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,7 @@
 pub use gosub_interface::config::*;
+pub use gosub_interface::draw::TreeDrawer;
 pub use gosub_interface::render_backend::ImageBuffer;
+pub use gosub_interface::render_backend::RenderBackend;
 pub use gosub_interface::render_backend::WindowedEventLoop;
 
 pub use gosub_shared::geo::*;


### PR DESCRIPTION
The gtk browser alraedy fetches the URL before the drawer. So instead of letting the drawer fetching the url, we provide the html source