### PR TITLE
allow css definitions to be used without being resolved

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,7 +1402,7 @@ checksum = "6b5fcb214137f01bc842c4fd633236255c51f8a24c6d3923eb8361c6d0940737"
 dependencies = [
  "bytemuck",
  "fontconfig-cache-parser",
- "hashbrown",
+ "hashbrown 0.15.2",
  "icu_locid",
  "memmap2",
  "objc2-core-foundation",
@@ -1971,13 +1971,14 @@ dependencies = [
 
 [[package]]
 name = "gosub_css3"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "colors-transform",
  "cow-utils",
  "gosub_interface",
  "gosub_shared",
+ "indexmap 1.9.3",
  "itertools 0.14.0",
  "lazy_static",
  "log",
@@ -2327,7 +2328,7 @@ checksum = "dcf29e94d6d243368b7a56caa16bc213e4f9f8ed38c4d9557069527b5d5281ca"
 dependencies = [
  "bitflags 2.9.0",
  "gpu-descriptor-types",
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -2491,6 +2492,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
@@ -2506,7 +2513,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -2835,12 +2842,22 @@ checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -3259,7 +3276,7 @@ dependencies = [
  "cfg_aliases 0.1.1",
  "codespan-reporting",
  "hexf-parse",
- "indexmap",
+ "indexmap 2.7.1",
  "log",
  "rustc-hash",
  "spirv",
@@ -3841,7 +3858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d1c2b33b240c246f06cfceac48dc6c96040cb177d2aa5348899982b298b5577"
 dependencies = [
  "fontique",
- "hashbrown",
+ "hashbrown 0.15.2",
  "peniko",
  "skrifa 0.26.6",
  "swash",
@@ -4666,7 +4683,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.1",
  "itoa",
  "memchr",
  "ryu",
@@ -5225,7 +5242,7 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5905,7 +5922,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cfg_aliases 0.1.1",
  "document-features",
- "indexmap",
+ "indexmap 2.7.1",
  "log",
  "naga",
  "once_cell",

--- a/crates/gosub_css3/Cargo.toml
+++ b/crates/gosub_css3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gosub_css3"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Gosub Community <info@gosub.io>"]
 license = "MIT"
@@ -21,3 +21,8 @@ serde_json = "1.0.137"
 thiserror = "2.0.11"
 nom = "8.0.0"
 cow-utils = "0.1.3"
+indexmap = { version = "1.6.2", optional = true }
+
+[features]
+default = []
+unresolved_syntax = ["dep:indexmap"]

--- a/crates/gosub_css3/src/matcher/property_definitions.rs
+++ b/crates/gosub_css3/src/matcher/property_definitions.rs
@@ -144,7 +144,15 @@ pub struct SyntaxDefinition {
     /// Actual syntax
     pub syntax: CssSyntaxTree,
     /// True when the element has already been resolved
-    resolved: bool,
+    pub resolved: bool,
+    pub ty: SyntaxType,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SyntaxType {
+    Quoted,
+    Definition,
+    None,
 }
 
 /// Defines a list of CSS properties and its syntax.
@@ -433,13 +441,16 @@ fn parse_syntax_file<M: Map<String, SyntaxDefinition>>(json: serde_json::Value) 
         match CssSyntax::new(entry.get("syntax").unwrap().as_str().unwrap()).compile() {
             Ok(ast) => {
                 let mut name = entry.get("name").unwrap().to_string();
+                let mut ty = SyntaxType::None;
 
                 if name.starts_with('"') {
                     name = name[1..].to_string();
+                    ty = SyntaxType::Quoted;
                 }
 
                 if name.starts_with('<') {
                     name = name[1..].to_string();
+                    ty = SyntaxType::Definition;
                 }
 
                 if name.ends_with('"') {
@@ -456,6 +467,7 @@ fn parse_syntax_file<M: Map<String, SyntaxDefinition>>(json: serde_json::Value) 
                         // name,
                         syntax: ast.clone(),
                         resolved: false,
+                        ty,
                     },
                 );
             }


### PR DESCRIPTION
This is needed for the css-typegen because we don't want to use resolved values as this bloats the css types very much