### PR TITLE
fix text layout problems

### DIFF
--- a/crates/gosub_interface/src/layout.rs
+++ b/crates/gosub_interface/src/layout.rs
@@ -34,7 +34,7 @@ pub trait Layouter: Sized + Clone + Send + 'static {
     type Cache: LayoutCache;
     type Layout: Layout + Send;
 
-    type TextLayout: TextLayout + Send;
+    type TextLayout: TextLayout + Send + Debug;
 
     const COLLAPSE_INLINE: bool;
 
@@ -127,21 +127,20 @@ pub trait LayoutNode<C: HasLayouter>: HasTextLayout<C> {
     fn get_property(&self, name: &str) -> Option<&C::CssProperty>;
     fn text_data(&self) -> Option<&str>;
 
-    fn text_size(&self) -> Option<Size>;
-
     /// This can only return true if the `Layout::COLLAPSE_INLINE` is set true for the layouter
     ///
     fn is_anon_inline_parent(&self) -> bool;
 }
 
 pub trait HasTextLayout<C: HasLayouter> {
-    fn set_text_layout(&mut self, layout: <C::Layouter as Layouter>::TextLayout);
+    fn clear_text_layout(&mut self);
+    fn add_text_layout(&mut self, layout: <C::Layouter as Layouter>::TextLayout);
+    fn get_text_layouts(&self) -> Option<&[<C::Layouter as Layouter>::TextLayout]>;
+    fn get_text_layouts_mut(&mut self) -> Option<&mut Vec<<C::Layouter as Layouter>::TextLayout>>;
 }
 
 pub trait TextLayout {
     type Font: Font;
-    fn dbg_layout(&self) -> String;
-
     fn size(&self) -> Size;
 
     fn glyphs(&self) -> &[Glyph];
@@ -153,6 +152,8 @@ pub trait TextLayout {
     fn coords(&self) -> &[i16];
 
     fn decorations(&self) -> &Decoration;
+
+    fn offset(&self) -> Point;
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/gosub_interface/src/render_backend.rs
+++ b/crates/gosub_interface/src/render_backend.rs
@@ -128,7 +128,7 @@ impl<B: RenderBackend> RenderRect<B> {
 
 #[derive(Clone, Debug)]
 pub struct RenderText<B: RenderBackend> {
-    pub text: B::Text,
+    pub text: Vec<B::Text>,
     pub rect: B::Rect,
     pub transform: Option<B::Transform>,
     pub brush: B::Brush,
@@ -136,7 +136,7 @@ pub struct RenderText<B: RenderBackend> {
 }
 
 impl<B: RenderBackend> RenderText<B> {
-    pub fn new(text: B::Text, rect: B::Rect, brush: B::Brush) -> Self {
+    pub fn new(text: Vec<B::Text>, rect: B::Rect, brush: B::Brush) -> Self {
         Self {
             text,
             rect,

--- a/crates/gosub_interface/src/render_tree.rs
+++ b/crates/gosub_interface/src/render_tree.rs
@@ -33,6 +33,6 @@ pub trait RenderTreeNode<C: HasLayouter>: Debug {
     fn layout_mut(&mut self) -> &mut <C::Layouter as Layouter>::Layout;
 
     fn element_attributes(&self) -> Option<&HashMap<String, String>>;
-    fn text_data(&self) -> Option<(&str, Option<&<C::Layouter as Layouter>::TextLayout>)>;
+    fn text_data(&self) -> Option<(&str, &[<C::Layouter as Layouter>::TextLayout])>;
     fn name(&self) -> &str;
 }

--- a/crates/gosub_renderer/src/draw.rs
+++ b/crates/gosub_renderer/src/draw.rs
@@ -23,7 +23,7 @@ use gosub_rendering::render_tree::RenderTree;
 use gosub_shared::geo::{Size, SizeU32, FP};
 use gosub_shared::node::NodeId;
 use gosub_shared::types::Result;
-use log::{error, info, warn};
+use log::{error, info};
 use std::future::Future;
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
@@ -490,13 +490,15 @@ fn render_text<C: HasDrawComponents>(
         .unwrap_or(Color::BLACK);
 
     if let Some((_, layout)) = &node.text_data() {
-        let Some(layout) = layout else {
-            warn!("No layout for text node");
-            return;
-        };
+        let text = layout
+            .iter()
+            .map(|layout| {
+                let text: <C::RenderBackend as RenderBackend>::Text =
+                    Text::new::<<C::Layouter as Layouter>::TextLayout>(layout);
 
-        let text: <C::RenderBackend as RenderBackend>::Text =
-            Text::new::<<C::Layouter as Layouter>::TextLayout>(layout);
+                text
+            })
+            .collect::<Vec<_>>();
 
         let size = node.layout().size();
 

--- a/crates/gosub_renderer/src/draw/testing.rs
+++ b/crates/gosub_renderer/src/draw/testing.rs
@@ -34,7 +34,7 @@ pub(crate) fn test_add_element<C: HasDrawComponents<RenderTree = RenderTree<C>, 
         "#text".to_string(),
         RenderNodeData::Text(Box::new(TextData {
             text: "test add element".to_string(),
-            layout: None,
+            layout: Vec::new(),
         })),
         props,
     );

--- a/crates/gosub_taffy/src/style/parse.rs
+++ b/crates/gosub_taffy/src/style/parse.rs
@@ -7,7 +7,6 @@ use taffy::{
 use gosub_interface::config::HasLayouter;
 use gosub_interface::css3::CssProperty;
 use gosub_interface::layout::LayoutNode;
-use gosub_shared::geo::Size;
 
 pub fn parse_len<C: HasLayouter>(node: &mut impl LayoutNode<C>, name: &str) -> LengthPercentage {
     let Some(property) = node.get_property(name) else {
@@ -55,16 +54,6 @@ pub fn parse_dimension<C: HasLayouter>(node: &mut impl LayoutNode<C>, name: &str
     }
 
     Dimension::Length(property.unit_to_px())
-}
-
-pub fn parse_text_dim(size: Size, name: &str) -> Dimension {
-    if name == "width" || name == "max-width" || name == "min-width" {
-        Dimension::Length(size.width)
-    } else if name == "height" || name == "max-height" || name == "min-height" {
-        Dimension::Length(size.height)
-    } else {
-        Dimension::Auto
-    }
 }
 
 pub fn parse_align_i<C: HasLayouter>(node: &mut impl LayoutNode<C>, name: &str) -> Option<AlignItems> {

--- a/crates/gosub_taffy/src/style/parse_properties.rs
+++ b/crates/gosub_taffy/src/style/parse_properties.rs
@@ -4,7 +4,7 @@ use taffy::{Overflow, Point, TextAlign};
 
 use crate::style::parse::{
     parse_align_c, parse_align_i, parse_dimension, parse_grid_auto, parse_grid_placement, parse_len, parse_len_auto,
-    parse_text_dim, parse_tracking_sizing_function,
+    parse_tracking_sizing_function,
 };
 use gosub_interface::config::HasLayouter;
 use gosub_interface::css3::CssProperty;
@@ -89,13 +89,6 @@ pub fn parse_inset<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> Rect<Length
 }
 
 pub fn parse_size<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> Size<Dimension> {
-    if let Some(t) = node.text_size() {
-        return Size {
-            width: parse_text_dim(t, "width"),
-            height: parse_text_dim(t, "height"),
-        };
-    }
-
     Size {
         width: parse_dimension(node, "width"),
         height: parse_dimension(node, "height"),
@@ -103,13 +96,6 @@ pub fn parse_size<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> Size<Dimensi
 }
 
 pub fn parse_min_size<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> Size<Dimension> {
-    if let Some(t) = node.text_size() {
-        return Size {
-            width: parse_text_dim(t, "min-width"),
-            height: parse_text_dim(t, "min-height"),
-        };
-    }
-
     Size {
         width: parse_dimension(node, "min-width"),
         height: parse_dimension(node, "min-height"),
@@ -117,13 +103,6 @@ pub fn parse_min_size<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> Size<Dim
 }
 
 pub fn parse_max_size<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> Size<Dimension> {
-    if let Some(t) = node.text_size() {
-        return Size {
-            width: parse_text_dim(t, "max-width"),
-            height: parse_text_dim(t, "max-height"),
-        };
-    }
-
     Size {
         width: parse_dimension(node, "max-width"),
         height: parse_dimension(node, "max-height"),

--- a/crates/gosub_taffy/src/text.rs
+++ b/crates/gosub_taffy/src/text.rs
@@ -1,8 +1,10 @@
 use gosub_interface::layout::{Decoration, TextLayout as TLayout};
 use gosub_shared::font::Font as TFont;
 use gosub_shared::font::Glyph;
-use gosub_shared::geo::Size;
+use gosub_shared::geo::{Point, Size};
 use parley::Font as PFont;
+use std::fmt;
+use std::fmt::{Debug, Formatter};
 
 #[derive(Debug, Clone)]
 pub struct Font(pub PFont);
@@ -19,7 +21,6 @@ impl From<Font> for PFont {
     }
 }
 
-#[derive(Debug)]
 pub struct TextLayout {
     pub glyphs: Vec<Glyph>,
     pub font: Font,
@@ -27,14 +28,22 @@ pub struct TextLayout {
     pub size: Size,
     pub coords: Vec<i16>,
     pub decoration: Decoration,
+    pub offset: Point,
+}
+
+impl Debug for TextLayout {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TextLayout")
+            .field("size", &self.size)
+            .field("font_size", &self.font_size)
+            .field("decoration", &self.decoration)
+            .field("offset", &self.offset)
+            .finish()
+    }
 }
 
 impl TLayout for TextLayout {
     type Font = Font;
-
-    fn dbg_layout(&self) -> String {
-        format!("TextLayout: {:?}", self)
-    }
 
     fn size(&self) -> Size {
         self.size
@@ -58,5 +67,9 @@ impl TLayout for TextLayout {
 
     fn decorations(&self) -> &Decoration {
         &self.decoration
+    }
+
+    fn offset(&self) -> Point {
+        self.offset
     }
 }


### PR DESCRIPTION
Previously, we were only rendering the last glyph run for one inline layout, which is completely wrong. That meant, that when you have two text nodes in one inline wrapper node, it would only render the last one.
This can be seen on the https://httpbin.org/html site.

Before: 
![image](https://github.com/user-attachments/assets/bee6f196-5333-47cf-af46-35e590884ffc)

After:
![image](https://github.com/user-attachments/assets/559a5156-9c04-4ba9-8733-937691101905)
