### PR TITLE
use `cow_to_ascii_lowercase` instead

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@
 Ahmed Ibrahim <me@ahmedibrahim.dev>
 DynamiteC <shethshails@gmail.com>
 Emre AYDIN <aeaydin1@gmail.com>
+heygsc <1596920983@qq.com>
 Joshua Thijssen <jthijssen@noxlogic.nl>
 Nicholas Nguyen <nicholas.nguyen@chargeitspot.com>
 Niklas Scheerhoorn <sinner1991@gmail.com>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cow-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,6 +1768,7 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "colors-transform",
+ "cow-utils",
  "gosub_interface",
  "gosub_shared",
  "itertools 0.14.0",

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+  { path = "str::to_ascii_lowercase", reason = "To avoid memory allocation, use `cow_utils::CowUtils::cow_to_ascii_lowercase` instead." },
+]

--- a/crates/gosub_css3/Cargo.toml
+++ b/crates/gosub_css3/Cargo.toml
@@ -20,3 +20,4 @@ serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.134"
 thiserror = "2.0.9"
 nom = "7.1.3"
+cow-utils = "0.1.3"

--- a/crates/gosub_css3/src/parser/url.rs
+++ b/crates/gosub_css3/src/parser/url.rs
@@ -1,6 +1,7 @@
 use crate::node::{Node, NodeType};
 use crate::tokenizer::TokenType;
 use crate::Css3;
+use cow_utils::CowUtils;
 use gosub_shared::errors::CssError;
 use gosub_shared::errors::CssResult;
 
@@ -11,7 +12,7 @@ impl Css3<'_> {
         let loc = self.tokenizer.current_location();
 
         let name = self.consume_function()?;
-        if name.to_ascii_lowercase() != "url" {
+        if name.cow_to_ascii_lowercase() != "url" {
             return Err(CssError::with_location(
                 format!("Expected url, got {:?}", name).as_str(),
                 self.tokenizer.current_location(),

--- a/crates/gosub_css3/src/parser/value.rs
+++ b/crates/gosub_css3/src/parser/value.rs
@@ -1,6 +1,7 @@
 use crate::node::{Node, NodeType};
 use crate::tokenizer::TokenType;
 use crate::Css3;
+use cow_utils::CowUtils;
 use gosub_shared::errors::CssError;
 use gosub_shared::errors::CssResult;
 
@@ -74,7 +75,7 @@ impl Css3<'_> {
                 Ok(Some(node))
             }
             TokenType::Function(name) => {
-                let node = match name.to_ascii_lowercase().as_str() {
+                let node = match name.cow_to_ascii_lowercase().as_ref() {
                     "calc" => self.parse_calc()?,
                     "url" => {
                         self.tokenizer.reconsume();

--- a/crates/gosub_html5/src/parser.rs
+++ b/crates/gosub_html5/src/parser.rs
@@ -2616,8 +2616,7 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
             {
                 if ["h1", "h2", "h3", "h4", "h5", "h6"]
                     .iter()
-                    .map(|tag| self.is_in_scope(tag, HTML_NAMESPACE, Scope::Regular))
-                    .any(|res| res)
+                    .any(|tag| self.is_in_scope(tag, HTML_NAMESPACE, Scope::Regular))
                 {
                     self.generate_implied_end_tags(Some(name), false);
 


### PR DESCRIPTION
part of #761 

https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_methods

If this PR can be merged, I will continue to use more cow methods in clippy.