### PR TITLE
make load_html_rendertree more generic

### DIFF
--- a/crates/gosub_instance/src/lib.rs
+++ b/crates/gosub_instance/src/lib.rs
@@ -57,7 +57,7 @@ impl<C: ModuleConfiguration> EngineInstance<C> {
         handles: Handles<C>,
     ) -> Result<Self> {
         let fetcher = Arc::new(Fetcher::new(url.clone()));
-        let data = C::TreeDrawer::with_fetcher(url.clone(), fetcher.clone(), layouter, false).await?;
+        let (data, _handle) = C::TreeDrawer::with_fetcher(url.clone(), fetcher.clone(), layouter, false).await?;
 
         let (itx, irx) = tokio::sync::mpsc::channel(128);
 

--- a/crates/gosub_interface/src/render_tree.rs
+++ b/crates/gosub_interface/src/render_tree.rs
@@ -1,5 +1,6 @@
-use crate::config::HasLayouter;
+use crate::config::{HasDocument, HasLayouter};
 use crate::css3::CssSystem;
+use crate::document_handle::DocumentHandle;
 use crate::layout::Layouter;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -18,6 +19,10 @@ pub trait RenderTree<C: HasLayouter>: Send + 'static {
     fn get_children(&self, id: Self::NodeId) -> Option<Vec<Self::NodeId>>;
 
     fn get_layout(&self, id: Self::NodeId) -> Option<&<C::Layouter as Layouter>::Layout>;
+
+    fn from_document(handle: DocumentHandle<C>) -> Self
+    where
+        C: HasDocument;
 }
 
 pub trait RenderTreeNode<C: HasLayouter>: Debug {

--- a/crates/gosub_renderer/src/render_tree.rs
+++ b/crates/gosub_renderer/src/render_tree.rs
@@ -5,18 +5,16 @@ use gosub_interface::document::{Document, DocumentBuilder};
 use gosub_interface::document_handle::DocumentHandle;
 use gosub_interface::html5::Html5Parser;
 use gosub_net::http::fetcher::Fetcher;
-use gosub_rendering::render_tree::{generate_render_tree, RenderTree};
+use gosub_rendering::render_tree::generate_render_tree;
 use gosub_shared::byte_stream::{ByteStream, Encoding};
 use std::fs;
 use url::Url;
 
-/// Generates a render tree from the given URL.. if the source is given, the URL is not loaded, but the source HTML is used instead
-pub async fn load_html_rendertree<
-    C: HasRenderTree<LayoutTree = RenderTree<C>, RenderTree = RenderTree<C>> + HasHtmlParser,
->(
+/// Generates a render tree from the given URL... if the source is given, the URL is not loaded, but the source HTML is used instead
+pub async fn load_html_rendertree<C: HasRenderTree + HasHtmlParser>(
     url: Url,
     source: Option<&str>,
-) -> gosub_shared::types::Result<(RenderTree<C>, Fetcher)> {
+) -> gosub_shared::types::Result<(C::RenderTree, Fetcher)> {
     let fetcher = Fetcher::new(url.clone());
 
     let rt = match source {
@@ -29,12 +27,10 @@ pub async fn load_html_rendertree<
 
 // Generate a render tree from the given source HTML. THe URL is needed to resolve relative URLs
 // and also to set the base URL for the document.
-pub fn load_html_rendertree_source<
-    C: HasRenderTree<LayoutTree = RenderTree<C>, RenderTree = RenderTree<C>> + HasHtmlParser,
->(
+pub fn load_html_rendertree_source<C: HasRenderTree + HasHtmlParser>(
     url: Url,
     source_html: &str,
-) -> gosub_shared::types::Result<RenderTree<C>> {
+) -> gosub_shared::types::Result<C::RenderTree> {
     let mut stream = ByteStream::new(Encoding::UTF8, None);
     stream.read_from_str(source_html, Some(Encoding::UTF8));
     stream.close();
@@ -56,12 +52,10 @@ pub fn load_html_rendertree_source<
 }
 
 /// Generates a render tree from the given URL. The complete HTML source is fetched from the URL async.
-pub async fn load_html_rendertree_fetcher<
-    C: HasRenderTree<LayoutTree = RenderTree<C>, RenderTree = RenderTree<C>> + HasHtmlParser,
->(
+pub async fn load_html_rendertree_fetcher<C: HasRenderTree + HasHtmlParser>(
     url: Url,
     fetcher: &Fetcher,
-) -> gosub_shared::types::Result<RenderTree<C>> {
+) -> gosub_shared::types::Result<C::RenderTree> {
     let html = if url.scheme() == "http" || url.scheme() == "https" {
         // Fetch the html from the url
         let response = fetcher.get(url.as_ref()).await?;
@@ -76,5 +70,5 @@ pub async fn load_html_rendertree_fetcher<
         bail!("Unsupported url scheme: {}", url.scheme());
     };
 
-    load_html_rendertree_source(url, &html)
+    load_html_rendertree_source::<C>(url, &html)
 }

--- a/crates/gosub_rendering/src/render_tree.rs
+++ b/crates/gosub_rendering/src/render_tree.rs
@@ -546,7 +546,7 @@ impl<C: HasRenderTree<LayoutTree = Self, RenderTree = Self> + HasDocument> Rende
     }
 }
 
-impl<C: HasLayouter<LayoutTree = Self>> render_tree::RenderTree<C> for RenderTree<C> {
+impl<C: HasRenderTree<LayoutTree = Self, RenderTree = Self>> render_tree::RenderTree<C> for RenderTree<C> {
     type NodeId = NodeId;
     type Node = RenderTreeNode<C>;
 
@@ -568,6 +568,13 @@ impl<C: HasLayouter<LayoutTree = Self>> render_tree::RenderTree<C> for RenderTre
 
     fn get_layout(&self, id: Self::NodeId) -> Option<&<C::Layouter as Layouter>::Layout> {
         Some(&LayoutTree::get_node(self, id)?.layout)
+    }
+
+    fn from_document(handle: DocumentHandle<C>) -> Self
+    where
+        C: HasDocument,
+    {
+        RenderTree::from_document(handle)
     }
 }
 
@@ -806,10 +813,8 @@ impl<C: HasLayouter> LayoutNode<C> for RenderTreeNode<C> {
 }
 
 /// Generates a render tree for the given document based on its loaded stylesheets
-pub fn generate_render_tree<C: HasDocument + HasRenderTree<LayoutTree = RenderTree<C>, RenderTree = RenderTree<C>>>(
-    document: DocumentHandle<C>,
-) -> Result<RenderTree<C>> {
-    let render_tree = RenderTree::from_document(document);
+pub fn generate_render_tree<C: HasDocument + HasRenderTree>(document: DocumentHandle<C>) -> Result<C::RenderTree> {
+    let render_tree = render_tree::RenderTree::from_document(document);
 
     Ok(render_tree)
 }


### PR DESCRIPTION
We now can use `load_html_rendertree*` with every render tree that is implemented