### PR TITLE
ci: expand the scope of clippy for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-cargo-target-${{ matrix.rust_version }}-
       - name: Run Clippy
-        run: cargo clippy --all --tests -- -D warnings
+        run: cargo clippy --all --all-targets -- -D warnings
 
   fmt:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
close: #764 

related: https://stackoverflow.com/questions/79365791/difference-between-cargo-clippy-all-fix-allow-dirty-allow-staged-and

If in examples/html5 parser.rs, add `let x='a';`,you will find an error message for `make fix-format`, but no error message for `cargo clippy --all --tests -- -D warnings` in ci. Now change it to include `examples`.