### PR TITLE
small fixes in css3 for the type generator

### DIFF
--- a/crates/gosub_css3/src/matcher.rs
+++ b/crates/gosub_css3/src/matcher.rs
@@ -1,6 +1,6 @@
 pub mod property_definitions;
 pub mod shorthands;
 pub mod styling;
-mod syntax;
+pub mod syntax;
 mod syntax_matcher;
 mod walker;

--- a/crates/gosub_css3/src/matcher/property_definitions.rs
+++ b/crates/gosub_css3/src/matcher/property_definitions.rs
@@ -314,7 +314,7 @@ impl CssDefinitions {
 
                 SyntaxComponent::Group {
                     components: resolved_components,
-                    combinator: combinator.clone(),
+                    combinator: *combinator,
                     multipliers: multipliers.clone(),
                 }
             }

--- a/crates/gosub_css3/src/matcher/syntax.rs
+++ b/crates/gosub_css3/src/matcher/syntax.rs
@@ -30,7 +30,7 @@ pub struct Group {
 }
 
 #[allow(dead_code)]
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone, Copy)]
 pub enum GroupCombinators {
     /// All elements must be matched in order (space delimited)
     Juxtaposition,
@@ -43,7 +43,7 @@ pub enum GroupCombinators {
 }
 
 /// Multiplier for a syntax component that defines how many times this component is allowed to appear
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone, Copy)]
 pub enum SyntaxComponentMultiplier {
     /// Default case
     Once,
@@ -78,7 +78,7 @@ impl Display for SyntaxComponentMultiplier {
 }
 
 /// Represent either a number (i64) or infinity
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 enum NumberOrInfinity {
     /// Nothing defined (no min or max)
     None,
@@ -91,7 +91,7 @@ enum NumberOrInfinity {
 }
 
 /// Represents an optional min and/or max range for a type definition
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Copy)]
 pub struct RangeType {
     /// Mininum value
     min: NumberOrInfinity,


### PR DESCRIPTION
This are some slight fixes for the css typegen

- make the matcher::syntax public
- implement copy for some enums