### PR TITLE
Fixed css syntax where literals where parsed as tokens

### DIFF
--- a/crates/gosub_css3/resources/definitions/definitions.json
+++ b/crates/gosub_css3/resources/definitions/definitions.json
@@ -1,10 +1,327 @@
 {
   "properties": [
     {
-      "name": "border-clip-top",
-      "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
+      "name": "-webkit-align-content",
+      "syntax": "",
       "computed": [],
-      "initial": "normal",
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-align-items",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-align-self",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-animation",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-animation-delay",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-animation-direction",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-animation-duration",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-animation-fill-mode",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-animation-iteration-count",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-animation-name",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-animation-play-state",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-animation-timing-function",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-appearance",
+      "syntax": "",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "noneButOverriddenInUserAgentCSS",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-backface-visibility",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-background-clip",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-background-origin",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-background-size",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-bottom-left-radius",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-bottom-right-radius",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-radius",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-top-left-radius",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-top-right-radius",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-box-align",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-box-flex",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-box-ordinal-group",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-box-orient",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-box-pack",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-box-shadow",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-box-sizing",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-filter",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-flex",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-flex-basis",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-flex-direction",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-flex-flow",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-flex-grow",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-flex-shrink",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-flex-wrap",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-justify-content",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-mask",
+      "syntax": "",
+      "computed": [
+        "-webkit-mask-image",
+        "-webkit-mask-repeat",
+        "-webkit-mask-attachment",
+        "-webkit-mask-position",
+        "-webkit-mask-origin",
+        "-webkit-mask-clip"
+      ],
+      "initial": [
+        "-webkit-mask-image",
+        "-webkit-mask-repeat",
+        "-webkit-mask-attachment",
+        "-webkit-mask-position",
+        "-webkit-mask-origin",
+        "-webkit-mask-clip"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "-webkit-mask-box-image",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-mask-box-image-outset",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-mask-box-image-repeat",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-mask-box-image-slice",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-mask-box-image-source",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
       "inherited": false
     },
     {
@@ -12,6 +329,24 @@
       "syntax": "",
       "computed": [],
       "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-mask-clip",
+      "syntax": "",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "border",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-mask-composite",
+      "syntax": "",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "source-over",
       "inherited": false
     },
     {
@@ -24,50 +359,231 @@
       "inherited": false
     },
     {
-      "name": "object-fit",
-      "syntax": "fill | contain | cover | none | scale-down",
+      "name": "-webkit-mask-origin",
+      "syntax": "",
       "computed": [
         "asSpecified"
       ],
-      "initial": "fill",
+      "initial": "padding",
       "inherited": false
     },
     {
-      "name": "outline",
-      "syntax": "[ <'outline-width'> || <'outline-style'> || <'outline-color'> ]",
+      "name": "-webkit-mask-position",
+      "syntax": "",
       "computed": [
-        "outline-color",
-        "outline-width",
-        "outline-style"
+        "absoluteLengthOrPercentage"
       ],
-      "initial": [
-        "outline-color",
-        "outline-style",
-        "outline-width"
-      ],
+      "initial": "0% 0%",
       "inherited": false
     },
     {
-      "name": "white-space",
-      "syntax": "normal | pre | nowrap | pre-wrap | break-spaces | pre-line",
+      "name": "-webkit-mask-repeat",
+      "syntax": "",
       "computed": [
         "asSpecified"
       ],
-      "initial": "normal",
+      "initial": "repeat",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-mask-size",
+      "syntax": "",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto auto",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-order",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-perspective",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-perspective-origin",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-text-fill-color",
+      "syntax": "<color>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
       "inherited": true
     },
     {
-      "name": "text-indent",
-      "syntax": "[ <length-percentage> ] && hanging? && each-line?",
+      "name": "-webkit-text-size-adjust",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-text-stroke",
+      "syntax": "<line-width> || <color>",
       "computed": [
-        "percentageOrAbsoluteLengthPlusKeywords"
+        "-webkit-text-stroke-width",
+        "-webkit-text-stroke-color"
+      ],
+      "initial": [
+        "-webkit-text-stroke-width",
+        "-webkit-text-stroke-color"
+      ],
+      "inherited": true
+    },
+    {
+      "name": "-webkit-text-stroke-color",
+      "syntax": "<color>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
+      "inherited": true
+    },
+    {
+      "name": "-webkit-text-stroke-width",
+      "syntax": "<line-width>",
+      "computed": [
+        "absoluteLength"
       ],
       "initial": "0",
       "inherited": true
     },
     {
-      "name": "column-span",
-      "syntax": "none | all",
+      "name": "-webkit-transform",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-transform-origin",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-transform-style",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-transition",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-transition-delay",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-transition-duration",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-transition-property",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-transition-timing-function",
+      "syntax": "",
+      "computed": [],
+      "initial": "",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-user-select",
+      "syntax": "",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "accent-color",
+      "syntax": "auto | <color>",
+      "computed": [
+        "asAutoOrColor"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "align-content",
+      "syntax": "normal | <baseline-position> | <content-distribution> | <overflow-position>? <content-position>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "align-items",
+      "syntax": "normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ] | anchor-center",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "align-self",
+      "syntax": "auto | normal | stretch | <baseline-position> | <overflow-position>? <self-position> | anchor-center",
+      "computed": [
+        "autoOnAbsolutelyPositionedElementsValueOfAlignItemsOnParent"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "alignment-baseline",
+      "syntax": "baseline | text-bottom | alphabetic | ideographic | middle | central | mathematical | text-top",
+      "computed": [
+        "theSpecifiedKeyword"
+      ],
+      "initial": "baseline",
+      "inherited": false
+    },
+    {
+      "name": "all",
+      "syntax": "initial | inherit | unset | revert | revert-layer",
+      "computed": [
+        "asSpecifiedAppliesToEachProperty"
+      ],
+      "initial": "noPracticalInitialValue",
+      "inherited": false
+    },
+    {
+      "name": "anchor-name",
+      "syntax": "none | <dashed-ident>#",
       "computed": [
         "asSpecified"
       ],
@@ -75,36 +591,1127 @@
       "inherited": false
     },
     {
-      "name": "shape-rendering",
-      "syntax": "auto | optimizeSpeed | crispEdges | geometricPrecision",
-      "computed": [],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "shape-outside",
-      "syntax": "none | [ <basic-shape> || <shape-box> ] | <image>",
+      "name": "anchor-scope",
+      "syntax": "none | all | <dashed-ident>#",
       "computed": [
-        "asDefinedForBasicShapeWithAbsoluteURIOtherwiseAsSpecified"
+        "asSpecified"
       ],
       "initial": "none",
       "inherited": false
     },
     {
-      "name": "min-height",
-      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()>",
+      "name": "animation",
+      "syntax": "<single-animation>#",
       "computed": [
-        "percentageAsSpecifiedOrAbsoluteLength"
+        "animation-name",
+        "animation-duration",
+        "animation-timing-function",
+        "animation-delay",
+        "animation-direction",
+        "animation-iteration-count",
+        "animation-fill-mode",
+        "animation-play-state",
+        "animation-timeline"
+      ],
+      "initial": [
+        "animation-name",
+        "animation-duration",
+        "animation-timing-function",
+        "animation-delay",
+        "animation-iteration-count",
+        "animation-direction",
+        "animation-fill-mode",
+        "animation-play-state",
+        "animation-timeline"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "animation-delay",
+      "syntax": "<time>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0s",
+      "inherited": false
+    },
+    {
+      "name": "animation-direction",
+      "syntax": "<single-animation-direction>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "animation-duration",
+      "syntax": "<time [0s,∞]>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0s",
+      "inherited": false
+    },
+    {
+      "name": "animation-fill-mode",
+      "syntax": "<single-animation-fill-mode>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "animation-iteration-count",
+      "syntax": "<single-animation-iteration-count>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "1",
+      "inherited": false
+    },
+    {
+      "name": "animation-name",
+      "syntax": "[ none | <keyframes-name> ]#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "animation-play-state",
+      "syntax": "<single-animation-play-state>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "running",
+      "inherited": false
+    },
+    {
+      "name": "animation-range",
+      "syntax": "[ <'animation-range-start'> <'animation-range-end'>? ]#",
+      "computed": [
+        "animation-range-start",
+        "animation-range-end"
+      ],
+      "initial": [
+        "animation-range-start",
+        "animation-range-end"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "animation-range-end",
+      "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+      "computed": [
+        "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "animation-range-start",
+      "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+      "computed": [
+        "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "animation-timing-function",
+      "syntax": "<easing-function>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "ease",
+      "inherited": false
+    },
+    {
+      "name": "appearance",
+      "syntax": "none | auto | base | <compat-auto> | <compat-special> | base",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "background",
+      "syntax": "<bg-layer>#? , <final-bg-layer>",
+      "computed": [
+        "background-image",
+        "background-position",
+        "background-size",
+        "background-repeat",
+        "background-origin",
+        "background-clip",
+        "background-attachment",
+        "background-color"
+      ],
+      "initial": [
+        "background-image",
+        "background-position",
+        "background-size",
+        "background-repeat",
+        "background-origin",
+        "background-clip",
+        "background-attachment",
+        "background-color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "background-attachment",
+      "syntax": "<attachment>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "scroll",
+      "inherited": false
+    },
+    {
+      "name": "background-blend-mode",
+      "syntax": "<mix-blend-mode>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "background-clip",
+      "syntax": "<visual-box>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "border-box",
+      "inherited": false
+    },
+    {
+      "name": "background-color",
+      "syntax": "<color>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "transparent",
+      "inherited": false
+    },
+    {
+      "name": "background-image",
+      "syntax": "<bg-image>#",
+      "computed": [
+        "asSpecifiedURLsAbsolute"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "background-origin",
+      "syntax": "<visual-box>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "padding-box",
+      "inherited": false
+    },
+    {
+      "name": "background-position",
+      "syntax": "<bg-position>#",
+      "computed": [
+        "background-position-x",
+        "background-position-y"
+      ],
+      "initial": "0% 0%",
+      "inherited": false
+    },
+    {
+      "name": "background-repeat",
+      "syntax": "<repeat-style>#",
+      "computed": [
+        "listEachItemHasTwoKeywordsOnePerDimension"
+      ],
+      "initial": "repeat",
+      "inherited": false
+    },
+    {
+      "name": "background-size",
+      "syntax": "<bg-size>#",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "auto auto",
+      "inherited": false
+    },
+    {
+      "name": "baseline-shift",
+      "syntax": "<length-percentage> | sub | super | top | center | bottom",
+      "computed": [
+        "theSpecifiedKeywordOrAComputedLengthPercentageValue"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "baseline-source",
+      "syntax": "auto | first | last",
+      "computed": [],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "block-size",
+      "syntax": "<'width'>",
+      "computed": [
+        "sameAsWidthAndHeight"
       ],
       "initial": "auto",
       "inherited": false
     },
     {
-      "name": "fill-rule",
-      "syntax": "nonzero | evenodd",
+      "name": "block-step",
+      "syntax": "<'block-step-size'> || <'block-step-insert'> || <'block-step-align'> || <'block-step-round'>",
       "computed": [],
-      "initial": "nonzero",
+      "initial": "see individual properties",
+      "inherited": false
+    },
+    {
+      "name": "block-step-align",
+      "syntax": "auto | center | start | end",
+      "computed": [],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "block-step-insert",
+      "syntax": "margin-box | padding-box | content-box",
+      "computed": [],
+      "initial": "margin-box",
+      "inherited": false
+    },
+    {
+      "name": "block-step-round",
+      "syntax": "up | down | nearest",
+      "computed": [],
+      "initial": "up",
+      "inherited": false
+    },
+    {
+      "name": "block-step-size",
+      "syntax": "none | <length [0,∞]>",
+      "computed": [],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "bookmark-label",
+      "syntax": "<content-list>",
+      "computed": [],
+      "initial": "content(text)",
+      "inherited": false
+    },
+    {
+      "name": "bookmark-level",
+      "syntax": "none | <integer [1,∞]>",
+      "computed": [],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "bookmark-state",
+      "syntax": "open | closed",
+      "computed": [],
+      "initial": "open",
+      "inherited": false
+    },
+    {
+      "name": "border",
+      "syntax": "<line-width> || <line-style> || <color>",
+      "computed": [
+        "border-width",
+        "border-style",
+        "border-color"
+      ],
+      "initial": [
+        "border-width",
+        "border-style",
+        "border-color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "border-block",
+      "syntax": "<'border-block-start'>",
+      "computed": [
+        "border-block-width",
+        "border-block-style",
+        "border-block-color"
+      ],
+      "initial": [
+        "border-block-width",
+        "border-block-style",
+        "border-block-color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "border-block-color",
+      "syntax": "<'border-top-color'>{1,2}",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
+      "inherited": false
+    },
+    {
+      "name": "border-block-end",
+      "syntax": "<line-width> || <line-style> || <color>",
+      "computed": [
+        "border-top-width",
+        "border-top-style",
+        "border-top-color"
+      ],
+      "initial": [
+        "border-top-width",
+        "border-top-style",
+        "border-top-color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "border-block-end-color",
+      "syntax": "<color> | <image-1D>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
+      "inherited": false
+    },
+    {
+      "name": "border-block-end-radius",
+      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
+      "computed": [],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "border-block-end-style",
+      "syntax": "<line-style>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "border-block-end-width",
+      "syntax": "<line-width>",
+      "computed": [
+        "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+      ],
+      "initial": "medium",
+      "inherited": false
+    },
+    {
+      "name": "border-block-start",
+      "syntax": "<line-width> || <line-style> || <color>",
+      "computed": [
+        "border-width",
+        "border-style",
+        "border-block-start-color"
+      ],
+      "initial": [
+        "border-width",
+        "border-style",
+        "color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "border-block-start-color",
+      "syntax": "<color> | <image-1D>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
+      "inherited": false
+    },
+    {
+      "name": "border-block-start-radius",
+      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
+      "computed": [],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "border-block-start-style",
+      "syntax": "<line-style>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "border-block-start-width",
+      "syntax": "<line-width>",
+      "computed": [
+        "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+      ],
+      "initial": "medium",
+      "inherited": false
+    },
+    {
+      "name": "border-block-style",
+      "syntax": "<'border-top-style'>{1,2}",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "border-block-width",
+      "syntax": "<'border-top-width'>{1,2}",
+      "computed": [
+        "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+      ],
+      "initial": "medium",
+      "inherited": false
+    },
+    {
+      "name": "border-bottom",
+      "syntax": "<line-width> || <line-style> || <color>",
+      "computed": [
+        "border-bottom-width",
+        "border-bottom-style",
+        "border-bottom-color"
+      ],
+      "initial": [
+        "border-bottom-width",
+        "border-bottom-style",
+        "border-bottom-color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "border-bottom-color",
+      "syntax": "<color> | <image-1D>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
+      "inherited": false
+    },
+    {
+      "name": "border-bottom-left-radius",
+      "syntax": "<length-percentage [0,∞]>{1,2}",
+      "computed": [
+        "twoAbsoluteLengthOrPercentages"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "border-bottom-radius",
+      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
+      "computed": [],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "border-bottom-right-radius",
+      "syntax": "<length-percentage [0,∞]>{1,2}",
+      "computed": [
+        "twoAbsoluteLengthOrPercentages"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "border-bottom-style",
+      "syntax": "<line-style>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "border-bottom-width",
+      "syntax": "<line-width>",
+      "computed": [
+        "absoluteLengthOr0IfBorderBottomStyleNoneOrHidden"
+      ],
+      "initial": "medium",
+      "inherited": false
+    },
+    {
+      "name": "border-boundary",
+      "syntax": "none | parent | display",
+      "computed": [],
+      "initial": "none",
       "inherited": true
+    },
+    {
+      "name": "border-clip",
+      "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
+      "computed": [],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "border-clip-bottom",
+      "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
+      "computed": [],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "border-clip-left",
+      "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
+      "computed": [],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "border-clip-right",
+      "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
+      "computed": [],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "border-clip-top",
+      "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
+      "computed": [],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "border-collapse",
+      "syntax": "separate | collapse",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "separate",
+      "inherited": true
+    },
+    {
+      "name": "border-color",
+      "syntax": "[ <color> | <image-1D> ]{1,4}",
+      "computed": [
+        "border-bottom-color",
+        "border-left-color",
+        "border-right-color",
+        "border-top-color"
+      ],
+      "initial": [
+        "border-top-color",
+        "border-right-color",
+        "border-bottom-color",
+        "border-left-color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "border-end-end-radius",
+      "syntax": "<length-percentage [0,∞]>{1,2}",
+      "computed": [
+        "twoAbsoluteLengthOrPercentages"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "border-end-start-radius",
+      "syntax": "<length-percentage [0,∞]>{1,2}",
+      "computed": [
+        "twoAbsoluteLengthOrPercentages"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "border-image",
+      "syntax": "<'border-image-source'> || <'border-image-slice'> [ / <'border-image-width'> | / <'border-image-width'>? / <'border-image-outset'> ]? || <'border-image-repeat'>",
+      "computed": [
+        "border-image-outset",
+        "border-image-repeat",
+        "border-image-slice",
+        "border-image-source",
+        "border-image-width"
+      ],
+      "initial": [
+        "border-image-source",
+        "border-image-slice",
+        "border-image-width",
+        "border-image-outset",
+        "border-image-repeat"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "border-image-outset",
+      "syntax": "[ <length [0,∞]> | <number [0,∞]> ]{1,4}",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "border-image-repeat",
+      "syntax": "[ stretch | repeat | round | space ]{1,2}",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "stretch",
+      "inherited": false
+    },
+    {
+      "name": "border-image-slice",
+      "syntax": "[<number [0,∞]> | <percentage [0,∞]>]{1,4} && fill?",
+      "computed": [
+        "oneToFourPercentagesOrAbsoluteLengthsPlusFill"
+      ],
+      "initial": "100%",
+      "inherited": false
+    },
+    {
+      "name": "border-image-source",
+      "syntax": "none | <image>",
+      "computed": [
+        "noneOrImageWithAbsoluteURI"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "border-image-width",
+      "syntax": "[ <length-percentage [0,∞]> | <number [0,∞]> | auto ]{1,4}",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "1",
+      "inherited": false
+    },
+    {
+      "name": "border-inline",
+      "syntax": "<'border-block-start'>",
+      "computed": [
+        "border-inline-width",
+        "border-inline-style",
+        "border-inline-color"
+      ],
+      "initial": [
+        "border-inline-width",
+        "border-inline-style",
+        "border-inline-color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "border-inline-color",
+      "syntax": "<'border-top-color'>{1,2}",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
+      "inherited": false
+    },
+    {
+      "name": "border-inline-end",
+      "syntax": "<line-width> || <line-style> || <color>",
+      "computed": [
+        "border-width",
+        "border-style",
+        "border-inline-end-color"
+      ],
+      "initial": [
+        "border-width",
+        "border-style",
+        "color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "border-inline-end-color",
+      "syntax": "<color> | <image-1D>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
+      "inherited": false
+    },
+    {
+      "name": "border-inline-end-radius",
+      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
+      "computed": [],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "border-inline-end-style",
+      "syntax": "<line-style>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "border-inline-end-width",
+      "syntax": "<line-width>",
+      "computed": [
+        "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+      ],
+      "initial": "medium",
+      "inherited": false
+    },
+    {
+      "name": "border-inline-start",
+      "syntax": "<line-width> || <line-style> || <color>",
+      "computed": [
+        "border-width",
+        "border-style",
+        "border-inline-start-color"
+      ],
+      "initial": [
+        "border-width",
+        "border-style",
+        "color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "border-inline-start-color",
+      "syntax": "<color> | <image-1D>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
+      "inherited": false
+    },
+    {
+      "name": "border-inline-start-radius",
+      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
+      "computed": [],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "border-inline-start-style",
+      "syntax": "<line-style>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "border-inline-start-width",
+      "syntax": "<line-width>",
+      "computed": [
+        "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+      ],
+      "initial": "medium",
+      "inherited": false
+    },
+    {
+      "name": "border-inline-style",
+      "syntax": "<'border-top-style'>{1,2}",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "border-inline-width",
+      "syntax": "<'border-top-width'>{1,2}",
+      "computed": [
+        "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+      ],
+      "initial": "medium",
+      "inherited": false
+    },
+    {
+      "name": "border-left",
+      "syntax": "<line-width> || <line-style> || <color>",
+      "computed": [
+        "border-left-width",
+        "border-left-style",
+        "border-left-color"
+      ],
+      "initial": [
+        "border-left-width",
+        "border-left-style",
+        "border-left-color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "border-left-color",
+      "syntax": "<color> | <image-1D>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
+      "inherited": false
+    },
+    {
+      "name": "border-left-radius",
+      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
+      "computed": [],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "border-left-style",
+      "syntax": "<line-style>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "border-left-width",
+      "syntax": "<line-width>",
+      "computed": [
+        "absoluteLengthOr0IfBorderLeftStyleNoneOrHidden"
+      ],
+      "initial": "medium",
+      "inherited": false
+    },
+    {
+      "name": "border-limit",
+      "syntax": "all | [ sides | corners ] <length-percentage [0,∞]>? | [ top | right | bottom | left ] <length-percentage [0,∞]>",
+      "computed": [],
+      "initial": "all",
+      "inherited": false
+    },
+    {
+      "name": "border-radius",
+      "syntax": "<length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?",
+      "computed": [
+        "border-bottom-left-radius",
+        "border-bottom-right-radius",
+        "border-top-left-radius",
+        "border-top-right-radius"
+      ],
+      "initial": [
+        "border-top-left-radius",
+        "border-top-right-radius",
+        "border-bottom-right-radius",
+        "border-bottom-left-radius"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "border-right",
+      "syntax": "<line-width> || <line-style> || <color>",
+      "computed": [
+        "border-right-width",
+        "border-right-style",
+        "border-right-color"
+      ],
+      "initial": [
+        "border-right-width",
+        "border-right-style",
+        "border-right-color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "border-right-color",
+      "syntax": "<color> | <image-1D>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
+      "inherited": false
+    },
+    {
+      "name": "border-right-radius",
+      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
+      "computed": [],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "border-right-style",
+      "syntax": "<line-style>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "border-right-width",
+      "syntax": "<line-width>",
+      "computed": [
+        "absoluteLengthOr0IfBorderRightStyleNoneOrHidden"
+      ],
+      "initial": "medium",
+      "inherited": false
+    },
+    {
+      "name": "border-shape",
+      "syntax": "none | [ <basic-shape> <geometry-box>?]{1,2}",
+      "computed": [],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "border-spacing",
+      "syntax": "<length>{1,2}",
+      "computed": [
+        "twoAbsoluteLengths"
+      ],
+      "initial": "0",
+      "inherited": true
+    },
+    {
+      "name": "border-start-end-radius",
+      "syntax": "<length-percentage [0,∞]>{1,2}",
+      "computed": [
+        "twoAbsoluteLengthOrPercentages"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "border-start-start-radius",
+      "syntax": "<length-percentage [0,∞]>{1,2}",
+      "computed": [
+        "twoAbsoluteLengthOrPercentages"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "border-style",
+      "syntax": "<line-style>{1,4}",
+      "computed": [
+        "border-bottom-style",
+        "border-left-style",
+        "border-right-style",
+        "border-top-style"
+      ],
+      "initial": [
+        "border-top-style",
+        "border-right-style",
+        "border-bottom-style",
+        "border-left-style"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "border-top",
+      "syntax": "<line-width> || <line-style> || <color>",
+      "computed": [
+        "border-top-width",
+        "border-top-style",
+        "border-top-color"
+      ],
+      "initial": [
+        "border-top-width",
+        "border-top-style",
+        "border-top-color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "border-top-color",
+      "syntax": "<color> | <image-1D>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
+      "inherited": false
+    },
+    {
+      "name": "border-top-left-radius",
+      "syntax": "<length-percentage [0,∞]>{1,2}",
+      "computed": [
+        "twoAbsoluteLengthOrPercentages"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "border-top-radius",
+      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
+      "computed": [],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "border-top-right-radius",
+      "syntax": "<length-percentage [0,∞]>{1,2}",
+      "computed": [
+        "twoAbsoluteLengthOrPercentages"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "border-top-style",
+      "syntax": "<line-style>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "border-top-width",
+      "syntax": "<line-width>",
+      "computed": [
+        "absoluteLengthOr0IfBorderTopStyleNoneOrHidden"
+      ],
+      "initial": "medium",
+      "inherited": false
+    },
+    {
+      "name": "border-width",
+      "syntax": "<line-width>{1,4}",
+      "computed": [
+        "border-bottom-width",
+        "border-left-width",
+        "border-right-width",
+        "border-top-width"
+      ],
+      "initial": [
+        "border-top-width",
+        "border-right-width",
+        "border-bottom-width",
+        "border-left-width"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "bottom",
+      "syntax": "auto | <length-percentage> | <anchor()> | <anchor-size()>",
+      "computed": [
+        "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "box-decoration-break",
+      "syntax": "slice | clone",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "slice",
+      "inherited": false
     },
     {
       "name": "box-shadow",
@@ -116,36 +1723,133 @@
       "inherited": false
     },
     {
-      "name": "dominant-baseline",
-      "syntax": "auto | text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top",
+      "name": "box-shadow-blur",
+      "syntax": "<length [0,∞]>#",
       "computed": [],
-      "initial": "auto",
-      "inherited": true
+      "initial": "0",
+      "inherited": false
     },
     {
-      "name": "stroke-dash-justify",
-      "syntax": "none | [ stretch | compress ] || [ dashes || gaps ]",
+      "name": "box-shadow-color",
+      "syntax": "<color>#",
+      "computed": [],
+      "initial": "currentcolor",
+      "inherited": false
+    },
+    {
+      "name": "box-shadow-offset",
+      "syntax": "[ none | <length>{2} ]#",
+      "computed": [],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "box-shadow-position",
+      "syntax": "[ outset | inset ]#",
+      "computed": [],
+      "initial": "outset",
+      "inherited": false
+    },
+    {
+      "name": "box-shadow-spread",
+      "syntax": "<length>#",
+      "computed": [],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "box-sizing",
+      "syntax": "content-box | border-box",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "content-box",
+      "inherited": false
+    },
+    {
+      "name": "box-snap",
+      "syntax": "none | block-start | block-end | center | baseline | last-baseline",
       "computed": [],
       "initial": "none",
       "inherited": true
     },
     {
-      "name": "stroke-opacity",
-      "syntax": "<'opacity'>",
-      "computed": [],
-      "initial": "1",
+      "name": "break-after",
+      "syntax": "auto | avoid | always | all | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "break-before",
+      "syntax": "auto | avoid | always | all | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "break-inside",
+      "syntax": "auto | avoid | avoid-page | avoid-column | avoid-region",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "caption-side",
+      "syntax": "top | bottom",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "top",
       "inherited": true
     },
     {
-      "name": "speak-as",
-      "syntax": "normal | spell-out || digits || [ literal-punctuation | no-punctuation ]",
-      "computed": [],
-      "initial": "normal",
+      "name": "caret",
+      "syntax": "<'caret-color'> || <'caret-animation'> || <'caret-shape'>",
+      "computed": [
+        "caret-color",
+        "caret-shape"
+      ],
+      "initial": [
+        "caret-color",
+        "caret-shape"
+      ],
       "inherited": true
     },
     {
-      "name": "column-rule-style",
-      "syntax": "<line-style>",
+      "name": "caret-animation",
+      "syntax": "auto | manual",
+      "computed": [],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "caret-color",
+      "syntax": "auto | <color>",
+      "computed": [
+        "asAutoOrColor"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "caret-shape",
+      "syntax": "auto | bar | block | underscore",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "clear",
+      "syntax": "inline-start | inline-end | block-start | block-end | left | right | top | bottom | both-inline | both-block | both | none",
       "computed": [
         "asSpecified"
       ],
@@ -153,19 +1857,393 @@
       "inherited": false
     },
     {
-      "name": "float-defer",
-      "syntax": "<integer> | last | none",
+      "name": "clip",
+      "syntax": "<rect()> | auto",
+      "computed": [
+        "autoOrRectangle"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "clip-path",
+      "syntax": "<clip-source> | [ <basic-shape> || <geometry-box> ] | none",
+      "computed": [
+        "asSpecifiedURLsAbsolute"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "clip-rule",
+      "syntax": "nonzero | evenodd",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "nonzero",
+      "inherited": true
+    },
+    {
+      "name": "color",
+      "syntax": "<color>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "canvastext",
+      "inherited": true
+    },
+    {
+      "name": "color-adjust",
+      "syntax": "<'print-color-adjust'>",
+      "computed": [],
+      "initial": "see individual properties",
+      "inherited": false
+    },
+    {
+      "name": "color-interpolation",
+      "syntax": "auto | sRGB | linearRGB",
+      "computed": [],
+      "initial": "sRGB",
+      "inherited": true
+    },
+    {
+      "name": "color-interpolation-filters",
+      "syntax": "auto | sRGB | linearRGB",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "linearRGB",
+      "inherited": true
+    },
+    {
+      "name": "color-scheme",
+      "syntax": "normal | [ light | dark | <custom-ident> ]+ && only?",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "column-count",
+      "syntax": "auto | <integer [1,∞]>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "column-fill",
+      "syntax": "auto | balance | balance-all",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "balance",
+      "inherited": false
+    },
+    {
+      "name": "column-gap",
+      "syntax": "normal | <length-percentage [0,∞]>",
+      "computed": [
+        "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "column-height",
+      "syntax": "auto | <length [0,∞]>",
+      "computed": [],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "column-rule",
+      "syntax": "<gap-rule-list> | <gap-auto-rule-list>",
+      "computed": [
+        "column-rule-color",
+        "column-rule-style",
+        "column-rule-width"
+      ],
+      "initial": [
+        "column-rule-width",
+        "column-rule-style",
+        "column-rule-color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "column-rule-break",
+      "syntax": "none | spanning-item | intersection",
+      "computed": [],
+      "initial": "spanning-item",
+      "inherited": false
+    },
+    {
+      "name": "column-rule-color",
+      "syntax": "<line-color-list> | <auto-line-color-list>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
+      "inherited": false
+    },
+    {
+      "name": "column-rule-outset",
+      "syntax": "<length-percentage>",
+      "computed": [],
+      "initial": "50%",
+      "inherited": false
+    },
+    {
+      "name": "column-rule-style",
+      "syntax": "<line-style-list> | <auto-line-style-list>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "column-rule-width",
+      "syntax": "<line-width-list> | <auto-line-width-list>",
+      "computed": [
+        "absoluteLength0IfColumnRuleStyleNoneOrHidden"
+      ],
+      "initial": "medium",
+      "inherited": false
+    },
+    {
+      "name": "column-span",
+      "syntax": "none | <integer [1,∞]> | all | auto",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "column-width",
+      "syntax": "auto | <length [0,∞]> | min-content | max-content | fit-content(<length-percentage>)",
+      "computed": [
+        "absoluteLengthZeroOrLarger"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "column-wrap",
+      "syntax": "auto | nowrap | wrap",
+      "computed": [],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "columns",
+      "syntax": "<'column-width'> || <'column-count'> [ / <'column-height'> ]?",
+      "computed": [
+        "column-width",
+        "column-count"
+      ],
+      "initial": [
+        "column-width",
+        "column-count"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "contain",
+      "syntax": "none | strict | content | [ [size | inline-size] || layout || style || paint ]",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "content",
+      "syntax": "normal | none | [ <content-replacement> | <content-list> ] [/ [ <string> | <counter> | <attr()> ]+ ]? | <element()>",
+      "computed": [
+        "normalOnElementsForPseudosNoneAbsoluteURIStringOrAsSpecified"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "content-visibility",
+      "syntax": "visible | auto | hidden",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "visible",
+      "inherited": false
+    },
+    {
+      "name": "corner-block-end-shape",
+      "syntax": "<corner-shape-value>",
+      "computed": [],
+      "initial": "round",
+      "inherited": false
+    },
+    {
+      "name": "corner-block-start-shape",
+      "syntax": "<corner-shape-value>",
+      "computed": [],
+      "initial": "round",
+      "inherited": false
+    },
+    {
+      "name": "corner-bottom-left-shape",
+      "syntax": "<corner-shape-value>",
+      "computed": [],
+      "initial": "round",
+      "inherited": false
+    },
+    {
+      "name": "corner-bottom-right-shape",
+      "syntax": "<corner-shape-value>",
+      "computed": [],
+      "initial": "round",
+      "inherited": false
+    },
+    {
+      "name": "corner-bottom-shape",
+      "syntax": "<corner-shape-value>",
+      "computed": [],
+      "initial": "round",
+      "inherited": false
+    },
+    {
+      "name": "corner-end-end-shape",
+      "syntax": "<corner-shape-value>",
+      "computed": [],
+      "initial": "round",
+      "inherited": false
+    },
+    {
+      "name": "corner-end-start-shape",
+      "syntax": "<corner-shape-value>",
+      "computed": [],
+      "initial": "round",
+      "inherited": false
+    },
+    {
+      "name": "corner-inline-end-shape",
+      "syntax": "<corner-shape-value>",
+      "computed": [],
+      "initial": "round",
+      "inherited": false
+    },
+    {
+      "name": "corner-inline-start-shape",
+      "syntax": "<corner-shape-value>",
+      "computed": [],
+      "initial": "round",
+      "inherited": false
+    },
+    {
+      "name": "corner-left-shape",
+      "syntax": "<corner-shape-value>",
+      "computed": [],
+      "initial": "round",
+      "inherited": false
+    },
+    {
+      "name": "corner-right-shape",
+      "syntax": "<corner-shape-value>",
+      "computed": [],
+      "initial": "round",
+      "inherited": false
+    },
+    {
+      "name": "corner-shape",
+      "syntax": "<corner-shape-value>{1,4}",
+      "computed": [],
+      "initial": "round",
+      "inherited": false
+    },
+    {
+      "name": "corner-start-end-shape",
+      "syntax": "<corner-shape-value>",
+      "computed": [],
+      "initial": "round",
+      "inherited": false
+    },
+    {
+      "name": "corner-start-start-shape",
+      "syntax": "<corner-shape-value>",
+      "computed": [],
+      "initial": "round",
+      "inherited": false
+    },
+    {
+      "name": "corner-top-left-shape",
+      "syntax": "<corner-shape-value>",
+      "computed": [],
+      "initial": "round",
+      "inherited": false
+    },
+    {
+      "name": "corner-top-right-shape",
+      "syntax": "<corner-shape-value>",
+      "computed": [],
+      "initial": "round",
+      "inherited": false
+    },
+    {
+      "name": "corner-top-shape",
+      "syntax": "<corner-shape-value>",
+      "computed": [],
+      "initial": "round",
+      "inherited": false
+    },
+    {
+      "name": "counter-increment",
+      "syntax": "[ <counter-name> <integer>? ]+ | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "counter-reset",
+      "syntax": "[ <counter-name> <integer>? | <reversed-counter-name> <integer>? ]+ | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "counter-set",
+      "syntax": "[ <counter-name> <integer>? ]+ | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "cue",
+      "syntax": "<'cue-before'> <'cue-after'>?",
+      "computed": [],
+      "initial": "see individual properties",
+      "inherited": false
+    },
+    {
+      "name": "cue-after",
+      "syntax": "<uri> <decibel>? | none",
       "computed": [],
       "initial": "none",
       "inherited": false
     },
     {
-      "name": "right",
-      "syntax": "auto | <length-percentage>",
-      "computed": [
-        "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
-      ],
-      "initial": "auto",
+      "name": "cue-before",
+      "syntax": "<uri> <decibel>? | none",
+      "computed": [],
+      "initial": "none",
       "inherited": false
     },
     {
@@ -178,30 +2256,191 @@
       "inherited": true
     },
     {
-      "name": "grid-row-start",
-      "syntax": "<grid-line>",
+      "name": "cx",
+      "syntax": "<length-percentage>",
       "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "scroll-margin-top",
-      "syntax": "<length>",
-      "computed": [
-        "asSpecified"
+        "percentageAsSpecifiedOrAbsoluteLength"
       ],
       "initial": "0",
       "inherited": false
     },
     {
-      "name": "zoom",
-      "syntax": "<number [0,∞]> || <percentage [0,∞]>",
+      "name": "cy",
+      "syntax": "<length-percentage>",
+      "computed": [
+        "percentageAsSpecifiedOrAbsoluteLength"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "d",
+      "syntax": "none | <string>",
       "computed": [
         "asSpecified"
       ],
-      "initial": "normal",
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "direction",
+      "syntax": "ltr | rtl",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "ltr",
+      "inherited": true
+    },
+    {
+      "name": "display",
+      "syntax": "[ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy> | <display-outside> || [ <display-inside> | math ]",
+      "computed": [
+        "asSpecifiedExceptPositionedFloatingAndRootElementsKeywordMaybeDifferent"
+      ],
+      "initial": "inline",
+      "inherited": false
+    },
+    {
+      "name": "dominant-baseline",
+      "syntax": "auto | text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "dynamic-range-limit",
+      "syntax": "standard | no-limit | constrained-high | <dynamic-range-limit-mix()>",
+      "computed": [],
+      "initial": "no-limit",
+      "inherited": true
+    },
+    {
+      "name": "empty-cells",
+      "syntax": "show | hide",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "show",
+      "inherited": true
+    },
+    {
+      "name": "field-sizing",
+      "syntax": "fixed | content",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "fixed",
+      "inherited": false
+    },
+    {
+      "name": "fill",
+      "syntax": "<paint>",
+      "computed": [
+        "asColorOrAbsoluteURL"
+      ],
+      "initial": "black",
+      "inherited": true
+    },
+    {
+      "name": "fill-break",
+      "syntax": "bounding-box | slice | clone",
+      "computed": [],
+      "initial": "bounding-box",
+      "inherited": false
+    },
+    {
+      "name": "fill-color",
+      "syntax": "<color>",
+      "computed": [],
+      "initial": "currentcolor",
+      "inherited": true
+    },
+    {
+      "name": "fill-image",
+      "syntax": "<paint>#",
+      "computed": [],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "fill-opacity",
+      "syntax": "<'opacity'>",
+      "computed": [
+        "specifiedValueNumberClipped0To1"
+      ],
+      "initial": "1",
+      "inherited": true
+    },
+    {
+      "name": "fill-origin",
+      "syntax": "match-parent | fill-box | stroke-box | content-box | padding-box | border-box",
+      "computed": [],
+      "initial": "match-parent",
+      "inherited": false
+    },
+    {
+      "name": "fill-position",
+      "syntax": "<position>#",
+      "computed": [],
+      "initial": "0% 0%",
+      "inherited": true
+    },
+    {
+      "name": "fill-repeat",
+      "syntax": "<repeat-style>#",
+      "computed": [],
+      "initial": "repeat",
+      "inherited": true
+    },
+    {
+      "name": "fill-rule",
+      "syntax": "nonzero | evenodd",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "nonzero",
+      "inherited": true
+    },
+    {
+      "name": "fill-size",
+      "syntax": "<bg-size>#",
+      "computed": [],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "filter",
+      "syntax": "none | <filter-value-list>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "flex",
+      "syntax": "none | [ <'flex-grow'> <'flex-shrink'>? || <'flex-basis'> ]",
+      "computed": [
+        "flex-grow",
+        "flex-shrink",
+        "flex-basis"
+      ],
+      "initial": [
+        "flex-grow",
+        "flex-shrink",
+        "flex-basis"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "flex-basis",
+      "syntax": "content | <'width'>",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "auto",
       "inherited": false
     },
     {
@@ -227,3253 +2466,12 @@
       "inherited": false
     },
     {
-      "name": "offset-path",
-      "syntax": "none | <offset-path> || <coord-box>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "rest",
-      "syntax": "<'rest-before'> <'rest-after'>?",
-      "computed": [],
-      "initial": "N/A (see individual properties)",
-      "inherited": false
-    },
-    {
-      "name": "region-fragment",
-      "syntax": "auto | break",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "column-rule",
-      "syntax": "<'column-rule-width'> || <'column-rule-style'> || <'column-rule-color'>",
-      "computed": [
-        "column-rule-color",
-        "column-rule-style",
-        "column-rule-width"
-      ],
-      "initial": [
-        "column-rule-width",
-        "column-rule-style",
-        "column-rule-color"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "pause-before",
-      "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "stroke-origin",
-      "syntax": "match-parent | fill-box | stroke-box | content-box | padding-box | border-box",
-      "computed": [],
-      "initial": "match-parent",
-      "inherited": false
-    },
-    {
-      "name": "mask-size",
-      "syntax": "<bg-size>#",
-      "computed": [
-        "asSpecifiedRelativeToAbsoluteLengths"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
       "name": "flex-grow",
       "syntax": "<number [0,∞]>",
       "computed": [
         "asSpecified"
       ],
       "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "border-bottom-right-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2}",
-      "computed": [
-        "twoAbsoluteLengthOrPercentages"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "voice-range",
-      "syntax": "<frequency [0Hz,∞]> && absolute | [[x-low | low | medium | high | x-high] || [<frequency> | <semitones> | <percentage>]]",
-      "computed": [],
-      "initial": "medium",
-      "inherited": true
-    },
-    {
-      "name": "border-collapse",
-      "syntax": "separate | collapse",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "separate",
-      "inherited": true
-    },
-    {
-      "name": "overflow-y",
-      "syntax": "visible | hidden | clip | scroll | auto",
-      "computed": [
-        "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
-      ],
-      "initial": "visible",
-      "inherited": false
-    },
-    {
-      "name": "shape-margin",
-      "syntax": "<length-percentage [0,∞]>",
-      "computed": [
-        "asSpecifiedRelativeToAbsoluteLengths"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "overflow-wrap",
-      "syntax": "normal | break-word | anywhere",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "-webkit-text-stroke-color",
-      "syntax": "<color>",
-      "computed": [
-        "computedColor"
-      ],
-      "initial": "currentcolor",
-      "inherited": true
-    },
-    {
-      "name": "-webkit-transition-delay",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "text-anchor",
-      "syntax": "start | middle | end",
-      "computed": [],
-      "initial": "start",
-      "inherited": true
-    },
-    {
-      "name": "counter-set",
-      "syntax": "[ <counter-name> <integer>? ]+ | none",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "top",
-      "syntax": "auto | <length-percentage>",
-      "computed": [
-        "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "animation-range-end",
-      "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
-      "computed": [
-        "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage"
-      ],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "animation-direction",
-      "syntax": "<single-animation-direction>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "page-break-inside",
-      "syntax": "avoid | auto | inherit",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "place-content",
-      "syntax": "<'align-content'> <'justify-content'>?",
-      "computed": [
-        "align-content",
-        "justify-content"
-      ],
-      "initial": [
-        "align-content",
-        "justify-content"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "grid-column-start",
-      "syntax": "<grid-line>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "inline-sizing",
-      "syntax": "normal | stretch",
-      "computed": [],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "cue-after",
-      "syntax": "<uri> <decibel>? | none",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "view-transition-name",
-      "syntax": "none | <custom-ident>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-mask-box-image-slice",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "nav-right",
-      "syntax": "auto | <id> [ current | root | <target-name> ]?",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "margin-left",
-      "syntax": "<length-percentage> | auto",
-      "computed": [
-        "percentageAsSpecifiedOrAbsoluteLength"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "mask-position",
-      "syntax": "<position>#",
-      "computed": [
-        "consistsOfTwoKeywordsForOriginAndOffsets"
-      ],
-      "initial": "0% 0%",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-text-stroke",
-      "syntax": "<line-width> || <color>",
-      "computed": [
-        "-webkit-text-stroke-width",
-        "-webkit-text-stroke-color"
-      ],
-      "initial": [
-        "-webkit-text-stroke-width",
-        "-webkit-text-stroke-color"
-      ],
-      "inherited": true
-    },
-    {
-      "name": "flow-into",
-      "syntax": "none | <ident> [element | content]?",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "rx",
-      "syntax": "<length-percentage> | auto",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "filter",
-      "syntax": "none | <filter-value-list>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "outline-width",
-      "syntax": "<line-width>",
-      "computed": [
-        "absoluteLength0ForNone"
-      ],
-      "initial": "medium",
-      "inherited": false
-    },
-    {
-      "name": "fill-origin",
-      "syntax": "match-parent | fill-box | stroke-box | content-box | padding-box | border-box",
-      "computed": [],
-      "initial": "match-parent",
-      "inherited": false
-    },
-    {
-      "name": "isolation",
-      "syntax": "<isolation-mode>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "border-block-start-style",
-      "syntax": "<line-style>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "voice-stress",
-      "syntax": "normal | strong | moderate | none | reduced",
-      "computed": [],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "image-orientation",
-      "syntax": "from-image | none | [ <angle> || flip ]",
-      "computed": [
-        "angleRoundedToNextQuarter"
-      ],
-      "initial": "from-image",
-      "inherited": true
-    },
-    {
-      "name": "text-decoration-color",
-      "syntax": "<color>",
-      "computed": [
-        "computedColor"
-      ],
-      "initial": "currentcolor",
-      "inherited": false
-    },
-    {
-      "name": "padding-top",
-      "syntax": "<length-percentage [0,∞]>",
-      "computed": [
-        "percentageAsSpecifiedOrAbsoluteLength"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "border-top-color",
-      "syntax": "<color> | <image-1D>",
-      "computed": [
-        "computedColor"
-      ],
-      "initial": "currentcolor",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-mask-box-image-source",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "text-decoration-style",
-      "syntax": "solid | double | dotted | dashed | wavy",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "solid",
-      "inherited": false
-    },
-    {
-      "name": "animation-timing-function",
-      "syntax": "<easing-function>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "ease",
-      "inherited": false
-    },
-    {
-      "name": "border-block-end-width",
-      "syntax": "<line-width>",
-      "computed": [
-        "absoluteLengthZeroIfBorderStyleNoneOrHidden"
-      ],
-      "initial": "medium",
-      "inherited": false
-    },
-    {
-      "name": "list-style-type",
-      "syntax": "<counter-style> | <string> | none",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "disc",
-      "inherited": true
-    },
-    {
-      "name": "border-left",
-      "syntax": "<line-width> || <line-style> || <color>",
-      "computed": [
-        "border-left-width",
-        "border-left-style",
-        "border-left-color"
-      ],
-      "initial": [
-        "border-left-width",
-        "border-left-style",
-        "border-left-color"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "text-emphasis",
-      "syntax": "<'text-emphasis-style'> || <'text-emphasis-color'>",
-      "computed": [
-        "text-emphasis-style",
-        "text-emphasis-color"
-      ],
-      "initial": [
-        "text-emphasis-style",
-        "text-emphasis-color"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "color-interpolation-filters",
-      "syntax": "auto | sRGB | linearRGB",
-      "computed": [],
-      "initial": "linearRGB",
-      "inherited": true
-    },
-    {
-      "name": "nav-up",
-      "syntax": "auto | <id> [ current | root | <target-name> ]?",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-transition-property",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "voice-rate",
-      "syntax": "[normal | x-slow | slow | medium | fast | x-fast] || <percentage [0,∞]>",
-      "computed": [],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "scroll-padding-inline",
-      "syntax": "[ auto | <length-percentage [0,∞]> ]{1,2}",
-      "computed": [
-        "scroll-padding-inline-start",
-        "scroll-padding-inline-end"
-      ],
-      "initial": [
-        "scroll-padding-inline-start",
-        "scroll-padding-inline-end"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "scroll-margin-left",
-      "syntax": "<length>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "text-decoration",
-      "syntax": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'>",
-      "computed": [
-        "text-decoration-line",
-        "text-decoration-style",
-        "text-decoration-color",
-        "text-decoration-thickness"
-      ],
-      "initial": [
-        "text-decoration-color",
-        "text-decoration-style",
-        "text-decoration-line"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "line-snap",
-      "syntax": "none | baseline | contain",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "width",
-      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()>",
-      "computed": [
-        "percentageAutoOrAbsoluteLength"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "stroke-position",
-      "syntax": "<position>#",
-      "computed": [],
-      "initial": "0% 0%",
-      "inherited": true
-    },
-    {
-      "name": "tab-size",
-      "syntax": "<number [0,∞]> | <length [0,∞]>",
-      "computed": [
-        "specifiedIntegerOrAbsoluteLength"
-      ],
-      "initial": "8",
-      "inherited": true
-    },
-    {
-      "name": "border-color",
-      "syntax": "[ <color> | <image-1D> ]{1,4}",
-      "computed": [
-        "border-bottom-color",
-        "border-left-color",
-        "border-right-color",
-        "border-top-color"
-      ],
-      "initial": [
-        "border-top-color",
-        "border-right-color",
-        "border-bottom-color",
-        "border-left-color"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "border-block-end-style",
-      "syntax": "<line-style>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-animation-fill-mode",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-box-flex",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "speak",
-      "syntax": "auto | never | always",
-      "computed": [],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "cy",
-      "syntax": "<length-percentage>",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "visibility",
-      "syntax": "visible | hidden | collapse",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "visible",
-      "inherited": true
-    },
-    {
-      "name": "grid-auto-rows",
-      "syntax": "<track-size>+",
-      "computed": [
-        "percentageAsSpecifiedOrAbsoluteLength"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "border-bottom",
-      "syntax": "<line-width> || <line-style> || <color>",
-      "computed": [
-        "border-bottom-width",
-        "border-bottom-style",
-        "border-bottom-color"
-      ],
-      "initial": [
-        "border-bottom-width",
-        "border-bottom-style",
-        "border-bottom-color"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "-webkit-box-pack",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "scroll-padding-inline-end",
-      "syntax": "auto | <length-percentage [0,∞]>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "min-width",
-      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()>",
-      "computed": [
-        "percentageAsSpecifiedOrAbsoluteLength"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "grid-template-rows",
-      "syntax": "none | <track-list> | <auto-track-list> | subgrid <line-name-list>?",
-      "computed": [
-        "asSpecifiedRelativeToAbsoluteLengths"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "scroll-padding",
-      "syntax": "[ auto | <length-percentage [0,∞]> ]{1,4}",
-      "computed": [
-        "scroll-padding-bottom",
-        "scroll-padding-left",
-        "scroll-padding-right",
-        "scroll-padding-top"
-      ],
-      "initial": [
-        "scroll-padding-bottom",
-        "scroll-padding-left",
-        "scroll-padding-right",
-        "scroll-padding-top"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "margin-right",
-      "syntax": "<length-percentage> | auto",
-      "computed": [
-        "percentageAsSpecifiedOrAbsoluteLength"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "bottom",
-      "syntax": "auto | <length-percentage>",
-      "computed": [
-        "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "block-step-insert",
-      "syntax": "margin | padding",
-      "computed": [],
-      "initial": "margin",
-      "inherited": false
-    },
-    {
-      "name": "stroke-align",
-      "syntax": "center | inset | outset",
-      "computed": [],
-      "initial": "center",
-      "inherited": true
-    },
-    {
-      "name": "font-synthesis-small-caps",
-      "syntax": "auto | none",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "align-content",
-      "syntax": "normal | <baseline-position> | <content-distribution> | <overflow-position>? <content-position>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "offset",
-      "syntax": "[ <'offset-position'>? [ <'offset-path'> [ <'offset-distance'> || <'offset-rotate'> ]? ]? ]! [ / <'offset-anchor'> ]?",
-      "computed": [
-        "offset-position",
-        "offset-path",
-        "offset-distance",
-        "offset-anchor",
-        "offset-rotate"
-      ],
-      "initial": [
-        "offset-position",
-        "offset-path",
-        "offset-distance",
-        "offset-anchor",
-        "offset-rotate"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "writing-mode",
-      "syntax": "horizontal-tb | vertical-rl | vertical-lr | sideways-rl | sideways-lr",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "horizontal-tb",
-      "inherited": true
-    },
-    {
-      "name": "break-inside",
-      "syntax": "auto | avoid | avoid-page | avoid-column | avoid-region",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "border-block",
-      "syntax": "<'border-block-start'>",
-      "computed": [
-        "border-block-width",
-        "border-block-style",
-        "border-block-color"
-      ],
-      "initial": [
-        "border-block-width",
-        "border-block-style",
-        "border-block-color"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "border-inline-end-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "border-radius",
-      "syntax": "<length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?",
-      "computed": [
-        "border-bottom-left-radius",
-        "border-bottom-right-radius",
-        "border-top-left-radius",
-        "border-top-right-radius"
-      ],
-      "initial": [
-        "border-top-left-radius",
-        "border-top-right-radius",
-        "border-bottom-right-radius",
-        "border-bottom-left-radius"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "border-image-slice",
-      "syntax": "[<number [0,∞]> | <percentage [0,∞]>]{1,4} && fill?",
-      "computed": [
-        "oneToFourPercentagesOrAbsoluteLengthsPlusFill"
-      ],
-      "initial": "100%",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-border-top-right-radius",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "marker-start",
-      "syntax": "none | <marker-ref>",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "pointer-events",
-      "syntax": "auto | bounding-box | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all | none",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "inset",
-      "syntax": "<'top'>{1,4}",
-      "computed": [
-        "top",
-        "bottom",
-        "left",
-        "right"
-      ],
-      "initial": [
-        "top",
-        "bottom",
-        "left",
-        "right"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "font-weight",
-      "syntax": "<font-weight-absolute> | bolder | lighter",
-      "computed": [
-        "keywordOrNumericalValueBolderLighterTransformedToRealValue"
-      ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "opacity",
-      "syntax": "<opacity-value>",
-      "computed": [
-        "specifiedValueNumberClipped0To1"
-      ],
-      "initial": "1",
-      "inherited": false
-    },
-    {
-      "name": "dynamic-range-limit",
-      "syntax": "standard | high | constrained-high",
-      "computed": [],
-      "initial": "high",
-      "inherited": false
-    },
-    {
-      "name": "columns",
-      "syntax": "<'column-width'> || <'column-count'>",
-      "computed": [
-        "column-width",
-        "column-count"
-      ],
-      "initial": [
-        "column-width",
-        "column-count"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "font-variation-settings",
-      "syntax": "normal | [ <opentype-tag> <number>]#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "mix-blend-mode",
-      "syntax": "<blend-mode> | plus-darker | plus-lighter",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "position",
-      "syntax": "static | relative | absolute | sticky | fixed | <running()>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "static",
-      "inherited": false
-    },
-    {
-      "name": "animation-delay",
-      "syntax": "<time>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "0s",
-      "inherited": false
-    },
-    {
-      "name": "border-inline-style",
-      "syntax": "<'border-top-style'>{1,2}",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "border-inline-end-width",
-      "syntax": "<line-width>",
-      "computed": [
-        "absoluteLengthZeroIfBorderStyleNoneOrHidden"
-      ],
-      "initial": "medium",
-      "inherited": false
-    },
-    {
-      "name": "scroll-padding-block-end",
-      "syntax": "auto | <length-percentage [0,∞]>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "overscroll-behavior-y",
-      "syntax": "contain | none | auto",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "font-variant-position",
-      "syntax": "normal | sub | super",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "justify-content",
-      "syntax": "normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ]",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "border-inline-end",
-      "syntax": "<line-width> || <line-style> || <color>",
-      "computed": [
-        "border-width",
-        "border-style",
-        "border-inline-end-color"
-      ],
-      "initial": [
-        "border-width",
-        "border-style",
-        "color"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "-webkit-text-size-adjust",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "font-optical-sizing",
-      "syntax": "auto | none",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "-webkit-background-size",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "transition-property",
-      "syntax": "none | <single-transition-property>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "all",
-      "inherited": false
-    },
-    {
-      "name": "scroll-timeline-name",
-      "syntax": "[ none | <dashed-ident> ]#",
-      "computed": [
-        "noneOrOrderedListOfIdentifiers"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "font-kerning",
-      "syntax": "auto | normal | none",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "padding",
-      "syntax": "<'padding-top'>{1,4}",
-      "computed": [
-        "padding-bottom",
-        "padding-left",
-        "padding-right",
-        "padding-top"
-      ],
-      "initial": [
-        "padding-bottom",
-        "padding-left",
-        "padding-right",
-        "padding-top"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "margin-inline-end",
-      "syntax": "<'margin-top'>",
-      "computed": [
-        "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "math-depth",
-      "syntax": "auto-add | add(<integer>) | <integer>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "0",
-      "inherited": true
-    },
-    {
-      "name": "view-timeline-name",
-      "syntax": "[ none | <dashed-ident> ]#",
-      "computed": [
-        "noneOrOrderedListOfIdentifiers"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "stroke-color",
-      "syntax": "<color>#",
-      "computed": [],
-      "initial": "transparent",
-      "inherited": true
-    },
-    {
-      "name": "all",
-      "syntax": "initial | inherit | unset | revert | revert-layer",
-      "computed": [
-        "asSpecifiedAppliesToEachProperty"
-      ],
-      "initial": "noPracticalInitialValue",
-      "inherited": false
-    },
-    {
-      "name": "outline-color",
-      "syntax": "auto | [ <color> | <image-1D> ]",
-      "computed": [
-        "autoForTranslucentColorRGBAOtherwiseRGB"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-flex-basis",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "cx",
-      "syntax": "<length-percentage>",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "scroll-margin-right",
-      "syntax": "<length>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "float-offset",
-      "syntax": "<length> | <percentage>",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "mask-origin",
-      "syntax": "<coord-box>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "border-box",
-      "inherited": false
-    },
-    {
-      "name": "align-self",
-      "syntax": "auto | normal | stretch | <baseline-position> | <overflow-position>? <self-position> | anchor-center",
-      "computed": [
-        "autoOnAbsolutelyPositionedElementsValueOfAlignItemsOnParent"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-mask-box-image-outset",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "contain",
-      "syntax": "none | strict | content | [ [size | inline-size] || layout || style || paint ]",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "max-block-size",
-      "syntax": "<'max-width'>",
-      "computed": [
-        "sameAsMaxWidthAndMaxHeight"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "margin-block-end",
-      "syntax": "<'margin-top'>",
-      "computed": [
-        "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "text-emphasis-position",
-      "syntax": "[ over | under ] && [ right | left ]?",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "over right",
-      "inherited": true
-    },
-    {
-      "name": "font-language-override",
-      "syntax": "normal | <string>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "border-style",
-      "syntax": "<line-style>{1,4}",
-      "computed": [
-        "border-bottom-style",
-        "border-left-style",
-        "border-right-style",
-        "border-top-style"
-      ],
-      "initial": [
-        "border-top-style",
-        "border-right-style",
-        "border-bottom-style",
-        "border-left-style"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "scroll-margin-inline-end",
-      "syntax": "<length>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "nav-down",
-      "syntax": "auto | <id> [ current | root | <target-name> ]?",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "height",
-      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()>",
-      "computed": [
-        "percentageAutoOrAbsoluteLength"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "border-image-repeat",
-      "syntax": "[ stretch | repeat | round | space ]{1,2}",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "stretch",
-      "inherited": false
-    },
-    {
-      "name": "line-break",
-      "syntax": "auto | loose | normal | strict | anywhere",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "-webkit-align-content",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "scroll-padding-block-start",
-      "syntax": "auto | <length-percentage [0,∞]>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "font-variant-numeric",
-      "syntax": "normal | [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ]",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "scrollbar-width",
-      "syntax": "auto | thin | none",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-box-orient",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "grid-row-gap",
-      "syntax": "",
-      "computed": [
-        "percentageAsSpecifiedOrAbsoluteLength"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "direction",
-      "syntax": "ltr | rtl",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "ltr",
-      "inherited": true
-    },
-    {
-      "name": "ruby-merge",
-      "syntax": "separate | merge | auto",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "separate",
-      "inherited": true
-    },
-    {
-      "name": "scroll-margin-inline-start",
-      "syntax": "<length>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "anchor-scope",
-      "syntax": "none | all | <dashed-ident>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "link-parameters",
-      "syntax": "none | <link-param>+",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "border-left-style",
-      "syntax": "<line-style>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "word-wrap",
-      "syntax": "normal | break-word | anywhere",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "border-block-end-color",
-      "syntax": "<color> | <image-1D>",
-      "computed": [
-        "computedColor"
-      ],
-      "initial": "currentcolor",
-      "inherited": false
-    },
-    {
-      "name": "border-left-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-transform-style",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "vector-effect",
-      "syntax": "none | non-scaling-stroke | non-scaling-size | non-rotation | fixed-position",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "scroll-margin",
-      "syntax": "<length>{1,4}",
-      "computed": [
-        "scroll-margin-bottom",
-        "scroll-margin-left",
-        "scroll-margin-right",
-        "scroll-margin-top"
-      ],
-      "initial": [
-        "scroll-margin-bottom",
-        "scroll-margin-left",
-        "scroll-margin-right",
-        "scroll-margin-top"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "page",
-      "syntax": "auto | <custom-ident>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "inset-inline",
-      "syntax": "<'top'>{1,2}",
-      "computed": [
-        "inset-inline-start",
-        "inset-inline-end"
-      ],
-      "initial": [
-        "inset-inline-start",
-        "inset-inline-end"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "margin",
-      "syntax": "<'margin-top'>{1,4}",
-      "computed": [
-        "margin-bottom",
-        "margin-left",
-        "margin-right",
-        "margin-top"
-      ],
-      "initial": [
-        "margin-bottom",
-        "margin-left",
-        "margin-right",
-        "margin-top"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "text-shadow",
-      "syntax": "none | [ <color>? && <length>{2,3} ]#",
-      "computed": [
-        "colorPlusThreeAbsoluteLengths"
-      ],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "justify-self",
-      "syntax": "auto | normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | anchor-center",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "offset-anchor",
-      "syntax": "auto | <position>",
-      "computed": [
-        "forLengthAbsoluteValueOtherwisePercentage"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "grid-template-columns",
-      "syntax": "none | <track-list> | <auto-track-list> | subgrid <line-name-list>?",
-      "computed": [
-        "asSpecifiedRelativeToAbsoluteLengths"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "border-block-start-color",
-      "syntax": "<color> | <image-1D>",
-      "computed": [
-        "computedColor"
-      ],
-      "initial": "currentcolor",
-      "inherited": false
-    },
-    {
-      "name": "border-bottom-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "column-rule-color",
-      "syntax": "<color>",
-      "computed": [
-        "computedColor"
-      ],
-      "initial": "currentcolor",
-      "inherited": false
-    },
-    {
-      "name": "inset-block-start",
-      "syntax": "auto | <length-percentage>",
-      "computed": [
-        "sameAsBoxOffsets"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "border-inline-end-style",
-      "syntax": "<line-style>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "voice-family",
-      "syntax": "[[<family-name> | <generic-voice>],]* [<family-name> | <generic-voice>] | preserve",
-      "computed": [],
-      "initial": "implementation-dependent",
-      "inherited": true
-    },
-    {
-      "name": "spatial-navigation-action",
-      "syntax": "auto | focus | scroll",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "position-visibility",
-      "syntax": "always | [ anchors-valid || anchors-visible || no-overflow ]",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "anchors-visible",
-      "inherited": false
-    },
-    {
-      "name": "user-select",
-      "syntax": "auto | text | none | contain | all",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "stroke-width",
-      "syntax": "[<length-percentage> | <number>]#",
-      "computed": [],
-      "initial": "1px",
-      "inherited": true
-    },
-    {
-      "name": "-webkit-box-align",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "rest-before",
-      "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "marker-end",
-      "syntax": "none | <marker-ref>",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "overflow-x",
-      "syntax": "visible | hidden | clip | scroll | auto",
-      "computed": [
-        "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
-      ],
-      "initial": "visible",
-      "inherited": false
-    },
-    {
-      "name": "text-decoration-line",
-      "syntax": "none | [ underline || overline || line-through || blink ]",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "scrollbar-gutter",
-      "syntax": "auto | stable && both-edges?",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "fill-color",
-      "syntax": "<color>",
-      "computed": [],
-      "initial": "currentcolor",
-      "inherited": true
-    },
-    {
-      "name": "stroke-dasharray",
-      "syntax": "none | [<length-percentage> | <number>]+#",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "border-inline-start-width",
-      "syntax": "<line-width>",
-      "computed": [
-        "absoluteLengthZeroIfBorderStyleNoneOrHidden"
-      ],
-      "initial": "medium",
-      "inherited": false
-    },
-    {
-      "name": "scroll-margin-block-start",
-      "syntax": "<length>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "scroll-margin-inline",
-      "syntax": "<length>{1,2}",
-      "computed": [
-        "scroll-margin-inline-start",
-        "scroll-margin-inline-end"
-      ],
-      "initial": [
-        "scroll-margin-inline-start",
-        "scroll-margin-inline-end"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "font-variant-east-asian",
-      "syntax": "normal | [ <east-asian-variant-values> || <east-asian-width-values> || ruby ]",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "box-decoration-break",
-      "syntax": "slice | clone",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "slice",
-      "inherited": false
-    },
-    {
-      "name": "border-top-right-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2}",
-      "computed": [
-        "twoAbsoluteLengthOrPercentages"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "pause",
-      "syntax": "<'pause-before'> <'pause-after'>?",
-      "computed": [],
-      "initial": "N/A (see individual properties)",
-      "inherited": false
-    },
-    {
-      "name": "voice-duration",
-      "syntax": "auto | <time [0s,∞]>",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "margin-block-start",
-      "syntax": "<'margin-top'>",
-      "computed": [
-        "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "grid-column-end",
-      "syntax": "<grid-line>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-animation-timing-function",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-border-bottom-left-radius",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "padding-inline-start",
-      "syntax": "<'padding-top'>",
-      "computed": [
-        "asLength"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "marker-side",
-      "syntax": "match-self | match-parent",
-      "computed": [],
-      "initial": "match-self",
-      "inherited": true
-    },
-    {
-      "name": "mask-border-mode",
-      "syntax": "luminance | alpha",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "alpha",
-      "inherited": false
-    },
-    {
-      "name": "flex-basis",
-      "syntax": "content | <'width'>",
-      "computed": [
-        "asSpecifiedRelativeToAbsoluteLengths"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "wrap-through",
-      "syntax": "wrap | none",
-      "computed": [],
-      "initial": "wrap",
-      "inherited": false
-    },
-    {
-      "name": "border-right-width",
-      "syntax": "<line-width>",
-      "computed": [
-        "absoluteLengthOr0IfBorderRightStyleNoneOrHidden"
-      ],
-      "initial": "medium",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-border-top-left-radius",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "bookmark-label",
-      "syntax": "<content-list>",
-      "computed": [],
-      "initial": "content(text)",
-      "inherited": false
-    },
-    {
-      "name": "max-inline-size",
-      "syntax": "<'max-width'>",
-      "computed": [
-        "sameAsMaxWidthAndMaxHeight"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "stroke-linejoin",
-      "syntax": "[ crop | arcs | miter ] || [ bevel | round | fallback ]",
-      "computed": [],
-      "initial": "miter",
-      "inherited": true
-    },
-    {
-      "name": "border-right-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "vertical-align",
-      "syntax": "[ first | last] || <'alignment-baseline'> || <'baseline-shift'>",
-      "computed": [
-        "absoluteLengthOrKeyword"
-      ],
-      "initial": "baseline",
-      "inherited": false
-    },
-    {
-      "name": "voice-pitch",
-      "syntax": "<frequency [0Hz,∞]> && absolute | [[x-low | low | medium | high | x-high] || [<frequency> | <semitones> | <percentage>]]",
-      "computed": [],
-      "initial": "medium",
-      "inherited": true
-    },
-    {
-      "name": "inset-inline-end",
-      "syntax": "auto | <length-percentage>",
-      "computed": [
-        "sameAsBoxOffsets"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "scroll-timeline",
-      "syntax": "[ <'scroll-timeline-name'> <'scroll-timeline-axis'>? ]#",
-      "computed": [
-        "scroll-timeline-name",
-        "scroll-timeline-axis"
-      ],
-      "initial": [
-        "scroll-timeline-name",
-        "scroll-timeline-axis"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "border-image",
-      "syntax": "<'border-image-source'> || <'border-image-slice'> [ / <'border-image-width'> | / <'border-image-width'>? / <'border-image-outset'> ]? || <'border-image-repeat'>",
-      "computed": [
-        "border-image-outset",
-        "border-image-repeat",
-        "border-image-slice",
-        "border-image-source",
-        "border-image-width"
-      ],
-      "initial": [
-        "border-image-source",
-        "border-image-slice",
-        "border-image-width",
-        "border-image-outset",
-        "border-image-repeat"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "transform-origin",
-      "syntax": "[ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] <length>? | [[ center | left | right ] && [ center | top | bottom ]] <length>?",
-      "computed": [
-        "forLengthAbsoluteValueOtherwisePercentage"
-      ],
-      "initial": "50% 50% 0",
-      "inherited": false
-    },
-    {
-      "name": "float",
-      "syntax": "block-start | block-end | inline-start | inline-end | snap-block | <snap-block()> | snap-inline | <snap-inline()> | left | right | top | bottom | none | footnote",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "scroll-padding-top",
-      "syntax": "auto | <length-percentage [0,∞]>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "font-synthesis-style",
-      "syntax": "auto | none",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "hanging-punctuation",
-      "syntax": "none | [ first || [ force-end | allow-end ] || last ]",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "-webkit-animation-duration",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-background-clip",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "alignment-baseline",
-      "syntax": "baseline | text-bottom | alphabetic | ideographic | middle | central | mathematical | text-top",
-      "computed": [],
-      "initial": "baseline",
-      "inherited": false
-    },
-    {
-      "name": "box-sizing",
-      "syntax": "content-box | border-box",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "content-box",
-      "inherited": false
-    },
-    {
-      "name": "box-shadow-offset",
-      "syntax": "[ none | <length>{2} ]#",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "block-step",
-      "syntax": "<'block-step-size'> || <'block-step-insert'> || <'block-step-align'> || <'block-step-round'>",
-      "computed": [],
-      "initial": "see individual properties",
-      "inherited": false
-    },
-    {
-      "name": "nav-left",
-      "syntax": "auto | <id> [ current | root | <target-name> ]?",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "background-repeat",
-      "syntax": "<repeat-style>#",
-      "computed": [
-        "listEachItemHasTwoKeywordsOnePerDimension"
-      ],
-      "initial": "repeat",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-mask-composite",
-      "syntax": "",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "source-over",
-      "inherited": false
-    },
-    {
-      "name": "initial-letter-align",
-      "syntax": "[ border-box? [ alphabetic | ideographic | hanging | leading ]? ]!",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "object-position",
-      "syntax": "<position>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "50% 50%",
-      "inherited": false
-    },
-    {
-      "name": "transition-delay",
-      "syntax": "<time>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "0s",
-      "inherited": false
-    },
-    {
-      "name": "border-block-width",
-      "syntax": "<'border-top-width'>{1,2}",
-      "computed": [
-        "absoluteLengthZeroIfBorderStyleNoneOrHidden"
-      ],
-      "initial": "medium",
-      "inherited": false
-    },
-    {
-      "name": "border-top-left-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2}",
-      "computed": [
-        "twoAbsoluteLengthOrPercentages"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "ruby-position",
-      "syntax": "[ alternate || [ over | under ] ] | inter-character",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "alternate",
-      "inherited": true
-    },
-    {
-      "name": "overflow-block",
-      "syntax": "visible | hidden | clip | scroll | auto",
-      "computed": [
-        "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-flex",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "marker",
-      "syntax": "none | <marker-ref>",
-      "computed": [],
-      "initial": "not defined for shorthand properties",
-      "inherited": true
-    },
-    {
-      "name": "order",
-      "syntax": "<integer>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-mask-origin",
-      "syntax": "",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "padding",
-      "inherited": false
-    },
-    {
-      "name": "table-layout",
-      "syntax": "auto | fixed",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "left",
-      "syntax": "auto | <length-percentage>",
-      "computed": [
-        "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "mask-type",
-      "syntax": "luminance | alpha",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "luminance",
-      "inherited": false
-    },
-    {
-      "name": "offset-rotate",
-      "syntax": "[ auto | reverse ] || <angle>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "letter-spacing",
-      "syntax": "normal | <length>",
-      "computed": [
-        "optimumValueOfAbsoluteLengthOrNormal"
-      ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "-webkit-animation-iteration-count",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "fill",
-      "syntax": "<paint>",
-      "computed": [],
-      "initial": "black",
-      "inherited": true
-    },
-    {
-      "name": "caret-animation",
-      "syntax": "auto | manual",
-      "computed": [],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "border-image-outset",
-      "syntax": "[ <length [0,∞]> | <number [0,∞]> ]{1,4}",
-      "computed": [
-        "asSpecifiedRelativeToAbsoluteLengths"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "text-align-all",
-      "syntax": "start | end | left | right | center | justify | match-parent",
-      "computed": [],
-      "initial": "start",
-      "inherited": true
-    },
-    {
-      "name": "widows",
-      "syntax": "<integer [1,∞]>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "2",
-      "inherited": true
-    },
-    {
-      "name": "initial-letter-wrap",
-      "syntax": "none | first | all | grid | <length-percentage>",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "cue",
-      "syntax": "<'cue-before'> <'cue-after'>?",
-      "computed": [],
-      "initial": "N/A (see individual properties)",
-      "inherited": false
-    },
-    {
-      "name": "overflow-anchor",
-      "syntax": "auto | none",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "animation-fill-mode",
-      "syntax": "<single-animation-fill-mode>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "border-block-style",
-      "syntax": "<'border-top-style'>{1,2}",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-flex-shrink",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-transition",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "scroll-padding-bottom",
-      "syntax": "auto | <length-percentage [0,∞]>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "inset-block-end",
-      "syntax": "auto | <length-percentage>",
-      "computed": [
-        "sameAsBoxOffsets"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-appearance",
-      "syntax": "",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "noneButOverriddenInUserAgentCSS",
-      "inherited": false
-    },
-    {
-      "name": "scroll-timeline-axis",
-      "syntax": "[ block | inline | x | y ]#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "block",
-      "inherited": false
-    },
-    {
-      "name": "view-timeline-axis",
-      "syntax": "[ block | inline | x | y ]#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "block",
-      "inherited": false
-    },
-    {
-      "name": "stroke-size",
-      "syntax": "<bg-size>#",
-      "computed": [],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "font-style",
-      "syntax": "normal | italic | oblique <angle [-90deg,90deg]>?",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "border-block-color",
-      "syntax": "<'border-top-color'>{1,2}",
-      "computed": [
-        "computedColor"
-      ],
-      "initial": "currentcolor",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-filter",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "column-rule-width",
-      "syntax": "<line-width>",
-      "computed": [
-        "absoluteLength0IfColumnRuleStyleNoneOrHidden"
-      ],
-      "initial": "medium",
-      "inherited": false
-    },
-    {
-      "name": "empty-cells",
-      "syntax": "show | hide",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "show",
-      "inherited": true
-    },
-    {
-      "name": "max-width",
-      "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()>",
-      "computed": [
-        "percentageAsSpecifiedAbsoluteLengthOrNone"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "grid-template-areas",
-      "syntax": "none | <string>+",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "border-inline-color",
-      "syntax": "<'border-top-color'>{1,2}",
-      "computed": [
-        "computedColor"
-      ],
-      "initial": "currentcolor",
-      "inherited": false
-    },
-    {
-      "name": "border-bottom-width",
-      "syntax": "<line-width>",
-      "computed": [
-        "absoluteLengthOr0IfBorderBottomStyleNoneOrHidden"
-      ],
-      "initial": "medium",
-      "inherited": false
-    },
-    {
-      "name": "border-start-end-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2}",
-      "computed": [
-        "twoAbsoluteLengthOrPercentages"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "flood-opacity",
-      "syntax": "<'opacity'>",
-      "computed": [],
-      "initial": "1",
-      "inherited": false
-    },
-    {
-      "name": "font-stretch",
-      "syntax": "",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "border-top",
-      "syntax": "<line-width> || <line-style> || <color>",
-      "computed": [
-        "border-top-width",
-        "border-top-style",
-        "border-top-color"
-      ],
-      "initial": [
-        "border-top-width",
-        "border-top-style",
-        "border-top-color"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "-webkit-animation-name",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "fill-repeat",
-      "syntax": "<repeat-style>#",
-      "computed": [],
-      "initial": "repeat",
-      "inherited": true
-    },
-    {
-      "name": "margin-trim",
-      "syntax": "none | [ block || inline ] | [ block-start || inline-start || block-end || inline-end ]",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-border-radius",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "stroke-dashcorner",
-      "syntax": "none | <length>",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "background-image",
-      "syntax": "<bg-image>#",
-      "computed": [
-        "asSpecifiedURLsAbsolute"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "mask-border-source",
-      "syntax": "none | <image>",
-      "computed": [
-        "asSpecifiedURLsAbsolute"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "quotes",
-      "syntax": "auto | none | match-parent | [ <string> <string> ]+",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "dependsOnUserAgent",
-      "inherited": true
-    },
-    {
-      "name": "overscroll-behavior-block",
-      "syntax": "contain | none | auto",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "timeline-scope",
-      "syntax": "none | all | <dashed-ident>#",
-      "computed": [
-        "noneOrOrderedListOfIdentifiers"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "border-image-source",
-      "syntax": "none | <image>",
-      "computed": [
-        "noneOrImageWithAbsoluteURI"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "border-bottom-left-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2}",
-      "computed": [
-        "twoAbsoluteLengthOrPercentages"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-justify-content",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "stroke-repeat",
-      "syntax": "<repeat-style>#",
-      "computed": [],
-      "initial": "repeat",
-      "inherited": true
-    },
-    {
-      "name": "font-feature-settings",
-      "syntax": "normal | <feature-tag-value>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "flex-wrap",
-      "syntax": "nowrap | wrap | wrap-reverse",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "nowrap",
-      "inherited": false
-    },
-    {
-      "name": "box-shadow-position",
-      "syntax": "[ outset | inset ]#",
-      "computed": [],
-      "initial": "outset",
-      "inherited": false
-    },
-    {
-      "name": "font-width",
-      "syntax": "normal | <percentage [0,∞]> | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded",
-      "computed": [],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "grid-gap",
-      "syntax": "",
-      "computed": [
-        "grid-row-gap",
-        "grid-column-gap"
-      ],
-      "initial": [
-        "grid-row-gap",
-        "grid-column-gap"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "scroll-snap-align",
-      "syntax": "[ none | start | end | center ]{1,2}",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "padding-left",
-      "syntax": "<length-percentage [0,∞]>",
-      "computed": [
-        "percentageAsSpecifiedOrAbsoluteLength"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "footnote-display",
-      "syntax": "block | inline | compact",
-      "computed": [],
-      "initial": "block",
-      "inherited": false
-    },
-    {
-      "name": "border-clip-right",
-      "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
-      "computed": [],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "mask-border-outset",
-      "syntax": "[ <length> | <number> ]{1,4}",
-      "computed": [
-        "asSpecifiedRelativeToAbsoluteLengths"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "touch-action",
-      "syntax": "auto | none | [ [ pan-x | pan-left | pan-right ] || [ pan-y | pan-up | pan-down ] || pinch-zoom ] | manipulation",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-animation-direction",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-mask-clip",
-      "syntax": "",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "border",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-transition-timing-function",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "scroll-margin-bottom",
-      "syntax": "<length>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "margin-inline-start",
-      "syntax": "<'margin-top'>",
-      "computed": [
-        "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "text-combine-upright",
-      "syntax": "none | all | [ digits <integer [2,4]>? ]",
-      "computed": [
-        "keywordPlusIntegerIfDigits"
-      ],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "text-rendering",
-      "syntax": "auto | optimizeSpeed | optimizeLegibility | geometricPrecision",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "text-size-adjust",
-      "syntax": "auto | none | <percentage [0,∞]>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "autoForSmartphoneBrowsersSupportingInflation",
-      "inherited": true
-    },
-    {
-      "name": "color-scheme",
-      "syntax": "normal | [ light | dark | <custom-ident> ]+ && only?",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "print-color-adjust",
-      "syntax": "economy | exact",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "economy",
-      "inherited": true
-    },
-    {
-      "name": "fill-break",
-      "syntax": "bounding-box | slice | clone",
-      "computed": [],
-      "initial": "bounding-box",
-      "inherited": false
-    },
-    {
-      "name": "fill-opacity",
-      "syntax": "<'opacity'>",
-      "computed": [],
-      "initial": "1",
-      "inherited": true
-    },
-    {
-      "name": "text-transform",
-      "syntax": "none | [capitalize | uppercase | lowercase ] || full-width || full-size-kana | math-auto",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "border-block-end-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "column-fill",
-      "syntax": "auto | balance | balance-all",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "balance",
-      "inherited": false
-    },
-    {
-      "name": "x",
-      "syntax": "<length-percentage>",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "caret-color",
-      "syntax": "auto | <color>",
-      "computed": [
-        "asAutoOrColor"
-      ],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "unicode-bidi",
-      "syntax": "normal | embed | isolate | bidi-override | isolate-override | plaintext",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-flex-grow",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "font-synthesis",
-      "syntax": "none | [ weight || style || small-caps || position]",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "weight style small-caps position ",
-      "inherited": true
-    },
-    {
-      "name": "footnote-policy",
-      "syntax": "auto | line | block",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "box-shadow-spread",
-      "syntax": "<length>#",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "text-box",
-      "syntax": "normal | <'text-box-trim'> || <'text-box-edge'>",
-      "computed": [],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "flow-from",
-      "syntax": "<ident> | none",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "text-overflow",
-      "syntax": "clip | ellipsis",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "clip",
-      "inherited": false
-    },
-    {
-      "name": "anchor-name",
-      "syntax": "none | <dashed-ident>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "animation-range",
-      "syntax": "[ <'animation-range-start'> <'animation-range-end'>? ]#",
-      "computed": [
-        "animation-range-start",
-        "animation-range-end"
-      ],
-      "initial": [
-        "animation-range-start",
-        "animation-range-end"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "background-blend-mode",
-      "syntax": "<mix-blend-mode>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "animation-name",
-      "syntax": "[ none | <keyframes-name> ]#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "padding-block",
-      "syntax": "<'padding-top'>{1,2}",
-      "computed": [
-        "padding-block-start",
-        "padding-block-end"
-      ],
-      "initial": [
-        "padding-block-start",
-        "padding-block-end"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "counter-reset",
-      "syntax": "[ <counter-name> <integer>? | <reversed-counter-name> <integer>? ]+ | none",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "mask-image",
-      "syntax": "<mask-reference>#",
-      "computed": [
-        "asSpecifiedURLsAbsolute"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-transition-duration",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "content-visibility",
-      "syntax": "visible | auto | hidden",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "visible",
-      "inherited": false
-    },
-    {
-      "name": "position-area",
-      "syntax": "none | <position-area>",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "view-timeline",
-      "syntax": "[ <'view-timeline-name'> [ <'view-timeline-axis'> || <'view-timeline-inset'> ]? ]#",
-      "computed": [
-        "view-timeline-name",
-        "view-timeline-axis"
-      ],
-      "initial": [
-        "view-timeline-name",
-        "view-timeline-axis"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "padding-bottom",
-      "syntax": "<length-percentage [0,∞]>",
-      "computed": [
-        "percentageAsSpecifiedOrAbsoluteLength"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "border-inline-start",
-      "syntax": "<line-width> || <line-style> || <color>",
-      "computed": [
-        "border-width",
-        "border-style",
-        "border-inline-start-color"
-      ],
-      "initial": [
-        "border-width",
-        "border-style",
-        "color"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "-webkit-flex-flow",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "line-height-step",
-      "syntax": "<length [0,∞]>",
-      "computed": [
-        "absoluteLength"
-      ],
-      "initial": "0",
-      "inherited": true
-    },
-    {
-      "name": "border-spacing",
-      "syntax": "<length>{1,2}",
-      "computed": [
-        "twoAbsoluteLengths"
-      ],
-      "initial": "0",
-      "inherited": true
-    },
-    {
-      "name": "text-underline-position",
-      "syntax": "auto | [ under || [ left | right ] ]",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "transform",
-      "syntax": "none | <transform-list>",
-      "computed": [
-        "asSpecifiedRelativeToAbsoluteLengths"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "transition-timing-function",
-      "syntax": "<easing-function>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "ease",
-      "inherited": false
-    },
-    {
-      "name": "scroll-margin-block-end",
-      "syntax": "<length>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "background-origin",
-      "syntax": "<visual-box>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "padding-box",
-      "inherited": false
-    },
-    {
-      "name": "animation-duration",
-      "syntax": "<time [0s,∞]>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "0s",
-      "inherited": false
-    },
-    {
-      "name": "border-clip-bottom",
-      "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
-      "computed": [],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-align-self",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "padding-block-end",
-      "syntax": "<'padding-top'>",
-      "computed": [
-        "asLength"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "overscroll-behavior-x",
-      "syntax": "contain | none | auto",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-user-select",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "font-variant-emoji",
-      "syntax": "normal | text | emoji | unicode",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "color",
-      "syntax": "<color>",
-      "computed": [
-        "computedColor"
-      ],
-      "initial": "canvastext",
-      "inherited": true
-    },
-    {
-      "name": "-webkit-mask-size",
-      "syntax": "",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto auto",
-      "inherited": false
-    },
-    {
-      "name": "voice-volume",
-      "syntax": "silent | [[x-soft | soft | medium | loud | x-loud] || <decibel>]",
-      "computed": [],
-      "initial": "medium",
-      "inherited": true
-    },
-    {
-      "name": "background-clip",
-      "syntax": "<visual-box>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "border-box",
-      "inherited": false
-    },
-    {
-      "name": "border-right",
-      "syntax": "<line-width> || <line-style> || <color>",
-      "computed": [
-        "border-right-width",
-        "border-right-style",
-        "border-right-color"
-      ],
-      "initial": [
-        "border-right-width",
-        "border-right-style",
-        "border-right-color"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "stroke-alignment",
-      "syntax": "center | inner | outer",
-      "computed": [],
-      "initial": "center",
-      "inherited": true
-    },
-    {
-      "name": "scroll-behavior",
-      "syntax": "auto | smooth",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "background-position",
-      "syntax": "<bg-position>#",
-      "computed": [
-        "background-position-x",
-        "background-position-y"
-      ],
-      "initial": "0% 0%",
-      "inherited": false
-    },
-    {
-      "name": "z-index",
-      "syntax": "auto | <integer> | inherit",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "column-gap",
-      "syntax": "normal | <length-percentage [0,∞]>",
-      "computed": [
-        "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn"
-      ],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "break-after",
-      "syntax": "auto | avoid | always | all | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "line-height",
-      "syntax": "normal | <number [0,∞]> | <length-percentage [0,∞]>",
-      "computed": [
-        "absoluteLengthOrAsSpecified"
-      ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "mask-border-width",
-      "syntax": "[ <length-percentage> | <number> | auto ]{1,4}",
-      "computed": [
-        "asSpecifiedRelativeToAbsoluteLengths"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "bookmark-state",
-      "syntax": "open | closed",
-      "computed": [],
-      "initial": "open",
-      "inherited": false
-    },
-    {
-      "name": "background-size",
-      "syntax": "<bg-size>#",
-      "computed": [
-        "asSpecifiedRelativeToAbsoluteLengths"
-      ],
-      "initial": "auto auto",
-      "inherited": false
-    },
-    {
-      "name": "display",
-      "syntax": "[ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy> | <display-outside> || [ <display-inside> | math ]",
-      "computed": [
-        "asSpecifiedExceptPositionedFloatingAndRootElementsKeywordMaybeDifferent"
-      ],
-      "initial": "inline",
       "inherited": false
     },
     {
@@ -3486,8 +2484,17 @@
       "inherited": false
     },
     {
-      "name": "border-right-style",
-      "syntax": "<line-style>",
+      "name": "flex-wrap",
+      "syntax": "nowrap | wrap | wrap-reverse",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "nowrap",
+      "inherited": false
+    },
+    {
+      "name": "float",
+      "syntax": "block-start | block-end | inline-start | inline-end | snap-block | <snap-block()> | snap-inline | <snap-inline()> | left | right | top | bottom | none | footnote",
       "computed": [
         "asSpecified"
       ],
@@ -3495,432 +2502,93 @@
       "inherited": false
     },
     {
-      "name": "baseline-source",
-      "syntax": "auto | first | last",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "text-orientation",
-      "syntax": "mixed | upright | sideways",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "mixed",
-      "inherited": true
-    },
-    {
-      "name": "text-align-last",
-      "syntax": "auto | start | end | left | right | center | justify | match-parent",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "orphans",
-      "syntax": "<integer [1,∞]>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "2",
-      "inherited": true
-    },
-    {
-      "name": "border-block-start-width",
-      "syntax": "<line-width>",
-      "computed": [
-        "absoluteLengthZeroIfBorderStyleNoneOrHidden"
-      ],
-      "initial": "medium",
-      "inherited": false
-    },
-    {
-      "name": "cue-before",
-      "syntax": "<uri> <decibel>? | none",
+      "name": "float-defer",
+      "syntax": "<integer> | last | none",
       "computed": [],
       "initial": "none",
       "inherited": false
     },
     {
-      "name": "y",
+      "name": "float-offset",
       "syntax": "<length-percentage>",
       "computed": [],
       "initial": "0",
       "inherited": false
     },
     {
-      "name": "content",
-      "syntax": "normal | none | [ <content-replacement> | <content-list> ] [/ [ <string> | <counter> | <attr()> ]+ ]? | <element()>",
-      "computed": [
-        "normalOnElementsForPseudosNoneAbsoluteURIStringOrAsSpecified"
-      ],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "break-before",
-      "syntax": "auto | avoid | always | all | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-text-stroke-width",
-      "syntax": "<line-width>",
-      "computed": [
-        "absoluteLength"
-      ],
-      "initial": "0",
-      "inherited": true
-    },
-    {
-      "name": "min-inline-size",
-      "syntax": "<'min-width'>",
-      "computed": [
-        "sameAsMinWidthAndMinHeight"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "clear",
-      "syntax": "inline-start | inline-end | block-start | block-end | left | right | top | bottom | both-inline | both-block | both | none",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "transition-duration",
-      "syntax": "<time [0s,∞]>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "0s",
-      "inherited": false
-    },
-    {
-      "name": "border-block-start-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
+      "name": "float-reference",
+      "syntax": "inline | column | region | page",
       "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "voice-balance",
-      "syntax": "<number> | left | center | right | leftwards | rightwards",
-      "computed": [],
-      "initial": "center",
-      "inherited": true
-    },
-    {
-      "name": "color-adjust",
-      "syntax": "<'print-color-adjust'>",
-      "computed": [],
-      "initial": "see individual properties",
-      "inherited": false
-    },
-    {
-      "name": "stroke-miterlimit",
-      "syntax": "<number>",
-      "computed": [],
-      "initial": "4",
-      "inherited": true
-    },
-    {
-      "name": "border-image-width",
-      "syntax": "[ <length-percentage [0,∞]> | <number [0,∞]> | auto ]{1,4}",
-      "computed": [
-        "asSpecifiedRelativeToAbsoluteLengths"
-      ],
-      "initial": "1",
-      "inherited": false
-    },
-    {
-      "name": "mask-clip",
-      "syntax": "[ <coord-box> | no-clip ]#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "border-box",
-      "inherited": false
-    },
-    {
-      "name": "row-gap",
-      "syntax": "normal | <length-percentage [0,∞]>",
-      "computed": [
-        "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn"
-      ],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "column-width",
-      "syntax": "auto | <length [0,∞]> | min-content | max-content | fit-content(<length-percentage>)",
-      "computed": [
-        "absoluteLengthZeroOrLarger"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "scroll-padding-left",
-      "syntax": "auto | <length-percentage [0,∞]>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "animation-range-start",
-      "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
-      "computed": [
-        "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage"
-      ],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "max-height",
-      "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()>",
-      "computed": [
-        "percentageAsSpecifiedAbsoluteLengthOrNone"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "font-synthesis-position",
-      "syntax": "auto | none",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "border-top-width",
-      "syntax": "<line-width>",
-      "computed": [
-        "absoluteLengthOr0IfBorderTopStyleNoneOrHidden"
-      ],
-      "initial": "medium",
-      "inherited": false
-    },
-    {
-      "name": "border-inline-width",
-      "syntax": "<'border-top-width'>{1,2}",
-      "computed": [
-        "absoluteLengthZeroIfBorderStyleNoneOrHidden"
-      ],
-      "initial": "medium",
-      "inherited": false
-    },
-    {
-      "name": "grid-auto-columns",
-      "syntax": "<track-size>+",
-      "computed": [
-        "percentageAsSpecifiedOrAbsoluteLength"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "border-bottom-color",
-      "syntax": "<color> | <image-1D>",
-      "computed": [
-        "computedColor"
-      ],
-      "initial": "currentcolor",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-text-fill-color",
-      "syntax": "<color>",
-      "computed": [
-        "computedColor"
-      ],
-      "initial": "currentcolor",
-      "inherited": true
-    },
-    {
-      "name": "-webkit-backface-visibility",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-box-shadow",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-perspective",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "pause-after",
-      "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "caption-side",
-      "syntax": "top | bottom",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "top",
-      "inherited": true
-    },
-    {
-      "name": "position-try-order",
-      "syntax": "normal | <try-size>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "offset-position",
-      "syntax": "normal | auto | <position>",
-      "computed": [
-        "forLengthAbsoluteValueOtherwisePercentage"
-      ],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "border-clip-left",
-      "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
-      "computed": [],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "r",
-      "syntax": "<length-percentage>",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "place-self",
-      "syntax": "<'align-self'> <'justify-self'>?",
-      "computed": [
-        "align-self",
-        "justify-self"
-      ],
-      "initial": [
-        "align-self",
-        "justify-self"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "scrollbar-color",
-      "syntax": "auto | <color>{2}",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "block-step-round",
-      "syntax": "up | down | nearest",
-      "computed": [],
-      "initial": "up",
-      "inherited": false
-    },
-    {
-      "name": "marker-mid",
-      "syntax": "none | <marker-ref>",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "inline-size",
-      "syntax": "<'width'>",
-      "computed": [
-        "sameAsWidthAndHeight"
-      ],
-      "initial": "auto",
+      "initial": "inline",
       "inherited": false
     },
     {
       "name": "flood-color",
       "syntax": "<color>",
-      "computed": [],
+      "computed": [
+        "asSpecified"
+      ],
       "initial": "black",
       "inherited": false
     },
     {
-      "name": "caret",
-      "syntax": "<'caret-color'> || <'caret-animation'> || <'caret-shape'>",
+      "name": "flood-opacity",
+      "syntax": "<'opacity'>",
       "computed": [
-        "caret-color",
-        "caret-shape"
+        "specifiedValueClipped0To1"
+      ],
+      "initial": "black",
+      "inherited": false
+    },
+    {
+      "name": "flow-from",
+      "syntax": "<ident> | none",
+      "computed": [],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "flow-into",
+      "syntax": "none | <ident> [element | content]?",
+      "computed": [],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "font",
+      "syntax": "[ [ <'font-style'> || <font-variant-css2> || <'font-weight'> || <font-width-css3> ]? <'font-size'> [ / <'line-height'> ]? <'font-family'># ] | <system-family-name>",
+      "computed": [
+        "font-style",
+        "font-variant",
+        "font-weight",
+        "font-stretch",
+        "font-size",
+        "line-height",
+        "font-family"
       ],
       "initial": [
-        "caret-color",
-        "caret-shape"
+        "font-style",
+        "font-variant",
+        "font-weight",
+        "font-stretch",
+        "font-size",
+        "line-height",
+        "font-family"
       ],
       "inherited": true
     },
     {
-      "name": "border-inline-start-color",
-      "syntax": "<color> | <image-1D>",
-      "computed": [
-        "computedColor"
-      ],
-      "initial": "currentcolor",
-      "inherited": false
-    },
-    {
-      "name": "border-end-start-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2}",
-      "computed": [
-        "twoAbsoluteLengthOrPercentages"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "column-count",
-      "syntax": "auto | <integer [1,∞]>",
+      "name": "font-family",
+      "syntax": "[ <family-name> | <generic-family> ]#",
       "computed": [
         "asSpecified"
       ],
-      "initial": "auto",
-      "inherited": false
+      "initial": "dependsOnUserAgent",
+      "inherited": true
     },
     {
-      "name": "stop-opacity",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "math-style",
-      "syntax": "normal | compact",
+      "name": "font-feature-settings",
+      "syntax": "normal | <feature-tag-value>#",
       "computed": [
         "asSpecified"
       ],
@@ -3928,19 +2596,30 @@
       "inherited": true
     },
     {
-      "name": "appearance",
-      "syntax": "none | auto | <compat-auto> | <compat-special>",
+      "name": "font-kerning",
+      "syntax": "auto | normal | none",
       "computed": [
         "asSpecified"
       ],
-      "initial": "none",
-      "inherited": false
+      "initial": "auto",
+      "inherited": true
     },
     {
-      "name": "stroke-dash-corner",
-      "syntax": "none | <length>",
-      "computed": [],
-      "initial": "none",
+      "name": "font-language-override",
+      "syntax": "normal | <string>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "font-optical-sizing",
+      "syntax": "auto | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
       "inherited": true
     },
     {
@@ -3953,373 +2632,26 @@
       "inherited": true
     },
     {
-      "name": "text-justify",
-      "syntax": "auto | none | inter-word | inter-character",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "-webkit-animation-delay",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "shape-subtract",
-      "syntax": "none | [ <basic-shape>| <uri> ]+",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "scroll-snap-stop",
-      "syntax": "normal | always",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "list-style",
-      "syntax": "<'list-style-position'> || <'list-style-image'> || <'list-style-type'>",
-      "computed": [
-        "list-style-image",
-        "list-style-position",
-        "list-style-type"
-      ],
-      "initial": [
-        "list-style-type",
-        "list-style-position",
-        "list-style-image"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "margin-break",
-      "syntax": "auto | keep | discard",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "border-left-width",
-      "syntax": "<line-width>",
-      "computed": [
-        "absoluteLengthOr0IfBorderLeftStyleNoneOrHidden"
-      ],
-      "initial": "medium",
-      "inherited": false
-    },
-    {
-      "name": "overflow-inline",
-      "syntax": "visible | hidden | clip | scroll | auto",
-      "computed": [
-        "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "block-size",
-      "syntax": "<'width'>",
-      "computed": [
-        "sameAsWidthAndHeight"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "overscroll-behavior",
-      "syntax": "[ contain | none | auto ]{1,2}",
-      "computed": [
-        "overscroll-behavior-x",
-        "overscroll-behavior-y"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "margin-bottom",
-      "syntax": "<length-percentage> | auto",
-      "computed": [
-        "percentageAsSpecifiedOrAbsoluteLength"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "padding-right",
-      "syntax": "<length-percentage [0,∞]>",
-      "computed": [
-        "percentageAsSpecifiedOrAbsoluteLength"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "page-break-before",
-      "syntax": "auto | always | avoid | left | right | inherit",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "box-shadow-blur",
-      "syntax": "<length [0,∞]>#",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-animation-play-state",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "fill-size",
-      "syntax": "<bg-size>#",
-      "computed": [],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "clip",
-      "syntax": "<rect()> | auto",
-      "computed": [
-        "autoOrRectangle"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "mask-composite",
-      "syntax": "<compositing-operator>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "add",
-      "inherited": false
-    },
-    {
-      "name": "border-inline-start-style",
-      "syntax": "<line-style>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "box-shadow-color",
-      "syntax": "<color>#",
-      "computed": [],
-      "initial": "currentcolor",
-      "inherited": false
-    },
-    {
-      "name": "stroke-image",
-      "syntax": "<paint>#",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "background-color",
-      "syntax": "<color>",
-      "computed": [
-        "computedColor"
-      ],
-      "initial": "transparent",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-mask-position",
-      "syntax": "",
-      "computed": [
-        "absoluteLengthOrPercentage"
-      ],
-      "initial": "0% 0%",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-box-ordinal-group",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "initial-letter",
-      "syntax": "normal | <number [1,∞]> <integer [1,∞]> | <number [1,∞]> && [ drop | raise ]?",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "d",
-      "syntax": "none | <string>",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "list-style-position",
-      "syntax": "inside | outside",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "outside",
-      "inherited": true
-    },
-    {
-      "name": "float-reference",
-      "syntax": "inline | column | region | page",
-      "computed": [],
-      "initial": "inline",
-      "inherited": false
-    },
-    {
       "name": "font-size",
       "syntax": "<absolute-size> | <relative-size> | <length-percentage [0,∞]> | math",
       "computed": [
-        "asSpecifiedRelativeToAbsoluteLengths"
+        "absoluteLength"
       ],
       "initial": "medium",
       "inherited": true
     },
     {
-      "name": "grid-row-end",
-      "syntax": "<grid-line>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "border-clip",
-      "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
-      "computed": [],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "padding-inline",
-      "syntax": "<'padding-top'>{1,2}",
-      "computed": [
-        "padding-inline-start",
-        "padding-inline-end"
-      ],
-      "initial": [
-        "padding-inline-start",
-        "padding-inline-end"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "lighting-color",
-      "syntax": "<color>",
-      "computed": [],
-      "initial": "white",
-      "inherited": false
-    },
-    {
-      "name": "math-shift",
-      "syntax": "normal | compact",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "mask-border-slice",
-      "syntax": "[ <number> | <percentage> ]{1,4} fill?",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "scroll-snap-type",
-      "syntax": "none | [ x | y | block | inline | both ] [ mandatory | proximity ]?",
+      "name": "font-size-adjust",
+      "syntax": "none | <number [0,∞]>",
       "computed": [
         "asSpecified"
       ],
       "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "transition",
-      "syntax": "<single-transition>#",
-      "computed": [
-        "transition-delay",
-        "transition-duration",
-        "transition-property",
-        "transition-timing-function",
-        "transition-behavior"
-      ],
-      "initial": [
-        "transition-delay",
-        "transition-duration",
-        "transition-property",
-        "transition-timing-function",
-        "transition-behavior"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "-webkit-animation",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "baseline-shift",
-      "syntax": "<length-percentage> | sub | super | top | center | bottom",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "stroke-break",
-      "syntax": "bounding-box | slice | clone",
-      "computed": [],
-      "initial": "bounding-box",
-      "inherited": false
-    },
-    {
-      "name": "stroke-dashoffset",
-      "syntax": "<length-percentage> | <number>",
-      "computed": [],
-      "initial": "0",
       "inherited": true
     },
     {
-      "name": "animation-iteration-count",
-      "syntax": "<single-animation-iteration-count>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "1",
-      "inherited": false
-    },
-    {
-      "name": "align-items",
-      "syntax": "normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ] | anchor-center",
+      "name": "font-stretch",
+      "syntax": "",
       "computed": [
         "asSpecified"
       ],
@@ -4327,21 +2659,8 @@
       "inherited": false
     },
     {
-      "name": "grid-row",
-      "syntax": "<grid-line> [ / <grid-line> ]?",
-      "computed": [
-        "grid-row-start",
-        "grid-row-end"
-      ],
-      "initial": [
-        "grid-row-start",
-        "grid-row-end"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "paint-order",
-      "syntax": "normal | [ fill || stroke || markers ]",
+      "name": "font-style",
+      "syntax": "normal | italic | oblique <angle [-90deg,90deg]>?",
       "computed": [
         "asSpecified"
       ],
@@ -4349,111 +2668,189 @@
       "inherited": true
     },
     {
-      "name": "stop-color",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "padding-inline-end",
-      "syntax": "<'padding-top'>",
-      "computed": [
-        "asLength"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "animation-play-state",
-      "syntax": "<single-animation-play-state>#",
+      "name": "font-synthesis",
+      "syntax": "none | [ weight || style || small-caps || position]",
       "computed": [
         "asSpecified"
       ],
-      "initial": "running",
-      "inherited": false
-    },
-    {
-      "name": "word-spacing",
-      "syntax": "normal | <length>",
-      "computed": [
-        "absoluteLength"
-      ],
-      "initial": "normal",
+      "initial": "weight style small-caps position ",
       "inherited": true
     },
     {
-      "name": "-webkit-mask",
-      "syntax": "",
-      "computed": [
-        "-webkit-mask-image",
-        "-webkit-mask-repeat",
-        "-webkit-mask-attachment",
-        "-webkit-mask-position",
-        "-webkit-mask-origin",
-        "-webkit-mask-clip"
-      ],
-      "initial": [
-        "-webkit-mask-image",
-        "-webkit-mask-repeat",
-        "-webkit-mask-attachment",
-        "-webkit-mask-position",
-        "-webkit-mask-origin",
-        "-webkit-mask-clip"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "ruby-overhang",
+      "name": "font-synthesis-position",
       "syntax": "auto | none",
-      "computed": [],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "text-emphasis-color",
-      "syntax": "<color>",
-      "computed": [
-        "computedColor"
-      ],
-      "initial": "currentcolor",
-      "inherited": true
-    },
-    {
-      "name": "position-try-fallbacks",
-      "syntax": "none | [ [<dashed-ident> || <try-tactic>] | <'position-area'> ]#",
       "computed": [
         "asSpecified"
       ],
       "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "inset-inline-start",
-      "syntax": "auto | <length-percentage>",
-      "computed": [
-        "sameAsBoxOffsets"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "will-change",
-      "syntax": "auto | <animateable-feature>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "font-family",
-      "syntax": "[ <family-name> | <generic-family> ]#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "dependsOnUserAgent",
       "inherited": true
+    },
+    {
+      "name": "font-synthesis-small-caps",
+      "syntax": "auto | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "font-synthesis-style",
+      "syntax": "auto | none | oblique-only",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "font-synthesis-weight",
+      "syntax": "auto | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "font-variant",
+      "syntax": "normal | none | [ [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ] || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ] || [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ] || [ <east-asian-variant-values> || <east-asian-width-values> || ruby ] || [ sub | super ] || [ text | emoji | unicode ] ]",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "font-variant-alternates",
+      "syntax": "normal | [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ]",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "font-variant-caps",
+      "syntax": "normal | small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "font-variant-east-asian",
+      "syntax": "normal | [ <east-asian-variant-values> || <east-asian-width-values> || ruby ]",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "font-variant-emoji",
+      "syntax": "normal | text | emoji | unicode",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "font-variant-ligatures",
+      "syntax": "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ]",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "font-variant-numeric",
+      "syntax": "normal | [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ]",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "font-variant-position",
+      "syntax": "normal | sub | super",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "font-variation-settings",
+      "syntax": "normal | [ <opentype-tag> <number>]#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "font-weight",
+      "syntax": "<font-weight-absolute> | bolder | lighter",
+      "computed": [
+        "keywordOrNumericalValueBolderLighterTransformedToRealValue"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "font-width",
+      "syntax": "normal | <percentage [0,∞]> | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded",
+      "computed": [],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "footnote-display",
+      "syntax": "block | inline | compact",
+      "computed": [],
+      "initial": "block",
+      "inherited": false
+    },
+    {
+      "name": "footnote-policy",
+      "syntax": "auto | line | block",
+      "computed": [],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "forced-color-adjust",
+      "syntax": "auto | none | preserve-parent-color",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "gap",
+      "syntax": "<'row-gap'> <'column-gap'>?",
+      "computed": [
+        "row-gap",
+        "column-gap"
+      ],
+      "initial": [
+        "row-gap",
+        "column-gap"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "glyph-orientation-vertical",
+      "syntax": "auto | 0deg | 90deg | 0 | 90",
+      "computed": [],
+      "initial": "n/a",
+      "inherited": false
     },
     {
       "name": "grid",
@@ -4485,113 +2882,6 @@
       "inherited": false
     },
     {
-      "name": "position-anchor",
-      "syntax": "auto | <anchor-element>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "implicit",
-      "inherited": false
-    },
-    {
-      "name": "view-timeline-inset",
-      "syntax": "[ [ auto | <length-percentage> ]{1,2} ]#",
-      "computed": [
-        "listEachItemConsistingOfPairsOfAutoOrLengthPercentage"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "background-attachment",
-      "syntax": "<attachment>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "scroll",
-      "inherited": false
-    },
-    {
-      "name": "clip-rule",
-      "syntax": "nonzero | evenodd",
-      "computed": [],
-      "initial": "nonzero",
-      "inherited": true
-    },
-    {
-      "name": "-webkit-mask-box-image-repeat",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "min-block-size",
-      "syntax": "<'min-width'>",
-      "computed": [
-        "sameAsMinWidthAndMinHeight"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "font",
-      "syntax": "[ [ <'font-style'> || <font-variant-css2> || <'font-weight'> || <font-width-css3> ]? <'font-size'> [ / <'line-height'> ]? <'font-family'> ] | <system-family-name>",
-      "computed": [
-        "font-style",
-        "font-variant",
-        "font-weight",
-        "font-stretch",
-        "font-size",
-        "line-height",
-        "font-family"
-      ],
-      "initial": [
-        "font-style",
-        "font-variant",
-        "font-weight",
-        "font-stretch",
-        "font-size",
-        "line-height",
-        "font-family"
-      ],
-      "inherited": true
-    },
-    {
-      "name": "animation",
-      "syntax": "<single-animation>#",
-      "computed": [
-        "animation-name",
-        "animation-duration",
-        "animation-timing-function",
-        "animation-delay",
-        "animation-direction",
-        "animation-iteration-count",
-        "animation-fill-mode",
-        "animation-play-state",
-        "animation-timeline"
-      ],
-      "initial": [
-        "animation-name",
-        "animation-duration",
-        "animation-timing-function",
-        "animation-delay",
-        "animation-iteration-count",
-        "animation-direction",
-        "animation-fill-mode",
-        "animation-play-state",
-        "animation-timeline"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "glyph-orientation-vertical",
-      "syntax": "auto | 0deg | 90deg | 0 | 90",
-      "computed": [],
-      "initial": "n/a",
-      "inherited": false
-    },
-    {
       "name": "grid-area",
       "syntax": "<grid-line> [ / <grid-line> ]{0,3}",
       "computed": [
@@ -4609,189 +2899,30 @@
       "inherited": false
     },
     {
-      "name": "border-top-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-transform",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "block-step-align",
-      "syntax": "auto | center | start | end",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "scroll-padding-right",
-      "syntax": "auto | <length-percentage [0,∞]>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "field-sizing",
-      "syntax": "fixed | content",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "fixed",
-      "inherited": false
-    },
-    {
-      "name": "fill-position",
-      "syntax": "<position>#",
-      "computed": [],
-      "initial": "0% 0%",
-      "inherited": true
-    },
-    {
-      "name": "grid-column-gap",
-      "syntax": "",
+      "name": "grid-auto-columns",
+      "syntax": "<track-size>+",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "text-box-edge",
-      "syntax": "auto | <text-edge>",
-      "computed": [],
       "initial": "auto",
       "inherited": false
     },
     {
-      "name": "overflow",
-      "syntax": "<'overflow-block'>{1,2}",
-      "computed": [
-        "overflow-x",
-        "overflow-y"
-      ],
-      "initial": "visible",
-      "inherited": false
-    },
-    {
-      "name": "counter-increment",
-      "syntax": "[ <counter-name> <integer>? ]+ | none",
+      "name": "grid-auto-flow",
+      "syntax": "[ row | column ] || dense",
       "computed": [
         "asSpecified"
       ],
-      "initial": "none",
+      "initial": "row",
       "inherited": false
     },
     {
-      "name": "caret-shape",
-      "syntax": "auto | bar | block | underscore",
+      "name": "grid-auto-rows",
+      "syntax": "<track-size>+",
       "computed": [
-        "asSpecified"
+        "percentageAsSpecifiedOrAbsoluteLength"
       ],
       "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "line-fit-edge",
-      "syntax": "leading | <text-edge>",
-      "computed": [],
-      "initial": "leading",
-      "inherited": true
-    },
-    {
-      "name": "-webkit-box-sizing",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-mask-box-image",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "spatial-navigation-contain",
-      "syntax": "auto | contain",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "margin-block",
-      "syntax": "<'margin-top'>{1,2}",
-      "computed": [
-        "margin-block-start",
-        "margin-block-end"
-      ],
-      "initial": [
-        "margin-block-start",
-        "margin-block-end"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "box-snap",
-      "syntax": "none | block-start | block-end | center | baseline | last-baseline",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "font-synthesis-weight",
-      "syntax": "auto | none",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "clip-path",
-      "syntax": "<clip-source> | [ <basic-shape> || <geometry-box> ] | none",
-      "computed": [
-        "asSpecifiedURLsAbsolute"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "mask-border-repeat",
-      "syntax": "[ stretch | repeat | round | space ]{1,2}",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "stretch",
-      "inherited": false
-    },
-    {
-      "name": "mask-border",
-      "syntax": "<'mask-border-source'> || <'mask-border-slice'> [ / <'mask-border-width'>? [ / <'mask-border-outset'> ]? ]? || <'mask-border-repeat'> || <'mask-border-mode'>",
-      "computed": [
-        "mask-border-mode",
-        "mask-border-outset",
-        "mask-border-repeat",
-        "mask-border-slice",
-        "mask-border-source",
-        "mask-border-width"
-      ],
-      "initial": [
-        "mask-border-mode",
-        "mask-border-outset",
-        "mask-border-repeat",
-        "mask-border-slice",
-        "mask-border-source",
-        "mask-border-width"
-      ],
       "inherited": false
     },
     {
@@ -4808,234 +2939,235 @@
       "inherited": false
     },
     {
-      "name": "string-set",
-      "syntax": "none | [ <custom-ident> <string>+ ]#",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "border-bottom-style",
-      "syntax": "<line-style>",
+      "name": "grid-column-end",
+      "syntax": "<grid-line>",
       "computed": [
         "asSpecified"
       ],
-      "initial": "none",
+      "initial": "auto",
       "inherited": false
     },
     {
-      "name": "-webkit-flex-wrap",
+      "name": "grid-column-gap",
       "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "border-boundary",
-      "syntax": "none | parent | display",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "scroll-padding-inline-start",
-      "syntax": "auto | <length-percentage [0,∞]>",
       "computed": [
-        "asSpecified"
+        "percentageAsSpecifiedOrAbsoluteLength"
       ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "list-style-image",
-      "syntax": "<image> | none",
-      "computed": [
-        "theKeywordListStyleImageNoneOrComputedValue"
-      ],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "mask-mode",
-      "syntax": "<masking-mode>#",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "match-source",
-      "inherited": false
-    },
-    {
-      "name": "wrap-flow",
-      "syntax": "auto | both | start | end | minimum | maximum | clear",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "border-right-color",
-      "syntax": "<color> | <image-1D>",
-      "computed": [
-        "computedColor"
-      ],
-      "initial": "currentcolor",
-      "inherited": false
-    },
-    {
-      "name": "border-block-start",
-      "syntax": "<line-width> || <line-style> || <color>",
-      "computed": [
-        "border-width",
-        "border-style",
-        "border-block-start-color"
-      ],
-      "initial": [
-        "border-width",
-        "border-style",
-        "color"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "bookmark-level",
-      "syntax": "none | <integer [1,∞]>",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "ruby-align",
-      "syntax": "start | center | space-between | space-around",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "space-around",
-      "inherited": true
-    },
-    {
-      "name": "font-variant-ligatures",
-      "syntax": "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ]",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "font-variant-alternates",
-      "syntax": "normal | [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ]",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "block-step-size",
-      "syntax": "none | <length [0,∞]>",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "stroke-linecap",
-      "syntax": "butt | round | square",
-      "computed": [],
-      "initial": "butt",
-      "inherited": true
-    },
-    {
-      "name": "border-inline",
-      "syntax": "<'border-block-start'>",
-      "computed": [
-        "border-inline-width",
-        "border-inline-style",
-        "border-inline-color"
-      ],
-      "initial": [
-        "border-inline-width",
-        "border-inline-style",
-        "border-inline-color"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "border-inline-start-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-      "computed": [],
       "initial": "0",
       "inherited": false
     },
     {
-      "name": "text-box-trim",
-      "syntax": "none | trim-start | trim-end | trim-both",
-      "computed": [],
+      "name": "grid-column-start",
+      "syntax": "<grid-line>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "grid-gap",
+      "syntax": "",
+      "computed": [
+        "grid-row-gap",
+        "grid-column-gap"
+      ],
+      "initial": [
+        "grid-row-gap",
+        "grid-column-gap"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "grid-row",
+      "syntax": "<grid-line> [ / <grid-line> ]?",
+      "computed": [
+        "grid-row-start",
+        "grid-row-end"
+      ],
+      "initial": [
+        "grid-row-start",
+        "grid-row-end"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "grid-row-end",
+      "syntax": "<grid-line>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "grid-row-gap",
+      "syntax": "",
+      "computed": [
+        "percentageAsSpecifiedOrAbsoluteLength"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "grid-row-start",
+      "syntax": "<grid-line>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "grid-template",
+      "syntax": "none | [ <'grid-template-rows'> / <'grid-template-columns'> ] | [ <line-names>? <string> <track-size>? <line-names>? ]+ [ / <explicit-track-list> ]?",
+      "computed": [
+        "grid-template-columns",
+        "grid-template-rows",
+        "grid-template-areas"
+      ],
+      "initial": [
+        "grid-template-columns",
+        "grid-template-rows",
+        "grid-template-areas"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "grid-template-areas",
+      "syntax": "none | <string>+",
+      "computed": [
+        "asSpecified"
+      ],
       "initial": "none",
       "inherited": false
     },
     {
-      "name": "ry",
-      "syntax": "<length-percentage> | auto",
-      "computed": [],
+      "name": "grid-template-columns",
+      "syntax": "none | <track-list> | <auto-track-list> | subgrid <line-name-list>?",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "grid-template-rows",
+      "syntax": "none | <track-list> | <auto-track-list> | subgrid <line-name-list>?",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "hanging-punctuation",
+      "syntax": "none | [ first || [ force-end | allow-end ] || last ]",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "height",
+      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+      "computed": [
+        "percentageAutoOrAbsoluteLength"
+      ],
       "initial": "auto",
       "inherited": false
+    },
+    {
+      "name": "hyphens",
+      "syntax": "none | manual | auto",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "manual",
+      "inherited": true
+    },
+    {
+      "name": "image-orientation",
+      "syntax": "from-image | none | [ <angle> || flip ]",
+      "computed": [
+        "angleRoundedToNextQuarter"
+      ],
+      "initial": "from-image",
+      "inherited": true
+    },
+    {
+      "name": "image-rendering",
+      "syntax": "auto | smooth | high-quality | pixelated | crisp-edges",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "initial-letter",
+      "syntax": "normal | <number [1,∞]> <integer [1,∞]> | <number [1,∞]> && [ drop | raise ]?",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "initial-letter-align",
+      "syntax": "[ border-box? [ alphabetic | ideographic | hanging | leading ]? ]!",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "initial-letter-wrap",
+      "syntax": "none | first | all | grid | <length-percentage>",
+      "computed": [],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "inline-size",
+      "syntax": "<'width'>",
+      "computed": [
+        "sameAsWidthAndHeight"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "inline-sizing",
+      "syntax": "normal | stretch",
+      "computed": [],
+      "initial": "normal",
+      "inherited": true
     },
     {
       "name": "input-security",
       "syntax": "auto | none",
-      "computed": [
-        "asSpecified"
-      ],
+      "computed": [],
       "initial": "auto",
       "inherited": false
     },
     {
-      "name": "font-variant-caps",
-      "syntax": "normal | small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps",
+      "name": "inset",
+      "syntax": "<'top'>{1,4}",
       "computed": [
-        "asSpecified"
+        "top",
+        "bottom",
+        "left",
+        "right"
       ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "justify-items",
-      "syntax": "normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | legacy | legacy && [ left | right | center ] | anchor-center",
-      "computed": [
-        "asSpecified"
+      "initial": [
+        "top",
+        "bottom",
+        "left",
+        "right"
       ],
-      "initial": "legacy",
-      "inherited": false
-    },
-    {
-      "name": "offset-distance",
-      "syntax": "<length-percentage>",
-      "computed": [
-        "forLengthAbsoluteValueOtherwisePercentage"
-      ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "grid-auto-flow",
-      "syntax": "[ row | column ] || dense",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "row",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-transform-origin",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "line-grid",
-      "syntax": "match-parent | create",
-      "computed": [],
-      "initial": "match-parent",
       "inherited": false
     },
     {
@@ -5052,13 +3184,398 @@
       "inherited": false
     },
     {
-      "name": "resize",
-      "syntax": "none | both | horizontal | vertical | block | inline",
+      "name": "inset-block-end",
+      "syntax": "auto | <length-percentage>",
+      "computed": [
+        "sameAsBoxOffsets"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "inset-block-start",
+      "syntax": "auto | <length-percentage>",
+      "computed": [
+        "sameAsBoxOffsets"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "inset-inline",
+      "syntax": "<'top'>{1,2}",
+      "computed": [
+        "inset-inline-start",
+        "inset-inline-end"
+      ],
+      "initial": [
+        "inset-inline-start",
+        "inset-inline-end"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "inset-inline-end",
+      "syntax": "auto | <length-percentage>",
+      "computed": [
+        "sameAsBoxOffsets"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "inset-inline-start",
+      "syntax": "auto | <length-percentage>",
+      "computed": [
+        "sameAsBoxOffsets"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "interactivity",
+      "syntax": "auto | inert",
+      "computed": [],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "isolation",
+      "syntax": "<isolation-mode>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "justify-content",
+      "syntax": "normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ]",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "justify-items",
+      "syntax": "normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | legacy | legacy && [ left | right | center ] | anchor-center",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "legacy",
+      "inherited": false
+    },
+    {
+      "name": "justify-self",
+      "syntax": "auto | normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | anchor-center",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "left",
+      "syntax": "auto | <length-percentage> | <anchor()> | <anchor-size()>",
+      "computed": [
+        "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "letter-spacing",
+      "syntax": "normal | <length>",
+      "computed": [
+        "optimumValueOfAbsoluteLengthOrNormal"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "lighting-color",
+      "syntax": "<color>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "white",
+      "inherited": false
+    },
+    {
+      "name": "line-break",
+      "syntax": "auto | loose | normal | strict | anywhere",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "line-fit-edge",
+      "syntax": "leading | <text-edge>",
+      "computed": [],
+      "initial": "leading",
+      "inherited": true
+    },
+    {
+      "name": "line-grid",
+      "syntax": "match-parent | create",
+      "computed": [],
+      "initial": "match-parent",
+      "inherited": false
+    },
+    {
+      "name": "line-height",
+      "syntax": "normal | <number [0,∞]> | <length-percentage [0,∞]>",
+      "computed": [
+        "absoluteLengthOrAsSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "line-height-step",
+      "syntax": "<length [0,∞]>",
+      "computed": [
+        "absoluteLength"
+      ],
+      "initial": "0",
+      "inherited": true
+    },
+    {
+      "name": "line-snap",
+      "syntax": "none | baseline | contain",
+      "computed": [],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "link-parameters",
+      "syntax": "none | <link-param>+",
+      "computed": [],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "list-style",
+      "syntax": "<'list-style-position'> || <'list-style-image'> || <'list-style-type'>",
+      "computed": [
+        "list-style-image",
+        "list-style-position",
+        "list-style-type"
+      ],
+      "initial": [
+        "list-style-type",
+        "list-style-position",
+        "list-style-image"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "list-style-image",
+      "syntax": "<image> | none",
+      "computed": [
+        "theKeywordListStyleImageNoneOrComputedValue"
+      ],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "list-style-position",
+      "syntax": "inside | outside",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "outside",
+      "inherited": true
+    },
+    {
+      "name": "list-style-type",
+      "syntax": "<counter-style> | <string> | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "disc",
+      "inherited": true
+    },
+    {
+      "name": "margin",
+      "syntax": "<'margin-top'>{1,4}",
+      "computed": [
+        "margin-bottom",
+        "margin-left",
+        "margin-right",
+        "margin-top"
+      ],
+      "initial": [
+        "margin-bottom",
+        "margin-left",
+        "margin-right",
+        "margin-top"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "margin-block",
+      "syntax": "<'margin-top'>{1,2}",
+      "computed": [
+        "margin-block-start",
+        "margin-block-end"
+      ],
+      "initial": [
+        "margin-block-start",
+        "margin-block-end"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "margin-block-end",
+      "syntax": "<'margin-top'>",
+      "computed": [
+        "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "margin-block-start",
+      "syntax": "<'margin-top'>",
+      "computed": [
+        "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "margin-bottom",
+      "syntax": "<length-percentage> | auto | <anchor-size()>",
+      "computed": [
+        "percentageAsSpecifiedOrAbsoluteLength"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "margin-break",
+      "syntax": "auto | keep | discard",
+      "computed": [],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "margin-inline",
+      "syntax": "<'margin-top'>{1,2}",
+      "computed": [
+        "margin-inline-start",
+        "margin-inline-end"
+      ],
+      "initial": [
+        "margin-inline-start",
+        "margin-inline-end"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "margin-inline-end",
+      "syntax": "<'margin-top'>",
+      "computed": [
+        "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "margin-inline-start",
+      "syntax": "<'margin-top'>",
+      "computed": [
+        "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "margin-left",
+      "syntax": "<length-percentage> | auto | <anchor-size()>",
+      "computed": [
+        "percentageAsSpecifiedOrAbsoluteLength"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "margin-right",
+      "syntax": "<length-percentage> | auto | <anchor-size()>",
+      "computed": [
+        "percentageAsSpecifiedOrAbsoluteLength"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "margin-top",
+      "syntax": "<length-percentage> | auto | <anchor-size()>",
+      "computed": [
+        "percentageAsSpecifiedOrAbsoluteLength"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "margin-trim",
+      "syntax": "none | [ block || inline ] | [ block-start || inline-start || block-end || inline-end ]",
       "computed": [
         "asSpecified"
       ],
       "initial": "none",
       "inherited": false
+    },
+    {
+      "name": "marker",
+      "syntax": "none | <marker-ref>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": [
+        "marker-start",
+        "marker-mid",
+        "marker-end"
+      ],
+      "inherited": true
+    },
+    {
+      "name": "marker-end",
+      "syntax": "none | <marker-ref>",
+      "computed": [
+        "asSpecifiedURLsAbsolute"
+      ],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "marker-mid",
+      "syntax": "none | <marker-ref>",
+      "computed": [
+        "asSpecifiedURLsAbsolute"
+      ],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "marker-side",
+      "syntax": "match-self | match-parent",
+      "computed": [],
+      "initial": "match-self",
+      "inherited": true
+    },
+    {
+      "name": "marker-start",
+      "syntax": "none | <marker-ref>",
+      "computed": [
+        "asSpecifiedURLsAbsolute"
+      ],
+      "initial": "none",
+      "inherited": true
     },
     {
       "name": "mask",
@@ -5086,17 +3603,483 @@
       "inherited": false
     },
     {
-      "name": "-webkit-background-origin",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "mask-border",
+      "syntax": "<'mask-border-source'> || <'mask-border-slice'> [ / <'mask-border-width'>? [ / <'mask-border-outset'> ]? ]? || <'mask-border-repeat'> || <'mask-border-mode'>",
+      "computed": [
+        "mask-border-mode",
+        "mask-border-outset",
+        "mask-border-repeat",
+        "mask-border-slice",
+        "mask-border-source",
+        "mask-border-width"
+      ],
+      "initial": [
+        "mask-border-mode",
+        "mask-border-outset",
+        "mask-border-repeat",
+        "mask-border-slice",
+        "mask-border-source",
+        "mask-border-width"
+      ],
       "inherited": false
     },
     {
-      "name": "spatial-navigation-function",
-      "syntax": "normal | grid",
-      "computed": [],
+      "name": "mask-border-mode",
+      "syntax": "luminance | alpha",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "alpha",
+      "inherited": false
+    },
+    {
+      "name": "mask-border-outset",
+      "syntax": "[ <length> | <number> ]{1,4}",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "mask-border-repeat",
+      "syntax": "[ stretch | repeat | round | space ]{1,2}",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "stretch",
+      "inherited": false
+    },
+    {
+      "name": "mask-border-slice",
+      "syntax": "[ <number> | <percentage> ]{1,4} fill?",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "mask-border-source",
+      "syntax": "none | <image>",
+      "computed": [
+        "asSpecifiedURLsAbsolute"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "mask-border-width",
+      "syntax": "[ <length-percentage> | <number> | auto ]{1,4}",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "mask-clip",
+      "syntax": "[ <coord-box> | no-clip ]#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "border-box",
+      "inherited": false
+    },
+    {
+      "name": "mask-composite",
+      "syntax": "<compositing-operator>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "add",
+      "inherited": false
+    },
+    {
+      "name": "mask-image",
+      "syntax": "<mask-reference>#",
+      "computed": [
+        "asSpecifiedURLsAbsolute"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "mask-mode",
+      "syntax": "<masking-mode>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "match-source",
+      "inherited": false
+    },
+    {
+      "name": "mask-origin",
+      "syntax": "<coord-box>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "border-box",
+      "inherited": false
+    },
+    {
+      "name": "mask-position",
+      "syntax": "<position>#",
+      "computed": [
+        "consistsOfTwoKeywordsForOriginAndOffsets"
+      ],
+      "initial": "0% 0%",
+      "inherited": false
+    },
+    {
+      "name": "mask-repeat",
+      "syntax": "<repeat-style>#",
+      "computed": [
+        "consistsOfTwoDimensionKeywords"
+      ],
+      "initial": "repeat",
+      "inherited": false
+    },
+    {
+      "name": "mask-size",
+      "syntax": "<bg-size>#",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "mask-type",
+      "syntax": "luminance | alpha",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "luminance",
+      "inherited": false
+    },
+    {
+      "name": "math-depth",
+      "syntax": "auto-add | add(<integer>) | <integer>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
+      "inherited": true
+    },
+    {
+      "name": "math-shift",
+      "syntax": "normal | compact",
+      "computed": [
+        "asSpecified"
+      ],
       "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "math-style",
+      "syntax": "normal | compact",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "max-block-size",
+      "syntax": "<'max-width'>",
+      "computed": [
+        "sameAsMaxWidthAndMaxHeight"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "max-height",
+      "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+      "computed": [
+        "percentageAsSpecifiedAbsoluteLengthOrNone"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "max-inline-size",
+      "syntax": "<'max-width'>",
+      "computed": [
+        "sameAsMaxWidthAndMaxHeight"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "max-width",
+      "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+      "computed": [
+        "percentageAsSpecifiedAbsoluteLengthOrNone"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "min-block-size",
+      "syntax": "<'min-width'>",
+      "computed": [
+        "sameAsMinWidthAndMinHeight"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "min-height",
+      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+      "computed": [
+        "percentageAsSpecifiedOrAbsoluteLength"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "min-inline-size",
+      "syntax": "<'min-width'>",
+      "computed": [
+        "sameAsMinWidthAndMinHeight"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "min-width",
+      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+      "computed": [
+        "percentageAsSpecifiedOrAbsoluteLength"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "mix-blend-mode",
+      "syntax": "<blend-mode> | plus-darker | plus-lighter",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "nav-down",
+      "syntax": "auto | <id> [ current | root | <target-name> ]?",
+      "computed": [],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "nav-left",
+      "syntax": "auto | <id> [ current | root | <target-name> ]?",
+      "computed": [],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "nav-right",
+      "syntax": "auto | <id> [ current | root | <target-name> ]?",
+      "computed": [],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "nav-up",
+      "syntax": "auto | <id> [ current | root | <target-name> ]?",
+      "computed": [],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "object-fit",
+      "syntax": "fill | contain | cover | none | scale-down",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "fill",
+      "inherited": false
+    },
+    {
+      "name": "object-position",
+      "syntax": "<position>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "50% 50%",
+      "inherited": false
+    },
+    {
+      "name": "offset",
+      "syntax": "[ <'offset-position'>? [ <'offset-path'> [ <'offset-distance'> || <'offset-rotate'> ]? ]? ]! [ / <'offset-anchor'> ]?",
+      "computed": [
+        "offset-position",
+        "offset-path",
+        "offset-distance",
+        "offset-anchor",
+        "offset-rotate"
+      ],
+      "initial": [
+        "offset-position",
+        "offset-path",
+        "offset-distance",
+        "offset-anchor",
+        "offset-rotate"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "offset-anchor",
+      "syntax": "auto | <position>",
+      "computed": [
+        "forLengthAbsoluteValueOtherwisePercentage"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "offset-distance",
+      "syntax": "<length-percentage>",
+      "computed": [
+        "forLengthAbsoluteValueOtherwisePercentage"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "offset-path",
+      "syntax": "none | <offset-path> || <coord-box>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "offset-position",
+      "syntax": "normal | auto | <position>",
+      "computed": [
+        "forLengthAbsoluteValueOtherwisePercentage"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "offset-rotate",
+      "syntax": "[ auto | reverse ] || <angle>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "opacity",
+      "syntax": "<opacity-value>",
+      "computed": [
+        "specifiedValueNumberClipped0To1"
+      ],
+      "initial": "1",
+      "inherited": false
+    },
+    {
+      "name": "order",
+      "syntax": "<integer>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "orphans",
+      "syntax": "<integer [1,∞]>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "2",
+      "inherited": true
+    },
+    {
+      "name": "outline",
+      "syntax": "<'outline-width'> || <'outline-style'> || <'outline-color'>",
+      "computed": [
+        "outline-width",
+        "outline-style",
+        "outline-color"
+      ],
+      "initial": [
+        "outline-width",
+        "outline-style",
+        "outline-color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "outline-color",
+      "syntax": "auto | <color> | <image-1D>",
+      "computed": [
+        "autoForTranslucentColorRGBAOtherwiseRGB"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "outline-offset",
+      "syntax": "<length>",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "outline-style",
+      "syntax": "auto | <outline-line-style>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "outline-width",
+      "syntax": "<line-width>",
+      "computed": [
+        "absoluteLength0ForNone"
+      ],
+      "initial": "medium",
+      "inherited": false
+    },
+    {
+      "name": "overflow",
+      "syntax": "<'overflow-block'>{1,2}",
+      "computed": [
+        "overflow-x",
+        "overflow-y"
+      ],
+      "initial": "visible",
+      "inherited": false
+    },
+    {
+      "name": "overflow-anchor",
+      "syntax": "auto | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "overflow-block",
+      "syntax": "visible | hidden | clip | scroll | auto",
+      "computed": [
+        "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
+      ],
+      "initial": "auto",
       "inherited": false
     },
     {
@@ -5109,64 +4092,122 @@
       "inherited": false
     },
     {
-      "name": "margin-inline",
-      "syntax": "<'margin-top'>{1,2}",
+      "name": "overflow-inline",
+      "syntax": "visible | hidden | clip | scroll | auto",
       "computed": [
-        "margin-inline-start",
-        "margin-inline-end"
+        "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "overflow-wrap",
+      "syntax": "normal | break-word | anywhere",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "overflow-x",
+      "syntax": "visible | hidden | clip | scroll | auto",
+      "computed": [
+        "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
+      ],
+      "initial": "visible",
+      "inherited": false
+    },
+    {
+      "name": "overflow-y",
+      "syntax": "visible | hidden | clip | scroll | auto",
+      "computed": [
+        "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
+      ],
+      "initial": "visible",
+      "inherited": false
+    },
+    {
+      "name": "overscroll-behavior",
+      "syntax": "[ contain | none | auto ]{1,2}",
+      "computed": [
+        "overscroll-behavior-x",
+        "overscroll-behavior-y"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "overscroll-behavior-block",
+      "syntax": "contain | none | auto",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "overscroll-behavior-inline",
+      "syntax": "contain | none | auto",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "overscroll-behavior-x",
+      "syntax": "contain | none | auto",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "overscroll-behavior-y",
+      "syntax": "contain | none | auto",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "padding",
+      "syntax": "<'padding-top'>{1,4}",
+      "computed": [
+        "padding-bottom",
+        "padding-left",
+        "padding-right",
+        "padding-top"
       ],
       "initial": [
-        "margin-inline-start",
-        "margin-inline-end"
+        "padding-bottom",
+        "padding-left",
+        "padding-right",
+        "padding-top"
       ],
       "inherited": false
     },
     {
-      "name": "border-width",
-      "syntax": "<line-width>{1,4}",
+      "name": "padding-block",
+      "syntax": "<'padding-top'>{1,2}",
       "computed": [
-        "border-bottom-width",
-        "border-left-width",
-        "border-right-width",
-        "border-top-width"
+        "padding-block-start",
+        "padding-block-end"
       ],
       "initial": [
-        "border-top-width",
-        "border-right-width",
-        "border-bottom-width",
-        "border-left-width"
+        "padding-block-start",
+        "padding-block-end"
       ],
       "inherited": false
     },
     {
-      "name": "grid-template",
-      "syntax": "none | [ <'grid-template-rows'> / <'grid-template-columns'> ] | [ <line-names>? <string> <track-size>? <line-names>? ]+ [ / <explicit-track-list> ]?",
+      "name": "padding-block-end",
+      "syntax": "<'padding-top'>",
       "computed": [
-        "grid-template-columns",
-        "grid-template-rows",
-        "grid-template-areas"
-      ],
-      "initial": [
-        "grid-template-columns",
-        "grid-template-rows",
-        "grid-template-areas"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "border-left-color",
-      "syntax": "<color> | <image-1D>",
-      "computed": [
-        "computedColor"
-      ],
-      "initial": "currentcolor",
-      "inherited": false
-    },
-    {
-      "name": "border-start-start-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2}",
-      "computed": [
-        "twoAbsoluteLengthOrPercentages"
+        "asLength"
       ],
       "initial": "0",
       "inherited": false
@@ -5181,177 +4222,79 @@
       "inherited": false
     },
     {
-      "name": "position-try",
-      "syntax": "<'position-try-order'>? <'position-try-fallbacks'>",
+      "name": "padding-bottom",
+      "syntax": "<length-percentage [0,∞]>",
       "computed": [
-        "position-try-fallbacks",
-        "position-try-order"
-      ],
-      "initial": [
-        "position-try-fallbacks",
-        "position-try-order"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "overscroll-behavior-inline",
-      "syntax": "contain | none | auto",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "outline-style",
-      "syntax": "auto | <outline-line-style>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "outline-offset",
-      "syntax": "<length>",
-      "computed": [
-        "asSpecifiedRelativeToAbsoluteLengths"
+        "percentageAsSpecifiedOrAbsoluteLength"
       ],
       "initial": "0",
       "inherited": false
     },
     {
-      "name": "fill-image",
-      "syntax": "<paint>#",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "text-align",
-      "syntax": "start | end | left | right | center | justify | match-parent | justify-all",
+      "name": "padding-inline",
+      "syntax": "<'padding-top'>{1,2}",
       "computed": [
-        "asSpecifiedExceptMatchParent"
-      ],
-      "initial": "startOrNamelessValueIfLTRRightIfRTL",
-      "inherited": true
-    },
-    {
-      "name": "stroke",
-      "syntax": "<paint>",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "-webkit-border-bottom-right-radius",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-order",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-perspective-origin",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "reading-flow",
-      "syntax": "normal | flex-visual | flex-flow | grid-rows | grid-columns | grid-order",
-      "computed": [],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "flex",
-      "syntax": "none | [ <'flex-grow'> <'flex-shrink'>? || <'flex-basis'> ]",
-      "computed": [
-        "flex-grow",
-        "flex-shrink",
-        "flex-basis"
+        "padding-inline-start",
+        "padding-inline-end"
       ],
       "initial": [
-        "flex-grow",
-        "flex-shrink",
-        "flex-basis"
+        "padding-inline-start",
+        "padding-inline-end"
       ],
       "inherited": false
     },
     {
-      "name": "border-limit",
-      "syntax": "all | [ sides | corners ] <length-percentage [0,∞]>? | [ top | right | bottom | left ] <length-percentage [0,∞]>",
-      "computed": [],
-      "initial": "all",
+      "name": "padding-inline-end",
+      "syntax": "<'padding-top'>",
+      "computed": [
+        "asLength"
+      ],
+      "initial": "0",
       "inherited": false
     },
     {
-      "name": "font-size-adjust",
-      "syntax": "none | <number [0,∞]>",
+      "name": "padding-inline-start",
+      "syntax": "<'padding-top'>",
       "computed": [
-        "asSpecified"
+        "asLength"
       ],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "word-break",
-      "syntax": "normal | keep-all | break-all | break-word",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "border-top-style",
-      "syntax": "<line-style>",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "none",
+      "initial": "0",
       "inherited": false
     },
     {
-      "name": "corners",
-      "syntax": "<'corner-shape'> || <'border-radius'>",
-      "computed": [],
-      "initial": "see individual properties",
+      "name": "padding-left",
+      "syntax": "<length-percentage [0,∞]>",
+      "computed": [
+        "percentageAsSpecifiedOrAbsoluteLength"
+      ],
+      "initial": "0",
       "inherited": false
     },
     {
-      "name": "shape-image-threshold",
-      "syntax": "<opacity-value>",
+      "name": "padding-right",
+      "syntax": "<length-percentage [0,∞]>",
       "computed": [
-        "specifiedValueNumberClipped0To1"
+        "percentageAsSpecifiedOrAbsoluteLength"
       ],
-      "initial": "0.0",
+      "initial": "0",
       "inherited": false
     },
     {
-      "name": "text-emphasis-style",
-      "syntax": "none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | <string>",
+      "name": "padding-top",
+      "syntax": "<length-percentage [0,∞]>",
       "computed": [
-        "asSpecified"
+        "percentageAsSpecifiedOrAbsoluteLength"
       ],
-      "initial": "none",
-      "inherited": true
+      "initial": "0",
+      "inherited": false
     },
     {
-      "name": "transform-box",
-      "syntax": "content-box | border-box | fill-box | stroke-box | view-box",
+      "name": "page",
+      "syntax": "auto | <custom-ident>",
       "computed": [
         "asSpecified"
       ],
-      "initial": "view-box",
+      "initial": "auto",
       "inherited": false
     },
     {
@@ -5364,64 +4307,64 @@
       "inherited": false
     },
     {
-      "name": "corner-shape",
-      "syntax": "[ round | angle ]{1,4}",
-      "computed": [],
-      "initial": "round",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-align-items",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-mask-repeat",
-      "syntax": "",
-      "computed": [
-        "asSpecified"
-      ],
-      "initial": "repeat",
-      "inherited": false
-    },
-    {
-      "name": "image-rendering",
-      "syntax": "auto | smooth | high-quality | pixelated | crisp-edges",
+      "name": "page-break-before",
+      "syntax": "auto | always | avoid | left | right | inherit",
       "computed": [
         "asSpecified"
       ],
       "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "color-interpolation",
-      "syntax": "auto | sRGB | linearRGB",
-      "computed": [],
-      "initial": "sRGB",
-      "inherited": true
-    },
-    {
-      "name": "scroll-padding-block",
-      "syntax": "[ auto | <length-percentage [0,∞]> ]{1,2}",
-      "computed": [
-        "scroll-padding-block-start",
-        "scroll-padding-block-end"
-      ],
-      "initial": [
-        "scroll-padding-block-start",
-        "scroll-padding-block-end"
-      ],
       "inherited": false
     },
     {
-      "name": "mask-repeat",
-      "syntax": "<repeat-style>#",
+      "name": "page-break-inside",
+      "syntax": "avoid | auto | inherit",
       "computed": [
-        "consistsOfTwoDimensionKeywords"
+        "asSpecified"
       ],
-      "initial": "repeat",
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "paint-order",
+      "syntax": "normal | [ fill || stroke || markers ]",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "pause",
+      "syntax": "<'pause-before'> <'pause-after'>?",
+      "computed": [],
+      "initial": "see individual properties",
+      "inherited": false
+    },
+    {
+      "name": "pause-after",
+      "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
+      "computed": [],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "pause-before",
+      "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
+      "computed": [],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "place-content",
+      "syntax": "<'align-content'> <'justify-content'>?",
+      "computed": [
+        "align-content",
+        "justify-content"
+      ],
+      "initial": [
+        "align-content",
+        "justify-content"
+      ],
       "inherited": false
     },
     {
@@ -5438,27 +4381,156 @@
       "inherited": false
     },
     {
-      "name": "hyphens",
-      "syntax": "none | manual | auto",
+      "name": "place-self",
+      "syntax": "<'align-self'> <'justify-self'>?",
+      "computed": [
+        "align-self",
+        "justify-self"
+      ],
+      "initial": [
+        "align-self",
+        "justify-self"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "pointer-events",
+      "syntax": "auto | bounding-box | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all | none",
       "computed": [
         "asSpecified"
       ],
-      "initial": "manual",
+      "initial": "auto",
       "inherited": true
     },
     {
-      "name": "border-block-end",
-      "syntax": "<line-width> || <line-style> || <color>",
+      "name": "position",
+      "syntax": "static | relative | absolute | sticky | fixed | <running()>",
       "computed": [
-        "border-top-width",
-        "border-top-style",
-        "border-top-color"
+        "asSpecified"
+      ],
+      "initial": "static",
+      "inherited": false
+    },
+    {
+      "name": "position-anchor",
+      "syntax": "auto | <anchor-name>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "position-area",
+      "syntax": "none | <position-area>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "position-try",
+      "syntax": "<'position-try-order'>? <'position-try-fallbacks'>",
+      "computed": [
+        "position-try-fallbacks",
+        "position-try-order"
       ],
       "initial": [
-        "border-top-width",
-        "border-top-style",
-        "border-top-color"
+        "position-try-fallbacks",
+        "position-try-order"
       ],
+      "inherited": false
+    },
+    {
+      "name": "position-try-fallbacks",
+      "syntax": "none | [ [<dashed-ident> || <try-tactic>] | <'position-area'> ]#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "position-try-order",
+      "syntax": "normal | <try-size>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "position-visibility",
+      "syntax": "always | [ anchors-valid || anchors-visible || no-overflow ]",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "anchors-visible",
+      "inherited": false
+    },
+    {
+      "name": "print-color-adjust",
+      "syntax": "economy | exact",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "economy",
+      "inherited": true
+    },
+    {
+      "name": "quotes",
+      "syntax": "auto | none | match-parent | [ <string> <string> ]+",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "dependsOnUserAgent",
+      "inherited": true
+    },
+    {
+      "name": "r",
+      "syntax": "<length-percentage>",
+      "computed": [
+        "percentageAsSpecifiedOrAbsoluteLength"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "reading-flow",
+      "syntax": "normal | source-order | flex-visual | flex-flow | grid-rows | grid-columns | grid-order",
+      "computed": [],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "reading-order",
+      "syntax": "<integer>",
+      "computed": [],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "region-fragment",
+      "syntax": "auto | break",
+      "computed": [],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "resize",
+      "syntax": "none | both | horizontal | vertical | block | inline",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "rest",
+      "syntax": "<'rest-before'> <'rest-after'>?",
+      "computed": [],
+      "initial": "see individual properties",
       "inherited": false
     },
     {
@@ -5469,32 +4541,157 @@
       "inherited": false
     },
     {
-      "name": "stroke-dashadjust",
-      "syntax": "none | [stretch | compress] [dashes | gaps]?",
+      "name": "rest-before",
+      "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
       "computed": [],
       "initial": "none",
-      "inherited": true
+      "inherited": false
     },
     {
-      "name": "forced-color-adjust",
-      "syntax": "auto | none | preserve-parent-color",
+      "name": "right",
+      "syntax": "auto | <length-percentage> | <anchor()> | <anchor-size()>",
+      "computed": [
+        "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "row-gap",
+      "syntax": "normal | <length-percentage [0,∞]>",
+      "computed": [
+        "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "row-rule",
+      "syntax": "<gap-rule-list> | <gap-auto-rule-list>",
+      "computed": [],
+      "initial": "see individual properties",
+      "inherited": false
+    },
+    {
+      "name": "row-rule-break",
+      "syntax": "none | spanning-item | intersection",
+      "computed": [],
+      "initial": "spanning-item",
+      "inherited": false
+    },
+    {
+      "name": "row-rule-color",
+      "syntax": "<line-color-list> | <auto-line-color-list>",
+      "computed": [],
+      "initial": "currentcolor",
+      "inherited": false
+    },
+    {
+      "name": "row-rule-outset",
+      "syntax": "<length-percentage>",
+      "computed": [],
+      "initial": "50%",
+      "inherited": false
+    },
+    {
+      "name": "row-rule-style",
+      "syntax": "<line-style-list> | <auto-line-style-list>",
+      "computed": [],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "row-rule-width",
+      "syntax": "<line-width-list> | <auto-line-width-list>",
+      "computed": [],
+      "initial": "medium",
+      "inherited": false
+    },
+    {
+      "name": "ruby-align",
+      "syntax": "start | center | space-between | space-around",
       "computed": [
         "asSpecified"
       ],
+      "initial": "space-around",
+      "inherited": true
+    },
+    {
+      "name": "ruby-merge",
+      "syntax": "separate | merge | auto",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "separate",
+      "inherited": true
+    },
+    {
+      "name": "ruby-overhang",
+      "syntax": "auto | none",
+      "computed": [],
       "initial": "auto",
       "inherited": true
     },
     {
-      "name": "font-variant",
-      "syntax": "normal | none | [ [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ] || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ] || [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ] || [ <east-asian-variant-values> || <east-asian-width-values> || ruby ] || [ sub | super ] || [ text | emoji | unicode ] ]",
+      "name": "ruby-position",
+      "syntax": "[ alternate || [ over | under ] ] | inter-character",
       "computed": [
         "asSpecified"
       ],
-      "initial": "normal",
+      "initial": "alternate",
       "inherited": true
     },
     {
-      "name": "margin-top",
+      "name": "rule",
+      "syntax": "<'column-rule'>",
+      "computed": [],
+      "initial": "see individual properties",
+      "inherited": false
+    },
+    {
+      "name": "rule-break",
+      "syntax": "<'column-rule-break'>",
+      "computed": [],
+      "initial": "see individual properties",
+      "inherited": false
+    },
+    {
+      "name": "rule-color",
+      "syntax": "<'column-rule-color'>",
+      "computed": [],
+      "initial": "see individual properties",
+      "inherited": false
+    },
+    {
+      "name": "rule-outset",
+      "syntax": "<'column-rule-outset'>",
+      "computed": [],
+      "initial": "see individual properties",
+      "inherited": false
+    },
+    {
+      "name": "rule-paint-order",
+      "syntax": "row-over-column | column-over-row",
+      "computed": [],
+      "initial": "row-over-column",
+      "inherited": false
+    },
+    {
+      "name": "rule-style",
+      "syntax": "<'column-rule-style'>",
+      "computed": [],
+      "initial": "see individual properties",
+      "inherited": false
+    },
+    {
+      "name": "rule-width",
+      "syntax": "<'column-rule-width'>",
+      "computed": [],
+      "initial": "see individual properties",
+      "inherited": false
+    },
+    {
+      "name": "rx",
       "syntax": "<length-percentage> | auto",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
@@ -5503,81 +4700,38 @@
       "inherited": false
     },
     {
-      "name": "gap",
-      "syntax": "<'row-gap'> <'column-gap'>?",
+      "name": "ry",
+      "syntax": "<length-percentage> | auto",
       "computed": [
-        "row-gap",
-        "column-gap"
-      ],
-      "initial": [
-        "row-gap",
-        "column-gap"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "border-end-end-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2}",
-      "computed": [
-        "twoAbsoluteLengthOrPercentages"
+        "percentageAsSpecifiedOrAbsoluteLength"
       ],
       "initial": "0",
       "inherited": false
     },
     {
-      "name": "background",
-      "syntax": "<bg-layer>#? , <final-bg-layer>",
+      "name": "scroll-behavior",
+      "syntax": "auto | smooth",
       "computed": [
-        "background-image",
-        "background-position",
-        "background-size",
-        "background-repeat",
-        "background-origin",
-        "background-clip",
-        "background-attachment",
-        "background-color"
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "scroll-margin",
+      "syntax": "<length>{1,4}",
+      "computed": [
+        "scroll-margin-bottom",
+        "scroll-margin-left",
+        "scroll-margin-right",
+        "scroll-margin-top"
       ],
       "initial": [
-        "background-image",
-        "background-position",
-        "background-size",
-        "background-repeat",
-        "background-origin",
-        "background-clip",
-        "background-attachment",
-        "background-color"
+        "scroll-margin-bottom",
+        "scroll-margin-left",
+        "scroll-margin-right",
+        "scroll-margin-top"
       ],
-      "inherited": false
-    },
-    {
-      "name": "border",
-      "syntax": "<line-width> || <line-style> || <color>",
-      "computed": [
-        "border-width",
-        "border-style",
-        "border-color"
-      ],
-      "initial": [
-        "border-width",
-        "border-style",
-        "border-color"
-      ],
-      "inherited": false
-    },
-    {
-      "name": "border-inline-end-color",
-      "syntax": "<color> | <image-1D>",
-      "computed": [
-        "computedColor"
-      ],
-      "initial": "currentcolor",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-flex-direction",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
       "inherited": false
     },
     {
@@ -5594,99 +4748,2115 @@
       "inherited": false
     },
     {
-      "name": "accent-color",
-      "syntax": "auto | <color>",
+      "name": "scroll-margin-block-end",
+      "syntax": "<length>",
       "computed": [
-        "asAutoOrColor"
+        "asSpecified"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "scroll-margin-block-start",
+      "syntax": "<length>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "scroll-margin-bottom",
+      "syntax": "<length>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "scroll-margin-inline",
+      "syntax": "<length>{1,2}",
+      "computed": [
+        "scroll-margin-inline-start",
+        "scroll-margin-inline-end"
+      ],
+      "initial": [
+        "scroll-margin-inline-start",
+        "scroll-margin-inline-end"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "scroll-margin-inline-end",
+      "syntax": "<length>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "scroll-margin-inline-start",
+      "syntax": "<length>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "scroll-margin-left",
+      "syntax": "<length>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "scroll-margin-right",
+      "syntax": "<length>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "scroll-margin-top",
+      "syntax": "<length>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "scroll-padding",
+      "syntax": "[ auto | <length-percentage [0,∞]> ]{1,4}",
+      "computed": [
+        "scroll-padding-bottom",
+        "scroll-padding-left",
+        "scroll-padding-right",
+        "scroll-padding-top"
+      ],
+      "initial": [
+        "scroll-padding-bottom",
+        "scroll-padding-left",
+        "scroll-padding-right",
+        "scroll-padding-top"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "scroll-padding-block",
+      "syntax": "[ auto | <length-percentage [0,∞]> ]{1,2}",
+      "computed": [
+        "scroll-padding-block-start",
+        "scroll-padding-block-end"
+      ],
+      "initial": [
+        "scroll-padding-block-start",
+        "scroll-padding-block-end"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "scroll-padding-block-end",
+      "syntax": "auto | <length-percentage [0,∞]>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "scroll-padding-block-start",
+      "syntax": "auto | <length-percentage [0,∞]>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "scroll-padding-bottom",
+      "syntax": "auto | <length-percentage [0,∞]>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "scroll-padding-inline",
+      "syntax": "[ auto | <length-percentage [0,∞]> ]{1,2}",
+      "computed": [
+        "scroll-padding-inline-start",
+        "scroll-padding-inline-end"
+      ],
+      "initial": [
+        "scroll-padding-inline-start",
+        "scroll-padding-inline-end"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "scroll-padding-inline-end",
+      "syntax": "auto | <length-percentage [0,∞]>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "scroll-padding-inline-start",
+      "syntax": "auto | <length-percentage [0,∞]>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "scroll-padding-left",
+      "syntax": "auto | <length-percentage [0,∞]>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "scroll-padding-right",
+      "syntax": "auto | <length-percentage [0,∞]>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "scroll-padding-top",
+      "syntax": "auto | <length-percentage [0,∞]>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "scroll-snap-align",
+      "syntax": "[ none | start | end | center ]{1,2}",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "scroll-snap-stop",
+      "syntax": "normal | always",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "scroll-snap-type",
+      "syntax": "none | [ x | y | block | inline | both ] [ mandatory | proximity ]?",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "scroll-timeline",
+      "syntax": "[ <'scroll-timeline-name'> <'scroll-timeline-axis'>? ]#",
+      "computed": [
+        "scroll-timeline-name",
+        "scroll-timeline-axis"
+      ],
+      "initial": [
+        "scroll-timeline-name",
+        "scroll-timeline-axis"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "scroll-timeline-axis",
+      "syntax": "[ block | inline | x | y ]#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "block",
+      "inherited": false
+    },
+    {
+      "name": "scroll-timeline-name",
+      "syntax": "[ none | <dashed-ident> ]#",
+      "computed": [
+        "noneOrOrderedListOfIdentifiers"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "scrollbar-color",
+      "syntax": "auto | <color>{2}",
+      "computed": [
+        "asSpecified"
       ],
       "initial": "auto",
       "inherited": true
+    },
+    {
+      "name": "scrollbar-gutter",
+      "syntax": "auto | stable && both-edges?",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "scrollbar-width",
+      "syntax": "auto | thin | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "shape-image-threshold",
+      "syntax": "<opacity-value>",
+      "computed": [
+        "specifiedValueNumberClipped0To1"
+      ],
+      "initial": "0.0",
+      "inherited": false
+    },
+    {
+      "name": "shape-margin",
+      "syntax": "<length-percentage [0,∞]>",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "shape-outside",
+      "syntax": "none | [ <basic-shape> || <shape-box> ] | <image>",
+      "computed": [
+        "asDefinedForBasicShapeWithAbsoluteURIOtherwiseAsSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "shape-rendering",
+      "syntax": "auto | optimizeSpeed | crispEdges | geometricPrecision",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "shape-subtract",
+      "syntax": "none | [ <basic-shape>| <uri> ]+",
+      "computed": [],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "slider-orientation",
+      "syntax": "auto | left-to-right | right-to-left | top-to-bottom | bottom-to-top",
+      "computed": [],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "spatial-navigation-action",
+      "syntax": "auto | focus | scroll",
+      "computed": [],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "spatial-navigation-contain",
+      "syntax": "auto | contain",
+      "computed": [],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "spatial-navigation-function",
+      "syntax": "normal | grid",
+      "computed": [],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "speak",
+      "syntax": "auto | never | always",
+      "computed": [],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "speak-as",
+      "syntax": "normal | spell-out || digits || [ literal-punctuation | no-punctuation ]",
+      "computed": [
+        "specifiedValue"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "stop-color",
+      "syntax": "",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "black",
+      "inherited": false
+    },
+    {
+      "name": "stop-opacity",
+      "syntax": "",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "black",
+      "inherited": false
+    },
+    {
+      "name": "string-set",
+      "syntax": "none | [ <custom-ident> <string>+ ]#",
+      "computed": [],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "stroke",
+      "syntax": "<paint>",
+      "computed": [
+        "asLonghands"
+      ],
+      "initial": [
+        "stroke-dasharray",
+        "stroke-dashoffset",
+        "stroke-linecap",
+        "stroke-linejoin",
+        "stroke-miterlimit",
+        "stroke-opacity",
+        "stroke-width"
+      ],
+      "inherited": true
+    },
+    {
+      "name": "stroke-align",
+      "syntax": "center | inset | outset",
+      "computed": [],
+      "initial": "center",
+      "inherited": true
+    },
+    {
+      "name": "stroke-alignment",
+      "syntax": "center | inner | outer",
+      "computed": [],
+      "initial": "center",
+      "inherited": true
+    },
+    {
+      "name": "stroke-break",
+      "syntax": "bounding-box | slice | clone",
+      "computed": [],
+      "initial": "bounding-box",
+      "inherited": false
+    },
+    {
+      "name": "stroke-color",
+      "syntax": "<color>#",
+      "computed": [],
+      "initial": "transparent",
+      "inherited": true
+    },
+    {
+      "name": "stroke-dash-corner",
+      "syntax": "none | <length>",
+      "computed": [],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "stroke-dash-justify",
+      "syntax": "none | [ stretch | compress ] || [ dashes || gaps ]",
+      "computed": [],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "stroke-dashadjust",
+      "syntax": "none | [stretch | compress] [dashes | gaps]?",
+      "computed": [],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "stroke-dasharray",
+      "syntax": "none | [<length-percentage> | <number>]+#",
+      "computed": [
+        "listEachItemConsistingOfAbsoluteLengthPercentageOrKeyword"
+      ],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "stroke-dashcorner",
+      "syntax": "none | <length>",
+      "computed": [],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "stroke-dashoffset",
+      "syntax": "<length-percentage> | <number>",
+      "computed": [
+        "absoluteLengthOrPercentageNumbersConverted"
+      ],
+      "initial": "0",
+      "inherited": true
+    },
+    {
+      "name": "stroke-image",
+      "syntax": "<paint>#",
+      "computed": [],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "stroke-linecap",
+      "syntax": "butt | round | square",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "butt",
+      "inherited": true
+    },
+    {
+      "name": "stroke-linejoin",
+      "syntax": "[ crop | arcs | miter ] || [ bevel | round | fallback ]",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "miter",
+      "inherited": true
+    },
+    {
+      "name": "stroke-miterlimit",
+      "syntax": "<number>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "4",
+      "inherited": true
+    },
+    {
+      "name": "stroke-opacity",
+      "syntax": "<'opacity'>",
+      "computed": [
+        "specifiedValueClipped0To1"
+      ],
+      "initial": "1",
+      "inherited": true
+    },
+    {
+      "name": "stroke-origin",
+      "syntax": "match-parent | fill-box | stroke-box | content-box | padding-box | border-box",
+      "computed": [],
+      "initial": "match-parent",
+      "inherited": false
+    },
+    {
+      "name": "stroke-position",
+      "syntax": "<position>#",
+      "computed": [],
+      "initial": "0% 0%",
+      "inherited": true
+    },
+    {
+      "name": "stroke-repeat",
+      "syntax": "<repeat-style>#",
+      "computed": [],
+      "initial": "repeat",
+      "inherited": true
+    },
+    {
+      "name": "stroke-size",
+      "syntax": "<bg-size>#",
+      "computed": [],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "stroke-width",
+      "syntax": "[<length-percentage> | <number>]#",
+      "computed": [
+        "absoluteLengthOrPercentageNumbersConverted"
+      ],
+      "initial": "1px",
+      "inherited": true
+    },
+    {
+      "name": "tab-size",
+      "syntax": "<number [0,∞]> | <length [0,∞]>",
+      "computed": [
+        "specifiedIntegerOrAbsoluteLength"
+      ],
+      "initial": "8",
+      "inherited": true
+    },
+    {
+      "name": "table-layout",
+      "syntax": "auto | fixed",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "text-align",
+      "syntax": "start | end | left | right | center | justify | match-parent | justify-all",
+      "computed": [
+        "asSpecifiedExceptMatchParent"
+      ],
+      "initial": "startOrNamelessValueIfLTRRightIfRTL",
+      "inherited": true
+    },
+    {
+      "name": "text-align-all",
+      "syntax": "start | end | left | right | center | justify | match-parent",
+      "computed": [],
+      "initial": "start",
+      "inherited": true
+    },
+    {
+      "name": "text-align-last",
+      "syntax": "auto | start | end | left | right | center | justify | match-parent",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "text-anchor",
+      "syntax": "start | middle | end",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "start",
+      "inherited": true
+    },
+    {
+      "name": "text-box",
+      "syntax": "normal | <'text-box-trim'> || <'text-box-edge'>",
+      "computed": [
+        "theSpecifiedKeyword"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "text-box-edge",
+      "syntax": "auto | <text-edge>",
+      "computed": [
+        "theSpecifiedKeyword"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "text-box-trim",
+      "syntax": "none | trim-start | trim-end | trim-both",
+      "computed": [
+        "theSpecifiedKeyword"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "text-combine-upright",
+      "syntax": "none | all | [ digits <integer [2,4]>? ]",
+      "computed": [
+        "keywordPlusIntegerIfDigits"
+      ],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "text-decoration",
+      "syntax": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'>",
+      "computed": [
+        "text-decoration-line",
+        "text-decoration-style",
+        "text-decoration-color",
+        "text-decoration-thickness"
+      ],
+      "initial": [
+        "text-decoration-color",
+        "text-decoration-style",
+        "text-decoration-line"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "text-decoration-color",
+      "syntax": "<color>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
+      "inherited": false
+    },
+    {
+      "name": "text-decoration-line",
+      "syntax": "none | [ underline || overline || line-through || blink ]",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "text-decoration-style",
+      "syntax": "solid | double | dotted | dashed | wavy",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "solid",
+      "inherited": false
+    },
+    {
+      "name": "text-emphasis",
+      "syntax": "<'text-emphasis-style'> || <'text-emphasis-color'>",
+      "computed": [
+        "text-emphasis-style",
+        "text-emphasis-color"
+      ],
+      "initial": [
+        "text-emphasis-style",
+        "text-emphasis-color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "text-emphasis-color",
+      "syntax": "<color>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
+      "inherited": true
+    },
+    {
+      "name": "text-emphasis-position",
+      "syntax": "[ over | under ] && [ right | left ]?",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "text-emphasis-style",
+      "syntax": "none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | <string>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "text-indent",
+      "syntax": "[ <length-percentage> ] && hanging? && each-line?",
+      "computed": [
+        "percentageOrAbsoluteLengthPlusKeywords"
+      ],
+      "initial": "0",
+      "inherited": true
+    },
+    {
+      "name": "text-justify",
+      "syntax": "auto | none | inter-word | inter-character",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "text-orientation",
+      "syntax": "mixed | upright | sideways",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "mixed",
+      "inherited": true
+    },
+    {
+      "name": "text-overflow",
+      "syntax": "clip | ellipsis",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "clip",
+      "inherited": false
+    },
+    {
+      "name": "text-rendering",
+      "syntax": "auto | optimizeSpeed | optimizeLegibility | geometricPrecision",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "text-shadow",
+      "syntax": "none | [ <color>? && <length>{2,3} ]#",
+      "computed": [
+        "colorPlusThreeAbsoluteLengths"
+      ],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "text-size-adjust",
+      "syntax": "auto | none | <percentage [0,∞]>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "autoForSmartphoneBrowsersSupportingInflation",
+      "inherited": true
+    },
+    {
+      "name": "text-transform",
+      "syntax": "none | [capitalize | uppercase | lowercase ] || full-width || full-size-kana",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "text-underline-position",
+      "syntax": "auto | [ under || [ left | right ] ]",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "timeline-scope",
+      "syntax": "none | all | <dashed-ident>#",
+      "computed": [
+        "noneOrOrderedListOfIdentifiers"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "top",
+      "syntax": "auto | <length-percentage> | <anchor()> | <anchor-size()>",
+      "computed": [
+        "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "touch-action",
+      "syntax": "auto | none | [ [ pan-x | pan-left | pan-right ] || [ pan-y | pan-up | pan-down ] || pinch-zoom ] | manipulation",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "transform",
+      "syntax": "none | <transform-list>",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "transform-box",
+      "syntax": "content-box | border-box | fill-box | stroke-box | view-box",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "view-box",
+      "inherited": false
+    },
+    {
+      "name": "transform-origin",
+      "syntax": "[ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] <length>? | [ [ center | left | right ] && [ center | top | bottom ] ] <length>?",
+      "computed": [
+        "forLengthAbsoluteValueOtherwisePercentage"
+      ],
+      "initial": "50% 50% 0",
+      "inherited": false
+    },
+    {
+      "name": "transition",
+      "syntax": "<single-transition>#",
+      "computed": [
+        "transition-delay",
+        "transition-duration",
+        "transition-property",
+        "transition-timing-function",
+        "transition-behavior"
+      ],
+      "initial": [
+        "transition-delay",
+        "transition-duration",
+        "transition-property",
+        "transition-timing-function",
+        "transition-behavior"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "transition-delay",
+      "syntax": "<time>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0s",
+      "inherited": false
+    },
+    {
+      "name": "transition-duration",
+      "syntax": "<time [0s,∞]>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0s",
+      "inherited": false
+    },
+    {
+      "name": "transition-property",
+      "syntax": "none | <single-transition-property>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "all",
+      "inherited": false
+    },
+    {
+      "name": "transition-timing-function",
+      "syntax": "<easing-function>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "ease",
+      "inherited": false
+    },
+    {
+      "name": "unicode-bidi",
+      "syntax": "normal | embed | isolate | bidi-override | isolate-override | plaintext",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "user-select",
+      "syntax": "auto | text | none | contain | all",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "vector-effect",
+      "syntax": "none | non-scaling-stroke | non-scaling-size | non-rotation | fixed-position",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "vertical-align",
+      "syntax": "[ first | last] || <'alignment-baseline'> || <'baseline-shift'>",
+      "computed": [
+        "absoluteLengthOrKeyword"
+      ],
+      "initial": "baseline",
+      "inherited": false
+    },
+    {
+      "name": "view-timeline",
+      "syntax": "[ <'view-timeline-name'> [ <'view-timeline-axis'> || <'view-timeline-inset'> ]? ]#",
+      "computed": [
+        "view-timeline-name",
+        "view-timeline-axis"
+      ],
+      "initial": [
+        "view-timeline-name",
+        "view-timeline-axis"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "view-timeline-axis",
+      "syntax": "[ block | inline | x | y ]#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "block",
+      "inherited": false
+    },
+    {
+      "name": "view-timeline-inset",
+      "syntax": "[ [ auto | <length-percentage> ]{1,2} ]#",
+      "computed": [
+        "listEachItemConsistingOfPairsOfAutoOrLengthPercentage"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "view-timeline-name",
+      "syntax": "[ none | <dashed-ident> ]#",
+      "computed": [
+        "noneOrOrderedListOfIdentifiers"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "view-transition-name",
+      "syntax": "none | <custom-ident>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "visibility",
+      "syntax": "visible | hidden | collapse",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "visible",
+      "inherited": true
+    },
+    {
+      "name": "voice-balance",
+      "syntax": "<number> | left | center | right | leftwards | rightwards",
+      "computed": [],
+      "initial": "center",
+      "inherited": true
+    },
+    {
+      "name": "voice-duration",
+      "syntax": "auto | <time [0s,∞]>",
+      "computed": [],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "voice-family",
+      "syntax": "[[<family-name> | <generic-voice>],]* [<family-name> | <generic-voice>] | preserve",
+      "computed": [],
+      "initial": "implementation-dependent",
+      "inherited": true
+    },
+    {
+      "name": "voice-pitch",
+      "syntax": "<frequency [0Hz,∞]> && absolute | [[x-low | low | medium | high | x-high] || [<frequency> | <semitones> | <percentage>]]",
+      "computed": [],
+      "initial": "medium",
+      "inherited": true
+    },
+    {
+      "name": "voice-range",
+      "syntax": "<frequency [0Hz,∞]> && absolute | [[x-low | low | medium | high | x-high] || [<frequency> | <semitones> | <percentage>]]",
+      "computed": [],
+      "initial": "medium",
+      "inherited": true
+    },
+    {
+      "name": "voice-rate",
+      "syntax": "[normal | x-slow | slow | medium | fast | x-fast] || <percentage [0,∞]>",
+      "computed": [],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "voice-stress",
+      "syntax": "normal | strong | moderate | none | reduced",
+      "computed": [],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "voice-volume",
+      "syntax": "silent | [[x-soft | soft | medium | loud | x-loud] || <decibel>]",
+      "computed": [],
+      "initial": "medium",
+      "inherited": true
+    },
+    {
+      "name": "white-space",
+      "syntax": "normal | pre | nowrap | pre-wrap | break-spaces | pre-line",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "widows",
+      "syntax": "<integer [1,∞]>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "2",
+      "inherited": true
+    },
+    {
+      "name": "width",
+      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+      "computed": [
+        "percentageAutoOrAbsoluteLength"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "will-change",
+      "syntax": "auto | <animateable-feature>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "word-break",
+      "syntax": "normal | keep-all | break-all | break-word",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "word-spacing",
+      "syntax": "normal | <length>",
+      "computed": [
+        "absoluteLength"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "word-wrap",
+      "syntax": "normal | break-word | anywhere",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "wrap-flow",
+      "syntax": "auto | both | start | end | minimum | maximum | clear",
+      "computed": [],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "wrap-through",
+      "syntax": "wrap | none",
+      "computed": [],
+      "initial": "wrap",
+      "inherited": false
+    },
+    {
+      "name": "writing-mode",
+      "syntax": "horizontal-tb | vertical-rl | vertical-lr | sideways-rl | sideways-lr",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "horizontal-tb",
+      "inherited": true
+    },
+    {
+      "name": "x",
+      "syntax": "<length-percentage>",
+      "computed": [
+        "percentageAsSpecifiedOrAbsoluteLength"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "y",
+      "syntax": "<length-percentage>",
+      "computed": [
+        "percentageAsSpecifiedOrAbsoluteLength"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "z-index",
+      "syntax": "auto | <integer> | inherit",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "zoom",
+      "syntax": "<number [0,∞]> || <percentage [0,∞]>",
+      "computed": [
+        "asSpecifiedButWithPercentageConvertedToTheEquivalentNumber"
+      ],
+      "initial": "1",
+      "inherited": false
     }
   ],
   "values": [
+    {
+      "name": "<alpha-value>",
+      "syntax": "<number> | <percentage>"
+    },
+    {
+      "name": "<an+b>",
+      "syntax": "odd | even | <integer> | <n-dimension> | '+'? n | -n | <ndashdigit-dimension> | '+'? <ndashdigit-ident> | <dashndashdigit-ident> | <n-dimension> <signed-integer> | '+'? n <signed-integer> | -n <signed-integer> | <ndash-dimension> <signless-integer> | '+'? n- <signless-integer> | -n- <signless-integer> | <n-dimension> ['+' | '-'] <signless-integer> | '+'? n ['+' | '-'] <signless-integer> | -n ['+' | '-'] <signless-integer>"
+    },
+    {
+      "name": "<anchor-name>",
+      "syntax": "<dashed-ident>"
+    },
+    {
+      "name": "<anchor-side>",
+      "syntax": "inside | outside | top | left | right | bottom | start | end | self-start | self-end | <percentage> | center"
+    },
+    {
+      "name": "<anchor-size>",
+      "syntax": "width | height | block | inline | self-block | self-inline"
+    },
+    {
+      "name": "<angle-percentage>",
+      "syntax": "[ <angle> | <percentage> ]"
+    },
+    {
+      "name": "<animateable-feature>",
+      "syntax": "scroll-position | contents | <custom-ident>"
+    },
+    {
+      "name": "<attachment>",
+      "syntax": "scroll | fixed | local"
+    },
+    {
+      "name": "<attr-matcher>",
+      "syntax": "[ '~' | '|' | '^' | '$' | '*' ]? '='"
+    },
+    {
+      "name": "<attr-modifier>",
+      "syntax": "i | s"
+    },
+    {
+      "name": "<attribute-selector>",
+      "syntax": "'[' <wq-name> ']' | '[' <wq-name> <attr-matcher> [ <string-token> | <ident-token> ] <attr-modifier>? ']'"
+    },
+    {
+      "name": "<auto-line-color-list>",
+      "syntax": "[ <line-color-or-repeat> ]* <auto-repeat-line-color> [ <line-color-or-repeat> ]*"
+    },
+    {
+      "name": "<auto-line-style-list>",
+      "syntax": "[ <line-style-or-repeat> ]* <auto-repeat-line-style> [ <line-style-or-repeat> ]*"
+    },
+    {
+      "name": "<auto-line-width-list>",
+      "syntax": "[ <line-width-or-repeat> ]* <auto-repeat-line-width> [ <line-width-or-repeat> ]*"
+    },
+    {
+      "name": "<auto-repeat-line-color>",
+      "syntax": "repeat( auto ',' [ <color> ]+ )"
+    },
+    {
+      "name": "<auto-repeat-line-style>",
+      "syntax": "repeat( auto ',' [ <line-style> ]+ )"
+    },
+    {
+      "name": "<auto-repeat-line-width>",
+      "syntax": "repeat( auto ',' [ <line-width> ]+ )"
+    },
+    {
+      "name": "<auto-repeat>",
+      "syntax": "repeat( [ auto-fill | auto-fit ] ',' [ <line-names>? <fixed-size> ]+ <line-names>? )"
+    },
+    {
+      "name": "<auto-track-list>",
+      "syntax": "[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>? <auto-repeat> [ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>?"
+    },
+    {
+      "name": "<axis>",
+      "syntax": "block | inline | x | y"
+    },
+    {
+      "name": "<baseline-position>",
+      "syntax": "[ first | last ]? && baseline"
+    },
     {
       "name": "<basic-shape-rect>",
       "syntax": "<inset()> | <rect()> | <xywh()>"
     },
     {
-      "name": "<shape-box>",
-      "syntax": "<visual-box> | margin-box"
+      "name": "<bg-image>",
+      "syntax": "<image> | none"
     },
     {
-      "name": "drop-shadow()",
-      "syntax": "drop-shadow( [ <color>? && <length>{2,3} ] )"
+      "name": "<bg-layer>",
+      "syntax": "<bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <visual-box> || <visual-box>"
     },
     {
-      "name": "<try-size>",
-      "syntax": "most-width | most-height | most-block-size | most-inline-size"
+      "name": "<bg-position>",
+      "syntax": "[ [ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ center | [ left | right ] <length-percentage>? ] && [ center | [ top | bottom ] <length-percentage>? ] ]"
     },
     {
-      "name": "<color-interpolation-method>",
-      "syntax": "in [ <rectangular-color-space> | <polar-color-space> <hue-interpolation-method>? ]"
-    },
-    {
-      "name": "<color-stop-list>",
-      "syntax": "<linear-color-stop> , [ <linear-color-hint>? , <linear-color-stop> ]#?"
-    },
-    {
-      "name": "<function-name>",
-      "syntax": "<dashed-ident>"
-    },
-    {
-      "name": "<reversed-counter-name>",
-      "syntax": "reversed( <counter-name> )"
-    },
-    {
-      "name": "<color-font-tech>",
-      "syntax": "[color-COLRv0 | color-COLRv1 | color-SVG | color-sbix | color-CBDT ]"
-    },
-    {
-      "name": "<mask-source>",
-      "syntax": "<url>"
-    },
-    {
-      "name": "atan()",
-      "syntax": "atan( <calc-sum> )"
-    },
-    {
-      "name": "<counter>",
-      "syntax": "<counter()> | <counters()>"
-    },
-    {
-      "name": "snap-inline()",
-      "syntax": "snap-inline( <length> , [ left | right | near ]? )"
+      "name": "<bg-size>",
+      "syntax": "[ <length-percentage [0,∞]> | auto ]{1,2} | cover | contain"
     },
     {
       "name": "<blend-mode>",
       "syntax": "normal | multiply | screen | overlay | darken | lighten | color-dodge |color-burn | hard-light | soft-light | difference | exclusion | hue | saturation | color | luminosity"
     },
     {
-      "name": "<custom-selector>",
-      "syntax": "<custom-arg>? : <extension-name> [ ( <custom-arg>+#? ) ]? ;"
+      "name": "<calc-keyword>",
+      "syntax": "e | pi | infinity | -infinity | NaN"
     },
     {
-      "name": "<pseudo-element-selector>",
-      "syntax": "':' <pseudo-class-selector> | <legacy-pseudo-element-selector>"
+      "name": "<calc-product>",
+      "syntax": "<calc-value> [ [ '*' | / ] <calc-value> ]*"
+    },
+    {
+      "name": "<calc-sum>",
+      "syntax": "<calc-product> [ [ '+' | '-' ] <calc-product> ]*"
+    },
+    {
+      "name": "<calc-value>",
+      "syntax": "<number> | <dimension> | <percentage> | <calc-keyword> | '(' <calc-sum> ')'"
+    },
+    {
+      "name": "<class-selector>",
+      "syntax": "'.' <ident-token>"
+    },
+    {
+      "name": "<clip-source>",
+      "syntax": "<url>"
+    },
+    {
+      "name": "<color-base>",
+      "syntax": "<hex-color> | <color-function> | <named-color> | transparent"
+    },
+    {
+      "name": "<color-font-tech>",
+      "syntax": "[color-COLRv0 | color-COLRv1 | color-SVG | color-sbix | color-CBDT ]"
+    },
+    {
+      "name": "<color-function>",
+      "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <oklab()> | <oklch()> | <ictcp()> | <jzazbz()> | <jzczhz()> | <color()>"
+    },
+    {
+      "name": "<color-interpolation-method>",
+      "syntax": "in [ <rectangular-color-space> | <polar-color-space> <hue-interpolation-method>? ]"
+    },
+    {
+      "name": "<color-space>",
+      "syntax": "<rectangular-color-space> | <polar-color-space>"
+    },
+    {
+      "name": "<color-stop-list>",
+      "syntax": "<linear-color-stop> ',' [ <linear-color-hint>? ',' <linear-color-stop> ]#?"
+    },
+    {
+      "name": "<color>",
+      "syntax": "<color-base> | currentColor | <system-color>"
+    },
+    {
+      "name": "<colorspace-params>",
+      "syntax": "[ <predefined-rgb-params> | <xyz-params>]"
+    },
+    {
+      "name": "<combinator>",
+      "syntax": "'>' | '+' | '~' | [ '|' '|' ]"
+    },
+    {
+      "name": "<common-lig-values>",
+      "syntax": "[ common-ligatures | no-common-ligatures ]"
+    },
+    {
+      "name": "<compat-auto>",
+      "syntax": "searchfield | textarea | checkbox | radio | menulist | listbox | meter | progress-bar | button"
+    },
+    {
+      "name": "<compat-special>",
+      "syntax": "textfield | menulist-button"
+    },
+    {
+      "name": "<complex-real-selector-list>",
+      "syntax": "<complex-real-selector>#"
+    },
+    {
+      "name": "<complex-real-selector>",
+      "syntax": "<compound-selector> [ <combinator>? <compound-selector> ]*"
+    },
+    {
+      "name": "<complex-selector-list>",
+      "syntax": "<complex-selector>#"
+    },
+    {
+      "name": "<complex-selector-unit>",
+      "syntax": "[ <compound-selector>? <pseudo-compound-selector>* ]!"
+    },
+    {
+      "name": "<complex-selector>",
+      "syntax": "<complex-selector-unit> [ <combinator>? <complex-selector-unit> ]*"
+    },
+    {
+      "name": "<composite-mode>",
+      "syntax": "clear | copy | source-over | destination-over | source-in | destination-in | source-out | destination-out | source-atop | destination-atop | xor | lighter | plus-darker | plus-lighter"
+    },
+    {
+      "name": "<compositing-operator>",
+      "syntax": "add | subtract | intersect | exclude"
+    },
+    {
+      "name": "<compound-selector-list>",
+      "syntax": "<compound-selector>#"
+    },
+    {
+      "name": "<compound-selector>",
+      "syntax": "[ <type-selector>? <subclass-selector>* ]!"
+    },
+    {
+      "name": "<content-distribution>",
+      "syntax": "space-between | space-around | space-evenly | stretch"
+    },
+    {
+      "name": "<content-list>",
+      "syntax": "[ <string> | <counter()> | <counters()> | <content()> | <attr()> ]+"
+    },
+    {
+      "name": "<content-position>",
+      "syntax": "center | start | end | flex-start | flex-end"
+    },
+    {
+      "name": "<content-replacement>",
+      "syntax": "<image>"
+    },
+    {
+      "name": "<contextual-alt-values>",
+      "syntax": "[ contextual | no-contextual ]"
+    },
+    {
+      "name": "<coord-box>",
+      "syntax": "<paint-box> | view-box"
+    },
+    {
+      "name": "<corner-shape-value>",
+      "syntax": "round | scoop | bevel | notch | straight | squircle | superellipse(<number [0,∞]> | infinity)"
+    },
+    {
+      "name": "<counter-style>",
+      "syntax": "<counter-style-name> | <symbols()>"
+    },
+    {
+      "name": "<counter>",
+      "syntax": "<counter()> | <counters()>"
+    },
+    {
+      "name": "<css-type>",
+      "syntax": "<syntax-component> | <type()>"
+    },
+    {
+      "name": "<cubic-bezier-easing-function>",
+      "syntax": "ease | ease-in | ease-out | ease-in-out | <cubic-bezier()>"
+    },
+    {
+      "name": "<custom-arg>",
+      "syntax": "'$' <ident-token> ';'"
+    },
+    {
+      "name": "<custom-selector>",
+      "syntax": "<custom-arg>? ':' <extension-name> [ '(' <custom-arg>+#? ')' ]? ';'"
+    },
+    {
+      "name": "<dasharray>",
+      "syntax": "[ [ <length-percentage> | <number> ]+ ]#"
+    },
+    {
+      "name": "<discretionary-lig-values>",
+      "syntax": "[ discretionary-ligatures | no-discretionary-ligatures ]"
+    },
+    {
+      "name": "<display-box>",
+      "syntax": "contents | none"
+    },
+    {
+      "name": "<display-inside>",
+      "syntax": "flow | flow-root | table | flex | grid | ruby"
+    },
+    {
+      "name": "<display-internal>",
+      "syntax": "table-row-group | table-header-group | table-footer-group | table-row | table-cell | table-column-group | table-column | table-caption | ruby-base | ruby-text | ruby-base-container | ruby-text-container"
+    },
+    {
+      "name": "<display-legacy>",
+      "syntax": "inline-block | inline-table | inline-flex | inline-grid"
+    },
+    {
+      "name": "<display-listitem>",
+      "syntax": "<display-outside>? && [ flow | flow-root ]? && list-item"
+    },
+    {
+      "name": "<display-outside>",
+      "syntax": "block | inline | run-in"
+    },
+    {
+      "name": "<easing-function>",
+      "syntax": "<linear-easing-function> | <cubic-bezier-easing-function> | <step-easing-function>"
+    },
+    {
+      "name": "<east-asian-variant-values>",
+      "syntax": "[ jis78 | jis83 | jis90 | jis04 | simplified | traditional ]"
+    },
+    {
+      "name": "<east-asian-width-values>",
+      "syntax": "[ full-width | proportional-width ]"
+    },
+    {
+      "name": "<explicit-track-list>",
+      "syntax": "[ <line-names>? <track-size> ]+ <line-names>?"
+    },
+    {
+      "name": "<family-name>",
+      "syntax": "<string> | <custom-ident>+"
+    },
+    {
+      "name": "<feature-value-name>",
+      "syntax": "<ident>"
+    },
+    {
+      "name": "<filter-function>",
+      "syntax": "<blur()> | <brightness()> | <contrast()> | <drop-shadow()> | <grayscale()> | <hue-rotate()> | <invert()> | <opacity()> | <sepia()> | <saturate()>"
+    },
+    {
+      "name": "<filter-value-list>",
+      "syntax": "[ <filter-function> | <url> ]+"
+    },
+    {
+      "name": "<final-bg-layer>",
+      "syntax": "<bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <visual-box> || <visual-box> || <'background-color'>"
+    },
+    {
+      "name": "<fixed-breadth>",
+      "syntax": "<length-percentage [0,∞]>"
+    },
+    {
+      "name": "<fixed-repeat>",
+      "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-names>? <fixed-size> ]+ <line-names>? )"
+    },
+    {
+      "name": "<fixed-size>",
+      "syntax": "<fixed-breadth> | minmax( <fixed-breadth> ',' <track-breadth> ) | minmax( <inflexible-breadth> ',' <fixed-breadth> )"
+    },
+    {
+      "name": "<font-features-tech>",
+      "syntax": "[features-opentype | features-aat | features-graphite]"
+    },
+    {
+      "name": "<font-format>",
+      "syntax": "[<string> | collection | embedded-opentype | opentype | svg | truetype | woff | woff2 ]"
+    },
+    {
+      "name": "<font-src>",
+      "syntax": "<url> [ format(<font-format>)]? [ tech( <font-tech>#)]? | local(<family-name>)"
+    },
+    {
+      "name": "<font-tech>",
+      "syntax": "[<font-features-tech> | <color-font-tech> | variations | palettes | incremental ]"
+    },
+    {
+      "name": "<font-variant-css2>",
+      "syntax": "normal | small-caps"
+    },
+    {
+      "name": "<font-weight-absolute>",
+      "syntax": "[normal | bold | <number [1,1000]>]"
+    },
+    {
+      "name": "<font-width-css3>",
+      "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
     },
     {
       "name": "<frequency-percentage>",
       "syntax": "[ <frequency> | <percentage> ]"
     },
     {
-      "name": "rgba()",
-      "syntax": "[ <legacy-rgba-syntax> | <modern-rgba-syntax> ]"
+      "name": "<function-parameter>",
+      "syntax": "<custom-property-name> <css-type>? [ ':' <declaration-value> ]?"
     },
     {
-      "name": "hsla()",
-      "syntax": "[ <legacy-hsla-syntax> | <modern-hsla-syntax> ]"
+      "name": "<gap-auto-repeat-rule>",
+      "syntax": "repeat( auto ',' <gap-rule># )"
     },
     {
-      "name": "sepia()",
-      "syntax": "sepia( [ <number> | <percentage> ]? )"
+      "name": "<gap-auto-rule-list>",
+      "syntax": "<gap-rule-or-repeat>#? ',' <gap-auto-repeat-rule> ',' <gap-rule-or-repeat>#?"
     },
     {
-      "name": "<font-tech>",
-      "syntax": "[<font-features-tech> | <color-font-tech> | variations | palettes | incremental ]"
+      "name": "<gap-repeat-rule>",
+      "syntax": "repeat( <integer [1,∞]> ',' <gap-rule># )"
+    },
+    {
+      "name": "<gap-rule-list>",
+      "syntax": "<gap-rule-or-repeat>#"
+    },
+    {
+      "name": "<gap-rule-or-repeat>",
+      "syntax": "<gap-rule> | <gap-repeat-rule>"
+    },
+    {
+      "name": "<gap-rule>",
+      "syntax": "<line-width> || <line-style> || <color>"
+    },
+    {
+      "name": "<generic-complete>",
+      "syntax": "serif | sans-serif | system-ui | cursive | fantasy | math | monospace"
+    },
+    {
+      "name": "<generic-family>",
+      "syntax": "<generic-script-specific>| <generic-complete> | <generic-incomplete>"
+    },
+    {
+      "name": "<generic-incomplete>",
+      "syntax": "ui-serif | ui-sans-serif | ui-monospace | ui-rounded"
+    },
+    {
+      "name": "<generic-script-specific>",
+      "syntax": "generic(fangsong) | generic(kai) | generic(khmer-mul) | generic(nastaliq)"
+    },
+    {
+      "name": "<generic-voice>",
+      "syntax": "[<age>? <gender> <integer>?]"
+    },
+    {
+      "name": "<geometry-box>",
+      "syntax": "<shape-box> | fill-box | stroke-box | view-box"
+    },
+    {
+      "name": "<gradient>",
+      "syntax": "<linear-gradient()> | <repeating-linear-gradient()> | <radial-gradient()> | <repeating-radial-gradient()>"
+    },
+    {
+      "name": "<grid-line>",
+      "syntax": "auto | <custom-ident> | [ [ <integer [-∞,-1]> | <integer [1,∞]> ] && <custom-ident>? ] | [ span && [ <integer [1,∞]> || <custom-ident> ] ]"
+    },
+    {
+      "name": "<historical-lig-values>",
+      "syntax": "[ historical-ligatures | no-historical-ligatures ]"
+    },
+    {
+      "name": "<hue-interpolation-method>",
+      "syntax": "[ shorter | longer | increasing | decreasing ] hue"
+    },
+    {
+      "name": "<hue>",
+      "syntax": "<number> | <angle>"
+    },
+    {
+      "name": "<id-selector>",
+      "syntax": "<hash-token>"
+    },
+    {
+      "name": "<image>",
+      "syntax": "<url> | <gradient>"
+    },
+    {
+      "name": "<import-conditions>",
+      "syntax": "[ supports( [ <supports-condition> | <declaration> ] ) ]? <media-query-list>?"
+    },
+    {
+      "name": "<inflexible-breadth>",
+      "syntax": "<length-percentage [0,∞]> | min-content | max-content | auto"
+    },
+    {
+      "name": "<isolation-mode>",
+      "syntax": "auto | isolate"
+    },
+    {
+      "name": "<keyframe-block>",
+      "syntax": "<keyframe-selector># '{' <declaration-list> '}'"
+    },
+    {
+      "name": "<keyframe-selector>",
+      "syntax": "from | to | <percentage [0,100]>"
+    },
+    {
+      "name": "<keyframes-name>",
+      "syntax": "<custom-ident> | <string>"
+    },
+    {
+      "name": "<layer-name>",
+      "syntax": "<ident> [ '.' <ident> ]*"
+    },
+    {
+      "name": "<layout-box>",
+      "syntax": "<visual-box> | margin-box"
+    },
+    {
+      "name": "<leader-type>",
+      "syntax": "dotted | solid | space | <string>"
+    },
+    {
+      "name": "<legacy-hsl-syntax>",
+      "syntax": "hsl( <hue>, <percentage>, <percentage>, <alpha-value>? )"
+    },
+    {
+      "name": "<legacy-hsla-syntax>",
+      "syntax": "hsla( <hue>, <percentage>, <percentage>, <alpha-value>? )"
+    },
+    {
+      "name": "<legacy-pseudo-element-selector>",
+      "syntax": "':' [before | after | first-line | first-letter]"
+    },
+    {
+      "name": "<legacy-rgb-syntax>",
+      "syntax": "rgb( <percentage>#{3} ',' <alpha-value>? ) | rgb( <number>#{3} ',' <alpha-value>? )"
+    },
+    {
+      "name": "<legacy-rgba-syntax>",
+      "syntax": "rgba( <percentage>#{3} ',' <alpha-value>? ) | rgba( <number>#{3} ',' <alpha-value>? )"
+    },
+    {
+      "name": "<length-percentage>",
+      "syntax": "[ <length> | <percentage> ]"
+    },
+    {
+      "name": "<line-color-list>",
+      "syntax": "[ <line-color-or-repeat> ]+"
+    },
+    {
+      "name": "<line-color-or-repeat>",
+      "syntax": "[ <color> | <repeat-line-color> ]"
+    },
+    {
+      "name": "<line-name-list>",
+      "syntax": "[ <line-names> | <name-repeat> ]+"
+    },
+    {
+      "name": "<line-names>",
+      "syntax": "'[' <custom-ident>* ']'"
+    },
+    {
+      "name": "<line-style-list>",
+      "syntax": "[ <line-style-or-repeat> ]+"
+    },
+    {
+      "name": "<line-style-or-repeat>",
+      "syntax": "[ <line-style> | <repeat-line-style> ]"
+    },
+    {
+      "name": "<line-style>",
+      "syntax": "none | hidden | dotted | dashed | solid | double | groove | ridge | inset | outset"
+    },
+    {
+      "name": "<line-width-list>",
+      "syntax": "[ <line-width-or-repeat> ]+"
+    },
+    {
+      "name": "<line-width-or-repeat>",
+      "syntax": "[ <line-width> | <repeat-line-width> ]"
+    },
+    {
+      "name": "<line-width>",
+      "syntax": "<length [0,∞]> | thin | medium | thick"
+    },
+    {
+      "name": "<linear-color-hint>",
+      "syntax": "<length-percentage>"
+    },
+    {
+      "name": "<linear-color-stop>",
+      "syntax": "<color> <length-percentage>?"
+    },
+    {
+      "name": "<linear-easing-function>",
+      "syntax": "linear | <linear()>"
+    },
+    {
+      "name": "<linear-gradient-syntax>",
+      "syntax": "[ <angle> | <zero> | to <side-or-corner> ]? ',' <color-stop-list>"
+    },
+    {
+      "name": "<link-param>",
+      "syntax": "param( <custom-property-name> <declaration-value>? )"
+    },
+    {
+      "name": "<marker-ref>",
+      "syntax": "<url>"
+    },
+    {
+      "name": "<mask-layer>",
+      "syntax": "<mask-reference> || <position> [ / <bg-size> ]? || <repeat-style> || <geometry-box> || [ <geometry-box> | no-clip ] || <compositing-operator> || <masking-mode>"
+    },
+    {
+      "name": "<mask-reference>",
+      "syntax": "none | <image> | <mask-source>"
+    },
+    {
+      "name": "<mask-source>",
+      "syntax": "<url>"
+    },
+    {
+      "name": "<masking-mode>",
+      "syntax": "alpha | luminance | match-source"
+    },
+    {
+      "name": "<media-and>",
+      "syntax": "and <media-in-parens>"
+    },
+    {
+      "name": "<media-condition-without-or>",
+      "syntax": "<media-not> | <media-in-parens> <media-and>*"
+    },
+    {
+      "name": "<media-condition>",
+      "syntax": "<media-not> | <media-in-parens> [ <media-and>* | <media-or>* ]"
+    },
+    {
+      "name": "<media-feature>",
+      "syntax": "[ <mf-plain> | <mf-boolean> | <mf-range> ]"
+    },
+    {
+      "name": "<media-in-parens>",
+      "syntax": "'(' <media-condition> ')' | '(' <media-feature> ')' | <general-enclosed>"
+    },
+    {
+      "name": "<media-not>",
+      "syntax": "not <media-in-parens>"
+    },
+    {
+      "name": "<media-or>",
+      "syntax": "or <media-in-parens>"
+    },
+    {
+      "name": "<media-query>",
+      "syntax": "<media-condition> | [ not | only ]? <media-type> [ and <media-condition-without-or> ]?"
+    },
+    {
+      "name": "<media-type>",
+      "syntax": "<ident>"
+    },
+    {
+      "name": "<mf-boolean>",
+      "syntax": "<mf-name>"
+    },
+    {
+      "name": "<mf-comparison>",
+      "syntax": "<mf-lt> | <mf-gt> | <mf-eq>"
+    },
+    {
+      "name": "<mf-eq>",
+      "syntax": "'='"
+    },
+    {
+      "name": "<mf-gt>",
+      "syntax": "'>' '='?"
+    },
+    {
+      "name": "<mf-lt>",
+      "syntax": "'<' '='?"
+    },
+    {
+      "name": "<mf-name>",
+      "syntax": "<ident>"
+    },
+    {
+      "name": "<mf-plain>",
+      "syntax": "<mf-name> ':' <mf-value>"
+    },
+    {
+      "name": "<mf-range>",
+      "syntax": "<mf-name> <mf-comparison> <mf-value> | <mf-value> <mf-comparison> <mf-name> | <mf-value> <mf-lt> <mf-name> <mf-lt> <mf-value> | <mf-value> <mf-gt> <mf-name> <mf-gt> <mf-value>"
+    },
+    {
+      "name": "<mf-value>",
+      "syntax": "<number> | <dimension> | <ident> | <ratio>"
+    },
+    {
+      "name": "<modern-hsl-syntax>",
+      "syntax": "hsl( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "<modern-hsla-syntax>",
+      "syntax": "hsla( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "<modern-rgb-syntax>",
+      "syntax": "rgb( [ <number> | <percentage> | none]{3} [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "<modern-rgba-syntax>",
+      "syntax": "rgba( [ <number> | <percentage> | none]{3} [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "<mq-boolean>",
+      "syntax": "<integer [0,1]>"
+    },
+    {
+      "name": "<name-repeat>",
+      "syntax": "repeat( [ <integer [1,∞]> | auto-fill ], <line-names>+)"
+    },
+    {
+      "name": "<namespace-prefix>",
+      "syntax": "<ident>"
+    },
+    {
+      "name": "<ns-prefix>",
+      "syntax": "[ <ident-token> | '*' ]? '|'"
+    },
+    {
+      "name": "<number-optional-number>",
+      "syntax": "<number> <number>?"
+    },
+    {
+      "name": "<numeric-figure-values>",
+      "syntax": "[ lining-nums | oldstyle-nums ]"
+    },
+    {
+      "name": "<numeric-fraction-values>",
+      "syntax": "[ diagonal-fractions | stacked-fractions ]"
+    },
+    {
+      "name": "<numeric-spacing-values>",
+      "syntax": "[ proportional-nums | tabular-nums ]"
+    },
+    {
+      "name": "<offset-path>",
+      "syntax": "<ray()> | <url> | <basic-shape>"
+    },
+    {
+      "name": "<opacity-value>",
+      "syntax": "<number> | <percentage>"
+    },
+    {
+      "name": "<opentype-tag>",
+      "syntax": "<string>"
+    },
+    {
+      "name": "<overflow-position>",
+      "syntax": "unsafe | safe"
+    },
+    {
+      "name": "<page-selector-list>",
+      "syntax": "<page-selector>#"
+    },
+    {
+      "name": "<page-selector>",
+      "syntax": "[ <ident-token>? <pseudo-page>* ]!"
+    },
+    {
+      "name": "<paint-box>",
+      "syntax": "<visual-box> | fill-box | stroke-box"
+    },
+    {
+      "name": "<paint>",
+      "syntax": "none | <image> | <svg-paint>"
+    },
+    {
+      "name": "<points>",
+      "syntax": "[ <number>+ ]#"
+    },
+    {
+      "name": "<polar-color-space>",
+      "syntax": "hsl | hwb | lch | oklch"
+    },
+    {
+      "name": "<position-area>",
+      "syntax": "[ [ left | center | right | span-left | span-right | x-start | x-end | span-x-start | span-x-end | x-self-start | x-self-end | span-x-self-start | span-x-self-end | span-all ] || [ top | center | bottom | span-top | span-bottom | y-start | y-end | span-y-start | span-y-end | y-self-start | y-self-end | span-y-self-start | span-y-self-end | span-all ] | [ block-start | center | block-end | span-block-start | span-block-end | span-all ] || [ inline-start | center | inline-end | span-inline-start | span-inline-end | span-all ] | [ self-block-start | center | self-block-end | span-self-block-start | span-self-block-end | span-all ] || [ self-inline-start | center | self-inline-end | span-self-inline-start | span-self-inline-end | span-all ] | [ start | center | end | span-start | span-end | span-all ]{1,2} | [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2} ]"
+    },
+    {
+      "name": "<position>",
+      "syntax": "[ [ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right ] && [ top | center | bottom ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ] ]"
+    },
+    {
+      "name": "<predefined-rgb-params>",
+      "syntax": "<predefined-rgb> [ <number> | <percentage> | none ]{3}"
+    },
+    {
+      "name": "<predefined-rgb>",
+      "syntax": "srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020 | rec2100-pq | rec2100-hlg | rec2100-linear"
+    },
+    {
+      "name": "<pseudo-class-selector>",
+      "syntax": "':' <ident-token> | ':' <function-token> <any-value> ')'"
+    },
+    {
+      "name": "<pseudo-compound-selector>",
+      "syntax": "<pseudo-element-selector> <pseudo-class-selector>*"
+    },
+    {
+      "name": "<pseudo-element-selector>",
+      "syntax": "':' <pseudo-class-selector> | <legacy-pseudo-element-selector>"
+    },
+    {
+      "name": "<pseudo-page>",
+      "syntax": "':' [ left | right | first | blank ]"
+    },
+    {
+      "name": "<pt-name-selector>",
+      "syntax": "'*' | <custom-ident>"
+    },
+    {
+      "name": "<quote>",
+      "syntax": "open-quote | close-quote | no-open-quote | no-close-quote"
+    },
+    {
+      "name": "<radial-extent>",
+      "syntax": "closest-corner | closest-side | farthest-corner | farthest-side"
+    },
+    {
+      "name": "<radial-gradient-syntax>",
+      "syntax": "[ <radial-shape> || <radial-size> ]? [ at <position> ]? ',' <color-stop-list>"
+    },
+    {
+      "name": "<radial-shape>",
+      "syntax": "circle | ellipse"
+    },
+    {
+      "name": "<radial-size>",
+      "syntax": "<radial-extent> | <length [0,∞]> | <length-percentage [0,∞]>{2}"
+    },
+    {
+      "name": "<ratio>",
+      "syntax": "<number [0,∞]> [ / <number [0,∞]> ]?"
+    },
+    {
+      "name": "<ray-size>",
+      "syntax": "closest-side | closest-corner | farthest-side | farthest-corner | sides"
+    },
+    {
+      "name": "<rectangular-color-space>",
+      "syntax": "srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020 | lab | oklab | xyz | xyz-d50 | xyz-d65"
+    },
+    {
+      "name": "<relative-real-selector-list>",
+      "syntax": "<relative-real-selector>#"
+    },
+    {
+      "name": "<relative-real-selector>",
+      "syntax": "<combinator>? <complex-real-selector>"
+    },
+    {
+      "name": "<relative-selector-list>",
+      "syntax": "<relative-selector>#"
+    },
+    {
+      "name": "<relative-selector>",
+      "syntax": "<combinator>? <complex-selector>"
+    },
+    {
+      "name": "<repeat-line-color>",
+      "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <color> ]+ )"
+    },
+    {
+      "name": "<repeat-line-style>",
+      "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-style> ]+ )"
+    },
+    {
+      "name": "<repeat-line-width>",
+      "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-width> ]+ )"
+    },
+    {
+      "name": "<repeat-style>",
+      "syntax": "repeat-x | repeat-y | [repeat | space | round | no-repeat]{1,2}"
+    },
+    {
+      "name": "<reversed-counter-name>",
+      "syntax": "reversed( <counter-name> )"
+    },
+    {
+      "name": "<rounding-strategy>",
+      "syntax": "nearest | up | down | to-zero"
+    },
+    {
+      "name": "<scroller>",
+      "syntax": "root | nearest | self"
+    },
+    {
+      "name": "<selector-list>",
+      "syntax": "<complex-selector-list>"
+    },
+    {
+      "name": "<self-position>",
+      "syntax": "center | start | end | self-start | self-end | flex-start | flex-end"
+    },
+    {
+      "name": "<shadow>",
+      "syntax": "<color>? && [<length>{2} <length [0,∞]>? <length>?] && inset?"
+    },
+    {
+      "name": "<shape-box>",
+      "syntax": "<visual-box> | margin-box"
+    },
+    {
+      "name": "<side-or-corner>",
+      "syntax": "[left | right] || [top | bottom]"
+    },
+    {
+      "name": "<simple-selector-list>",
+      "syntax": "<simple-selector>#"
+    },
+    {
+      "name": "<simple-selector>",
+      "syntax": "<type-selector> | <subclass-selector>"
+    },
+    {
+      "name": "<single-animation-direction>",
+      "syntax": "normal | reverse | alternate | alternate-reverse"
+    },
+    {
+      "name": "<single-animation-fill-mode>",
+      "syntax": "none | forwards | backwards | both"
     },
     {
       "name": "<single-animation-iteration-count>",
@@ -5697,1184 +6867,388 @@
       "syntax": "running | paused"
     },
     {
-      "name": "target-counter()",
-      "syntax": "target-counter( [ <string> | <url> ] , <custom-ident> , <counter-style>? )"
-    },
-    {
-      "name": "rotate()",
-      "syntax": "rotate( [ <angle> | <zero> ] )"
-    },
-    {
-      "name": "<compat-auto>",
-      "syntax": "searchfield | textarea | checkbox | radio | menulist | listbox | meter | progress-bar | button"
-    },
-    {
-      "name": "<composite-mode>",
-      "syntax": "clear | copy | source-over | destination-over | source-in | destination-in | source-out | destination-out | source-atop | destination-atop | xor | lighter | plus-darker | plus-lighter"
-    },
-    {
-      "name": "mod()",
-      "syntax": "mod( <calc-sum>, <calc-sum> )"
-    },
-    {
-      "name": "<wq-name>",
-      "syntax": "<ns-prefix>? <ident-token>"
-    },
-    {
-      "name": "<fixed-size>",
-      "syntax": "<fixed-breadth> | minmax( <fixed-breadth> , <track-breadth> ) | minmax( <inflexible-breadth> , <fixed-breadth> )"
-    },
-    {
-      "name": "<position-area>",
-      "syntax": "[ [ left | center | right | span-left | span-right | x-start | x-end | span-x-start | span-x-end | x-self-start | x-self-end | span-x-self-start | span-x-self-end | span-all ] || [ top | center | bottom | span-top | span-bottom | y-start | y-end | span-y-start | span-y-end | y-self-start | y-self-end | span-y-self-start | span-y-self-end | span-all ] | [ block-start | center | block-end | span-block-start | span-block-end | span-all ] || [ inline-start | center | inline-end | span-inline-start | span-inline-end | span-all ] | [ self-block-start | center | self-block-end | span-self-block-start | span-self-block-end | span-all ] || [ self-inline-start | center | self-inline-end | span-self-inline-start | span-self-inline-end | span-all ] | [ start | center | end | span-start | span-end | span-all ]{1,2} | [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2} ]"
-    },
-    {
-      "name": "<display-outside>",
-      "syntax": "block | inline | run-in"
-    },
-    {
-      "name": "<simple-selector-list>",
-      "syntax": "<simple-selector>#"
-    },
-    {
-      "name": "<ratio>",
-      "syntax": "<number [0,∞]> [ / <number [0,∞]> ]?"
-    },
-    {
-      "name": "min()",
-      "syntax": "min( <calc-sum># )"
-    },
-    {
-      "name": "<legacy-rgba-syntax>",
-      "syntax": "rgba( <percentage>#{3} , <alpha-value>? ) | rgba( <number>#{3} , <alpha-value>? )"
-    },
-    {
-      "name": "<side-or-corner>",
-      "syntax": "[left | right] || [top | bottom]"
-    },
-    {
-      "name": "<contextual-alt-values>",
-      "syntax": "[ contextual | no-contextual ]"
-    },
-    {
-      "name": "<step-position>",
-      "syntax": "jump-start | jump-end | jump-none | jump-both | start | end"
-    },
-    {
-      "name": "<single-animation-fill-mode>",
-      "syntax": "none | forwards | backwards | both"
-    },
-    {
-      "name": "symbols()",
-      "syntax": "symbols( <symbols-type>? [ <string> | <image> ]+ )"
-    },
-    {
-      "name": "<supports-in-parens>",
-      "syntax": "( <supports-condition> ) | <supports-feature> | <general-enclosed>"
-    },
-    {
-      "name": "<compat-special>",
-      "syntax": "textfield | menulist-button"
-    },
-    {
-      "name": "view()",
-      "syntax": "view( [ <axis> || <'view-timeline-inset'> ]? )"
-    },
-    {
-      "name": "<display-listitem>",
-      "syntax": "<display-outside>? && [ flow | flow-root ]? && list-item"
-    },
-    {
-      "name": "fit-content()",
-      "syntax": "fit-content( <length-percentage> )"
-    },
-    {
-      "name": "<relative-real-selector-list>",
-      "syntax": "<relative-real-selector>#"
-    },
-    {
-      "name": "<track-list>",
-      "syntax": "[ <line-names>? [ <track-size> | <track-repeat> ] ]+ <line-names>?"
-    },
-    {
-      "name": "<auto-track-list>",
-      "syntax": "[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>? <auto-repeat> [ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>?"
-    },
-    {
-      "name": "<symbol>",
-      "syntax": "<string> | <image> | <custom-ident>"
-    },
-    {
-      "name": "scale()",
-      "syntax": "scale( <number> , <number>? )"
-    },
-    {
-      "name": "<shadow>",
-      "syntax": "<color>? && [<length>{2} <length [0,∞]>? <length>?] && inset?"
-    },
-    {
-      "name": "<link-param>",
-      "syntax": "param( <custom-property-name> <declaration-value>? )"
-    },
-    {
-      "name": "<compound-selector-list>",
-      "syntax": "<compound-selector>#"
-    },
-    {
-      "name": "<radial-size>",
-      "syntax": "<radial-extent> | <length [0,∞]> | <length-percentage [0,∞]>{2}"
-    },
-    {
-      "name": "<font-features-tech>",
-      "syntax": "[features-opentype | features-aat | features-graphite]"
-    },
-    {
-      "name": "running()",
-      "syntax": "running( <custom-ident> )"
-    },
-    {
-      "name": "<keyframe-selector>",
-      "syntax": "from | to | <percentage [0,100]>"
-    },
-    {
-      "name": "<linear-gradient-syntax>",
-      "syntax": "[ <angle> | to <side-or-corner> ]? , <color-stop-list>"
-    },
-    {
-      "name": "<anchor-size>",
-      "syntax": "width | height | block | inline | self-block | self-inline"
-    },
-    {
-      "name": "<linear-stop>",
-      "syntax": "<number> && <linear-stop-length>?"
-    },
-    {
-      "name": "<css-type>",
-      "syntax": "<syntax-component> | <type()>"
-    },
-    {
-      "name": "<target>",
-      "syntax": "<target-counter()> | <target-counters()> | <target-text()>"
-    },
-    {
-      "name": "<easing-function>",
-      "syntax": "linear | <linear-easing-function> | <cubic-bezier-easing-function> | <step-easing-function>"
-    },
-    {
-      "name": "<legacy-hsla-syntax>",
-      "syntax": "hsla( <hue>, <percentage>, <percentage>, <alpha-value>? )"
-    },
-    {
-      "name": "<modern-hsla-syntax>",
-      "syntax": "hsla( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
-    },
-    {
-      "name": "blur()",
-      "syntax": "blur( <length>? )"
-    },
-    {
-      "name": "filter()",
-      "syntax": "filter( [ <image> | <string> ], <filter-value-list> )"
-    },
-    {
-      "name": "<pt-name-selector>",
-      "syntax": "'*' | <custom-ident>"
+      "name": "<single-animation>",
+      "syntax": "<time [0s,∞]> || <easing-function> || <time> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ]"
     },
     {
       "name": "<single-transition-property>",
       "syntax": "all | <custom-ident>"
     },
     {
-      "name": "<visual-box>",
-      "syntax": "content-box | padding-box | border-box"
-    },
-    {
-      "name": "<length-percentage>",
-      "syntax": "[ <length> | <percentage> ]"
-    },
-    {
-      "name": "<spread-shadow>",
-      "syntax": "<'box-shadow-color'>? && [ <'box-shadow-offset'> [ <'box-shadow-blur'> <'box-shadow-spread'>? ]? ] && <'box-shadow-position'>?"
-    },
-    {
-      "name": "<predefined-rgb-params>",
-      "syntax": "<predefined-rgb> [ <number> | <percentage> | none ]{3}"
-    },
-    {
-      "name": "<symbols-type>",
-      "syntax": "cyclic | numeric | alphabetic | symbolic | fixed"
-    },
-    {
-      "name": "<scroller>",
-      "syntax": "root | nearest | self"
-    },
-    {
-      "name": "<generic-complete>",
-      "syntax": "serif | sans-serif | system-ui | cursive | fantasy | math | monospace"
-    },
-    {
-      "name": "<east-asian-width-values>",
-      "syntax": "[ full-width | proportional-width ]"
-    },
-    {
-      "name": "<geometry-box>",
-      "syntax": "<shape-box> | fill-box | stroke-box | view-box"
-    },
-    {
-      "name": "<media-not>",
-      "syntax": "not <media-in-parens>"
-    },
-    {
-      "name": "<opacity-value>",
-      "syntax": "<number> | <percentage>"
-    },
-    {
-      "name": "<hue>",
-      "syntax": "<number> | <angle>"
-    },
-    {
-      "name": "tan()",
-      "syntax": "tan( <calc-sum> )"
-    },
-    {
-      "name": "<boolean>",
-      "syntax": "<bool-not> | <bool-in-parens> [ <bool-and>* | <bool-or>* ]"
-    },
-    {
-      "name": "snap-block()",
-      "syntax": "snap-block( <length> , [ start | end | near ]? )"
-    },
-    {
-      "name": "<paint>",
-      "syntax": "none | <image> | <svg-paint>"
-    },
-    {
-      "name": "<generic-incomplete>",
-      "syntax": "ui-serif | ui-sans-serif | ui-monospace | ui-rounded"
-    },
-    {
-      "name": "exp()",
-      "syntax": "exp( <calc-sum> )"
-    },
-    {
-      "name": "<pseudo-page>",
-      "syntax": "':' [ left | right | first | blank ]"
-    },
-    {
-      "name": "<track-size>",
-      "syntax": "<track-breadth> | minmax( <inflexible-breadth> , <track-breadth> ) | fit-content( <length-percentage [0,∞]> )"
-    },
-    {
-      "name": "<hue-interpolation-method>",
-      "syntax": "[ shorter | longer | increasing | decreasing ] hue"
-    },
-    {
-      "name": "<predefined-rectangular>",
-      "syntax": "jzazbz | ictcp"
-    },
-    {
-      "name": "contrast()",
-      "syntax": "contrast( [ <number> | <percentage> ]? )"
-    },
-    {
-      "name": "<svg-paint>",
-      "syntax": "child | child( <integer> )"
-    },
-    {
-      "name": "<single-animation>",
-      "syntax": "<time [0s,∞]> || <easing-function> || <time> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ]"
-    },
-    {
-      "name": "<media-query>",
-      "syntax": "<media-condition> | [ not | only ]? <media-type> [ and <media-condition-without-or> ]?"
-    },
-    {
-      "name": "<display-legacy>",
-      "syntax": "inline-block | inline-table | inline-flex | inline-grid"
-    },
-    {
-      "name": "<complex-real-selector>",
-      "syntax": "<compound-selector> [ <combinator>? <compound-selector> ]*"
-    },
-    {
-      "name": "<generic-voice>",
-      "syntax": "[<age>? <gender> <integer>?]"
-    },
-    {
-      "name": "<points>",
-      "syntax": "[ <number>+ ]#"
-    },
-    {
-      "name": "xywh()",
-      "syntax": "xywh( <length-percentage>{2} <length-percentage [0,∞]>{2} [ round <'border-radius'> ]? )"
-    },
-    {
-      "name": "<historical-lig-values>",
-      "syntax": "[ historical-ligatures | no-historical-ligatures ]"
-    },
-    {
-      "name": "<isolation-mode>",
-      "syntax": "auto | isolate"
-    },
-    {
-      "name": "<bg-size>",
-      "syntax": "[ <length-percentage [0,∞]> | auto ]{1,2} | cover | contain"
-    },
-    {
-      "name": "<bool-not>",
-      "syntax": "not <bool-in-parens>"
-    },
-    {
-      "name": "<color-base>",
-      "syntax": "<hex-color> | <color-function> | <named-color> | transparent"
-    },
-    {
-      "name": "<image>",
-      "syntax": "<url> | <gradient>"
-    },
-    {
-      "name": "skew()",
-      "syntax": "skew( [ <angle> | <zero> ] , [ <angle> | <zero> ]? )"
-    },
-    {
-      "name": "<mf-comparison>",
-      "syntax": "<mf-lt> | <mf-gt> | <mf-eq>"
-    },
-    {
-      "name": "asin()",
-      "syntax": "asin( <calc-sum> )"
-    },
-    {
-      "name": "paint()",
-      "syntax": "paint( <ident>, <declaration-value>? )"
-    },
-    {
-      "name": "<font-format>",
-      "syntax": "[<string> | collection | embedded-opentype | opentype | svg | truetype | woff | woff2 ]"
-    },
-    {
-      "name": "<pseudo-class-selector>",
-      "syntax": "':' <ident-token> | ':' <function-token> <any-value> ')'"
-    },
-    {
-      "name": "minmax()",
-      "syntax": "minmax(min, max)"
-    },
-    {
-      "name": "sign()",
-      "syntax": "sign( <calc-sum> )"
-    },
-    {
-      "name": "<legacy-rgb-syntax>",
-      "syntax": "rgb( <percentage>#{3} , <alpha-value>? ) | rgb( <number>#{3} , <alpha-value>? )"
-    },
-    {
-      "name": "counters()",
-      "syntax": "counters( <counter-name>, <string>, <counter-style>? )"
-    },
-    {
-      "name": "<numeric-spacing-values>",
-      "syntax": "[ proportional-nums | tabular-nums ]"
-    },
-    {
-      "name": "<display-inside>",
-      "syntax": "flow | flow-root | table | flex | grid | ruby"
-    },
-    {
-      "name": "sqrt()",
-      "syntax": "sqrt( <calc-sum> )"
-    },
-    {
-      "name": "<dasharray>",
-      "syntax": "[ [ <length-percentage> | <number> ]+ ]#"
-    },
-    {
-      "name": "<an+b>",
-      "syntax": "odd | even | <integer> | <n-dimension> | '+'? n | -n | <ndashdigit-dimension> | '+'? <ndashdigit-ident> | <dashndashdigit-ident> | <n-dimension> <signed-integer> | '+'? n <signed-integer> | -n <signed-integer> | <ndash-dimension> <signless-integer> | '+'? n- <signless-integer> | -n- <signless-integer> | <n-dimension> ['+' | '-'] <signless-integer> | '+'? n ['+' | '-'] <signless-integer> | -n ['+' | '-'] <signless-integer>"
-    },
-    {
-      "name": "opacity()",
-      "syntax": "opacity( [ <number> | <percentage> ]? )"
-    },
-    {
-      "name": "<attachment>",
-      "syntax": "scroll | fixed | local"
-    },
-    {
-      "name": "<subclass-selector>",
-      "syntax": "<id-selector> | <class-selector> | <attribute-selector> | <pseudo-class-selector>"
-    },
-    {
-      "name": "atan2()",
-      "syntax": "atan2( <calc-sum>, <calc-sum> )"
-    },
-    {
-      "name": "saturate()",
-      "syntax": "saturate( [ <number> | <percentage> ]? )"
-    },
-    {
-      "name": "<filter-function>",
-      "syntax": "<blur()> | <brightness()> | <contrast()> | <drop-shadow()> | <grayscale()> | <hue-rotate()> | <invert()> | <opacity()> | <sepia()> | <saturate()>"
-    },
-    {
-      "name": "<number-optional-number>",
-      "syntax": "<number> <number>?"
-    },
-    {
-      "name": "<discretionary-lig-values>",
-      "syntax": "[ discretionary-ligatures | no-discretionary-ligatures ]"
-    },
-    {
-      "name": "<keyframe-block>",
-      "syntax": "<keyframe-selector># { <declaration-list> }"
-    },
-    {
-      "name": "<mask-layer>",
-      "syntax": "<mask-reference> || <position> [ / <bg-size> ]? || <repeat-style> || <geometry-box> || [ <geometry-box> | no-clip ] || <compositing-operator> || <masking-mode>"
-    },
-    {
-      "name": "<grid-line>",
-      "syntax": "auto | <custom-ident> | [ [ <integer [-∞,-1]> | <integer [1,∞]> ] && <custom-ident>? ] | [ span && [ <integer [1,∞]> || <custom-ident> ] ]"
-    },
-    {
-      "name": "<fixed-repeat>",
-      "syntax": "repeat( [ <integer [1,∞]> ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
-    },
-    {
-      "name": "lab()",
-      "syntax": "lab( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
-    },
-    {
-      "name": "<page-selector-list>",
-      "syntax": "<page-selector>#"
-    },
-    {
-      "name": "hue-rotate()",
-      "syntax": "hue-rotate( [ <angle> | <zero> ]? )"
-    },
-    {
-      "name": "<anchor-element>",
-      "syntax": "<dashed-ident>"
-    },
-    {
-      "name": "linear()",
-      "syntax": "linear(<linear-stop-list>)"
-    },
-    {
-      "name": "<bg-position>",
-      "syntax": "[ [ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ center | [ left | right ] <length-percentage>? ] && [ center | [ top | bottom ] <length-percentage>? ] ]"
+      "name": "<single-transition>",
+      "syntax": "[ none | <single-transition-property> ] || <time> || <easing-function> || <time>"
     },
     {
       "name": "<source-size-list>",
-      "syntax": "<source-size>#? , <source-size-value>"
-    },
-    {
-      "name": "scaleX()",
-      "syntax": "scaleX( <number> )"
-    },
-    {
-      "name": "<transform-list>",
-      "syntax": "<transform-function>+"
-    },
-    {
-      "name": "<media-feature>",
-      "syntax": "[ <mf-plain> | <mf-boolean> | <mf-range> ]"
-    },
-    {
-      "name": "src()",
-      "syntax": "src( <string> <url-modifier>* )"
-    },
-    {
-      "name": "<explicit-track-list>",
-      "syntax": "[ <line-names>? <track-size> ]+ <line-names>?"
-    },
-    {
-      "name": "<inflexible-breadth>",
-      "syntax": "<length-percentage [0,∞]> | min-content | max-content | auto"
-    },
-    {
-      "name": "<step-easing-function>",
-      "syntax": "step-start | step-end | steps(<integer> , <step-position>?)"
-    },
-    {
-      "name": "<id-selector>",
-      "syntax": "<hash-token>"
-    },
-    {
-      "name": "<auto-repeat>",
-      "syntax": "repeat( [ auto-fill | auto-fit ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
-    },
-    {
-      "name": "target-text()",
-      "syntax": "target-text( [ <string> | <url> ] , [ content | before | after | first-letter ]? )"
-    },
-    {
-      "name": "abs()",
-      "syntax": "abs( <calc-sum> )"
-    },
-    {
-      "name": "<calc-value>",
-      "syntax": "<number> | <dimension> | <percentage> | <calc-keyword> | ( <calc-sum> )"
-    },
-    {
-      "name": "<color-function>",
-      "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <oklab()> | <oklch()> | <color()>"
+      "syntax": "<source-size>#? ',' <source-size-value>"
     },
     {
       "name": "<source-size-value>",
       "syntax": "<length> | auto"
     },
     {
-      "name": "<self-position>",
-      "syntax": "center | start | end | self-start | self-end | flex-start | flex-end"
+      "name": "<source-size>",
+      "syntax": "<media-condition> <source-size-value> | auto"
     },
     {
-      "name": "<offset-path>",
-      "syntax": "<ray()> | <url> | <basic-shape>"
+      "name": "<spread-shadow>",
+      "syntax": "<'box-shadow-color'>? && [ <'box-shadow-offset'> [ <'box-shadow-blur'> <'box-shadow-spread'>? ]? ] && <'box-shadow-position'>?"
     },
     {
-      "name": "translate()",
-      "syntax": "translate( <length-percentage> , <length-percentage>? )"
+      "name": "<step-easing-function>",
+      "syntax": "step-start | step-end | <steps()>"
     },
     {
-      "name": "<media-or>",
-      "syntax": "or <media-in-parens>"
+      "name": "<step-position>",
+      "syntax": "jump-start | jump-end | jump-none | jump-both | start | end"
     },
     {
-      "name": "<xyz>",
-      "syntax": "xyz | xyz-d50 | xyz-d65"
+      "name": "<subclass-selector>",
+      "syntax": "<id-selector> | <class-selector> | <attribute-selector> | <pseudo-class-selector>"
     },
     {
-      "name": "clamp()",
-      "syntax": "clamp( [ <calc-sum> | none ], <calc-sum>, [ <calc-sum> | none ] )"
+      "name": "<supports-condition>",
+      "syntax": "not <supports-in-parens> | <supports-in-parens> [ and <supports-in-parens> ]* | <supports-in-parens> [ or <supports-in-parens> ]*"
     },
     {
-      "name": "<general-enclosed>",
-      "syntax": "[ <function-token> <any-value>? ) ] | [ ( <any-value>? ) ]"
-    },
-    {
-      "name": "<repeat-style>",
-      "syntax": "repeat-x | repeat-y | [repeat | space | round | no-repeat]{1,2}"
-    },
-    {
-      "name": "<single-animation-direction>",
-      "syntax": "normal | reverse | alternate | alternate-reverse"
-    },
-    {
-      "name": "<bool-and>",
-      "syntax": "and <bool-in-parens>"
-    },
-    {
-      "name": "target-counters()",
-      "syntax": "target-counters( [ <string> | <url> ] , <custom-ident> , <string> , <counter-style>? )"
-    },
-    {
-      "name": "<legacy-pseudo-element-selector>",
-      "syntax": "':' [before | after | first-line | first-letter]"
-    },
-    {
-      "name": "max()",
-      "syntax": "max( <calc-sum># )"
-    },
-    {
-      "name": "<class-selector>",
-      "syntax": "'.' <ident-token>"
-    },
-    {
-      "name": "<mf-range>",
-      "syntax": "<mf-name> <mf-comparison> <mf-value> | <mf-value> <mf-comparison> <mf-name> | <mf-value> <mf-lt> <mf-name> <mf-lt> <mf-value> | <mf-value> <mf-gt> <mf-name> <mf-gt> <mf-value>"
-    },
-    {
-      "name": "<calc-keyword>",
-      "syntax": "e | pi | infinity | -infinity | NaN"
-    },
-    {
-      "name": "<modern-rgba-syntax>",
-      "syntax": "rgba( [ <number> | <percentage> | none]{3} [ / [<alpha-value> | none] ]? )"
-    },
-    {
-      "name": "lch()",
-      "syntax": "lch( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )"
-    },
-    {
-      "name": "oklch()",
-      "syntax": "oklch( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )"
-    },
-    {
-      "name": "<linear-easing-function>",
-      "syntax": "linear(<linear-stop-list>)"
-    },
-    {
-      "name": "var()",
-      "syntax": "var( <custom-property-name> , <declaration-value>? )"
-    },
-    {
-      "name": "<marker-ref>",
-      "syntax": "<url>"
-    },
-    {
-      "name": "<feature-value-name>",
-      "syntax": "<ident>"
-    },
-    {
-      "name": "skewX()",
-      "syntax": "skewX( [ <angle> | <zero> ] )"
-    },
-    {
-      "name": "<predefined-polar-params>",
-      "syntax": "jzczhz [ <number> | <percentage> | none ]{2} [ <hue> | none]"
-    },
-    {
-      "name": "<linear-color-hint>",
-      "syntax": "<length-percentage>"
-    },
-    {
-      "name": "<predefined-rectangular-params>",
-      "syntax": "<predefined-rectangular> [ <number> | <percentage> | none ]{3}"
-    },
-    {
-      "name": "<quote>",
-      "syntax": "open-quote | close-quote | no-open-quote | no-close-quote"
-    },
-    {
-      "name": "<leader-type>",
-      "syntax": "dotted | solid | space | <string>"
-    },
-    {
-      "name": "<function-parameter-list>",
-      "syntax": "<function-parameter>#"
-    },
-    {
-      "name": "<radial-extent>",
-      "syntax": "closest-corner | closest-side | farthest-corner | farthest-side"
-    },
-    {
-      "name": "<numeric-figure-values>",
-      "syntax": "[ lining-nums | oldstyle-nums ]"
-    },
-    {
-      "name": "<bg-image>",
-      "syntax": "<image> | none"
-    },
-    {
-      "name": "ray()",
-      "syntax": "ray( <angle> && <ray-size>? && contain? && [at <position>]? )"
-    },
-    {
-      "name": "<east-asian-variant-values>",
-      "syntax": "[ jis78 | jis83 | jis90 | jis04 | simplified | traditional ]"
-    },
-    {
-      "name": "rgb()",
-      "syntax": "[ <legacy-rgb-syntax> | <modern-rgb-syntax> ]"
-    },
-    {
-      "name": "<syntax-combinator>",
-      "syntax": "'|'"
-    },
-    {
-      "name": "<namespace-prefix>",
-      "syntax": "<ident>"
-    },
-    {
-      "name": "<page-selector>",
-      "syntax": "[ <ident-token>? <pseudo-page>* ]!"
-    },
-    {
-      "name": "cubic-bezier()",
-      "syntax": "cubic-bezier(<number [0,1]>, <number>, <number [0,1]>, <number>)"
-    },
-    {
-      "name": "<complex-selector-unit>",
-      "syntax": "[ <compound-selector>? <pseudo-compound-selector>* ]!"
-    },
-    {
-      "name": "<media-condition-without-or>",
-      "syntax": "<media-not> | <media-in-parens> <media-and>*"
-    },
-    {
-      "name": "translateX()",
-      "syntax": "translateX( <length-percentage> )"
-    },
-    {
-      "name": "scaleY()",
-      "syntax": "scaleY( <number> )"
-    },
-    {
-      "name": "scroll()",
-      "syntax": "scroll( [ <scroller> || <axis> ]? )"
-    },
-    {
-      "name": "<font-variant-css2>",
-      "syntax": "[normal | small-caps]"
-    },
-    {
-      "name": "env()",
-      "syntax": "env( <custom-ident> <integer [0,∞]>*, <declaration-value>? )"
-    },
-    {
-      "name": "<selector-list>",
-      "syntax": "<complex-selector-list>"
-    },
-    {
-      "name": "<legacy-hsl-syntax>",
-      "syntax": "hsl( <hue>, <percentage>, <percentage>, <alpha-value>? )"
-    },
-    {
-      "name": "<mask-reference>",
-      "syntax": "none | <image> | <mask-source>"
-    },
-    {
-      "name": "<custom-arg>",
-      "syntax": "$ <ident-token> ;"
-    },
-    {
-      "name": "<gradient>",
-      "syntax": "<linear-gradient()> | <repeating-linear-gradient()> | <radial-gradient()> | <repeating-radial-gradient()>"
-    },
-    {
-      "name": "radial-gradient()",
-      "syntax": "radial-gradient( [ <radial-gradient-syntax> ] )"
-    },
-    {
-      "name": "brightness()",
-      "syntax": "brightness( [ <number> | <percentage> ]? )"
-    },
-    {
-      "name": "<family-name>",
-      "syntax": "<string> | <custom-ident>+"
-    },
-    {
-      "name": "steps()",
-      "syntax": "steps(<integer>, <step-position>?)"
-    },
-    {
-      "name": "<function-parameter>",
-      "syntax": "<custom-property-name> <css-type>? [ : <declaration-value> ]?"
-    },
-    {
-      "name": "<mq-boolean>",
-      "syntax": "<integer [0,1]>"
-    },
-    {
-      "name": "hypot()",
-      "syntax": "hypot( <calc-sum># )"
-    },
-    {
-      "name": "oklab()",
-      "syntax": "oklab( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
-    },
-    {
-      "name": "<counter-style>",
-      "syntax": "<counter-style-name> | <symbols()>"
+      "name": "<supports-decl>",
+      "syntax": "'(' <declaration> ')'"
     },
     {
       "name": "<supports-feature>",
       "syntax": "<supports-decl>"
     },
     {
-      "name": "<try-tactic>",
-      "syntax": "flip-block || flip-inline || flip-start"
+      "name": "<supports-in-parens>",
+      "syntax": "'(' <supports-condition> ')' | <supports-feature> | <general-enclosed>"
     },
     {
-      "name": "<line-width>",
-      "syntax": "<length [0,∞]> | thin | medium | thick"
+      "name": "<svg-paint>",
+      "syntax": "child | child( <integer> )"
     },
     {
-      "name": "<media-type>",
-      "syntax": "<ident>"
+      "name": "<symbol>",
+      "syntax": "<string> | <image> | <custom-ident>"
     },
     {
-      "name": "matrix()",
-      "syntax": "matrix( <number>#{6} )"
-    },
-    {
-      "name": "palette-mix()",
-      "syntax": "palette-mix(<color-interpolation-method> , [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})"
-    },
-    {
-      "name": "<complex-real-selector-list>",
-      "syntax": "<complex-real-selector>#"
-    },
-    {
-      "name": "<simple-selector>",
-      "syntax": "<type-selector> | <subclass-selector>"
-    },
-    {
-      "name": "<mf-boolean>",
-      "syntax": "<mf-name>"
-    },
-    {
-      "name": "<rectangular-color-space>",
-      "syntax": "srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020 | lab | oklab | xyz | xyz-d50 | xyz-d65"
-    },
-    {
-      "name": "dynamic-range-limit-mix()",
-      "syntax": "dynamic-range-limit-mix( [ <ident> && <percentage [0,100]>? ]#{2})"
-    },
-    {
-      "name": "<content-replacement>",
-      "syntax": "<image>"
-    },
-    {
-      "name": "<display-internal>",
-      "syntax": "table-row-group | table-header-group | table-footer-group | table-row | table-cell | table-column-group | table-column | table-caption | ruby-base | ruby-text | ruby-base-container | ruby-text-container"
-    },
-    {
-      "name": "<display-box>",
-      "syntax": "contents | none"
-    },
-    {
-      "name": "anchor()",
-      "syntax": "anchor( <anchor-element>? && <anchor-side>, <length-percentage>? )"
-    },
-    {
-      "name": "string()",
-      "syntax": "string( <custom-ident> , [ first | start | last | first-except ]? )"
-    },
-    {
-      "name": "<syntax-component-name>",
-      "syntax": "'<' <syntax-type> '>' | <custom-ident>"
-    },
-    {
-      "name": "round()",
-      "syntax": "round( <rounding-strategy>?, <calc-sum>, <calc-sum>? )"
-    },
-    {
-      "name": "rem()",
-      "syntax": "rem( <calc-sum>, <calc-sum> )"
-    },
-    {
-      "name": "sin()",
-      "syntax": "sin( <calc-sum> )"
-    },
-    {
-      "name": "<boolean-without-or>",
-      "syntax": "<bool-not> | <bool-in-parens> <bool-and>*"
-    },
-    {
-      "name": "<content-distribution>",
-      "syntax": "space-between | space-around | space-evenly | stretch"
-    },
-    {
-      "name": "<mf-name>",
-      "syntax": "<ident>"
-    },
-    {
-      "name": "ellipse()",
-      "syntax": "ellipse( <radial-size>? [ at <position> ]? )"
-    },
-    {
-      "name": "rect()",
-      "syntax": "rect( <top>, <right>, <bottom>, <left> )"
-    },
-    {
-      "name": "<complex-selector-list>",
-      "syntax": "<complex-selector>#"
-    },
-    {
-      "name": "<type()>",
-      "syntax": "type( <syntax> )"
-    },
-    {
-      "name": "counter()",
-      "syntax": "counter( <counter-name>, <counter-style>? )"
-    },
-    {
-      "name": "anchor-size()",
-      "syntax": "anchor-size( [ <anchor-element> || <anchor-size> ]? , <length-percentage>? )"
-    },
-    {
-      "name": "skewY()",
-      "syntax": "skewY( [ <angle> | <zero> ] )"
-    },
-    {
-      "name": "<content-position>",
-      "syntax": "center | start | end | flex-start | flex-end"
-    },
-    {
-      "name": "<custom-params>",
-      "syntax": "<dashed-ident> [ <number> | <percentage> | none ]+"
-    },
-    {
-      "name": "<content-list>",
-      "syntax": "[ <string> | <counter()> | <counters()> | <content()> | <attr()> ]+"
-    },
-    {
-      "name": "<filter-value-list>",
-      "syntax": "[ <filter-function> | <url> ]+"
-    },
-    {
-      "name": "<font-src>",
-      "syntax": "<url> [ format(<font-format>)]? [ tech( <font-tech>#)]? | local(<family-name>)"
-    },
-    {
-      "name": "<linear-stop-length>",
-      "syntax": "<percentage>{1,2}"
-    },
-    {
-      "name": "<track-repeat>",
-      "syntax": "repeat( [ <integer [1,∞]> ] , [ <line-names>? <track-size> ]+ <line-names>? )"
-    },
-    {
-      "name": "<polar-color-space>",
-      "syntax": "hsl | hwb | lch | oklch"
-    },
-    {
-      "name": "<font-width-css3>",
-      "syntax": "[normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded]"
-    },
-    {
-      "name": "<paint-box>",
-      "syntax": "<visual-box> | fill-box | stroke-box"
-    },
-    {
-      "name": "cos()",
-      "syntax": "cos( <calc-sum> )"
-    },
-    {
-      "name": "<mf-gt>",
-      "syntax": "'>' '='?"
-    },
-    {
-      "name": "<bool-or>",
-      "syntax": "or <bool-in-parens>"
-    },
-    {
-      "name": "<predefined-rgb>",
-      "syntax": "srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020 | rec2100-pq | rec2100-hlg | rec2100-linear"
-    },
-    {
-      "name": "<overflow-position>",
-      "syntax": "unsafe | safe"
-    },
-    {
-      "name": "<relative-selector-list>",
-      "syntax": "<relative-selector>#"
-    },
-    {
-      "name": "path()",
-      "syntax": "path( <'fill-rule'>? , <string> )"
-    },
-    {
-      "name": "<generic-family>",
-      "syntax": "<generic-script-specific>| <generic-complete> | <generic-incomplete>"
-    },
-    {
-      "name": "<attr-modifier>",
-      "syntax": "i | s"
-    },
-    {
-      "name": "<media-in-parens>",
-      "syntax": "( <media-condition> ) | ( <media-feature> ) | <general-enclosed>"
-    },
-    {
-      "name": "<alpha-value>",
-      "syntax": "<number> | <percentage>"
-    },
-    {
-      "name": "<modern-rgb-syntax>",
-      "syntax": "rgb( [ <number> | <percentage> | none]{3} [ / [<alpha-value> | none] ]? )"
-    },
-    {
-      "name": "<radial-shape>",
-      "syntax": "circle | ellipse"
-    },
-    {
-      "name": "<final-bg-layer>",
-      "syntax": "<bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <visual-box> || <visual-box> || <'background-color'>"
-    },
-    {
-      "name": "pow()",
-      "syntax": "pow( <calc-sum>, <calc-sum> )"
+      "name": "<symbols-type>",
+      "syntax": "cyclic | numeric | alphabetic | symbolic | fixed"
     },
     {
       "name": "<system-family-name>",
       "syntax": "caption | icon | menu | message-box | small-caption | status-bar"
     },
     {
-      "name": "<complex-selector>",
-      "syntax": "<complex-selector-unit> [ <combinator>? <complex-selector-unit> ]*"
+      "name": "<target>",
+      "syntax": "<target-counter()> | <target-counters()> | <target-text()>"
     },
     {
-      "name": "<xyz-space>",
-      "syntax": "xyz | xyz-d50 | xyz-d65"
+      "name": "<text-edge>",
+      "syntax": "[ text | ideographic | ideographic-ink ] | [ text | ideographic | ideographic-ink | cap | ex ] [ text | ideographic | ideographic-ink | alphabetic ]"
     },
     {
-      "name": "polygon()",
-      "syntax": "polygon( <'fill-rule'>? , [<length-percentage> <length-percentage>]# )"
-    },
-    {
-      "name": "<animateable-feature>",
-      "syntax": "scroll-position | contents | <custom-ident>"
-    },
-    {
-      "name": "<layout-box>",
-      "syntax": "<visual-box> | margin-box"
-    },
-    {
-      "name": "<combinator>",
-      "syntax": "'>' | '+' | '~' | [ '|' '|' ]"
+      "name": "<time-percentage>",
+      "syntax": "[ <time> | <percentage> ]"
     },
     {
       "name": "<track-breadth>",
       "syntax": "<length-percentage [0,∞]> | <flex [0,∞]> | min-content | max-content | auto"
     },
     {
-      "name": "<line-names>",
-      "syntax": "'[' <custom-ident>* ']'"
+      "name": "<track-list>",
+      "syntax": "[ <line-names>? [ <track-size> | <track-repeat> ] ]+ <line-names>?"
     },
     {
-      "name": "<single-transition>",
-      "syntax": "[ none | <single-transition-property> ] || <time> || <easing-function> || <time>"
+      "name": "<track-repeat>",
+      "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-names>? <track-size> ]+ <line-names>? )"
     },
     {
-      "name": "<numeric-fraction-values>",
-      "syntax": "[ diagonal-fractions | stacked-fractions ]"
+      "name": "<track-size>",
+      "syntax": "<track-breadth> | minmax( <inflexible-breadth> ',' <track-breadth> ) | fit-content( <length-percentage [0,∞]> )"
     },
     {
-      "name": "<cubic-bezier-easing-function>",
-      "syntax": "ease | ease-in | ease-out | ease-in-out | cubic-bezier(<number [0,1]>, <number>, <number [0,1]>, <number>)"
+      "name": "<transform-list>",
+      "syntax": "<transform-function>+"
     },
     {
-      "name": "<media-and>",
-      "syntax": "and <media-in-parens>"
+      "name": "<try-size>",
+      "syntax": "most-width | most-height | most-block-size | most-inline-size"
     },
     {
-      "name": "<mf-eq>",
-      "syntax": "'='"
-    },
-    {
-      "name": "<syntax-type>",
-      "syntax": "angle | color | custom-ident | image | integer | length | length-percentage | number | percentage | resolution | string | time | url | transform-function"
-    },
-    {
-      "name": "linear-gradient()",
-      "syntax": "linear-gradient( [ <linear-gradient-syntax> ] )"
-    },
-    {
-      "name": "<attribute-selector>",
-      "syntax": "'[' <wq-name> ']' | '[' <wq-name> <attr-matcher> [ <string-token> | <ident-token> ] <attr-modifier>? ']'"
-    },
-    {
-      "name": "<mf-lt>",
-      "syntax": "'<' '='?"
-    },
-    {
-      "name": "<generic-script-specific>",
-      "syntax": "generic(kai) | generic(fangsong) | generic(nastaliq)"
-    },
-    {
-      "name": "<compound-selector>",
-      "syntax": "[ <type-selector>? <subclass-selector>* ]!"
-    },
-    {
-      "name": "content()",
-      "syntax": "content( [ text | before | after | first-letter | marker ]? )"
-    },
-    {
-      "name": "hwb()",
-      "syntax": "hwb( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
-    },
-    {
-      "name": "<xyz-params>",
-      "syntax": "<xyz> [ <number> | <percentage> | none ]{3}"
-    },
-    {
-      "name": "<supports-decl>",
-      "syntax": "( <declaration> )"
-    },
-    {
-      "name": "<linear-color-stop>",
-      "syntax": "<color> <length-percentage>?"
-    },
-    {
-      "name": "translateY()",
-      "syntax": "translateY( <length-percentage> )"
+      "name": "<try-tactic>",
+      "syntax": "flip-block || flip-inline || flip-start"
     },
     {
       "name": "<type-selector>",
       "syntax": "<wq-name> | <ns-prefix>? '*'"
     },
     {
-      "name": "<angle-percentage>",
-      "syntax": "[ <angle> | <percentage> ]"
+      "name": "<type>",
+      "syntax": "'<' [ number | string ] '>'"
     },
     {
-      "name": "<modern-hsl-syntax>",
-      "syntax": "hsl( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+      "name": "<url>",
+      "syntax": "<url()> | <src()>"
     },
     {
-      "name": "<color-space>",
-      "syntax": "<rectangular-color-space> | <polar-color-space>"
+      "name": "<visual-box>",
+      "syntax": "content-box | padding-box | border-box"
     },
     {
-      "name": "<text-edge>",
-      "syntax": "[ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]?"
+      "name": "<wq-name>",
+      "syntax": "<ns-prefix>? <ident-token>"
     },
     {
-      "name": "<function-dependency-list>",
-      "syntax": "<function-parameter>#"
+      "name": "<xyz-params>",
+      "syntax": "<xyz-space> [ <number> | <percentage> | none ]{3}"
     },
     {
-      "name": "<syntax>",
-      "syntax": "'*' | <syntax-component> [ <syntax-combinator> <syntax-component> ]+"
+      "name": "<xyz-space>",
+      "syntax": "xyz | xyz-d50 | xyz-d65"
     },
     {
-      "name": "<attr-matcher>",
-      "syntax": "[ '~' | '|' | '^' | '$' | '*' ]? '='"
+      "name": "abs()",
+      "syntax": "abs( <calc-sum> )"
     },
     {
-      "name": "<ray-size>",
-      "syntax": "closest-side | closest-corner | farthest-side | farthest-corner | sides"
+      "name": "acos()",
+      "syntax": "acos( <calc-sum> )"
     },
     {
-      "name": "<syntax-component>",
-      "syntax": "<syntax-component-name> <syntax-multiplier>? | '<' transform-list '>'"
+      "name": "anchor()",
+      "syntax": "anchor( <anchor-name>? && <anchor-side>, <length-percentage>? )"
     },
     {
-      "name": "<opentype-tag>",
-      "syntax": "<string>"
+      "name": "anchor-size()",
+      "syntax": "anchor-size( [ <anchor-name> || <anchor-size> ]? ',' <length-percentage>? )"
     },
     {
-      "name": "<layer-name>",
-      "syntax": "<ident> [ '.' <ident> ]*"
+      "name": "asin()",
+      "syntax": "asin( <calc-sum> )"
     },
     {
-      "name": "<mf-plain>",
-      "syntax": "<mf-name> : <mf-value>"
+      "name": "atan()",
+      "syntax": "atan( <calc-sum> )"
     },
     {
-      "name": "<media-condition>",
-      "syntax": "<media-not> | <media-in-parens> [ <media-and>* | <media-or>* ]"
+      "name": "atan2()",
+      "syntax": "atan2( <calc-sum>, <calc-sum> )"
     },
     {
-      "name": "<position>",
-      "syntax": "[ [ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right ] && [ top | center | bottom ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ] ]"
+      "name": "blur()",
+      "syntax": "blur( <length>? )"
     },
     {
-      "name": "<rounding-strategy>",
-      "syntax": "nearest | up | down | to-zero"
+      "name": "brightness()",
+      "syntax": "brightness( [ <number> | <percentage> ]? )"
     },
     {
-      "name": "<coord-box>",
-      "syntax": "<paint-box> | view-box"
+      "name": "calc()",
+      "syntax": "calc( <calc-sum> )"
     },
     {
-      "name": "<import-conditions>",
-      "syntax": "[ supports( [ <supports-condition> | <declaration> ] ) ]? <media-query-list>?"
+      "name": "circle()",
+      "syntax": "circle( <radial-size>? [ at <position> ]? )"
     },
     {
-      "name": "url()",
-      "syntax": "url( <string> <url-modifier>* ) | <url-token>"
+      "name": "clamp()",
+      "syntax": "clamp( [ <calc-sum> | none ], <calc-sum>, [ <calc-sum> | none ] )"
     },
     {
-      "name": "<fixed-breadth>",
-      "syntax": "<length-percentage [0,∞]>"
+      "name": "content()",
+      "syntax": "content( [ text | before | after | first-letter | marker ]? )"
     },
     {
-      "name": "<color>",
-      "syntax": "<color-base> | currentColor | <system-color>"
+      "name": "contrast()",
+      "syntax": "contrast( [ <number> | <percentage> ]? )"
+    },
+    {
+      "name": "control-value()",
+      "syntax": "control-value( <type>? )"
+    },
+    {
+      "name": "cos()",
+      "syntax": "cos( <calc-sum> )"
+    },
+    {
+      "name": "counter()",
+      "syntax": "counter( <counter-name>, <counter-style>? )"
+    },
+    {
+      "name": "counters()",
+      "syntax": "counters( <counter-name>, <string>, <counter-style>? )"
+    },
+    {
+      "name": "cubic-bezier()",
+      "syntax": "cubic-bezier( [ <number [0,1]>, <number> ]#{2} )"
+    },
+    {
+      "name": "drop-shadow()",
+      "syntax": "drop-shadow( [ <color>? && <length>{2,3} ] )"
+    },
+    {
+      "name": "dynamic-range-limit-mix()",
+      "syntax": "dynamic-range-limit-mix( [ <'dynamic-range-limit'> && <percentage [0,100]> ]#{2,} )"
+    },
+    {
+      "name": "ellipse()",
+      "syntax": "ellipse( <radial-size>? [ at <position> ]? )"
+    },
+    {
+      "name": "env()",
+      "syntax": "env( <custom-ident> <integer [0,∞]>*, <declaration-value>? )"
+    },
+    {
+      "name": "exp()",
+      "syntax": "exp( <calc-sum> )"
+    },
+    {
+      "name": "filter()",
+      "syntax": "filter( [ <image> | <string> ], <filter-value-list> )"
+    },
+    {
+      "name": "fit-content()",
+      "syntax": "fit-content( <length-percentage> )"
+    },
+    {
+      "name": "grayscale()",
+      "syntax": "grayscale( [ <number> | <percentage> ]? )"
+    },
+    {
+      "name": "hdr-color()",
+      "syntax": "color-hdr([ <color> && <number [0,∞]>? ]#{2})"
+    },
+    {
+      "name": "hsl()",
+      "syntax": "[ <legacy-hsl-syntax> | <modern-hsl-syntax> ]"
+    },
+    {
+      "name": "hsla()",
+      "syntax": "[ <legacy-hsla-syntax> | <modern-hsla-syntax> ]"
+    },
+    {
+      "name": "hue-rotate()",
+      "syntax": "hue-rotate( [ <angle> | <zero> ]? )"
+    },
+    {
+      "name": "hwb()",
+      "syntax": "hwb( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "hypot()",
+      "syntax": "hypot( <calc-sum># )"
+    },
+    {
+      "name": "ictcp()",
+      "syntax": "ictcp([from <color>]? [<percentage> | <number> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "inset()",
+      "syntax": "inset( <length-percentage>{1,4} [ round <'border-radius'> ]? )"
+    },
+    {
+      "name": "invert()",
+      "syntax": "invert( [ <number> | <percentage> ]? )"
+    },
+    {
+      "name": "jzazbz()",
+      "syntax": "jzazbz([from <color>]? [<percentage> | <number> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "jzczhz()",
+      "syntax": "jzczhz([from <color>]? [<percentage> | <number> | none] [<percentage> | <number> | none] [<hue> | none] [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "lab()",
+      "syntax": "lab( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "lch()",
+      "syntax": "lch( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "leader()",
+      "syntax": "leader( <leader-type> )"
+    },
+    {
+      "name": "linear()",
+      "syntax": "linear( [ <number> && <percentage>{0,2} ]# )"
+    },
+    {
+      "name": "linear-gradient()",
+      "syntax": "linear-gradient( [ <linear-gradient-syntax> ] )"
+    },
+    {
+      "name": "log()",
+      "syntax": "log( <calc-sum>, <calc-sum>? )"
+    },
+    {
+      "name": "matrix()",
+      "syntax": "matrix( <number>#{6} )"
+    },
+    {
+      "name": "max()",
+      "syntax": "max( <calc-sum># )"
+    },
+    {
+      "name": "min()",
+      "syntax": "min( <calc-sum># )"
+    },
+    {
+      "name": "minmax()",
+      "syntax": "minmax(min, max)"
+    },
+    {
+      "name": "mod()",
+      "syntax": "mod( <calc-sum>, <calc-sum> )"
+    },
+    {
+      "name": "oklab()",
+      "syntax": "oklab( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "oklch()",
+      "syntax": "oklch( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "opacity()",
+      "syntax": "opacity( [ <number> | <percentage> ]? )"
+    },
+    {
+      "name": "paint()",
+      "syntax": "paint( <ident>, <declaration-value>? )"
+    },
+    {
+      "name": "palette-mix()",
+      "syntax": "palette-mix(<color-interpolation-method> ',' [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})"
+    },
+    {
+      "name": "path()",
+      "syntax": "path( <'fill-rule'>? ',' <string> )"
+    },
+    {
+      "name": "polygon()",
+      "syntax": "polygon( <'fill-rule'>? [ round <length> ]? ',' [<length-percentage> <length-percentage>]# )"
+    },
+    {
+      "name": "pow()",
+      "syntax": "pow( <calc-sum>, <calc-sum> )"
+    },
+    {
+      "name": "radial-gradient()",
+      "syntax": "radial-gradient( [ <radial-gradient-syntax> ] )"
+    },
+    {
+      "name": "ray()",
+      "syntax": "ray( <angle> && <ray-size>? && contain? && [at <position>]? )"
+    },
+    {
+      "name": "rect()",
+      "syntax": "rect( <top>, <right>, <bottom>, <left> )"
+    },
+    {
+      "name": "rem()",
+      "syntax": "rem( <calc-sum>, <calc-sum> )"
     },
     {
       "name": "repeating-linear-gradient()",
@@ -6885,165 +7259,164 @@
       "syntax": "repeating-radial-gradient( [ <radial-gradient-syntax> ] )"
     },
     {
-      "name": "inset()",
-      "syntax": "inset( <length-percentage>{1,4} [ round <'border-radius'> ]? )"
+      "name": "rgb()",
+      "syntax": "[ <legacy-rgb-syntax> | <modern-rgb-syntax> ]"
     },
     {
-      "name": "<keyframes-name>",
-      "syntax": "<custom-ident> | <string>"
+      "name": "rgba()",
+      "syntax": "[ <legacy-rgba-syntax> | <modern-rgba-syntax> ]"
     },
     {
-      "name": "<ns-prefix>",
-      "syntax": "[ <ident-token> | '*' ]? '|'"
+      "name": "rotate()",
+      "syntax": "rotate( [ <angle> | <zero> ] )"
     },
     {
-      "name": "<font-weight-absolute>",
-      "syntax": "[normal | bold | <number [1,1000]>]"
+      "name": "round()",
+      "syntax": "round( <rounding-strategy>?, <calc-sum>, <calc-sum>? )"
     },
     {
-      "name": "<common-lig-values>",
-      "syntax": "[ common-ligatures | no-common-ligatures ]"
+      "name": "running()",
+      "syntax": "running( <custom-ident> )"
     },
     {
-      "name": "<bool-in-parens>",
-      "syntax": "( <boolean> ) | <bool-test> | <general-enclosed>"
+      "name": "saturate()",
+      "syntax": "saturate( [ <number> | <percentage> ]? )"
     },
     {
-      "name": "<name-repeat>",
-      "syntax": "repeat( [ <integer [1,∞]> | auto-fill ], <line-names>+)"
+      "name": "scale()",
+      "syntax": "scale( <number> ',' <number>? )"
     },
     {
-      "name": "<radial-gradient-syntax>",
-      "syntax": "[ <radial-shape> || <radial-size> ]? [ at <position> ]? , <color-stop-list>"
+      "name": "scaleX()",
+      "syntax": "scaleX( <number> )"
     },
     {
-      "name": "<bg-layer>",
-      "syntax": "<bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <visual-box> || <visual-box>"
+      "name": "scaleY()",
+      "syntax": "scaleY( <number> )"
     },
     {
-      "name": "acos()",
-      "syntax": "acos( <calc-sum> )"
+      "name": "scroll()",
+      "syntax": "scroll( [ <scroller> || <axis> ]? )"
     },
     {
-      "name": "<url>",
-      "syntax": "<url()> | <src()>"
+      "name": "sepia()",
+      "syntax": "sepia( [ <number> | <percentage> ]? )"
     },
     {
-      "name": "log()",
-      "syntax": "log( <calc-sum>, <calc-sum>? )"
+      "name": "sign()",
+      "syntax": "sign( <calc-sum> )"
     },
     {
-      "name": "<calc-sum>",
-      "syntax": "<calc-product> [ [ '+' | '-' ] <calc-product> ]*"
+      "name": "sin()",
+      "syntax": "sin( <calc-sum> )"
     },
     {
-      "name": "<syntax-multiplier>",
-      "syntax": "[ '#' | '+' ]"
+      "name": "skew()",
+      "syntax": "skew( [ <angle> | <zero> ] ',' [ <angle> | <zero> ]? )"
     },
     {
-      "name": "circle()",
-      "syntax": "circle( <radial-size>? [ at <position> ]? )"
+      "name": "skewX()",
+      "syntax": "skewX( [ <angle> | <zero> ] )"
     },
     {
-      "name": "grayscale()",
-      "syntax": "grayscale( [ <number> | <percentage> ]? )"
+      "name": "skewY()",
+      "syntax": "skewY( [ <angle> | <zero> ] )"
     },
     {
-      "name": "<masking-mode>",
-      "syntax": "alpha | luminance | match-source"
+      "name": "snap-block()",
+      "syntax": "snap-block( <length> ',' [ start | end | near ]? )"
     },
     {
-      "name": "<mf-value>",
-      "syntax": "<number> | <dimension> | <ident> | <ratio>"
+      "name": "snap-inline()",
+      "syntax": "snap-inline( <length> ',' [ left | right | near ]? )"
     },
     {
-      "name": "<anchor-side>",
-      "syntax": "inside | outside | top | left | right | bottom | start | end | self-start | self-end | <percentage> | center"
+      "name": "sqrt()",
+      "syntax": "sqrt( <calc-sum> )"
     },
     {
-      "name": "<time-percentage>",
-      "syntax": "[ <time> | <percentage> ]"
+      "name": "src()",
+      "syntax": "src( <string> <url-modifier>* )"
     },
     {
-      "name": "<calc-product>",
-      "syntax": "<calc-value> [ [ '*' | '/' ] <calc-value> ]*"
+      "name": "steps()",
+      "syntax": "steps( <integer>, <step-position>?)"
     },
     {
-      "name": "<colorspace-params>",
-      "syntax": "[<custom-params> | <predefined-rgb-params> | <predefined-polar-params> | <predefined-rectangular-params> | <xyz-params>]"
+      "name": "string()",
+      "syntax": "string( <custom-ident> ',' [ first | start | last | first-except ]? )"
     },
     {
-      "name": "<supports-condition>",
-      "syntax": "not <supports-in-parens> | <supports-in-parens> [ and <supports-in-parens> ]* | <supports-in-parens> [ or <supports-in-parens> ]*"
+      "name": "superellipse()",
+      "syntax": "superellipse( <number> | infinity )"
     },
     {
-      "name": "<relative-selector>",
-      "syntax": "<combinator>? <complex-selector>"
+      "name": "symbols()",
+      "syntax": "symbols( <symbols-type>? [ <string> | <image> ]+ )"
     },
     {
-      "name": "<relative-real-selector>",
-      "syntax": "<combinator>? <complex-real-selector>"
+      "name": "tan()",
+      "syntax": "tan( <calc-sum> )"
     },
     {
-      "name": "<baseline-position>",
-      "syntax": "[ first | last ]? && baseline"
+      "name": "target-counter()",
+      "syntax": "target-counter( [ <string> | <url> ] ',' <custom-ident> ',' <counter-style>? )"
     },
     {
-      "name": "<pseudo-compound-selector>",
-      "syntax": "<pseudo-element-selector> <pseudo-class-selector>*"
+      "name": "target-counters()",
+      "syntax": "target-counters( [ <string> | <url> ] ',' <custom-ident> ',' <string> ',' <counter-style>? )"
     },
     {
-      "name": "<line-name-list>",
-      "syntax": "[ <line-names> | <name-repeat> ]+"
+      "name": "target-text()",
+      "syntax": "target-text( [ <string> | <url> ] ',' [ content | before | after | first-letter ]? )"
     },
     {
-      "name": "hsl()",
-      "syntax": "[ <legacy-hsl-syntax> | <modern-hsl-syntax> ]"
+      "name": "translate()",
+      "syntax": "translate( <length-percentage> ',' <length-percentage>? )"
     },
     {
-      "name": "leader()",
-      "syntax": "leader( <leader-type> )"
+      "name": "translateX()",
+      "syntax": "translateX( <length-percentage> )"
     },
     {
-      "name": "<axis>",
-      "syntax": "block | inline | x | y"
+      "name": "translateY()",
+      "syntax": "translateY( <length-percentage> )"
     },
     {
-      "name": "<line-style>",
-      "syntax": "none | hidden | dotted | dashed | solid | double | groove | ridge | inset | outset"
+      "name": "url()",
+      "syntax": "url( <string> <url-modifier>* ) | <url-token>"
     },
     {
-      "name": "<clip-source>",
-      "syntax": "<url>"
+      "name": "var()",
+      "syntax": "var( <custom-property-name> ',' <declaration-value>? )"
     },
     {
-      "name": "calc()",
-      "syntax": "calc( <calc-sum> )"
+      "name": "view()",
+      "syntax": "view( [ <axis> || <'view-timeline-inset'> ]? )"
     },
     {
-      "name": "invert()",
-      "syntax": "invert( [ <number> | <percentage> ]? )"
-    },
-    {
-      "name": "color()",
-      "syntax": "color( [from <color>]? <colorspace-params> [ / [ <alpha-value> | none ] ]? )"
-    },
-    {
-      "name": "<source-size>",
-      "syntax": "<media-condition> <source-size-value> | auto"
-    },
-    {
-      "name": "<linear-stop-list>",
-      "syntax": "[ <linear-stop> ]#"
-    },
-    {
-      "name": "<compositing-operator>",
-      "syntax": "add | subtract | intersect | exclude"
+      "name": "xywh()",
+      "syntax": "xywh( <length-percentage>{2} <length-percentage [0,∞]>{2} [ round <'border-radius'> ]? )"
     }
   ],
   "atrules": [
     {
-      "name": "@layer",
+      "name": "@-webkit-keyframes",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@bottom-center",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@bottom-left",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@bottom-left-corner",
       "descriptors": [],
       "Values": null
     },
@@ -7058,51 +7431,9 @@
       "Values": null
     },
     {
-      "name": "@page",
-      "descriptors": [
-        {
-          "name": "size",
-          "syntax": "<length [0,∞]>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]",
-          "initial": "auto"
-        },
-        {
-          "name": "page-orientation",
-          "syntax": "upright | rotate-left | rotate-right",
-          "initial": "upright"
-        },
-        {
-          "name": "marks",
-          "syntax": "none | [ crop || cross ]",
-          "initial": ""
-        },
-        {
-          "name": "bleed",
-          "syntax": "auto | <length>",
-          "initial": "auto"
-        }
-      ],
-      "Values": [
-        {
-          "name": ":left",
-          "value": ":left",
-          "Values": null
-        },
-        {
-          "name": ":right",
-          "value": ":right",
-          "Values": null
-        },
-        {
-          "name": ":first",
-          "value": ":first",
-          "Values": null
-        },
-        {
-          "name": ":blank",
-          "value": ":blank",
-          "Values": null
-        }
-      ]
+      "name": "@charset",
+      "descriptors": [],
+      "Values": null
     },
     {
       "name": "@counter-style",
@@ -7161,44 +7492,84 @@
       "Values": null
     },
     {
-      "name": "@function",
+      "name": "@custom-selector",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@font-face",
       "descriptors": [
         {
-          "name": "result",
-          "syntax": "<declaration-value>?",
+          "name": "font-family",
+          "syntax": "<family-name>",
+          "initial": ""
+        },
+        {
+          "name": "src",
+          "syntax": "<font-src-list>",
+          "initial": ""
+        },
+        {
+          "name": "font-style",
+          "syntax": "auto | normal | italic | oblique [ <angle [-90deg,90deg]>{1,2} ]?",
+          "initial": "auto"
+        },
+        {
+          "name": "font-weight",
+          "syntax": "auto | <font-weight-absolute>{1,2}",
+          "initial": "auto"
+        },
+        {
+          "name": "font-width",
+          "syntax": "auto | <'font-width'>{1,2}",
+          "initial": "auto"
+        },
+        {
+          "name": "unicode-range",
+          "syntax": "<unicode-range-token>#",
+          "initial": "U+0-10FFFF"
+        },
+        {
+          "name": "font-feature-settings",
+          "syntax": "normal | <feature-tag-value>#",
+          "initial": ""
+        },
+        {
+          "name": "font-variation-settings",
+          "syntax": "normal | [ <string> <number>]#",
+          "initial": ""
+        },
+        {
+          "name": "font-named-instance",
+          "syntax": "auto | <string>",
+          "initial": "auto"
+        },
+        {
+          "name": "font-display",
+          "syntax": "auto | block | swap | fallback | optional",
+          "initial": "auto"
+        },
+        {
+          "name": "font-language-override",
+          "syntax": "normal | <string>",
+          "initial": ""
+        },
+        {
+          "name": "ascent-override",
+          "syntax": "normal | <percentage [0,∞]>",
+          "initial": ""
+        },
+        {
+          "name": "descent-override",
+          "syntax": "normal | <percentage [0,∞]>",
+          "initial": ""
+        },
+        {
+          "name": "line-gap-override",
+          "syntax": "normal | <percentage [0,∞]>",
           "initial": ""
         }
       ],
-      "Values": null
-    },
-    {
-      "name": "@charset",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@top-center",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@bottom-left",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@left-middle",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@left-bottom",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@right-bottom",
-      "descriptors": [],
       "Values": null
     },
     {
@@ -7269,12 +7640,44 @@
       "Values": null
     },
     {
+      "name": "@function",
+      "descriptors": [
+        {
+          "name": "result",
+          "syntax": "<declaration-value>?",
+          "initial": ""
+        }
+      ],
+      "Values": [
+        {
+          "name": "type()",
+          "value": "type( <syntax> )",
+          "Values": null
+        }
+      ]
+    },
+    {
+      "name": "@import",
+      "descriptors": [],
+      "Values": null
+    },
+    {
       "name": "@keyframes",
       "descriptors": [],
       "Values": null
     },
     {
-      "name": "@namespace",
+      "name": "@layer",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@left-bottom",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@left-middle",
       "descriptors": [],
       "Values": null
     },
@@ -7286,6 +7689,16 @@
     {
       "name": "@media",
       "descriptors": [
+        {
+          "name": "-webkit-device-pixel-ratio",
+          "syntax": "<number>",
+          "initial": ""
+        },
+        {
+          "name": "-webkit-transform-3d",
+          "syntax": "<mq-boolean>",
+          "initial": ""
+        },
         {
           "name": "width",
           "syntax": "<length>",
@@ -7389,16 +7802,6 @@
         {
           "name": "device-aspect-ratio",
           "syntax": "<ratio>",
-          "initial": ""
-        },
-        {
-          "name": "-webkit-device-pixel-ratio",
-          "syntax": "<number>",
-          "initial": ""
-        },
-        {
-          "name": "-webkit-transform-3d",
-          "syntax": "<mq-boolean>",
           "initial": ""
         },
         {
@@ -7531,6 +7934,63 @@
       ]
     },
     {
+      "name": "@namespace",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@page",
+      "descriptors": [
+        {
+          "name": "size",
+          "syntax": "<length [0,∞]>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]",
+          "initial": "auto"
+        },
+        {
+          "name": "page-orientation",
+          "syntax": "upright | rotate-left | rotate-right",
+          "initial": "upright"
+        },
+        {
+          "name": "marks",
+          "syntax": "none | [ crop || cross ]",
+          "initial": ""
+        },
+        {
+          "name": "bleed",
+          "syntax": "auto | <length>",
+          "initial": "auto"
+        }
+      ],
+      "Values": [
+        {
+          "name": ":left",
+          "value": ":left",
+          "Values": null
+        },
+        {
+          "name": ":right",
+          "value": ":right",
+          "Values": null
+        },
+        {
+          "name": ":first",
+          "value": ":first",
+          "Values": null
+        },
+        {
+          "name": ":blank",
+          "value": ":blank",
+          "Values": null
+        }
+      ]
+    },
+    {
+      "name": "@position-try",
+      "descriptors": [],
+      "Values": null
+    },
+    {
       "name": "@property",
       "descriptors": [
         {
@@ -7552,93 +8012,7 @@
       "Values": null
     },
     {
-      "name": "@bottom-left-corner",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@font-face",
-      "descriptors": [
-        {
-          "name": "font-family",
-          "syntax": "<family-name>",
-          "initial": ""
-        },
-        {
-          "name": "src",
-          "syntax": "<font-src-list>",
-          "initial": ""
-        },
-        {
-          "name": "font-style",
-          "syntax": "auto | normal | italic | oblique [ <angle [-90deg,90deg]>{1,2} ]?",
-          "initial": "auto"
-        },
-        {
-          "name": "font-weight",
-          "syntax": "auto | <font-weight-absolute>{1,2}",
-          "initial": "auto"
-        },
-        {
-          "name": "font-width",
-          "syntax": "auto | <'font-width'>{1,2}",
-          "initial": "auto"
-        },
-        {
-          "name": "unicode-range",
-          "syntax": "<urange>#",
-          "initial": "U+0-10FFFF"
-        },
-        {
-          "name": "font-feature-settings",
-          "syntax": "normal | <feature-tag-value>#",
-          "initial": ""
-        },
-        {
-          "name": "font-variation-settings",
-          "syntax": "normal | [ <string> <number>]#",
-          "initial": ""
-        },
-        {
-          "name": "font-named-instance",
-          "syntax": "auto | <string>",
-          "initial": "auto"
-        },
-        {
-          "name": "font-display",
-          "syntax": "auto | block | swap | fallback | optional",
-          "initial": "auto"
-        },
-        {
-          "name": "font-language-override",
-          "syntax": "normal | <string>",
-          "initial": ""
-        },
-        {
-          "name": "ascent-override",
-          "syntax": "normal | <percentage [0,∞]>",
-          "initial": ""
-        },
-        {
-          "name": "descent-override",
-          "syntax": "normal | <percentage [0,∞]>",
-          "initial": ""
-        },
-        {
-          "name": "line-gap-override",
-          "syntax": "normal | <percentage [0,∞]>",
-          "initial": ""
-        }
-      ],
-      "Values": null
-    },
-    {
-      "name": "@-webkit-keyframes",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@position-try",
+      "name": "@right-bottom",
       "descriptors": [],
       "Values": null
     },
@@ -7648,7 +8022,7 @@
       "Values": null
     },
     {
-      "name": "@custom-selector",
+      "name": "@right-top",
       "descriptors": [],
       "Values": null
     },
@@ -7658,7 +8032,7 @@
       "Values": null
     },
     {
-      "name": "@top-left-corner",
+      "name": "@top-center",
       "descriptors": [],
       "Values": null
     },
@@ -7668,29 +8042,8 @@
       "Values": null
     },
     {
-      "name": "@top-right-corner",
+      "name": "@top-left-corner",
       "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@right-top",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@import",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@viewport",
-      "descriptors": [
-        {
-          "name": "viewport-fit",
-          "syntax": "auto | contain | cover",
-          "initial": "auto"
-        }
-      ],
       "Values": null
     },
     {
@@ -7699,44 +8052,329 @@
       "Values": null
     },
     {
-      "name": "@bottom-center",
+      "name": "@top-right-corner",
       "descriptors": [],
       "Values": null
     }
   ],
   "selectors": [
     {
-      "name": ":volume-locked"
+      "name": "&"
     },
     {
-      "name": ":last-child"
+      "name": "+"
     },
     {
-      "name": ":hover"
+      "name": "::after"
     },
     {
-      "name": ":root"
+      "name": "::before"
+    },
+    {
+      "name": "::checkmark"
+    },
+    {
+      "name": "::clear-icon"
+    },
+    {
+      "name": "::color-swatch"
+    },
+    {
+      "name": "::column"
+    },
+    {
+      "name": "::cue"
+    },
+    {
+      "name": "::cue()"
+    },
+    {
+      "name": "::cue-region"
+    },
+    {
+      "name": "::cue-region()"
+    },
+    {
+      "name": "::details-content"
+    },
+    {
+      "name": "::field-component"
+    },
+    {
+      "name": "::field-separator"
+    },
+    {
+      "name": "::field-text"
+    },
+    {
+      "name": "::file-selector-button"
+    },
+    {
+      "name": "::first-letter"
+    },
+    {
+      "name": "::first-line"
     },
     {
       "name": "::grammar-error"
     },
     {
-      "name": ":first-line"
+      "name": "::highlight()"
     },
     {
-      "name": ":closed"
+      "name": "::marker"
+    },
+    {
+      "name": "::part()"
+    },
+    {
+      "name": "::picker()"
+    },
+    {
+      "name": "::picker-icon"
+    },
+    {
+      "name": "::placeholder"
+    },
+    {
+      "name": "::search-text"
+    },
+    {
+      "name": "::selection"
+    },
+    {
+      "name": "::slider-fill"
+    },
+    {
+      "name": "::slider-thumb"
+    },
+    {
+      "name": "::slider-track"
+    },
+    {
+      "name": "::slotted()"
+    },
+    {
+      "name": "::spelling-error"
+    },
+    {
+      "name": "::step-control"
+    },
+    {
+      "name": "::step-down"
+    },
+    {
+      "name": "::step-up"
+    },
+    {
+      "name": "::target-text"
+    },
+    {
+      "name": "::view-transition"
+    },
+    {
+      "name": "::view-transition-group()"
+    },
+    {
+      "name": "::view-transition-image-pair()"
+    },
+    {
+      "name": "::view-transition-new()"
+    },
+    {
+      "name": "::view-transition-old()"
+    },
+    {
+      "name": ":active"
+    },
+    {
+      "name": ":after"
+    },
+    {
+      "name": ":any-link"
+    },
+    {
+      "name": ":autofill"
+    },
+    {
+      "name": ":before"
+    },
+    {
+      "name": ":blank"
+    },
+    {
+      "name": ":buffering"
+    },
+    {
+      "name": ":checked"
+    },
+    {
+      "name": ":current"
+    },
+    {
+      "name": ":current()"
+    },
+    {
+      "name": ":default"
+    },
+    {
+      "name": ":defined"
+    },
+    {
+      "name": ":dir()"
+    },
+    {
+      "name": ":disabled"
+    },
+    {
+      "name": ":empty"
     },
     {
       "name": ":enabled"
     },
     {
-      "name": ":invalid"
+      "name": ":first"
+    },
+    {
+      "name": ":first-child"
+    },
+    {
+      "name": ":first-letter"
+    },
+    {
+      "name": ":first-line"
+    },
+    {
+      "name": ":first-of-type"
+    },
+    {
+      "name": ":focus"
+    },
+    {
+      "name": ":focus-visible"
+    },
+    {
+      "name": ":focus-within"
     },
     {
       "name": ":fullscreen"
     },
     {
-      "name": "~"
+      "name": ":future"
+    },
+    {
+      "name": ":has()"
+    },
+    {
+      "name": ":has-slotted"
+    },
+    {
+      "name": ":high-value"
+    },
+    {
+      "name": ":host"
+    },
+    {
+      "name": ":host()"
+    },
+    {
+      "name": ":host-context()"
+    },
+    {
+      "name": ":hover"
+    },
+    {
+      "name": ":in-range"
+    },
+    {
+      "name": ":indeterminate"
+    },
+    {
+      "name": ":invalid"
+    },
+    {
+      "name": ":is()"
+    },
+    {
+      "name": ":lang"
+    },
+    {
+      "name": ":lang()"
+    },
+    {
+      "name": ":last-child"
+    },
+    {
+      "name": ":last-of-type"
+    },
+    {
+      "name": ":left"
+    },
+    {
+      "name": ":link"
+    },
+    {
+      "name": ":local-link"
+    },
+    {
+      "name": ":low-value"
+    },
+    {
+      "name": ":matches()"
+    },
+    {
+      "name": ":modal"
+    },
+    {
+      "name": ":muted"
+    },
+    {
+      "name": ":not()"
+    },
+    {
+      "name": ":nth()"
+    },
+    {
+      "name": ":nth-child()"
+    },
+    {
+      "name": ":nth-col()"
+    },
+    {
+      "name": ":nth-last-child()"
+    },
+    {
+      "name": ":nth-last-col()"
+    },
+    {
+      "name": ":nth-last-of-type()"
+    },
+    {
+      "name": ":nth-of-type()"
+    },
+    {
+      "name": ":only-child"
+    },
+    {
+      "name": ":only-of-type"
+    },
+    {
+      "name": ":open"
+    },
+    {
+      "name": ":optimal-value"
+    },
+    {
+      "name": ":optional"
+    },
+    {
+      "name": ":out-of-range"
+    },
+    {
+      "name": ":past"
+    },
+    {
+      "name": ":paused"
     },
     {
       "name": ":picture-in-picture"
@@ -7745,292 +8383,70 @@
       "name": ":placeholder-shown"
     },
     {
-      "name": ":target-within"
+      "name": ":playing"
     },
     {
-      "name": ":matches()"
-    },
-    {
-      "name": ":target"
-    },
-    {
-      "name": "::view-transition"
-    },
-    {
-      "name": ":lang"
-    },
-    {
-      "name": ":open"
-    },
-    {
-      "name": "::cue()"
-    },
-    {
-      "name": ":has()"
-    },
-    {
-      "name": ":blank"
-    },
-    {
-      "name": "::placeholder"
-    },
-    {
-      "name": ":not()"
-    },
-    {
-      "name": ":disabled"
-    },
-    {
-      "name": ":nth-child()"
-    },
-    {
-      "name": ":nth-of-type()"
-    },
-    {
-      "name": ":first-letter"
-    },
-    {
-      "name": ":is()"
-    },
-    {
-      "name": ":dir()"
-    },
-    {
-      "name": ":stalled"
-    },
-    {
-      "name": ":modal"
-    },
-    {
-      "name": ":read-write"
-    },
-    {
-      "name": ":nth-col()"
-    },
-    {
-      "name": "::marker"
-    },
-    {
-      "name": "&"
-    },
-    {
-      "name": ":optional"
-    },
-    {
-      "name": "::after"
+      "name": ":popover-open"
     },
     {
       "name": ":read-only"
     },
     {
-      "name": ":out-of-range"
-    },
-    {
-      "name": "::cue-region"
-    },
-    {
-      "name": ":defined"
-    },
-    {
-      "name": ":link"
-    },
-    {
-      "name": ":visited"
-    },
-    {
-      "name": ":current"
-    },
-    {
-      "name": "::selection"
-    },
-    {
-      "name": ":nth-last-col()"
-    },
-    {
-      "name": "::cue"
-    },
-    {
-      "name": ":where()"
-    },
-    {
-      "name": ":current()"
-    },
-    {
-      "name": ":nth-last-child()"
-    },
-    {
-      "name": ":lang()"
-    },
-    {
-      "name": ":focus"
-    },
-    {
-      "name": ":buffering"
-    },
-    {
-      "name": "::view-transition-old()"
-    },
-    {
-      "name": "::before"
-    },
-    {
-      "name": ":host"
-    },
-    {
-      "name": ":any-link"
-    },
-    {
-      "name": ":playing"
-    },
-    {
-      "name": ":in-range"
-    },
-    {
-      "name": "::view-transition-image-pair()"
-    },
-    {
-      "name": ":before"
-    },
-    {
-      "name": "::spelling-error"
-    },
-    {
-      "name": "::file-selector-button"
-    },
-    {
-      "name": ":muted"
-    },
-    {
-      "name": ":first-child"
-    },
-    {
-      "name": ":first-of-type"
-    },
-    {
-      "name": ">"
-    },
-    {
-      "name": "+"
-    },
-    {
-      "name": "::cue-region()"
-    },
-    {
-      "name": ":left"
-    },
-    {
-      "name": "::part()"
-    },
-    {
-      "name": ":host-context()"
-    },
-    {
-      "name": "::target-text"
-    },
-    {
-      "name": ":host()"
-    },
-    {
-      "name": ":after"
-    },
-    {
-      "name": ":default"
-    },
-    {
-      "name": ":only-child"
-    },
-    {
-      "name": "::first-letter"
-    },
-    {
-      "name": ":active"
-    },
-    {
-      "name": ":seeking"
-    },
-    {
-      "name": ":empty"
-    },
-    {
-      "name": "::slotted()"
-    },
-    {
-      "name": ":focus-visible"
-    },
-    {
-      "name": ":valid"
-    },
-    {
-      "name": ":only-of-type"
-    },
-    {
-      "name": "||"
-    },
-    {
-      "name": ":local-link"
-    },
-    {
-      "name": ":focus-within"
-    },
-    {
-      "name": "::details-content"
-    },
-    {
-      "name": ":right"
-    },
-    {
-      "name": ":scope"
-    },
-    {
-      "name": ":paused"
-    },
-    {
-      "name": ":user-valid"
-    },
-    {
-      "name": "::view-transition-new()"
-    },
-    {
-      "name": ":nth()"
-    },
-    {
-      "name": ":first"
-    },
-    {
-      "name": ":future"
-    },
-    {
-      "name": ":indeterminate"
-    },
-    {
-      "name": "::first-line"
-    },
-    {
-      "name": ":past"
-    },
-    {
-      "name": ":user-invalid"
-    },
-    {
-      "name": ":last-of-type"
+      "name": ":read-write"
     },
     {
       "name": ":required"
     },
     {
-      "name": ":nth-last-of-type()"
+      "name": ":right"
     },
     {
-      "name": ":autofill"
+      "name": ":root"
     },
     {
-      "name": ":checked"
+      "name": ":scope"
     },
     {
-      "name": "::highlight()"
+      "name": ":seeking"
     },
     {
-      "name": "::view-transition-group()"
+      "name": ":stalled"
+    },
+    {
+      "name": ":target"
+    },
+    {
+      "name": ":target-within"
+    },
+    {
+      "name": ":user-invalid"
+    },
+    {
+      "name": ":user-valid"
+    },
+    {
+      "name": ":valid"
+    },
+    {
+      "name": ":visited"
+    },
+    {
+      "name": ":volume-locked"
+    },
+    {
+      "name": ":where()"
+    },
+    {
+      "name": ":xr-overlay"
+    },
+    {
+      "name": ">"
+    },
+    {
+      "name": "||"
+    },
+    {
+      "name": "~"
     }
   ]
 }

--- a/crates/gosub_css3/resources/definitions/definitions_at-rules.json
+++ b/crates/gosub_css3/resources/definitions/definitions_at-rules.json
@@ -1,6 +1,21 @@
 [
   {
-    "name": "@layer",
+    "name": "@-webkit-keyframes",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@bottom-center",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@bottom-left",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@bottom-left-corner",
     "descriptors": [],
     "Values": null
   },
@@ -15,51 +30,9 @@
     "Values": null
   },
   {
-    "name": "@page",
-    "descriptors": [
-      {
-        "name": "size",
-        "syntax": "<length [0,∞]>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]",
-        "initial": "auto"
-      },
-      {
-        "name": "page-orientation",
-        "syntax": "upright | rotate-left | rotate-right",
-        "initial": "upright"
-      },
-      {
-        "name": "marks",
-        "syntax": "none | [ crop || cross ]",
-        "initial": ""
-      },
-      {
-        "name": "bleed",
-        "syntax": "auto | <length>",
-        "initial": "auto"
-      }
-    ],
-    "Values": [
-      {
-        "name": ":left",
-        "value": ":left",
-        "Values": null
-      },
-      {
-        "name": ":right",
-        "value": ":right",
-        "Values": null
-      },
-      {
-        "name": ":first",
-        "value": ":first",
-        "Values": null
-      },
-      {
-        "name": ":blank",
-        "value": ":blank",
-        "Values": null
-      }
-    ]
+    "name": "@charset",
+    "descriptors": [],
+    "Values": null
   },
   {
     "name": "@counter-style",
@@ -118,44 +91,84 @@
     "Values": null
   },
   {
-    "name": "@function",
+    "name": "@custom-selector",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@font-face",
     "descriptors": [
       {
-        "name": "result",
-        "syntax": "<declaration-value>?",
+        "name": "font-family",
+        "syntax": "<family-name>",
+        "initial": ""
+      },
+      {
+        "name": "src",
+        "syntax": "<font-src-list>",
+        "initial": ""
+      },
+      {
+        "name": "font-style",
+        "syntax": "auto | normal | italic | oblique [ <angle [-90deg,90deg]>{1,2} ]?",
+        "initial": "auto"
+      },
+      {
+        "name": "font-weight",
+        "syntax": "auto | <font-weight-absolute>{1,2}",
+        "initial": "auto"
+      },
+      {
+        "name": "font-width",
+        "syntax": "auto | <'font-width'>{1,2}",
+        "initial": "auto"
+      },
+      {
+        "name": "unicode-range",
+        "syntax": "<unicode-range-token>#",
+        "initial": "U+0-10FFFF"
+      },
+      {
+        "name": "font-feature-settings",
+        "syntax": "normal | <feature-tag-value>#",
+        "initial": ""
+      },
+      {
+        "name": "font-variation-settings",
+        "syntax": "normal | [ <string> <number>]#",
+        "initial": ""
+      },
+      {
+        "name": "font-named-instance",
+        "syntax": "auto | <string>",
+        "initial": "auto"
+      },
+      {
+        "name": "font-display",
+        "syntax": "auto | block | swap | fallback | optional",
+        "initial": "auto"
+      },
+      {
+        "name": "font-language-override",
+        "syntax": "normal | <string>",
+        "initial": ""
+      },
+      {
+        "name": "ascent-override",
+        "syntax": "normal | <percentage [0,∞]>",
+        "initial": ""
+      },
+      {
+        "name": "descent-override",
+        "syntax": "normal | <percentage [0,∞]>",
+        "initial": ""
+      },
+      {
+        "name": "line-gap-override",
+        "syntax": "normal | <percentage [0,∞]>",
         "initial": ""
       }
     ],
-    "Values": null
-  },
-  {
-    "name": "@charset",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@top-center",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@bottom-left",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@left-middle",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@left-bottom",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@right-bottom",
-    "descriptors": [],
     "Values": null
   },
   {
@@ -226,12 +239,44 @@
     "Values": null
   },
   {
+    "name": "@function",
+    "descriptors": [
+      {
+        "name": "result",
+        "syntax": "<declaration-value>?",
+        "initial": ""
+      }
+    ],
+    "Values": [
+      {
+        "name": "type()",
+        "value": "type( <syntax> )",
+        "Values": null
+      }
+    ]
+  },
+  {
+    "name": "@import",
+    "descriptors": [],
+    "Values": null
+  },
+  {
     "name": "@keyframes",
     "descriptors": [],
     "Values": null
   },
   {
-    "name": "@namespace",
+    "name": "@layer",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@left-bottom",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@left-middle",
     "descriptors": [],
     "Values": null
   },
@@ -243,6 +288,16 @@
   {
     "name": "@media",
     "descriptors": [
+      {
+        "name": "-webkit-device-pixel-ratio",
+        "syntax": "<number>",
+        "initial": ""
+      },
+      {
+        "name": "-webkit-transform-3d",
+        "syntax": "<mq-boolean>",
+        "initial": ""
+      },
       {
         "name": "width",
         "syntax": "<length>",
@@ -346,16 +401,6 @@
       {
         "name": "device-aspect-ratio",
         "syntax": "<ratio>",
-        "initial": ""
-      },
-      {
-        "name": "-webkit-device-pixel-ratio",
-        "syntax": "<number>",
-        "initial": ""
-      },
-      {
-        "name": "-webkit-transform-3d",
-        "syntax": "<mq-boolean>",
         "initial": ""
       },
       {
@@ -488,6 +533,63 @@
     ]
   },
   {
+    "name": "@namespace",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@page",
+    "descriptors": [
+      {
+        "name": "size",
+        "syntax": "<length [0,∞]>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]",
+        "initial": "auto"
+      },
+      {
+        "name": "page-orientation",
+        "syntax": "upright | rotate-left | rotate-right",
+        "initial": "upright"
+      },
+      {
+        "name": "marks",
+        "syntax": "none | [ crop || cross ]",
+        "initial": ""
+      },
+      {
+        "name": "bleed",
+        "syntax": "auto | <length>",
+        "initial": "auto"
+      }
+    ],
+    "Values": [
+      {
+        "name": ":left",
+        "value": ":left",
+        "Values": null
+      },
+      {
+        "name": ":right",
+        "value": ":right",
+        "Values": null
+      },
+      {
+        "name": ":first",
+        "value": ":first",
+        "Values": null
+      },
+      {
+        "name": ":blank",
+        "value": ":blank",
+        "Values": null
+      }
+    ]
+  },
+  {
+    "name": "@position-try",
+    "descriptors": [],
+    "Values": null
+  },
+  {
     "name": "@property",
     "descriptors": [
       {
@@ -509,93 +611,7 @@
     "Values": null
   },
   {
-    "name": "@bottom-left-corner",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@font-face",
-    "descriptors": [
-      {
-        "name": "font-family",
-        "syntax": "<family-name>",
-        "initial": ""
-      },
-      {
-        "name": "src",
-        "syntax": "<font-src-list>",
-        "initial": ""
-      },
-      {
-        "name": "font-style",
-        "syntax": "auto | normal | italic | oblique [ <angle [-90deg,90deg]>{1,2} ]?",
-        "initial": "auto"
-      },
-      {
-        "name": "font-weight",
-        "syntax": "auto | <font-weight-absolute>{1,2}",
-        "initial": "auto"
-      },
-      {
-        "name": "font-width",
-        "syntax": "auto | <'font-width'>{1,2}",
-        "initial": "auto"
-      },
-      {
-        "name": "unicode-range",
-        "syntax": "<urange>#",
-        "initial": "U+0-10FFFF"
-      },
-      {
-        "name": "font-feature-settings",
-        "syntax": "normal | <feature-tag-value>#",
-        "initial": ""
-      },
-      {
-        "name": "font-variation-settings",
-        "syntax": "normal | [ <string> <number>]#",
-        "initial": ""
-      },
-      {
-        "name": "font-named-instance",
-        "syntax": "auto | <string>",
-        "initial": "auto"
-      },
-      {
-        "name": "font-display",
-        "syntax": "auto | block | swap | fallback | optional",
-        "initial": "auto"
-      },
-      {
-        "name": "font-language-override",
-        "syntax": "normal | <string>",
-        "initial": ""
-      },
-      {
-        "name": "ascent-override",
-        "syntax": "normal | <percentage [0,∞]>",
-        "initial": ""
-      },
-      {
-        "name": "descent-override",
-        "syntax": "normal | <percentage [0,∞]>",
-        "initial": ""
-      },
-      {
-        "name": "line-gap-override",
-        "syntax": "normal | <percentage [0,∞]>",
-        "initial": ""
-      }
-    ],
-    "Values": null
-  },
-  {
-    "name": "@-webkit-keyframes",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@position-try",
+    "name": "@right-bottom",
     "descriptors": [],
     "Values": null
   },
@@ -605,7 +621,7 @@
     "Values": null
   },
   {
-    "name": "@custom-selector",
+    "name": "@right-top",
     "descriptors": [],
     "Values": null
   },
@@ -615,7 +631,7 @@
     "Values": null
   },
   {
-    "name": "@top-left-corner",
+    "name": "@top-center",
     "descriptors": [],
     "Values": null
   },
@@ -625,29 +641,8 @@
     "Values": null
   },
   {
-    "name": "@top-right-corner",
+    "name": "@top-left-corner",
     "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@right-top",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@import",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@viewport",
-    "descriptors": [
-      {
-        "name": "viewport-fit",
-        "syntax": "auto | contain | cover",
-        "initial": "auto"
-      }
-    ],
     "Values": null
   },
   {
@@ -656,7 +651,7 @@
     "Values": null
   },
   {
-    "name": "@bottom-center",
+    "name": "@top-right-corner",
     "descriptors": [],
     "Values": null
   }

--- a/crates/gosub_css3/resources/definitions/definitions_properties.json
+++ b/crates/gosub_css3/resources/definitions/definitions_properties.json
@@ -1,9 +1,326 @@
 [
   {
-    "name": "border-clip-top",
-    "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
+    "name": "-webkit-align-content",
+    "syntax": "",
     "computed": [],
-    "initial": "normal",
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-align-items",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-align-self",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-animation",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-animation-delay",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-animation-direction",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-animation-duration",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-animation-fill-mode",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-animation-iteration-count",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-animation-name",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-animation-play-state",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-animation-timing-function",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-appearance",
+    "syntax": "",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "noneButOverriddenInUserAgentCSS",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-backface-visibility",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-background-clip",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-background-origin",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-background-size",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-bottom-left-radius",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-bottom-right-radius",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-radius",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-top-left-radius",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-top-right-radius",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-box-align",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-box-flex",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-box-ordinal-group",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-box-orient",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-box-pack",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-box-shadow",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-box-sizing",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-filter",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-flex",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-flex-basis",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-flex-direction",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-flex-flow",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-flex-grow",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-flex-shrink",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-flex-wrap",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-justify-content",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-mask",
+    "syntax": "",
+    "computed": [
+      "-webkit-mask-image",
+      "-webkit-mask-repeat",
+      "-webkit-mask-attachment",
+      "-webkit-mask-position",
+      "-webkit-mask-origin",
+      "-webkit-mask-clip"
+    ],
+    "initial": [
+      "-webkit-mask-image",
+      "-webkit-mask-repeat",
+      "-webkit-mask-attachment",
+      "-webkit-mask-position",
+      "-webkit-mask-origin",
+      "-webkit-mask-clip"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "-webkit-mask-box-image",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-mask-box-image-outset",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-mask-box-image-repeat",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-mask-box-image-slice",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-mask-box-image-source",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
     "inherited": false
   },
   {
@@ -11,6 +328,24 @@
     "syntax": "",
     "computed": [],
     "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-mask-clip",
+    "syntax": "",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "border",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-mask-composite",
+    "syntax": "",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "source-over",
     "inherited": false
   },
   {
@@ -23,50 +358,231 @@
     "inherited": false
   },
   {
-    "name": "object-fit",
-    "syntax": "fill | contain | cover | none | scale-down",
+    "name": "-webkit-mask-origin",
+    "syntax": "",
     "computed": [
       "asSpecified"
     ],
-    "initial": "fill",
+    "initial": "padding",
     "inherited": false
   },
   {
-    "name": "outline",
-    "syntax": "[ <'outline-width'> || <'outline-style'> || <'outline-color'> ]",
+    "name": "-webkit-mask-position",
+    "syntax": "",
     "computed": [
-      "outline-color",
-      "outline-width",
-      "outline-style"
+      "absoluteLengthOrPercentage"
     ],
-    "initial": [
-      "outline-color",
-      "outline-style",
-      "outline-width"
-    ],
+    "initial": "0% 0%",
     "inherited": false
   },
   {
-    "name": "white-space",
-    "syntax": "normal | pre | nowrap | pre-wrap | break-spaces | pre-line",
+    "name": "-webkit-mask-repeat",
+    "syntax": "",
     "computed": [
       "asSpecified"
     ],
-    "initial": "normal",
+    "initial": "repeat",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-mask-size",
+    "syntax": "",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto auto",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-order",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-perspective",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-perspective-origin",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-text-fill-color",
+    "syntax": "<color>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
     "inherited": true
   },
   {
-    "name": "text-indent",
-    "syntax": "[ <length-percentage> ] && hanging? && each-line?",
+    "name": "-webkit-text-size-adjust",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-text-stroke",
+    "syntax": "<line-width> || <color>",
     "computed": [
-      "percentageOrAbsoluteLengthPlusKeywords"
+      "-webkit-text-stroke-width",
+      "-webkit-text-stroke-color"
+    ],
+    "initial": [
+      "-webkit-text-stroke-width",
+      "-webkit-text-stroke-color"
+    ],
+    "inherited": true
+  },
+  {
+    "name": "-webkit-text-stroke-color",
+    "syntax": "<color>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
+    "inherited": true
+  },
+  {
+    "name": "-webkit-text-stroke-width",
+    "syntax": "<line-width>",
+    "computed": [
+      "absoluteLength"
     ],
     "initial": "0",
     "inherited": true
   },
   {
-    "name": "column-span",
-    "syntax": "none | all",
+    "name": "-webkit-transform",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-transform-origin",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-transform-style",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-transition",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-transition-delay",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-transition-duration",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-transition-property",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-transition-timing-function",
+    "syntax": "",
+    "computed": [],
+    "initial": "",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-user-select",
+    "syntax": "",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "accent-color",
+    "syntax": "auto | <color>",
+    "computed": [
+      "asAutoOrColor"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "align-content",
+    "syntax": "normal | <baseline-position> | <content-distribution> | <overflow-position>? <content-position>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "align-items",
+    "syntax": "normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ] | anchor-center",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "align-self",
+    "syntax": "auto | normal | stretch | <baseline-position> | <overflow-position>? <self-position> | anchor-center",
+    "computed": [
+      "autoOnAbsolutelyPositionedElementsValueOfAlignItemsOnParent"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "alignment-baseline",
+    "syntax": "baseline | text-bottom | alphabetic | ideographic | middle | central | mathematical | text-top",
+    "computed": [
+      "theSpecifiedKeyword"
+    ],
+    "initial": "baseline",
+    "inherited": false
+  },
+  {
+    "name": "all",
+    "syntax": "initial | inherit | unset | revert | revert-layer",
+    "computed": [
+      "asSpecifiedAppliesToEachProperty"
+    ],
+    "initial": "noPracticalInitialValue",
+    "inherited": false
+  },
+  {
+    "name": "anchor-name",
+    "syntax": "none | <dashed-ident>#",
     "computed": [
       "asSpecified"
     ],
@@ -74,36 +590,1127 @@
     "inherited": false
   },
   {
-    "name": "shape-rendering",
-    "syntax": "auto | optimizeSpeed | crispEdges | geometricPrecision",
-    "computed": [],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "shape-outside",
-    "syntax": "none | [ <basic-shape> || <shape-box> ] | <image>",
+    "name": "anchor-scope",
+    "syntax": "none | all | <dashed-ident>#",
     "computed": [
-      "asDefinedForBasicShapeWithAbsoluteURIOtherwiseAsSpecified"
+      "asSpecified"
     ],
     "initial": "none",
     "inherited": false
   },
   {
-    "name": "min-height",
-    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()>",
+    "name": "animation",
+    "syntax": "<single-animation>#",
     "computed": [
-      "percentageAsSpecifiedOrAbsoluteLength"
+      "animation-name",
+      "animation-duration",
+      "animation-timing-function",
+      "animation-delay",
+      "animation-direction",
+      "animation-iteration-count",
+      "animation-fill-mode",
+      "animation-play-state",
+      "animation-timeline"
+    ],
+    "initial": [
+      "animation-name",
+      "animation-duration",
+      "animation-timing-function",
+      "animation-delay",
+      "animation-iteration-count",
+      "animation-direction",
+      "animation-fill-mode",
+      "animation-play-state",
+      "animation-timeline"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "animation-delay",
+    "syntax": "<time>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0s",
+    "inherited": false
+  },
+  {
+    "name": "animation-direction",
+    "syntax": "<single-animation-direction>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "animation-duration",
+    "syntax": "<time [0s,∞]>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0s",
+    "inherited": false
+  },
+  {
+    "name": "animation-fill-mode",
+    "syntax": "<single-animation-fill-mode>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "animation-iteration-count",
+    "syntax": "<single-animation-iteration-count>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "1",
+    "inherited": false
+  },
+  {
+    "name": "animation-name",
+    "syntax": "[ none | <keyframes-name> ]#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "animation-play-state",
+    "syntax": "<single-animation-play-state>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "running",
+    "inherited": false
+  },
+  {
+    "name": "animation-range",
+    "syntax": "[ <'animation-range-start'> <'animation-range-end'>? ]#",
+    "computed": [
+      "animation-range-start",
+      "animation-range-end"
+    ],
+    "initial": [
+      "animation-range-start",
+      "animation-range-end"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "animation-range-end",
+    "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+    "computed": [
+      "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "animation-range-start",
+    "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+    "computed": [
+      "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "animation-timing-function",
+    "syntax": "<easing-function>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "ease",
+    "inherited": false
+  },
+  {
+    "name": "appearance",
+    "syntax": "none | auto | base | <compat-auto> | <compat-special> | base",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "background",
+    "syntax": "<bg-layer>#? , <final-bg-layer>",
+    "computed": [
+      "background-image",
+      "background-position",
+      "background-size",
+      "background-repeat",
+      "background-origin",
+      "background-clip",
+      "background-attachment",
+      "background-color"
+    ],
+    "initial": [
+      "background-image",
+      "background-position",
+      "background-size",
+      "background-repeat",
+      "background-origin",
+      "background-clip",
+      "background-attachment",
+      "background-color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "background-attachment",
+    "syntax": "<attachment>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "scroll",
+    "inherited": false
+  },
+  {
+    "name": "background-blend-mode",
+    "syntax": "<mix-blend-mode>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "background-clip",
+    "syntax": "<visual-box>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "border-box",
+    "inherited": false
+  },
+  {
+    "name": "background-color",
+    "syntax": "<color>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "transparent",
+    "inherited": false
+  },
+  {
+    "name": "background-image",
+    "syntax": "<bg-image>#",
+    "computed": [
+      "asSpecifiedURLsAbsolute"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "background-origin",
+    "syntax": "<visual-box>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "padding-box",
+    "inherited": false
+  },
+  {
+    "name": "background-position",
+    "syntax": "<bg-position>#",
+    "computed": [
+      "background-position-x",
+      "background-position-y"
+    ],
+    "initial": "0% 0%",
+    "inherited": false
+  },
+  {
+    "name": "background-repeat",
+    "syntax": "<repeat-style>#",
+    "computed": [
+      "listEachItemHasTwoKeywordsOnePerDimension"
+    ],
+    "initial": "repeat",
+    "inherited": false
+  },
+  {
+    "name": "background-size",
+    "syntax": "<bg-size>#",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "auto auto",
+    "inherited": false
+  },
+  {
+    "name": "baseline-shift",
+    "syntax": "<length-percentage> | sub | super | top | center | bottom",
+    "computed": [
+      "theSpecifiedKeywordOrAComputedLengthPercentageValue"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "baseline-source",
+    "syntax": "auto | first | last",
+    "computed": [],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "block-size",
+    "syntax": "<'width'>",
+    "computed": [
+      "sameAsWidthAndHeight"
     ],
     "initial": "auto",
     "inherited": false
   },
   {
-    "name": "fill-rule",
-    "syntax": "nonzero | evenodd",
+    "name": "block-step",
+    "syntax": "<'block-step-size'> || <'block-step-insert'> || <'block-step-align'> || <'block-step-round'>",
     "computed": [],
-    "initial": "nonzero",
+    "initial": "see individual properties",
+    "inherited": false
+  },
+  {
+    "name": "block-step-align",
+    "syntax": "auto | center | start | end",
+    "computed": [],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "block-step-insert",
+    "syntax": "margin-box | padding-box | content-box",
+    "computed": [],
+    "initial": "margin-box",
+    "inherited": false
+  },
+  {
+    "name": "block-step-round",
+    "syntax": "up | down | nearest",
+    "computed": [],
+    "initial": "up",
+    "inherited": false
+  },
+  {
+    "name": "block-step-size",
+    "syntax": "none | <length [0,∞]>",
+    "computed": [],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "bookmark-label",
+    "syntax": "<content-list>",
+    "computed": [],
+    "initial": "content(text)",
+    "inherited": false
+  },
+  {
+    "name": "bookmark-level",
+    "syntax": "none | <integer [1,∞]>",
+    "computed": [],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "bookmark-state",
+    "syntax": "open | closed",
+    "computed": [],
+    "initial": "open",
+    "inherited": false
+  },
+  {
+    "name": "border",
+    "syntax": "<line-width> || <line-style> || <color>",
+    "computed": [
+      "border-width",
+      "border-style",
+      "border-color"
+    ],
+    "initial": [
+      "border-width",
+      "border-style",
+      "border-color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "border-block",
+    "syntax": "<'border-block-start'>",
+    "computed": [
+      "border-block-width",
+      "border-block-style",
+      "border-block-color"
+    ],
+    "initial": [
+      "border-block-width",
+      "border-block-style",
+      "border-block-color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "border-block-color",
+    "syntax": "<'border-top-color'>{1,2}",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
+    "inherited": false
+  },
+  {
+    "name": "border-block-end",
+    "syntax": "<line-width> || <line-style> || <color>",
+    "computed": [
+      "border-top-width",
+      "border-top-style",
+      "border-top-color"
+    ],
+    "initial": [
+      "border-top-width",
+      "border-top-style",
+      "border-top-color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "border-block-end-color",
+    "syntax": "<color> | <image-1D>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
+    "inherited": false
+  },
+  {
+    "name": "border-block-end-radius",
+    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
+    "computed": [],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "border-block-end-style",
+    "syntax": "<line-style>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "border-block-end-width",
+    "syntax": "<line-width>",
+    "computed": [
+      "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+    ],
+    "initial": "medium",
+    "inherited": false
+  },
+  {
+    "name": "border-block-start",
+    "syntax": "<line-width> || <line-style> || <color>",
+    "computed": [
+      "border-width",
+      "border-style",
+      "border-block-start-color"
+    ],
+    "initial": [
+      "border-width",
+      "border-style",
+      "color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "border-block-start-color",
+    "syntax": "<color> | <image-1D>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
+    "inherited": false
+  },
+  {
+    "name": "border-block-start-radius",
+    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
+    "computed": [],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "border-block-start-style",
+    "syntax": "<line-style>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "border-block-start-width",
+    "syntax": "<line-width>",
+    "computed": [
+      "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+    ],
+    "initial": "medium",
+    "inherited": false
+  },
+  {
+    "name": "border-block-style",
+    "syntax": "<'border-top-style'>{1,2}",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "border-block-width",
+    "syntax": "<'border-top-width'>{1,2}",
+    "computed": [
+      "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+    ],
+    "initial": "medium",
+    "inherited": false
+  },
+  {
+    "name": "border-bottom",
+    "syntax": "<line-width> || <line-style> || <color>",
+    "computed": [
+      "border-bottom-width",
+      "border-bottom-style",
+      "border-bottom-color"
+    ],
+    "initial": [
+      "border-bottom-width",
+      "border-bottom-style",
+      "border-bottom-color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "border-bottom-color",
+    "syntax": "<color> | <image-1D>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
+    "inherited": false
+  },
+  {
+    "name": "border-bottom-left-radius",
+    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "computed": [
+      "twoAbsoluteLengthOrPercentages"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "border-bottom-radius",
+    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
+    "computed": [],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "border-bottom-right-radius",
+    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "computed": [
+      "twoAbsoluteLengthOrPercentages"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "border-bottom-style",
+    "syntax": "<line-style>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "border-bottom-width",
+    "syntax": "<line-width>",
+    "computed": [
+      "absoluteLengthOr0IfBorderBottomStyleNoneOrHidden"
+    ],
+    "initial": "medium",
+    "inherited": false
+  },
+  {
+    "name": "border-boundary",
+    "syntax": "none | parent | display",
+    "computed": [],
+    "initial": "none",
     "inherited": true
+  },
+  {
+    "name": "border-clip",
+    "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
+    "computed": [],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "border-clip-bottom",
+    "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
+    "computed": [],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "border-clip-left",
+    "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
+    "computed": [],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "border-clip-right",
+    "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
+    "computed": [],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "border-clip-top",
+    "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
+    "computed": [],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "border-collapse",
+    "syntax": "separate | collapse",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "separate",
+    "inherited": true
+  },
+  {
+    "name": "border-color",
+    "syntax": "[ <color> | <image-1D> ]{1,4}",
+    "computed": [
+      "border-bottom-color",
+      "border-left-color",
+      "border-right-color",
+      "border-top-color"
+    ],
+    "initial": [
+      "border-top-color",
+      "border-right-color",
+      "border-bottom-color",
+      "border-left-color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "border-end-end-radius",
+    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "computed": [
+      "twoAbsoluteLengthOrPercentages"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "border-end-start-radius",
+    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "computed": [
+      "twoAbsoluteLengthOrPercentages"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "border-image",
+    "syntax": "<'border-image-source'> || <'border-image-slice'> [ / <'border-image-width'> | / <'border-image-width'>? / <'border-image-outset'> ]? || <'border-image-repeat'>",
+    "computed": [
+      "border-image-outset",
+      "border-image-repeat",
+      "border-image-slice",
+      "border-image-source",
+      "border-image-width"
+    ],
+    "initial": [
+      "border-image-source",
+      "border-image-slice",
+      "border-image-width",
+      "border-image-outset",
+      "border-image-repeat"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "border-image-outset",
+    "syntax": "[ <length [0,∞]> | <number [0,∞]> ]{1,4}",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "border-image-repeat",
+    "syntax": "[ stretch | repeat | round | space ]{1,2}",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "stretch",
+    "inherited": false
+  },
+  {
+    "name": "border-image-slice",
+    "syntax": "[<number [0,∞]> | <percentage [0,∞]>]{1,4} && fill?",
+    "computed": [
+      "oneToFourPercentagesOrAbsoluteLengthsPlusFill"
+    ],
+    "initial": "100%",
+    "inherited": false
+  },
+  {
+    "name": "border-image-source",
+    "syntax": "none | <image>",
+    "computed": [
+      "noneOrImageWithAbsoluteURI"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "border-image-width",
+    "syntax": "[ <length-percentage [0,∞]> | <number [0,∞]> | auto ]{1,4}",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "1",
+    "inherited": false
+  },
+  {
+    "name": "border-inline",
+    "syntax": "<'border-block-start'>",
+    "computed": [
+      "border-inline-width",
+      "border-inline-style",
+      "border-inline-color"
+    ],
+    "initial": [
+      "border-inline-width",
+      "border-inline-style",
+      "border-inline-color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "border-inline-color",
+    "syntax": "<'border-top-color'>{1,2}",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
+    "inherited": false
+  },
+  {
+    "name": "border-inline-end",
+    "syntax": "<line-width> || <line-style> || <color>",
+    "computed": [
+      "border-width",
+      "border-style",
+      "border-inline-end-color"
+    ],
+    "initial": [
+      "border-width",
+      "border-style",
+      "color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "border-inline-end-color",
+    "syntax": "<color> | <image-1D>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
+    "inherited": false
+  },
+  {
+    "name": "border-inline-end-radius",
+    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
+    "computed": [],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "border-inline-end-style",
+    "syntax": "<line-style>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "border-inline-end-width",
+    "syntax": "<line-width>",
+    "computed": [
+      "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+    ],
+    "initial": "medium",
+    "inherited": false
+  },
+  {
+    "name": "border-inline-start",
+    "syntax": "<line-width> || <line-style> || <color>",
+    "computed": [
+      "border-width",
+      "border-style",
+      "border-inline-start-color"
+    ],
+    "initial": [
+      "border-width",
+      "border-style",
+      "color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "border-inline-start-color",
+    "syntax": "<color> | <image-1D>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
+    "inherited": false
+  },
+  {
+    "name": "border-inline-start-radius",
+    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
+    "computed": [],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "border-inline-start-style",
+    "syntax": "<line-style>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "border-inline-start-width",
+    "syntax": "<line-width>",
+    "computed": [
+      "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+    ],
+    "initial": "medium",
+    "inherited": false
+  },
+  {
+    "name": "border-inline-style",
+    "syntax": "<'border-top-style'>{1,2}",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "border-inline-width",
+    "syntax": "<'border-top-width'>{1,2}",
+    "computed": [
+      "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+    ],
+    "initial": "medium",
+    "inherited": false
+  },
+  {
+    "name": "border-left",
+    "syntax": "<line-width> || <line-style> || <color>",
+    "computed": [
+      "border-left-width",
+      "border-left-style",
+      "border-left-color"
+    ],
+    "initial": [
+      "border-left-width",
+      "border-left-style",
+      "border-left-color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "border-left-color",
+    "syntax": "<color> | <image-1D>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
+    "inherited": false
+  },
+  {
+    "name": "border-left-radius",
+    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
+    "computed": [],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "border-left-style",
+    "syntax": "<line-style>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "border-left-width",
+    "syntax": "<line-width>",
+    "computed": [
+      "absoluteLengthOr0IfBorderLeftStyleNoneOrHidden"
+    ],
+    "initial": "medium",
+    "inherited": false
+  },
+  {
+    "name": "border-limit",
+    "syntax": "all | [ sides | corners ] <length-percentage [0,∞]>? | [ top | right | bottom | left ] <length-percentage [0,∞]>",
+    "computed": [],
+    "initial": "all",
+    "inherited": false
+  },
+  {
+    "name": "border-radius",
+    "syntax": "<length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?",
+    "computed": [
+      "border-bottom-left-radius",
+      "border-bottom-right-radius",
+      "border-top-left-radius",
+      "border-top-right-radius"
+    ],
+    "initial": [
+      "border-top-left-radius",
+      "border-top-right-radius",
+      "border-bottom-right-radius",
+      "border-bottom-left-radius"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "border-right",
+    "syntax": "<line-width> || <line-style> || <color>",
+    "computed": [
+      "border-right-width",
+      "border-right-style",
+      "border-right-color"
+    ],
+    "initial": [
+      "border-right-width",
+      "border-right-style",
+      "border-right-color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "border-right-color",
+    "syntax": "<color> | <image-1D>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
+    "inherited": false
+  },
+  {
+    "name": "border-right-radius",
+    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
+    "computed": [],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "border-right-style",
+    "syntax": "<line-style>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "border-right-width",
+    "syntax": "<line-width>",
+    "computed": [
+      "absoluteLengthOr0IfBorderRightStyleNoneOrHidden"
+    ],
+    "initial": "medium",
+    "inherited": false
+  },
+  {
+    "name": "border-shape",
+    "syntax": "none | [ <basic-shape> <geometry-box>?]{1,2}",
+    "computed": [],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "border-spacing",
+    "syntax": "<length>{1,2}",
+    "computed": [
+      "twoAbsoluteLengths"
+    ],
+    "initial": "0",
+    "inherited": true
+  },
+  {
+    "name": "border-start-end-radius",
+    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "computed": [
+      "twoAbsoluteLengthOrPercentages"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "border-start-start-radius",
+    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "computed": [
+      "twoAbsoluteLengthOrPercentages"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "border-style",
+    "syntax": "<line-style>{1,4}",
+    "computed": [
+      "border-bottom-style",
+      "border-left-style",
+      "border-right-style",
+      "border-top-style"
+    ],
+    "initial": [
+      "border-top-style",
+      "border-right-style",
+      "border-bottom-style",
+      "border-left-style"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "border-top",
+    "syntax": "<line-width> || <line-style> || <color>",
+    "computed": [
+      "border-top-width",
+      "border-top-style",
+      "border-top-color"
+    ],
+    "initial": [
+      "border-top-width",
+      "border-top-style",
+      "border-top-color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "border-top-color",
+    "syntax": "<color> | <image-1D>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
+    "inherited": false
+  },
+  {
+    "name": "border-top-left-radius",
+    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "computed": [
+      "twoAbsoluteLengthOrPercentages"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "border-top-radius",
+    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
+    "computed": [],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "border-top-right-radius",
+    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "computed": [
+      "twoAbsoluteLengthOrPercentages"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "border-top-style",
+    "syntax": "<line-style>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "border-top-width",
+    "syntax": "<line-width>",
+    "computed": [
+      "absoluteLengthOr0IfBorderTopStyleNoneOrHidden"
+    ],
+    "initial": "medium",
+    "inherited": false
+  },
+  {
+    "name": "border-width",
+    "syntax": "<line-width>{1,4}",
+    "computed": [
+      "border-bottom-width",
+      "border-left-width",
+      "border-right-width",
+      "border-top-width"
+    ],
+    "initial": [
+      "border-top-width",
+      "border-right-width",
+      "border-bottom-width",
+      "border-left-width"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "bottom",
+    "syntax": "auto | <length-percentage> | <anchor()> | <anchor-size()>",
+    "computed": [
+      "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "box-decoration-break",
+    "syntax": "slice | clone",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "slice",
+    "inherited": false
   },
   {
     "name": "box-shadow",
@@ -115,36 +1722,133 @@
     "inherited": false
   },
   {
-    "name": "dominant-baseline",
-    "syntax": "auto | text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top",
+    "name": "box-shadow-blur",
+    "syntax": "<length [0,∞]>#",
     "computed": [],
-    "initial": "auto",
-    "inherited": true
+    "initial": "0",
+    "inherited": false
   },
   {
-    "name": "stroke-dash-justify",
-    "syntax": "none | [ stretch | compress ] || [ dashes || gaps ]",
+    "name": "box-shadow-color",
+    "syntax": "<color>#",
+    "computed": [],
+    "initial": "currentcolor",
+    "inherited": false
+  },
+  {
+    "name": "box-shadow-offset",
+    "syntax": "[ none | <length>{2} ]#",
+    "computed": [],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "box-shadow-position",
+    "syntax": "[ outset | inset ]#",
+    "computed": [],
+    "initial": "outset",
+    "inherited": false
+  },
+  {
+    "name": "box-shadow-spread",
+    "syntax": "<length>#",
+    "computed": [],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "box-sizing",
+    "syntax": "content-box | border-box",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "content-box",
+    "inherited": false
+  },
+  {
+    "name": "box-snap",
+    "syntax": "none | block-start | block-end | center | baseline | last-baseline",
     "computed": [],
     "initial": "none",
     "inherited": true
   },
   {
-    "name": "stroke-opacity",
-    "syntax": "<'opacity'>",
-    "computed": [],
-    "initial": "1",
+    "name": "break-after",
+    "syntax": "auto | avoid | always | all | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "break-before",
+    "syntax": "auto | avoid | always | all | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "break-inside",
+    "syntax": "auto | avoid | avoid-page | avoid-column | avoid-region",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "caption-side",
+    "syntax": "top | bottom",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "top",
     "inherited": true
   },
   {
-    "name": "speak-as",
-    "syntax": "normal | spell-out || digits || [ literal-punctuation | no-punctuation ]",
-    "computed": [],
-    "initial": "normal",
+    "name": "caret",
+    "syntax": "<'caret-color'> || <'caret-animation'> || <'caret-shape'>",
+    "computed": [
+      "caret-color",
+      "caret-shape"
+    ],
+    "initial": [
+      "caret-color",
+      "caret-shape"
+    ],
     "inherited": true
   },
   {
-    "name": "column-rule-style",
-    "syntax": "<line-style>",
+    "name": "caret-animation",
+    "syntax": "auto | manual",
+    "computed": [],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "caret-color",
+    "syntax": "auto | <color>",
+    "computed": [
+      "asAutoOrColor"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "caret-shape",
+    "syntax": "auto | bar | block | underscore",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "clear",
+    "syntax": "inline-start | inline-end | block-start | block-end | left | right | top | bottom | both-inline | both-block | both | none",
     "computed": [
       "asSpecified"
     ],
@@ -152,19 +1856,393 @@
     "inherited": false
   },
   {
-    "name": "float-defer",
-    "syntax": "<integer> | last | none",
+    "name": "clip",
+    "syntax": "<rect()> | auto",
+    "computed": [
+      "autoOrRectangle"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "clip-path",
+    "syntax": "<clip-source> | [ <basic-shape> || <geometry-box> ] | none",
+    "computed": [
+      "asSpecifiedURLsAbsolute"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "clip-rule",
+    "syntax": "nonzero | evenodd",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "nonzero",
+    "inherited": true
+  },
+  {
+    "name": "color",
+    "syntax": "<color>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "canvastext",
+    "inherited": true
+  },
+  {
+    "name": "color-adjust",
+    "syntax": "<'print-color-adjust'>",
+    "computed": [],
+    "initial": "see individual properties",
+    "inherited": false
+  },
+  {
+    "name": "color-interpolation",
+    "syntax": "auto | sRGB | linearRGB",
+    "computed": [],
+    "initial": "sRGB",
+    "inherited": true
+  },
+  {
+    "name": "color-interpolation-filters",
+    "syntax": "auto | sRGB | linearRGB",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "linearRGB",
+    "inherited": true
+  },
+  {
+    "name": "color-scheme",
+    "syntax": "normal | [ light | dark | <custom-ident> ]+ && only?",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "column-count",
+    "syntax": "auto | <integer [1,∞]>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "column-fill",
+    "syntax": "auto | balance | balance-all",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "balance",
+    "inherited": false
+  },
+  {
+    "name": "column-gap",
+    "syntax": "normal | <length-percentage [0,∞]>",
+    "computed": [
+      "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "column-height",
+    "syntax": "auto | <length [0,∞]>",
+    "computed": [],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "column-rule",
+    "syntax": "<gap-rule-list> | <gap-auto-rule-list>",
+    "computed": [
+      "column-rule-color",
+      "column-rule-style",
+      "column-rule-width"
+    ],
+    "initial": [
+      "column-rule-width",
+      "column-rule-style",
+      "column-rule-color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "column-rule-break",
+    "syntax": "none | spanning-item | intersection",
+    "computed": [],
+    "initial": "spanning-item",
+    "inherited": false
+  },
+  {
+    "name": "column-rule-color",
+    "syntax": "<line-color-list> | <auto-line-color-list>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
+    "inherited": false
+  },
+  {
+    "name": "column-rule-outset",
+    "syntax": "<length-percentage>",
+    "computed": [],
+    "initial": "50%",
+    "inherited": false
+  },
+  {
+    "name": "column-rule-style",
+    "syntax": "<line-style-list> | <auto-line-style-list>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "column-rule-width",
+    "syntax": "<line-width-list> | <auto-line-width-list>",
+    "computed": [
+      "absoluteLength0IfColumnRuleStyleNoneOrHidden"
+    ],
+    "initial": "medium",
+    "inherited": false
+  },
+  {
+    "name": "column-span",
+    "syntax": "none | <integer [1,∞]> | all | auto",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "column-width",
+    "syntax": "auto | <length [0,∞]> | min-content | max-content | fit-content(<length-percentage>)",
+    "computed": [
+      "absoluteLengthZeroOrLarger"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "column-wrap",
+    "syntax": "auto | nowrap | wrap",
+    "computed": [],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "columns",
+    "syntax": "<'column-width'> || <'column-count'> [ / <'column-height'> ]?",
+    "computed": [
+      "column-width",
+      "column-count"
+    ],
+    "initial": [
+      "column-width",
+      "column-count"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "contain",
+    "syntax": "none | strict | content | [ [size | inline-size] || layout || style || paint ]",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "content",
+    "syntax": "normal | none | [ <content-replacement> | <content-list> ] [/ [ <string> | <counter> | <attr()> ]+ ]? | <element()>",
+    "computed": [
+      "normalOnElementsForPseudosNoneAbsoluteURIStringOrAsSpecified"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "content-visibility",
+    "syntax": "visible | auto | hidden",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "visible",
+    "inherited": false
+  },
+  {
+    "name": "corner-block-end-shape",
+    "syntax": "<corner-shape-value>",
+    "computed": [],
+    "initial": "round",
+    "inherited": false
+  },
+  {
+    "name": "corner-block-start-shape",
+    "syntax": "<corner-shape-value>",
+    "computed": [],
+    "initial": "round",
+    "inherited": false
+  },
+  {
+    "name": "corner-bottom-left-shape",
+    "syntax": "<corner-shape-value>",
+    "computed": [],
+    "initial": "round",
+    "inherited": false
+  },
+  {
+    "name": "corner-bottom-right-shape",
+    "syntax": "<corner-shape-value>",
+    "computed": [],
+    "initial": "round",
+    "inherited": false
+  },
+  {
+    "name": "corner-bottom-shape",
+    "syntax": "<corner-shape-value>",
+    "computed": [],
+    "initial": "round",
+    "inherited": false
+  },
+  {
+    "name": "corner-end-end-shape",
+    "syntax": "<corner-shape-value>",
+    "computed": [],
+    "initial": "round",
+    "inherited": false
+  },
+  {
+    "name": "corner-end-start-shape",
+    "syntax": "<corner-shape-value>",
+    "computed": [],
+    "initial": "round",
+    "inherited": false
+  },
+  {
+    "name": "corner-inline-end-shape",
+    "syntax": "<corner-shape-value>",
+    "computed": [],
+    "initial": "round",
+    "inherited": false
+  },
+  {
+    "name": "corner-inline-start-shape",
+    "syntax": "<corner-shape-value>",
+    "computed": [],
+    "initial": "round",
+    "inherited": false
+  },
+  {
+    "name": "corner-left-shape",
+    "syntax": "<corner-shape-value>",
+    "computed": [],
+    "initial": "round",
+    "inherited": false
+  },
+  {
+    "name": "corner-right-shape",
+    "syntax": "<corner-shape-value>",
+    "computed": [],
+    "initial": "round",
+    "inherited": false
+  },
+  {
+    "name": "corner-shape",
+    "syntax": "<corner-shape-value>{1,4}",
+    "computed": [],
+    "initial": "round",
+    "inherited": false
+  },
+  {
+    "name": "corner-start-end-shape",
+    "syntax": "<corner-shape-value>",
+    "computed": [],
+    "initial": "round",
+    "inherited": false
+  },
+  {
+    "name": "corner-start-start-shape",
+    "syntax": "<corner-shape-value>",
+    "computed": [],
+    "initial": "round",
+    "inherited": false
+  },
+  {
+    "name": "corner-top-left-shape",
+    "syntax": "<corner-shape-value>",
+    "computed": [],
+    "initial": "round",
+    "inherited": false
+  },
+  {
+    "name": "corner-top-right-shape",
+    "syntax": "<corner-shape-value>",
+    "computed": [],
+    "initial": "round",
+    "inherited": false
+  },
+  {
+    "name": "corner-top-shape",
+    "syntax": "<corner-shape-value>",
+    "computed": [],
+    "initial": "round",
+    "inherited": false
+  },
+  {
+    "name": "counter-increment",
+    "syntax": "[ <counter-name> <integer>? ]+ | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "counter-reset",
+    "syntax": "[ <counter-name> <integer>? | <reversed-counter-name> <integer>? ]+ | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "counter-set",
+    "syntax": "[ <counter-name> <integer>? ]+ | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "cue",
+    "syntax": "<'cue-before'> <'cue-after'>?",
+    "computed": [],
+    "initial": "see individual properties",
+    "inherited": false
+  },
+  {
+    "name": "cue-after",
+    "syntax": "<uri> <decibel>? | none",
     "computed": [],
     "initial": "none",
     "inherited": false
   },
   {
-    "name": "right",
-    "syntax": "auto | <length-percentage>",
-    "computed": [
-      "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
-    ],
-    "initial": "auto",
+    "name": "cue-before",
+    "syntax": "<uri> <decibel>? | none",
+    "computed": [],
+    "initial": "none",
     "inherited": false
   },
   {
@@ -177,30 +2255,191 @@
     "inherited": true
   },
   {
-    "name": "grid-row-start",
-    "syntax": "<grid-line>",
+    "name": "cx",
+    "syntax": "<length-percentage>",
     "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "scroll-margin-top",
-    "syntax": "<length>",
-    "computed": [
-      "asSpecified"
+      "percentageAsSpecifiedOrAbsoluteLength"
     ],
     "initial": "0",
     "inherited": false
   },
   {
-    "name": "zoom",
-    "syntax": "<number [0,∞]> || <percentage [0,∞]>",
+    "name": "cy",
+    "syntax": "<length-percentage>",
+    "computed": [
+      "percentageAsSpecifiedOrAbsoluteLength"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "d",
+    "syntax": "none | <string>",
     "computed": [
       "asSpecified"
     ],
-    "initial": "normal",
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "direction",
+    "syntax": "ltr | rtl",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "ltr",
+    "inherited": true
+  },
+  {
+    "name": "display",
+    "syntax": "[ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy> | <display-outside> || [ <display-inside> | math ]",
+    "computed": [
+      "asSpecifiedExceptPositionedFloatingAndRootElementsKeywordMaybeDifferent"
+    ],
+    "initial": "inline",
+    "inherited": false
+  },
+  {
+    "name": "dominant-baseline",
+    "syntax": "auto | text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "dynamic-range-limit",
+    "syntax": "standard | no-limit | constrained-high | <dynamic-range-limit-mix()>",
+    "computed": [],
+    "initial": "no-limit",
+    "inherited": true
+  },
+  {
+    "name": "empty-cells",
+    "syntax": "show | hide",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "show",
+    "inherited": true
+  },
+  {
+    "name": "field-sizing",
+    "syntax": "fixed | content",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "fixed",
+    "inherited": false
+  },
+  {
+    "name": "fill",
+    "syntax": "<paint>",
+    "computed": [
+      "asColorOrAbsoluteURL"
+    ],
+    "initial": "black",
+    "inherited": true
+  },
+  {
+    "name": "fill-break",
+    "syntax": "bounding-box | slice | clone",
+    "computed": [],
+    "initial": "bounding-box",
+    "inherited": false
+  },
+  {
+    "name": "fill-color",
+    "syntax": "<color>",
+    "computed": [],
+    "initial": "currentcolor",
+    "inherited": true
+  },
+  {
+    "name": "fill-image",
+    "syntax": "<paint>#",
+    "computed": [],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "fill-opacity",
+    "syntax": "<'opacity'>",
+    "computed": [
+      "specifiedValueNumberClipped0To1"
+    ],
+    "initial": "1",
+    "inherited": true
+  },
+  {
+    "name": "fill-origin",
+    "syntax": "match-parent | fill-box | stroke-box | content-box | padding-box | border-box",
+    "computed": [],
+    "initial": "match-parent",
+    "inherited": false
+  },
+  {
+    "name": "fill-position",
+    "syntax": "<position>#",
+    "computed": [],
+    "initial": "0% 0%",
+    "inherited": true
+  },
+  {
+    "name": "fill-repeat",
+    "syntax": "<repeat-style>#",
+    "computed": [],
+    "initial": "repeat",
+    "inherited": true
+  },
+  {
+    "name": "fill-rule",
+    "syntax": "nonzero | evenodd",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "nonzero",
+    "inherited": true
+  },
+  {
+    "name": "fill-size",
+    "syntax": "<bg-size>#",
+    "computed": [],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "filter",
+    "syntax": "none | <filter-value-list>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "flex",
+    "syntax": "none | [ <'flex-grow'> <'flex-shrink'>? || <'flex-basis'> ]",
+    "computed": [
+      "flex-grow",
+      "flex-shrink",
+      "flex-basis"
+    ],
+    "initial": [
+      "flex-grow",
+      "flex-shrink",
+      "flex-basis"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "flex-basis",
+    "syntax": "content | <'width'>",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "auto",
     "inherited": false
   },
   {
@@ -226,3253 +2465,12 @@
     "inherited": false
   },
   {
-    "name": "offset-path",
-    "syntax": "none | <offset-path> || <coord-box>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "rest",
-    "syntax": "<'rest-before'> <'rest-after'>?",
-    "computed": [],
-    "initial": "N/A (see individual properties)",
-    "inherited": false
-  },
-  {
-    "name": "region-fragment",
-    "syntax": "auto | break",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "column-rule",
-    "syntax": "<'column-rule-width'> || <'column-rule-style'> || <'column-rule-color'>",
-    "computed": [
-      "column-rule-color",
-      "column-rule-style",
-      "column-rule-width"
-    ],
-    "initial": [
-      "column-rule-width",
-      "column-rule-style",
-      "column-rule-color"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "pause-before",
-    "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "stroke-origin",
-    "syntax": "match-parent | fill-box | stroke-box | content-box | padding-box | border-box",
-    "computed": [],
-    "initial": "match-parent",
-    "inherited": false
-  },
-  {
-    "name": "mask-size",
-    "syntax": "<bg-size>#",
-    "computed": [
-      "asSpecifiedRelativeToAbsoluteLengths"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
     "name": "flex-grow",
     "syntax": "<number [0,∞]>",
     "computed": [
       "asSpecified"
     ],
     "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "border-bottom-right-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2}",
-    "computed": [
-      "twoAbsoluteLengthOrPercentages"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "voice-range",
-    "syntax": "<frequency [0Hz,∞]> && absolute | [[x-low | low | medium | high | x-high] || [<frequency> | <semitones> | <percentage>]]",
-    "computed": [],
-    "initial": "medium",
-    "inherited": true
-  },
-  {
-    "name": "border-collapse",
-    "syntax": "separate | collapse",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "separate",
-    "inherited": true
-  },
-  {
-    "name": "overflow-y",
-    "syntax": "visible | hidden | clip | scroll | auto",
-    "computed": [
-      "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
-    ],
-    "initial": "visible",
-    "inherited": false
-  },
-  {
-    "name": "shape-margin",
-    "syntax": "<length-percentage [0,∞]>",
-    "computed": [
-      "asSpecifiedRelativeToAbsoluteLengths"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "overflow-wrap",
-    "syntax": "normal | break-word | anywhere",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "-webkit-text-stroke-color",
-    "syntax": "<color>",
-    "computed": [
-      "computedColor"
-    ],
-    "initial": "currentcolor",
-    "inherited": true
-  },
-  {
-    "name": "-webkit-transition-delay",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "text-anchor",
-    "syntax": "start | middle | end",
-    "computed": [],
-    "initial": "start",
-    "inherited": true
-  },
-  {
-    "name": "counter-set",
-    "syntax": "[ <counter-name> <integer>? ]+ | none",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "top",
-    "syntax": "auto | <length-percentage>",
-    "computed": [
-      "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "animation-range-end",
-    "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
-    "computed": [
-      "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage"
-    ],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "animation-direction",
-    "syntax": "<single-animation-direction>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "page-break-inside",
-    "syntax": "avoid | auto | inherit",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "place-content",
-    "syntax": "<'align-content'> <'justify-content'>?",
-    "computed": [
-      "align-content",
-      "justify-content"
-    ],
-    "initial": [
-      "align-content",
-      "justify-content"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "grid-column-start",
-    "syntax": "<grid-line>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "inline-sizing",
-    "syntax": "normal | stretch",
-    "computed": [],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "cue-after",
-    "syntax": "<uri> <decibel>? | none",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "view-transition-name",
-    "syntax": "none | <custom-ident>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-mask-box-image-slice",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "nav-right",
-    "syntax": "auto | <id> [ current | root | <target-name> ]?",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "margin-left",
-    "syntax": "<length-percentage> | auto",
-    "computed": [
-      "percentageAsSpecifiedOrAbsoluteLength"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "mask-position",
-    "syntax": "<position>#",
-    "computed": [
-      "consistsOfTwoKeywordsForOriginAndOffsets"
-    ],
-    "initial": "0% 0%",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-text-stroke",
-    "syntax": "<line-width> || <color>",
-    "computed": [
-      "-webkit-text-stroke-width",
-      "-webkit-text-stroke-color"
-    ],
-    "initial": [
-      "-webkit-text-stroke-width",
-      "-webkit-text-stroke-color"
-    ],
-    "inherited": true
-  },
-  {
-    "name": "flow-into",
-    "syntax": "none | <ident> [element | content]?",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "rx",
-    "syntax": "<length-percentage> | auto",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "filter",
-    "syntax": "none | <filter-value-list>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "outline-width",
-    "syntax": "<line-width>",
-    "computed": [
-      "absoluteLength0ForNone"
-    ],
-    "initial": "medium",
-    "inherited": false
-  },
-  {
-    "name": "fill-origin",
-    "syntax": "match-parent | fill-box | stroke-box | content-box | padding-box | border-box",
-    "computed": [],
-    "initial": "match-parent",
-    "inherited": false
-  },
-  {
-    "name": "isolation",
-    "syntax": "<isolation-mode>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "border-block-start-style",
-    "syntax": "<line-style>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "voice-stress",
-    "syntax": "normal | strong | moderate | none | reduced",
-    "computed": [],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "image-orientation",
-    "syntax": "from-image | none | [ <angle> || flip ]",
-    "computed": [
-      "angleRoundedToNextQuarter"
-    ],
-    "initial": "from-image",
-    "inherited": true
-  },
-  {
-    "name": "text-decoration-color",
-    "syntax": "<color>",
-    "computed": [
-      "computedColor"
-    ],
-    "initial": "currentcolor",
-    "inherited": false
-  },
-  {
-    "name": "padding-top",
-    "syntax": "<length-percentage [0,∞]>",
-    "computed": [
-      "percentageAsSpecifiedOrAbsoluteLength"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "border-top-color",
-    "syntax": "<color> | <image-1D>",
-    "computed": [
-      "computedColor"
-    ],
-    "initial": "currentcolor",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-mask-box-image-source",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "text-decoration-style",
-    "syntax": "solid | double | dotted | dashed | wavy",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "solid",
-    "inherited": false
-  },
-  {
-    "name": "animation-timing-function",
-    "syntax": "<easing-function>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "ease",
-    "inherited": false
-  },
-  {
-    "name": "border-block-end-width",
-    "syntax": "<line-width>",
-    "computed": [
-      "absoluteLengthZeroIfBorderStyleNoneOrHidden"
-    ],
-    "initial": "medium",
-    "inherited": false
-  },
-  {
-    "name": "list-style-type",
-    "syntax": "<counter-style> | <string> | none",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "disc",
-    "inherited": true
-  },
-  {
-    "name": "border-left",
-    "syntax": "<line-width> || <line-style> || <color>",
-    "computed": [
-      "border-left-width",
-      "border-left-style",
-      "border-left-color"
-    ],
-    "initial": [
-      "border-left-width",
-      "border-left-style",
-      "border-left-color"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "text-emphasis",
-    "syntax": "<'text-emphasis-style'> || <'text-emphasis-color'>",
-    "computed": [
-      "text-emphasis-style",
-      "text-emphasis-color"
-    ],
-    "initial": [
-      "text-emphasis-style",
-      "text-emphasis-color"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "color-interpolation-filters",
-    "syntax": "auto | sRGB | linearRGB",
-    "computed": [],
-    "initial": "linearRGB",
-    "inherited": true
-  },
-  {
-    "name": "nav-up",
-    "syntax": "auto | <id> [ current | root | <target-name> ]?",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-transition-property",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "voice-rate",
-    "syntax": "[normal | x-slow | slow | medium | fast | x-fast] || <percentage [0,∞]>",
-    "computed": [],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "scroll-padding-inline",
-    "syntax": "[ auto | <length-percentage [0,∞]> ]{1,2}",
-    "computed": [
-      "scroll-padding-inline-start",
-      "scroll-padding-inline-end"
-    ],
-    "initial": [
-      "scroll-padding-inline-start",
-      "scroll-padding-inline-end"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "scroll-margin-left",
-    "syntax": "<length>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "text-decoration",
-    "syntax": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'>",
-    "computed": [
-      "text-decoration-line",
-      "text-decoration-style",
-      "text-decoration-color",
-      "text-decoration-thickness"
-    ],
-    "initial": [
-      "text-decoration-color",
-      "text-decoration-style",
-      "text-decoration-line"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "line-snap",
-    "syntax": "none | baseline | contain",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "width",
-    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()>",
-    "computed": [
-      "percentageAutoOrAbsoluteLength"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "stroke-position",
-    "syntax": "<position>#",
-    "computed": [],
-    "initial": "0% 0%",
-    "inherited": true
-  },
-  {
-    "name": "tab-size",
-    "syntax": "<number [0,∞]> | <length [0,∞]>",
-    "computed": [
-      "specifiedIntegerOrAbsoluteLength"
-    ],
-    "initial": "8",
-    "inherited": true
-  },
-  {
-    "name": "border-color",
-    "syntax": "[ <color> | <image-1D> ]{1,4}",
-    "computed": [
-      "border-bottom-color",
-      "border-left-color",
-      "border-right-color",
-      "border-top-color"
-    ],
-    "initial": [
-      "border-top-color",
-      "border-right-color",
-      "border-bottom-color",
-      "border-left-color"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "border-block-end-style",
-    "syntax": "<line-style>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-animation-fill-mode",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-box-flex",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "speak",
-    "syntax": "auto | never | always",
-    "computed": [],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "cy",
-    "syntax": "<length-percentage>",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "visibility",
-    "syntax": "visible | hidden | collapse",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "visible",
-    "inherited": true
-  },
-  {
-    "name": "grid-auto-rows",
-    "syntax": "<track-size>+",
-    "computed": [
-      "percentageAsSpecifiedOrAbsoluteLength"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "border-bottom",
-    "syntax": "<line-width> || <line-style> || <color>",
-    "computed": [
-      "border-bottom-width",
-      "border-bottom-style",
-      "border-bottom-color"
-    ],
-    "initial": [
-      "border-bottom-width",
-      "border-bottom-style",
-      "border-bottom-color"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "-webkit-box-pack",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "scroll-padding-inline-end",
-    "syntax": "auto | <length-percentage [0,∞]>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "min-width",
-    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()>",
-    "computed": [
-      "percentageAsSpecifiedOrAbsoluteLength"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "grid-template-rows",
-    "syntax": "none | <track-list> | <auto-track-list> | subgrid <line-name-list>?",
-    "computed": [
-      "asSpecifiedRelativeToAbsoluteLengths"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "scroll-padding",
-    "syntax": "[ auto | <length-percentage [0,∞]> ]{1,4}",
-    "computed": [
-      "scroll-padding-bottom",
-      "scroll-padding-left",
-      "scroll-padding-right",
-      "scroll-padding-top"
-    ],
-    "initial": [
-      "scroll-padding-bottom",
-      "scroll-padding-left",
-      "scroll-padding-right",
-      "scroll-padding-top"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "margin-right",
-    "syntax": "<length-percentage> | auto",
-    "computed": [
-      "percentageAsSpecifiedOrAbsoluteLength"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "bottom",
-    "syntax": "auto | <length-percentage>",
-    "computed": [
-      "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "block-step-insert",
-    "syntax": "margin | padding",
-    "computed": [],
-    "initial": "margin",
-    "inherited": false
-  },
-  {
-    "name": "stroke-align",
-    "syntax": "center | inset | outset",
-    "computed": [],
-    "initial": "center",
-    "inherited": true
-  },
-  {
-    "name": "font-synthesis-small-caps",
-    "syntax": "auto | none",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "align-content",
-    "syntax": "normal | <baseline-position> | <content-distribution> | <overflow-position>? <content-position>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "offset",
-    "syntax": "[ <'offset-position'>? [ <'offset-path'> [ <'offset-distance'> || <'offset-rotate'> ]? ]? ]! [ / <'offset-anchor'> ]?",
-    "computed": [
-      "offset-position",
-      "offset-path",
-      "offset-distance",
-      "offset-anchor",
-      "offset-rotate"
-    ],
-    "initial": [
-      "offset-position",
-      "offset-path",
-      "offset-distance",
-      "offset-anchor",
-      "offset-rotate"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "writing-mode",
-    "syntax": "horizontal-tb | vertical-rl | vertical-lr | sideways-rl | sideways-lr",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "horizontal-tb",
-    "inherited": true
-  },
-  {
-    "name": "break-inside",
-    "syntax": "auto | avoid | avoid-page | avoid-column | avoid-region",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "border-block",
-    "syntax": "<'border-block-start'>",
-    "computed": [
-      "border-block-width",
-      "border-block-style",
-      "border-block-color"
-    ],
-    "initial": [
-      "border-block-width",
-      "border-block-style",
-      "border-block-color"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "border-inline-end-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "border-radius",
-    "syntax": "<length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?",
-    "computed": [
-      "border-bottom-left-radius",
-      "border-bottom-right-radius",
-      "border-top-left-radius",
-      "border-top-right-radius"
-    ],
-    "initial": [
-      "border-top-left-radius",
-      "border-top-right-radius",
-      "border-bottom-right-radius",
-      "border-bottom-left-radius"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "border-image-slice",
-    "syntax": "[<number [0,∞]> | <percentage [0,∞]>]{1,4} && fill?",
-    "computed": [
-      "oneToFourPercentagesOrAbsoluteLengthsPlusFill"
-    ],
-    "initial": "100%",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-border-top-right-radius",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "marker-start",
-    "syntax": "none | <marker-ref>",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "pointer-events",
-    "syntax": "auto | bounding-box | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all | none",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "inset",
-    "syntax": "<'top'>{1,4}",
-    "computed": [
-      "top",
-      "bottom",
-      "left",
-      "right"
-    ],
-    "initial": [
-      "top",
-      "bottom",
-      "left",
-      "right"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "font-weight",
-    "syntax": "<font-weight-absolute> | bolder | lighter",
-    "computed": [
-      "keywordOrNumericalValueBolderLighterTransformedToRealValue"
-    ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "opacity",
-    "syntax": "<opacity-value>",
-    "computed": [
-      "specifiedValueNumberClipped0To1"
-    ],
-    "initial": "1",
-    "inherited": false
-  },
-  {
-    "name": "dynamic-range-limit",
-    "syntax": "standard | high | constrained-high",
-    "computed": [],
-    "initial": "high",
-    "inherited": false
-  },
-  {
-    "name": "columns",
-    "syntax": "<'column-width'> || <'column-count'>",
-    "computed": [
-      "column-width",
-      "column-count"
-    ],
-    "initial": [
-      "column-width",
-      "column-count"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "font-variation-settings",
-    "syntax": "normal | [ <opentype-tag> <number>]#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "mix-blend-mode",
-    "syntax": "<blend-mode> | plus-darker | plus-lighter",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "position",
-    "syntax": "static | relative | absolute | sticky | fixed | <running()>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "static",
-    "inherited": false
-  },
-  {
-    "name": "animation-delay",
-    "syntax": "<time>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "0s",
-    "inherited": false
-  },
-  {
-    "name": "border-inline-style",
-    "syntax": "<'border-top-style'>{1,2}",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "border-inline-end-width",
-    "syntax": "<line-width>",
-    "computed": [
-      "absoluteLengthZeroIfBorderStyleNoneOrHidden"
-    ],
-    "initial": "medium",
-    "inherited": false
-  },
-  {
-    "name": "scroll-padding-block-end",
-    "syntax": "auto | <length-percentage [0,∞]>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "overscroll-behavior-y",
-    "syntax": "contain | none | auto",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "font-variant-position",
-    "syntax": "normal | sub | super",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "justify-content",
-    "syntax": "normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ]",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "border-inline-end",
-    "syntax": "<line-width> || <line-style> || <color>",
-    "computed": [
-      "border-width",
-      "border-style",
-      "border-inline-end-color"
-    ],
-    "initial": [
-      "border-width",
-      "border-style",
-      "color"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "-webkit-text-size-adjust",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "font-optical-sizing",
-    "syntax": "auto | none",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "-webkit-background-size",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "transition-property",
-    "syntax": "none | <single-transition-property>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "all",
-    "inherited": false
-  },
-  {
-    "name": "scroll-timeline-name",
-    "syntax": "[ none | <dashed-ident> ]#",
-    "computed": [
-      "noneOrOrderedListOfIdentifiers"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "font-kerning",
-    "syntax": "auto | normal | none",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "padding",
-    "syntax": "<'padding-top'>{1,4}",
-    "computed": [
-      "padding-bottom",
-      "padding-left",
-      "padding-right",
-      "padding-top"
-    ],
-    "initial": [
-      "padding-bottom",
-      "padding-left",
-      "padding-right",
-      "padding-top"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "margin-inline-end",
-    "syntax": "<'margin-top'>",
-    "computed": [
-      "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "math-depth",
-    "syntax": "auto-add | add(<integer>) | <integer>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "0",
-    "inherited": true
-  },
-  {
-    "name": "view-timeline-name",
-    "syntax": "[ none | <dashed-ident> ]#",
-    "computed": [
-      "noneOrOrderedListOfIdentifiers"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "stroke-color",
-    "syntax": "<color>#",
-    "computed": [],
-    "initial": "transparent",
-    "inherited": true
-  },
-  {
-    "name": "all",
-    "syntax": "initial | inherit | unset | revert | revert-layer",
-    "computed": [
-      "asSpecifiedAppliesToEachProperty"
-    ],
-    "initial": "noPracticalInitialValue",
-    "inherited": false
-  },
-  {
-    "name": "outline-color",
-    "syntax": "auto | [ <color> | <image-1D> ]",
-    "computed": [
-      "autoForTranslucentColorRGBAOtherwiseRGB"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-flex-basis",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "cx",
-    "syntax": "<length-percentage>",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "scroll-margin-right",
-    "syntax": "<length>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "float-offset",
-    "syntax": "<length> | <percentage>",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "mask-origin",
-    "syntax": "<coord-box>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "border-box",
-    "inherited": false
-  },
-  {
-    "name": "align-self",
-    "syntax": "auto | normal | stretch | <baseline-position> | <overflow-position>? <self-position> | anchor-center",
-    "computed": [
-      "autoOnAbsolutelyPositionedElementsValueOfAlignItemsOnParent"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-mask-box-image-outset",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "contain",
-    "syntax": "none | strict | content | [ [size | inline-size] || layout || style || paint ]",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "max-block-size",
-    "syntax": "<'max-width'>",
-    "computed": [
-      "sameAsMaxWidthAndMaxHeight"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "margin-block-end",
-    "syntax": "<'margin-top'>",
-    "computed": [
-      "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "text-emphasis-position",
-    "syntax": "[ over | under ] && [ right | left ]?",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "over right",
-    "inherited": true
-  },
-  {
-    "name": "font-language-override",
-    "syntax": "normal | <string>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "border-style",
-    "syntax": "<line-style>{1,4}",
-    "computed": [
-      "border-bottom-style",
-      "border-left-style",
-      "border-right-style",
-      "border-top-style"
-    ],
-    "initial": [
-      "border-top-style",
-      "border-right-style",
-      "border-bottom-style",
-      "border-left-style"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "scroll-margin-inline-end",
-    "syntax": "<length>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "nav-down",
-    "syntax": "auto | <id> [ current | root | <target-name> ]?",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "height",
-    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()>",
-    "computed": [
-      "percentageAutoOrAbsoluteLength"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "border-image-repeat",
-    "syntax": "[ stretch | repeat | round | space ]{1,2}",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "stretch",
-    "inherited": false
-  },
-  {
-    "name": "line-break",
-    "syntax": "auto | loose | normal | strict | anywhere",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "-webkit-align-content",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "scroll-padding-block-start",
-    "syntax": "auto | <length-percentage [0,∞]>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "font-variant-numeric",
-    "syntax": "normal | [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ]",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "scrollbar-width",
-    "syntax": "auto | thin | none",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-box-orient",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "grid-row-gap",
-    "syntax": "",
-    "computed": [
-      "percentageAsSpecifiedOrAbsoluteLength"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "direction",
-    "syntax": "ltr | rtl",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "ltr",
-    "inherited": true
-  },
-  {
-    "name": "ruby-merge",
-    "syntax": "separate | merge | auto",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "separate",
-    "inherited": true
-  },
-  {
-    "name": "scroll-margin-inline-start",
-    "syntax": "<length>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "anchor-scope",
-    "syntax": "none | all | <dashed-ident>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "link-parameters",
-    "syntax": "none | <link-param>+",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "border-left-style",
-    "syntax": "<line-style>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "word-wrap",
-    "syntax": "normal | break-word | anywhere",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "border-block-end-color",
-    "syntax": "<color> | <image-1D>",
-    "computed": [
-      "computedColor"
-    ],
-    "initial": "currentcolor",
-    "inherited": false
-  },
-  {
-    "name": "border-left-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-transform-style",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "vector-effect",
-    "syntax": "none | non-scaling-stroke | non-scaling-size | non-rotation | fixed-position",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "scroll-margin",
-    "syntax": "<length>{1,4}",
-    "computed": [
-      "scroll-margin-bottom",
-      "scroll-margin-left",
-      "scroll-margin-right",
-      "scroll-margin-top"
-    ],
-    "initial": [
-      "scroll-margin-bottom",
-      "scroll-margin-left",
-      "scroll-margin-right",
-      "scroll-margin-top"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "page",
-    "syntax": "auto | <custom-ident>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "inset-inline",
-    "syntax": "<'top'>{1,2}",
-    "computed": [
-      "inset-inline-start",
-      "inset-inline-end"
-    ],
-    "initial": [
-      "inset-inline-start",
-      "inset-inline-end"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "margin",
-    "syntax": "<'margin-top'>{1,4}",
-    "computed": [
-      "margin-bottom",
-      "margin-left",
-      "margin-right",
-      "margin-top"
-    ],
-    "initial": [
-      "margin-bottom",
-      "margin-left",
-      "margin-right",
-      "margin-top"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "text-shadow",
-    "syntax": "none | [ <color>? && <length>{2,3} ]#",
-    "computed": [
-      "colorPlusThreeAbsoluteLengths"
-    ],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "justify-self",
-    "syntax": "auto | normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | anchor-center",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "offset-anchor",
-    "syntax": "auto | <position>",
-    "computed": [
-      "forLengthAbsoluteValueOtherwisePercentage"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "grid-template-columns",
-    "syntax": "none | <track-list> | <auto-track-list> | subgrid <line-name-list>?",
-    "computed": [
-      "asSpecifiedRelativeToAbsoluteLengths"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "border-block-start-color",
-    "syntax": "<color> | <image-1D>",
-    "computed": [
-      "computedColor"
-    ],
-    "initial": "currentcolor",
-    "inherited": false
-  },
-  {
-    "name": "border-bottom-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "column-rule-color",
-    "syntax": "<color>",
-    "computed": [
-      "computedColor"
-    ],
-    "initial": "currentcolor",
-    "inherited": false
-  },
-  {
-    "name": "inset-block-start",
-    "syntax": "auto | <length-percentage>",
-    "computed": [
-      "sameAsBoxOffsets"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "border-inline-end-style",
-    "syntax": "<line-style>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "voice-family",
-    "syntax": "[[<family-name> | <generic-voice>],]* [<family-name> | <generic-voice>] | preserve",
-    "computed": [],
-    "initial": "implementation-dependent",
-    "inherited": true
-  },
-  {
-    "name": "spatial-navigation-action",
-    "syntax": "auto | focus | scroll",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "position-visibility",
-    "syntax": "always | [ anchors-valid || anchors-visible || no-overflow ]",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "anchors-visible",
-    "inherited": false
-  },
-  {
-    "name": "user-select",
-    "syntax": "auto | text | none | contain | all",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "stroke-width",
-    "syntax": "[<length-percentage> | <number>]#",
-    "computed": [],
-    "initial": "1px",
-    "inherited": true
-  },
-  {
-    "name": "-webkit-box-align",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "rest-before",
-    "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "marker-end",
-    "syntax": "none | <marker-ref>",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "overflow-x",
-    "syntax": "visible | hidden | clip | scroll | auto",
-    "computed": [
-      "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
-    ],
-    "initial": "visible",
-    "inherited": false
-  },
-  {
-    "name": "text-decoration-line",
-    "syntax": "none | [ underline || overline || line-through || blink ]",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "scrollbar-gutter",
-    "syntax": "auto | stable && both-edges?",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "fill-color",
-    "syntax": "<color>",
-    "computed": [],
-    "initial": "currentcolor",
-    "inherited": true
-  },
-  {
-    "name": "stroke-dasharray",
-    "syntax": "none | [<length-percentage> | <number>]+#",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "border-inline-start-width",
-    "syntax": "<line-width>",
-    "computed": [
-      "absoluteLengthZeroIfBorderStyleNoneOrHidden"
-    ],
-    "initial": "medium",
-    "inherited": false
-  },
-  {
-    "name": "scroll-margin-block-start",
-    "syntax": "<length>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "scroll-margin-inline",
-    "syntax": "<length>{1,2}",
-    "computed": [
-      "scroll-margin-inline-start",
-      "scroll-margin-inline-end"
-    ],
-    "initial": [
-      "scroll-margin-inline-start",
-      "scroll-margin-inline-end"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "font-variant-east-asian",
-    "syntax": "normal | [ <east-asian-variant-values> || <east-asian-width-values> || ruby ]",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "box-decoration-break",
-    "syntax": "slice | clone",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "slice",
-    "inherited": false
-  },
-  {
-    "name": "border-top-right-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2}",
-    "computed": [
-      "twoAbsoluteLengthOrPercentages"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "pause",
-    "syntax": "<'pause-before'> <'pause-after'>?",
-    "computed": [],
-    "initial": "N/A (see individual properties)",
-    "inherited": false
-  },
-  {
-    "name": "voice-duration",
-    "syntax": "auto | <time [0s,∞]>",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "margin-block-start",
-    "syntax": "<'margin-top'>",
-    "computed": [
-      "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "grid-column-end",
-    "syntax": "<grid-line>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-animation-timing-function",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-border-bottom-left-radius",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "padding-inline-start",
-    "syntax": "<'padding-top'>",
-    "computed": [
-      "asLength"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "marker-side",
-    "syntax": "match-self | match-parent",
-    "computed": [],
-    "initial": "match-self",
-    "inherited": true
-  },
-  {
-    "name": "mask-border-mode",
-    "syntax": "luminance | alpha",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "alpha",
-    "inherited": false
-  },
-  {
-    "name": "flex-basis",
-    "syntax": "content | <'width'>",
-    "computed": [
-      "asSpecifiedRelativeToAbsoluteLengths"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "wrap-through",
-    "syntax": "wrap | none",
-    "computed": [],
-    "initial": "wrap",
-    "inherited": false
-  },
-  {
-    "name": "border-right-width",
-    "syntax": "<line-width>",
-    "computed": [
-      "absoluteLengthOr0IfBorderRightStyleNoneOrHidden"
-    ],
-    "initial": "medium",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-border-top-left-radius",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "bookmark-label",
-    "syntax": "<content-list>",
-    "computed": [],
-    "initial": "content(text)",
-    "inherited": false
-  },
-  {
-    "name": "max-inline-size",
-    "syntax": "<'max-width'>",
-    "computed": [
-      "sameAsMaxWidthAndMaxHeight"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "stroke-linejoin",
-    "syntax": "[ crop | arcs | miter ] || [ bevel | round | fallback ]",
-    "computed": [],
-    "initial": "miter",
-    "inherited": true
-  },
-  {
-    "name": "border-right-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "vertical-align",
-    "syntax": "[ first | last] || <'alignment-baseline'> || <'baseline-shift'>",
-    "computed": [
-      "absoluteLengthOrKeyword"
-    ],
-    "initial": "baseline",
-    "inherited": false
-  },
-  {
-    "name": "voice-pitch",
-    "syntax": "<frequency [0Hz,∞]> && absolute | [[x-low | low | medium | high | x-high] || [<frequency> | <semitones> | <percentage>]]",
-    "computed": [],
-    "initial": "medium",
-    "inherited": true
-  },
-  {
-    "name": "inset-inline-end",
-    "syntax": "auto | <length-percentage>",
-    "computed": [
-      "sameAsBoxOffsets"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "scroll-timeline",
-    "syntax": "[ <'scroll-timeline-name'> <'scroll-timeline-axis'>? ]#",
-    "computed": [
-      "scroll-timeline-name",
-      "scroll-timeline-axis"
-    ],
-    "initial": [
-      "scroll-timeline-name",
-      "scroll-timeline-axis"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "border-image",
-    "syntax": "<'border-image-source'> || <'border-image-slice'> [ / <'border-image-width'> | / <'border-image-width'>? / <'border-image-outset'> ]? || <'border-image-repeat'>",
-    "computed": [
-      "border-image-outset",
-      "border-image-repeat",
-      "border-image-slice",
-      "border-image-source",
-      "border-image-width"
-    ],
-    "initial": [
-      "border-image-source",
-      "border-image-slice",
-      "border-image-width",
-      "border-image-outset",
-      "border-image-repeat"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "transform-origin",
-    "syntax": "[ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] <length>? | [[ center | left | right ] && [ center | top | bottom ]] <length>?",
-    "computed": [
-      "forLengthAbsoluteValueOtherwisePercentage"
-    ],
-    "initial": "50% 50% 0",
-    "inherited": false
-  },
-  {
-    "name": "float",
-    "syntax": "block-start | block-end | inline-start | inline-end | snap-block | <snap-block()> | snap-inline | <snap-inline()> | left | right | top | bottom | none | footnote",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "scroll-padding-top",
-    "syntax": "auto | <length-percentage [0,∞]>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "font-synthesis-style",
-    "syntax": "auto | none",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "hanging-punctuation",
-    "syntax": "none | [ first || [ force-end | allow-end ] || last ]",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "-webkit-animation-duration",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-background-clip",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "alignment-baseline",
-    "syntax": "baseline | text-bottom | alphabetic | ideographic | middle | central | mathematical | text-top",
-    "computed": [],
-    "initial": "baseline",
-    "inherited": false
-  },
-  {
-    "name": "box-sizing",
-    "syntax": "content-box | border-box",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "content-box",
-    "inherited": false
-  },
-  {
-    "name": "box-shadow-offset",
-    "syntax": "[ none | <length>{2} ]#",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "block-step",
-    "syntax": "<'block-step-size'> || <'block-step-insert'> || <'block-step-align'> || <'block-step-round'>",
-    "computed": [],
-    "initial": "see individual properties",
-    "inherited": false
-  },
-  {
-    "name": "nav-left",
-    "syntax": "auto | <id> [ current | root | <target-name> ]?",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "background-repeat",
-    "syntax": "<repeat-style>#",
-    "computed": [
-      "listEachItemHasTwoKeywordsOnePerDimension"
-    ],
-    "initial": "repeat",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-mask-composite",
-    "syntax": "",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "source-over",
-    "inherited": false
-  },
-  {
-    "name": "initial-letter-align",
-    "syntax": "[ border-box? [ alphabetic | ideographic | hanging | leading ]? ]!",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "object-position",
-    "syntax": "<position>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "50% 50%",
-    "inherited": false
-  },
-  {
-    "name": "transition-delay",
-    "syntax": "<time>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "0s",
-    "inherited": false
-  },
-  {
-    "name": "border-block-width",
-    "syntax": "<'border-top-width'>{1,2}",
-    "computed": [
-      "absoluteLengthZeroIfBorderStyleNoneOrHidden"
-    ],
-    "initial": "medium",
-    "inherited": false
-  },
-  {
-    "name": "border-top-left-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2}",
-    "computed": [
-      "twoAbsoluteLengthOrPercentages"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "ruby-position",
-    "syntax": "[ alternate || [ over | under ] ] | inter-character",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "alternate",
-    "inherited": true
-  },
-  {
-    "name": "overflow-block",
-    "syntax": "visible | hidden | clip | scroll | auto",
-    "computed": [
-      "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-flex",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "marker",
-    "syntax": "none | <marker-ref>",
-    "computed": [],
-    "initial": "not defined for shorthand properties",
-    "inherited": true
-  },
-  {
-    "name": "order",
-    "syntax": "<integer>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-mask-origin",
-    "syntax": "",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "padding",
-    "inherited": false
-  },
-  {
-    "name": "table-layout",
-    "syntax": "auto | fixed",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "left",
-    "syntax": "auto | <length-percentage>",
-    "computed": [
-      "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "mask-type",
-    "syntax": "luminance | alpha",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "luminance",
-    "inherited": false
-  },
-  {
-    "name": "offset-rotate",
-    "syntax": "[ auto | reverse ] || <angle>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "letter-spacing",
-    "syntax": "normal | <length>",
-    "computed": [
-      "optimumValueOfAbsoluteLengthOrNormal"
-    ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "-webkit-animation-iteration-count",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "fill",
-    "syntax": "<paint>",
-    "computed": [],
-    "initial": "black",
-    "inherited": true
-  },
-  {
-    "name": "caret-animation",
-    "syntax": "auto | manual",
-    "computed": [],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "border-image-outset",
-    "syntax": "[ <length [0,∞]> | <number [0,∞]> ]{1,4}",
-    "computed": [
-      "asSpecifiedRelativeToAbsoluteLengths"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "text-align-all",
-    "syntax": "start | end | left | right | center | justify | match-parent",
-    "computed": [],
-    "initial": "start",
-    "inherited": true
-  },
-  {
-    "name": "widows",
-    "syntax": "<integer [1,∞]>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "2",
-    "inherited": true
-  },
-  {
-    "name": "initial-letter-wrap",
-    "syntax": "none | first | all | grid | <length-percentage>",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "cue",
-    "syntax": "<'cue-before'> <'cue-after'>?",
-    "computed": [],
-    "initial": "N/A (see individual properties)",
-    "inherited": false
-  },
-  {
-    "name": "overflow-anchor",
-    "syntax": "auto | none",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "animation-fill-mode",
-    "syntax": "<single-animation-fill-mode>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "border-block-style",
-    "syntax": "<'border-top-style'>{1,2}",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-flex-shrink",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-transition",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "scroll-padding-bottom",
-    "syntax": "auto | <length-percentage [0,∞]>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "inset-block-end",
-    "syntax": "auto | <length-percentage>",
-    "computed": [
-      "sameAsBoxOffsets"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-appearance",
-    "syntax": "",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "noneButOverriddenInUserAgentCSS",
-    "inherited": false
-  },
-  {
-    "name": "scroll-timeline-axis",
-    "syntax": "[ block | inline | x | y ]#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "block",
-    "inherited": false
-  },
-  {
-    "name": "view-timeline-axis",
-    "syntax": "[ block | inline | x | y ]#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "block",
-    "inherited": false
-  },
-  {
-    "name": "stroke-size",
-    "syntax": "<bg-size>#",
-    "computed": [],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "font-style",
-    "syntax": "normal | italic | oblique <angle [-90deg,90deg]>?",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "border-block-color",
-    "syntax": "<'border-top-color'>{1,2}",
-    "computed": [
-      "computedColor"
-    ],
-    "initial": "currentcolor",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-filter",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "column-rule-width",
-    "syntax": "<line-width>",
-    "computed": [
-      "absoluteLength0IfColumnRuleStyleNoneOrHidden"
-    ],
-    "initial": "medium",
-    "inherited": false
-  },
-  {
-    "name": "empty-cells",
-    "syntax": "show | hide",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "show",
-    "inherited": true
-  },
-  {
-    "name": "max-width",
-    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()>",
-    "computed": [
-      "percentageAsSpecifiedAbsoluteLengthOrNone"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "grid-template-areas",
-    "syntax": "none | <string>+",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "border-inline-color",
-    "syntax": "<'border-top-color'>{1,2}",
-    "computed": [
-      "computedColor"
-    ],
-    "initial": "currentcolor",
-    "inherited": false
-  },
-  {
-    "name": "border-bottom-width",
-    "syntax": "<line-width>",
-    "computed": [
-      "absoluteLengthOr0IfBorderBottomStyleNoneOrHidden"
-    ],
-    "initial": "medium",
-    "inherited": false
-  },
-  {
-    "name": "border-start-end-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2}",
-    "computed": [
-      "twoAbsoluteLengthOrPercentages"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "flood-opacity",
-    "syntax": "<'opacity'>",
-    "computed": [],
-    "initial": "1",
-    "inherited": false
-  },
-  {
-    "name": "font-stretch",
-    "syntax": "",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "border-top",
-    "syntax": "<line-width> || <line-style> || <color>",
-    "computed": [
-      "border-top-width",
-      "border-top-style",
-      "border-top-color"
-    ],
-    "initial": [
-      "border-top-width",
-      "border-top-style",
-      "border-top-color"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "-webkit-animation-name",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "fill-repeat",
-    "syntax": "<repeat-style>#",
-    "computed": [],
-    "initial": "repeat",
-    "inherited": true
-  },
-  {
-    "name": "margin-trim",
-    "syntax": "none | [ block || inline ] | [ block-start || inline-start || block-end || inline-end ]",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-border-radius",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "stroke-dashcorner",
-    "syntax": "none | <length>",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "background-image",
-    "syntax": "<bg-image>#",
-    "computed": [
-      "asSpecifiedURLsAbsolute"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "mask-border-source",
-    "syntax": "none | <image>",
-    "computed": [
-      "asSpecifiedURLsAbsolute"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "quotes",
-    "syntax": "auto | none | match-parent | [ <string> <string> ]+",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "dependsOnUserAgent",
-    "inherited": true
-  },
-  {
-    "name": "overscroll-behavior-block",
-    "syntax": "contain | none | auto",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "timeline-scope",
-    "syntax": "none | all | <dashed-ident>#",
-    "computed": [
-      "noneOrOrderedListOfIdentifiers"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "border-image-source",
-    "syntax": "none | <image>",
-    "computed": [
-      "noneOrImageWithAbsoluteURI"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "border-bottom-left-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2}",
-    "computed": [
-      "twoAbsoluteLengthOrPercentages"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-justify-content",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "stroke-repeat",
-    "syntax": "<repeat-style>#",
-    "computed": [],
-    "initial": "repeat",
-    "inherited": true
-  },
-  {
-    "name": "font-feature-settings",
-    "syntax": "normal | <feature-tag-value>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "flex-wrap",
-    "syntax": "nowrap | wrap | wrap-reverse",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "nowrap",
-    "inherited": false
-  },
-  {
-    "name": "box-shadow-position",
-    "syntax": "[ outset | inset ]#",
-    "computed": [],
-    "initial": "outset",
-    "inherited": false
-  },
-  {
-    "name": "font-width",
-    "syntax": "normal | <percentage [0,∞]> | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded",
-    "computed": [],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "grid-gap",
-    "syntax": "",
-    "computed": [
-      "grid-row-gap",
-      "grid-column-gap"
-    ],
-    "initial": [
-      "grid-row-gap",
-      "grid-column-gap"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "scroll-snap-align",
-    "syntax": "[ none | start | end | center ]{1,2}",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "padding-left",
-    "syntax": "<length-percentage [0,∞]>",
-    "computed": [
-      "percentageAsSpecifiedOrAbsoluteLength"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "footnote-display",
-    "syntax": "block | inline | compact",
-    "computed": [],
-    "initial": "block",
-    "inherited": false
-  },
-  {
-    "name": "border-clip-right",
-    "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
-    "computed": [],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "mask-border-outset",
-    "syntax": "[ <length> | <number> ]{1,4}",
-    "computed": [
-      "asSpecifiedRelativeToAbsoluteLengths"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "touch-action",
-    "syntax": "auto | none | [ [ pan-x | pan-left | pan-right ] || [ pan-y | pan-up | pan-down ] || pinch-zoom ] | manipulation",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-animation-direction",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-mask-clip",
-    "syntax": "",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "border",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-transition-timing-function",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "scroll-margin-bottom",
-    "syntax": "<length>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "margin-inline-start",
-    "syntax": "<'margin-top'>",
-    "computed": [
-      "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "text-combine-upright",
-    "syntax": "none | all | [ digits <integer [2,4]>? ]",
-    "computed": [
-      "keywordPlusIntegerIfDigits"
-    ],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "text-rendering",
-    "syntax": "auto | optimizeSpeed | optimizeLegibility | geometricPrecision",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "text-size-adjust",
-    "syntax": "auto | none | <percentage [0,∞]>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "autoForSmartphoneBrowsersSupportingInflation",
-    "inherited": true
-  },
-  {
-    "name": "color-scheme",
-    "syntax": "normal | [ light | dark | <custom-ident> ]+ && only?",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "print-color-adjust",
-    "syntax": "economy | exact",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "economy",
-    "inherited": true
-  },
-  {
-    "name": "fill-break",
-    "syntax": "bounding-box | slice | clone",
-    "computed": [],
-    "initial": "bounding-box",
-    "inherited": false
-  },
-  {
-    "name": "fill-opacity",
-    "syntax": "<'opacity'>",
-    "computed": [],
-    "initial": "1",
-    "inherited": true
-  },
-  {
-    "name": "text-transform",
-    "syntax": "none | [capitalize | uppercase | lowercase ] || full-width || full-size-kana | math-auto",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "border-block-end-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "column-fill",
-    "syntax": "auto | balance | balance-all",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "balance",
-    "inherited": false
-  },
-  {
-    "name": "x",
-    "syntax": "<length-percentage>",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "caret-color",
-    "syntax": "auto | <color>",
-    "computed": [
-      "asAutoOrColor"
-    ],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "unicode-bidi",
-    "syntax": "normal | embed | isolate | bidi-override | isolate-override | plaintext",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-flex-grow",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "font-synthesis",
-    "syntax": "none | [ weight || style || small-caps || position]",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "weight style small-caps position ",
-    "inherited": true
-  },
-  {
-    "name": "footnote-policy",
-    "syntax": "auto | line | block",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "box-shadow-spread",
-    "syntax": "<length>#",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "text-box",
-    "syntax": "normal | <'text-box-trim'> || <'text-box-edge'>",
-    "computed": [],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "flow-from",
-    "syntax": "<ident> | none",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "text-overflow",
-    "syntax": "clip | ellipsis",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "clip",
-    "inherited": false
-  },
-  {
-    "name": "anchor-name",
-    "syntax": "none | <dashed-ident>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "animation-range",
-    "syntax": "[ <'animation-range-start'> <'animation-range-end'>? ]#",
-    "computed": [
-      "animation-range-start",
-      "animation-range-end"
-    ],
-    "initial": [
-      "animation-range-start",
-      "animation-range-end"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "background-blend-mode",
-    "syntax": "<mix-blend-mode>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "animation-name",
-    "syntax": "[ none | <keyframes-name> ]#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "padding-block",
-    "syntax": "<'padding-top'>{1,2}",
-    "computed": [
-      "padding-block-start",
-      "padding-block-end"
-    ],
-    "initial": [
-      "padding-block-start",
-      "padding-block-end"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "counter-reset",
-    "syntax": "[ <counter-name> <integer>? | <reversed-counter-name> <integer>? ]+ | none",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "mask-image",
-    "syntax": "<mask-reference>#",
-    "computed": [
-      "asSpecifiedURLsAbsolute"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-transition-duration",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "content-visibility",
-    "syntax": "visible | auto | hidden",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "visible",
-    "inherited": false
-  },
-  {
-    "name": "position-area",
-    "syntax": "none | <position-area>",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "view-timeline",
-    "syntax": "[ <'view-timeline-name'> [ <'view-timeline-axis'> || <'view-timeline-inset'> ]? ]#",
-    "computed": [
-      "view-timeline-name",
-      "view-timeline-axis"
-    ],
-    "initial": [
-      "view-timeline-name",
-      "view-timeline-axis"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "padding-bottom",
-    "syntax": "<length-percentage [0,∞]>",
-    "computed": [
-      "percentageAsSpecifiedOrAbsoluteLength"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "border-inline-start",
-    "syntax": "<line-width> || <line-style> || <color>",
-    "computed": [
-      "border-width",
-      "border-style",
-      "border-inline-start-color"
-    ],
-    "initial": [
-      "border-width",
-      "border-style",
-      "color"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "-webkit-flex-flow",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "line-height-step",
-    "syntax": "<length [0,∞]>",
-    "computed": [
-      "absoluteLength"
-    ],
-    "initial": "0",
-    "inherited": true
-  },
-  {
-    "name": "border-spacing",
-    "syntax": "<length>{1,2}",
-    "computed": [
-      "twoAbsoluteLengths"
-    ],
-    "initial": "0",
-    "inherited": true
-  },
-  {
-    "name": "text-underline-position",
-    "syntax": "auto | [ under || [ left | right ] ]",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "transform",
-    "syntax": "none | <transform-list>",
-    "computed": [
-      "asSpecifiedRelativeToAbsoluteLengths"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "transition-timing-function",
-    "syntax": "<easing-function>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "ease",
-    "inherited": false
-  },
-  {
-    "name": "scroll-margin-block-end",
-    "syntax": "<length>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "background-origin",
-    "syntax": "<visual-box>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "padding-box",
-    "inherited": false
-  },
-  {
-    "name": "animation-duration",
-    "syntax": "<time [0s,∞]>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "0s",
-    "inherited": false
-  },
-  {
-    "name": "border-clip-bottom",
-    "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
-    "computed": [],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-align-self",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "padding-block-end",
-    "syntax": "<'padding-top'>",
-    "computed": [
-      "asLength"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "overscroll-behavior-x",
-    "syntax": "contain | none | auto",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-user-select",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "font-variant-emoji",
-    "syntax": "normal | text | emoji | unicode",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "color",
-    "syntax": "<color>",
-    "computed": [
-      "computedColor"
-    ],
-    "initial": "canvastext",
-    "inherited": true
-  },
-  {
-    "name": "-webkit-mask-size",
-    "syntax": "",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto auto",
-    "inherited": false
-  },
-  {
-    "name": "voice-volume",
-    "syntax": "silent | [[x-soft | soft | medium | loud | x-loud] || <decibel>]",
-    "computed": [],
-    "initial": "medium",
-    "inherited": true
-  },
-  {
-    "name": "background-clip",
-    "syntax": "<visual-box>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "border-box",
-    "inherited": false
-  },
-  {
-    "name": "border-right",
-    "syntax": "<line-width> || <line-style> || <color>",
-    "computed": [
-      "border-right-width",
-      "border-right-style",
-      "border-right-color"
-    ],
-    "initial": [
-      "border-right-width",
-      "border-right-style",
-      "border-right-color"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "stroke-alignment",
-    "syntax": "center | inner | outer",
-    "computed": [],
-    "initial": "center",
-    "inherited": true
-  },
-  {
-    "name": "scroll-behavior",
-    "syntax": "auto | smooth",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "background-position",
-    "syntax": "<bg-position>#",
-    "computed": [
-      "background-position-x",
-      "background-position-y"
-    ],
-    "initial": "0% 0%",
-    "inherited": false
-  },
-  {
-    "name": "z-index",
-    "syntax": "auto | <integer> | inherit",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "column-gap",
-    "syntax": "normal | <length-percentage [0,∞]>",
-    "computed": [
-      "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn"
-    ],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "break-after",
-    "syntax": "auto | avoid | always | all | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "line-height",
-    "syntax": "normal | <number [0,∞]> | <length-percentage [0,∞]>",
-    "computed": [
-      "absoluteLengthOrAsSpecified"
-    ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "mask-border-width",
-    "syntax": "[ <length-percentage> | <number> | auto ]{1,4}",
-    "computed": [
-      "asSpecifiedRelativeToAbsoluteLengths"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "bookmark-state",
-    "syntax": "open | closed",
-    "computed": [],
-    "initial": "open",
-    "inherited": false
-  },
-  {
-    "name": "background-size",
-    "syntax": "<bg-size>#",
-    "computed": [
-      "asSpecifiedRelativeToAbsoluteLengths"
-    ],
-    "initial": "auto auto",
-    "inherited": false
-  },
-  {
-    "name": "display",
-    "syntax": "[ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy> | <display-outside> || [ <display-inside> | math ]",
-    "computed": [
-      "asSpecifiedExceptPositionedFloatingAndRootElementsKeywordMaybeDifferent"
-    ],
-    "initial": "inline",
     "inherited": false
   },
   {
@@ -3485,8 +2483,17 @@
     "inherited": false
   },
   {
-    "name": "border-right-style",
-    "syntax": "<line-style>",
+    "name": "flex-wrap",
+    "syntax": "nowrap | wrap | wrap-reverse",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "nowrap",
+    "inherited": false
+  },
+  {
+    "name": "float",
+    "syntax": "block-start | block-end | inline-start | inline-end | snap-block | <snap-block()> | snap-inline | <snap-inline()> | left | right | top | bottom | none | footnote",
     "computed": [
       "asSpecified"
     ],
@@ -3494,432 +2501,93 @@
     "inherited": false
   },
   {
-    "name": "baseline-source",
-    "syntax": "auto | first | last",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "text-orientation",
-    "syntax": "mixed | upright | sideways",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "mixed",
-    "inherited": true
-  },
-  {
-    "name": "text-align-last",
-    "syntax": "auto | start | end | left | right | center | justify | match-parent",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "orphans",
-    "syntax": "<integer [1,∞]>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "2",
-    "inherited": true
-  },
-  {
-    "name": "border-block-start-width",
-    "syntax": "<line-width>",
-    "computed": [
-      "absoluteLengthZeroIfBorderStyleNoneOrHidden"
-    ],
-    "initial": "medium",
-    "inherited": false
-  },
-  {
-    "name": "cue-before",
-    "syntax": "<uri> <decibel>? | none",
+    "name": "float-defer",
+    "syntax": "<integer> | last | none",
     "computed": [],
     "initial": "none",
     "inherited": false
   },
   {
-    "name": "y",
+    "name": "float-offset",
     "syntax": "<length-percentage>",
     "computed": [],
     "initial": "0",
     "inherited": false
   },
   {
-    "name": "content",
-    "syntax": "normal | none | [ <content-replacement> | <content-list> ] [/ [ <string> | <counter> | <attr()> ]+ ]? | <element()>",
-    "computed": [
-      "normalOnElementsForPseudosNoneAbsoluteURIStringOrAsSpecified"
-    ],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "break-before",
-    "syntax": "auto | avoid | always | all | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-text-stroke-width",
-    "syntax": "<line-width>",
-    "computed": [
-      "absoluteLength"
-    ],
-    "initial": "0",
-    "inherited": true
-  },
-  {
-    "name": "min-inline-size",
-    "syntax": "<'min-width'>",
-    "computed": [
-      "sameAsMinWidthAndMinHeight"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "clear",
-    "syntax": "inline-start | inline-end | block-start | block-end | left | right | top | bottom | both-inline | both-block | both | none",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "transition-duration",
-    "syntax": "<time [0s,∞]>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "0s",
-    "inherited": false
-  },
-  {
-    "name": "border-block-start-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
+    "name": "float-reference",
+    "syntax": "inline | column | region | page",
     "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "voice-balance",
-    "syntax": "<number> | left | center | right | leftwards | rightwards",
-    "computed": [],
-    "initial": "center",
-    "inherited": true
-  },
-  {
-    "name": "color-adjust",
-    "syntax": "<'print-color-adjust'>",
-    "computed": [],
-    "initial": "see individual properties",
-    "inherited": false
-  },
-  {
-    "name": "stroke-miterlimit",
-    "syntax": "<number>",
-    "computed": [],
-    "initial": "4",
-    "inherited": true
-  },
-  {
-    "name": "border-image-width",
-    "syntax": "[ <length-percentage [0,∞]> | <number [0,∞]> | auto ]{1,4}",
-    "computed": [
-      "asSpecifiedRelativeToAbsoluteLengths"
-    ],
-    "initial": "1",
-    "inherited": false
-  },
-  {
-    "name": "mask-clip",
-    "syntax": "[ <coord-box> | no-clip ]#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "border-box",
-    "inherited": false
-  },
-  {
-    "name": "row-gap",
-    "syntax": "normal | <length-percentage [0,∞]>",
-    "computed": [
-      "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn"
-    ],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "column-width",
-    "syntax": "auto | <length [0,∞]> | min-content | max-content | fit-content(<length-percentage>)",
-    "computed": [
-      "absoluteLengthZeroOrLarger"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "scroll-padding-left",
-    "syntax": "auto | <length-percentage [0,∞]>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "animation-range-start",
-    "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
-    "computed": [
-      "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage"
-    ],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "max-height",
-    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()>",
-    "computed": [
-      "percentageAsSpecifiedAbsoluteLengthOrNone"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "font-synthesis-position",
-    "syntax": "auto | none",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "border-top-width",
-    "syntax": "<line-width>",
-    "computed": [
-      "absoluteLengthOr0IfBorderTopStyleNoneOrHidden"
-    ],
-    "initial": "medium",
-    "inherited": false
-  },
-  {
-    "name": "border-inline-width",
-    "syntax": "<'border-top-width'>{1,2}",
-    "computed": [
-      "absoluteLengthZeroIfBorderStyleNoneOrHidden"
-    ],
-    "initial": "medium",
-    "inherited": false
-  },
-  {
-    "name": "grid-auto-columns",
-    "syntax": "<track-size>+",
-    "computed": [
-      "percentageAsSpecifiedOrAbsoluteLength"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "border-bottom-color",
-    "syntax": "<color> | <image-1D>",
-    "computed": [
-      "computedColor"
-    ],
-    "initial": "currentcolor",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-text-fill-color",
-    "syntax": "<color>",
-    "computed": [
-      "computedColor"
-    ],
-    "initial": "currentcolor",
-    "inherited": true
-  },
-  {
-    "name": "-webkit-backface-visibility",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-box-shadow",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-perspective",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "pause-after",
-    "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "caption-side",
-    "syntax": "top | bottom",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "top",
-    "inherited": true
-  },
-  {
-    "name": "position-try-order",
-    "syntax": "normal | <try-size>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "offset-position",
-    "syntax": "normal | auto | <position>",
-    "computed": [
-      "forLengthAbsoluteValueOtherwisePercentage"
-    ],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "border-clip-left",
-    "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
-    "computed": [],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "r",
-    "syntax": "<length-percentage>",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "place-self",
-    "syntax": "<'align-self'> <'justify-self'>?",
-    "computed": [
-      "align-self",
-      "justify-self"
-    ],
-    "initial": [
-      "align-self",
-      "justify-self"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "scrollbar-color",
-    "syntax": "auto | <color>{2}",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "block-step-round",
-    "syntax": "up | down | nearest",
-    "computed": [],
-    "initial": "up",
-    "inherited": false
-  },
-  {
-    "name": "marker-mid",
-    "syntax": "none | <marker-ref>",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "inline-size",
-    "syntax": "<'width'>",
-    "computed": [
-      "sameAsWidthAndHeight"
-    ],
-    "initial": "auto",
+    "initial": "inline",
     "inherited": false
   },
   {
     "name": "flood-color",
     "syntax": "<color>",
-    "computed": [],
+    "computed": [
+      "asSpecified"
+    ],
     "initial": "black",
     "inherited": false
   },
   {
-    "name": "caret",
-    "syntax": "<'caret-color'> || <'caret-animation'> || <'caret-shape'>",
+    "name": "flood-opacity",
+    "syntax": "<'opacity'>",
     "computed": [
-      "caret-color",
-      "caret-shape"
+      "specifiedValueClipped0To1"
+    ],
+    "initial": "black",
+    "inherited": false
+  },
+  {
+    "name": "flow-from",
+    "syntax": "<ident> | none",
+    "computed": [],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "flow-into",
+    "syntax": "none | <ident> [element | content]?",
+    "computed": [],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "font",
+    "syntax": "[ [ <'font-style'> || <font-variant-css2> || <'font-weight'> || <font-width-css3> ]? <'font-size'> [ / <'line-height'> ]? <'font-family'># ] | <system-family-name>",
+    "computed": [
+      "font-style",
+      "font-variant",
+      "font-weight",
+      "font-stretch",
+      "font-size",
+      "line-height",
+      "font-family"
     ],
     "initial": [
-      "caret-color",
-      "caret-shape"
+      "font-style",
+      "font-variant",
+      "font-weight",
+      "font-stretch",
+      "font-size",
+      "line-height",
+      "font-family"
     ],
     "inherited": true
   },
   {
-    "name": "border-inline-start-color",
-    "syntax": "<color> | <image-1D>",
-    "computed": [
-      "computedColor"
-    ],
-    "initial": "currentcolor",
-    "inherited": false
-  },
-  {
-    "name": "border-end-start-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2}",
-    "computed": [
-      "twoAbsoluteLengthOrPercentages"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "column-count",
-    "syntax": "auto | <integer [1,∞]>",
+    "name": "font-family",
+    "syntax": "[ <family-name> | <generic-family> ]#",
     "computed": [
       "asSpecified"
     ],
-    "initial": "auto",
-    "inherited": false
+    "initial": "dependsOnUserAgent",
+    "inherited": true
   },
   {
-    "name": "stop-opacity",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "math-style",
-    "syntax": "normal | compact",
+    "name": "font-feature-settings",
+    "syntax": "normal | <feature-tag-value>#",
     "computed": [
       "asSpecified"
     ],
@@ -3927,19 +2595,30 @@
     "inherited": true
   },
   {
-    "name": "appearance",
-    "syntax": "none | auto | <compat-auto> | <compat-special>",
+    "name": "font-kerning",
+    "syntax": "auto | normal | none",
     "computed": [
       "asSpecified"
     ],
-    "initial": "none",
-    "inherited": false
+    "initial": "auto",
+    "inherited": true
   },
   {
-    "name": "stroke-dash-corner",
-    "syntax": "none | <length>",
-    "computed": [],
-    "initial": "none",
+    "name": "font-language-override",
+    "syntax": "normal | <string>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "font-optical-sizing",
+    "syntax": "auto | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
     "inherited": true
   },
   {
@@ -3952,373 +2631,26 @@
     "inherited": true
   },
   {
-    "name": "text-justify",
-    "syntax": "auto | none | inter-word | inter-character",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "-webkit-animation-delay",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "shape-subtract",
-    "syntax": "none | [ <basic-shape>| <uri> ]+",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "scroll-snap-stop",
-    "syntax": "normal | always",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "list-style",
-    "syntax": "<'list-style-position'> || <'list-style-image'> || <'list-style-type'>",
-    "computed": [
-      "list-style-image",
-      "list-style-position",
-      "list-style-type"
-    ],
-    "initial": [
-      "list-style-type",
-      "list-style-position",
-      "list-style-image"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "margin-break",
-    "syntax": "auto | keep | discard",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "border-left-width",
-    "syntax": "<line-width>",
-    "computed": [
-      "absoluteLengthOr0IfBorderLeftStyleNoneOrHidden"
-    ],
-    "initial": "medium",
-    "inherited": false
-  },
-  {
-    "name": "overflow-inline",
-    "syntax": "visible | hidden | clip | scroll | auto",
-    "computed": [
-      "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "block-size",
-    "syntax": "<'width'>",
-    "computed": [
-      "sameAsWidthAndHeight"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "overscroll-behavior",
-    "syntax": "[ contain | none | auto ]{1,2}",
-    "computed": [
-      "overscroll-behavior-x",
-      "overscroll-behavior-y"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "margin-bottom",
-    "syntax": "<length-percentage> | auto",
-    "computed": [
-      "percentageAsSpecifiedOrAbsoluteLength"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "padding-right",
-    "syntax": "<length-percentage [0,∞]>",
-    "computed": [
-      "percentageAsSpecifiedOrAbsoluteLength"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "page-break-before",
-    "syntax": "auto | always | avoid | left | right | inherit",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "box-shadow-blur",
-    "syntax": "<length [0,∞]>#",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-animation-play-state",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "fill-size",
-    "syntax": "<bg-size>#",
-    "computed": [],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "clip",
-    "syntax": "<rect()> | auto",
-    "computed": [
-      "autoOrRectangle"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "mask-composite",
-    "syntax": "<compositing-operator>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "add",
-    "inherited": false
-  },
-  {
-    "name": "border-inline-start-style",
-    "syntax": "<line-style>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "box-shadow-color",
-    "syntax": "<color>#",
-    "computed": [],
-    "initial": "currentcolor",
-    "inherited": false
-  },
-  {
-    "name": "stroke-image",
-    "syntax": "<paint>#",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "background-color",
-    "syntax": "<color>",
-    "computed": [
-      "computedColor"
-    ],
-    "initial": "transparent",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-mask-position",
-    "syntax": "",
-    "computed": [
-      "absoluteLengthOrPercentage"
-    ],
-    "initial": "0% 0%",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-box-ordinal-group",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "initial-letter",
-    "syntax": "normal | <number [1,∞]> <integer [1,∞]> | <number [1,∞]> && [ drop | raise ]?",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "d",
-    "syntax": "none | <string>",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "list-style-position",
-    "syntax": "inside | outside",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "outside",
-    "inherited": true
-  },
-  {
-    "name": "float-reference",
-    "syntax": "inline | column | region | page",
-    "computed": [],
-    "initial": "inline",
-    "inherited": false
-  },
-  {
     "name": "font-size",
     "syntax": "<absolute-size> | <relative-size> | <length-percentage [0,∞]> | math",
     "computed": [
-      "asSpecifiedRelativeToAbsoluteLengths"
+      "absoluteLength"
     ],
     "initial": "medium",
     "inherited": true
   },
   {
-    "name": "grid-row-end",
-    "syntax": "<grid-line>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "border-clip",
-    "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
-    "computed": [],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "padding-inline",
-    "syntax": "<'padding-top'>{1,2}",
-    "computed": [
-      "padding-inline-start",
-      "padding-inline-end"
-    ],
-    "initial": [
-      "padding-inline-start",
-      "padding-inline-end"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "lighting-color",
-    "syntax": "<color>",
-    "computed": [],
-    "initial": "white",
-    "inherited": false
-  },
-  {
-    "name": "math-shift",
-    "syntax": "normal | compact",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "mask-border-slice",
-    "syntax": "[ <number> | <percentage> ]{1,4} fill?",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "scroll-snap-type",
-    "syntax": "none | [ x | y | block | inline | both ] [ mandatory | proximity ]?",
+    "name": "font-size-adjust",
+    "syntax": "none | <number [0,∞]>",
     "computed": [
       "asSpecified"
     ],
     "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "transition",
-    "syntax": "<single-transition>#",
-    "computed": [
-      "transition-delay",
-      "transition-duration",
-      "transition-property",
-      "transition-timing-function",
-      "transition-behavior"
-    ],
-    "initial": [
-      "transition-delay",
-      "transition-duration",
-      "transition-property",
-      "transition-timing-function",
-      "transition-behavior"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "-webkit-animation",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "baseline-shift",
-    "syntax": "<length-percentage> | sub | super | top | center | bottom",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "stroke-break",
-    "syntax": "bounding-box | slice | clone",
-    "computed": [],
-    "initial": "bounding-box",
-    "inherited": false
-  },
-  {
-    "name": "stroke-dashoffset",
-    "syntax": "<length-percentage> | <number>",
-    "computed": [],
-    "initial": "0",
     "inherited": true
   },
   {
-    "name": "animation-iteration-count",
-    "syntax": "<single-animation-iteration-count>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "1",
-    "inherited": false
-  },
-  {
-    "name": "align-items",
-    "syntax": "normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ] | anchor-center",
+    "name": "font-stretch",
+    "syntax": "",
     "computed": [
       "asSpecified"
     ],
@@ -4326,21 +2658,8 @@
     "inherited": false
   },
   {
-    "name": "grid-row",
-    "syntax": "<grid-line> [ / <grid-line> ]?",
-    "computed": [
-      "grid-row-start",
-      "grid-row-end"
-    ],
-    "initial": [
-      "grid-row-start",
-      "grid-row-end"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "paint-order",
-    "syntax": "normal | [ fill || stroke || markers ]",
+    "name": "font-style",
+    "syntax": "normal | italic | oblique <angle [-90deg,90deg]>?",
     "computed": [
       "asSpecified"
     ],
@@ -4348,111 +2667,189 @@
     "inherited": true
   },
   {
-    "name": "stop-color",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "padding-inline-end",
-    "syntax": "<'padding-top'>",
-    "computed": [
-      "asLength"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "animation-play-state",
-    "syntax": "<single-animation-play-state>#",
+    "name": "font-synthesis",
+    "syntax": "none | [ weight || style || small-caps || position]",
     "computed": [
       "asSpecified"
     ],
-    "initial": "running",
-    "inherited": false
-  },
-  {
-    "name": "word-spacing",
-    "syntax": "normal | <length>",
-    "computed": [
-      "absoluteLength"
-    ],
-    "initial": "normal",
+    "initial": "weight style small-caps position ",
     "inherited": true
   },
   {
-    "name": "-webkit-mask",
-    "syntax": "",
-    "computed": [
-      "-webkit-mask-image",
-      "-webkit-mask-repeat",
-      "-webkit-mask-attachment",
-      "-webkit-mask-position",
-      "-webkit-mask-origin",
-      "-webkit-mask-clip"
-    ],
-    "initial": [
-      "-webkit-mask-image",
-      "-webkit-mask-repeat",
-      "-webkit-mask-attachment",
-      "-webkit-mask-position",
-      "-webkit-mask-origin",
-      "-webkit-mask-clip"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "ruby-overhang",
+    "name": "font-synthesis-position",
     "syntax": "auto | none",
-    "computed": [],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "text-emphasis-color",
-    "syntax": "<color>",
-    "computed": [
-      "computedColor"
-    ],
-    "initial": "currentcolor",
-    "inherited": true
-  },
-  {
-    "name": "position-try-fallbacks",
-    "syntax": "none | [ [<dashed-ident> || <try-tactic>] | <'position-area'> ]#",
     "computed": [
       "asSpecified"
     ],
     "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "inset-inline-start",
-    "syntax": "auto | <length-percentage>",
-    "computed": [
-      "sameAsBoxOffsets"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "will-change",
-    "syntax": "auto | <animateable-feature>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "font-family",
-    "syntax": "[ <family-name> | <generic-family> ]#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "dependsOnUserAgent",
     "inherited": true
+  },
+  {
+    "name": "font-synthesis-small-caps",
+    "syntax": "auto | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "font-synthesis-style",
+    "syntax": "auto | none | oblique-only",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "font-synthesis-weight",
+    "syntax": "auto | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "font-variant",
+    "syntax": "normal | none | [ [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ] || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ] || [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ] || [ <east-asian-variant-values> || <east-asian-width-values> || ruby ] || [ sub | super ] || [ text | emoji | unicode ] ]",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "font-variant-alternates",
+    "syntax": "normal | [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ]",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "font-variant-caps",
+    "syntax": "normal | small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "font-variant-east-asian",
+    "syntax": "normal | [ <east-asian-variant-values> || <east-asian-width-values> || ruby ]",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "font-variant-emoji",
+    "syntax": "normal | text | emoji | unicode",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "font-variant-ligatures",
+    "syntax": "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ]",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "font-variant-numeric",
+    "syntax": "normal | [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ]",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "font-variant-position",
+    "syntax": "normal | sub | super",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "font-variation-settings",
+    "syntax": "normal | [ <opentype-tag> <number>]#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "font-weight",
+    "syntax": "<font-weight-absolute> | bolder | lighter",
+    "computed": [
+      "keywordOrNumericalValueBolderLighterTransformedToRealValue"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "font-width",
+    "syntax": "normal | <percentage [0,∞]> | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded",
+    "computed": [],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "footnote-display",
+    "syntax": "block | inline | compact",
+    "computed": [],
+    "initial": "block",
+    "inherited": false
+  },
+  {
+    "name": "footnote-policy",
+    "syntax": "auto | line | block",
+    "computed": [],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "forced-color-adjust",
+    "syntax": "auto | none | preserve-parent-color",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "gap",
+    "syntax": "<'row-gap'> <'column-gap'>?",
+    "computed": [
+      "row-gap",
+      "column-gap"
+    ],
+    "initial": [
+      "row-gap",
+      "column-gap"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "glyph-orientation-vertical",
+    "syntax": "auto | 0deg | 90deg | 0 | 90",
+    "computed": [],
+    "initial": "n/a",
+    "inherited": false
   },
   {
     "name": "grid",
@@ -4484,113 +2881,6 @@
     "inherited": false
   },
   {
-    "name": "position-anchor",
-    "syntax": "auto | <anchor-element>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "implicit",
-    "inherited": false
-  },
-  {
-    "name": "view-timeline-inset",
-    "syntax": "[ [ auto | <length-percentage> ]{1,2} ]#",
-    "computed": [
-      "listEachItemConsistingOfPairsOfAutoOrLengthPercentage"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "background-attachment",
-    "syntax": "<attachment>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "scroll",
-    "inherited": false
-  },
-  {
-    "name": "clip-rule",
-    "syntax": "nonzero | evenodd",
-    "computed": [],
-    "initial": "nonzero",
-    "inherited": true
-  },
-  {
-    "name": "-webkit-mask-box-image-repeat",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "min-block-size",
-    "syntax": "<'min-width'>",
-    "computed": [
-      "sameAsMinWidthAndMinHeight"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "font",
-    "syntax": "[ [ <'font-style'> || <font-variant-css2> || <'font-weight'> || <font-width-css3> ]? <'font-size'> [ / <'line-height'> ]? <'font-family'> ] | <system-family-name>",
-    "computed": [
-      "font-style",
-      "font-variant",
-      "font-weight",
-      "font-stretch",
-      "font-size",
-      "line-height",
-      "font-family"
-    ],
-    "initial": [
-      "font-style",
-      "font-variant",
-      "font-weight",
-      "font-stretch",
-      "font-size",
-      "line-height",
-      "font-family"
-    ],
-    "inherited": true
-  },
-  {
-    "name": "animation",
-    "syntax": "<single-animation>#",
-    "computed": [
-      "animation-name",
-      "animation-duration",
-      "animation-timing-function",
-      "animation-delay",
-      "animation-direction",
-      "animation-iteration-count",
-      "animation-fill-mode",
-      "animation-play-state",
-      "animation-timeline"
-    ],
-    "initial": [
-      "animation-name",
-      "animation-duration",
-      "animation-timing-function",
-      "animation-delay",
-      "animation-iteration-count",
-      "animation-direction",
-      "animation-fill-mode",
-      "animation-play-state",
-      "animation-timeline"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "glyph-orientation-vertical",
-    "syntax": "auto | 0deg | 90deg | 0 | 90",
-    "computed": [],
-    "initial": "n/a",
-    "inherited": false
-  },
-  {
     "name": "grid-area",
     "syntax": "<grid-line> [ / <grid-line> ]{0,3}",
     "computed": [
@@ -4608,189 +2898,30 @@
     "inherited": false
   },
   {
-    "name": "border-top-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-transform",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "block-step-align",
-    "syntax": "auto | center | start | end",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "scroll-padding-right",
-    "syntax": "auto | <length-percentage [0,∞]>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "field-sizing",
-    "syntax": "fixed | content",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "fixed",
-    "inherited": false
-  },
-  {
-    "name": "fill-position",
-    "syntax": "<position>#",
-    "computed": [],
-    "initial": "0% 0%",
-    "inherited": true
-  },
-  {
-    "name": "grid-column-gap",
-    "syntax": "",
+    "name": "grid-auto-columns",
+    "syntax": "<track-size>+",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "text-box-edge",
-    "syntax": "auto | <text-edge>",
-    "computed": [],
     "initial": "auto",
     "inherited": false
   },
   {
-    "name": "overflow",
-    "syntax": "<'overflow-block'>{1,2}",
-    "computed": [
-      "overflow-x",
-      "overflow-y"
-    ],
-    "initial": "visible",
-    "inherited": false
-  },
-  {
-    "name": "counter-increment",
-    "syntax": "[ <counter-name> <integer>? ]+ | none",
+    "name": "grid-auto-flow",
+    "syntax": "[ row | column ] || dense",
     "computed": [
       "asSpecified"
     ],
-    "initial": "none",
+    "initial": "row",
     "inherited": false
   },
   {
-    "name": "caret-shape",
-    "syntax": "auto | bar | block | underscore",
+    "name": "grid-auto-rows",
+    "syntax": "<track-size>+",
     "computed": [
-      "asSpecified"
+      "percentageAsSpecifiedOrAbsoluteLength"
     ],
     "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "line-fit-edge",
-    "syntax": "leading | <text-edge>",
-    "computed": [],
-    "initial": "leading",
-    "inherited": true
-  },
-  {
-    "name": "-webkit-box-sizing",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-mask-box-image",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "spatial-navigation-contain",
-    "syntax": "auto | contain",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "margin-block",
-    "syntax": "<'margin-top'>{1,2}",
-    "computed": [
-      "margin-block-start",
-      "margin-block-end"
-    ],
-    "initial": [
-      "margin-block-start",
-      "margin-block-end"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "box-snap",
-    "syntax": "none | block-start | block-end | center | baseline | last-baseline",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "font-synthesis-weight",
-    "syntax": "auto | none",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "clip-path",
-    "syntax": "<clip-source> | [ <basic-shape> || <geometry-box> ] | none",
-    "computed": [
-      "asSpecifiedURLsAbsolute"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "mask-border-repeat",
-    "syntax": "[ stretch | repeat | round | space ]{1,2}",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "stretch",
-    "inherited": false
-  },
-  {
-    "name": "mask-border",
-    "syntax": "<'mask-border-source'> || <'mask-border-slice'> [ / <'mask-border-width'>? [ / <'mask-border-outset'> ]? ]? || <'mask-border-repeat'> || <'mask-border-mode'>",
-    "computed": [
-      "mask-border-mode",
-      "mask-border-outset",
-      "mask-border-repeat",
-      "mask-border-slice",
-      "mask-border-source",
-      "mask-border-width"
-    ],
-    "initial": [
-      "mask-border-mode",
-      "mask-border-outset",
-      "mask-border-repeat",
-      "mask-border-slice",
-      "mask-border-source",
-      "mask-border-width"
-    ],
     "inherited": false
   },
   {
@@ -4807,234 +2938,235 @@
     "inherited": false
   },
   {
-    "name": "string-set",
-    "syntax": "none | [ <custom-ident> <string>+ ]#",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "border-bottom-style",
-    "syntax": "<line-style>",
+    "name": "grid-column-end",
+    "syntax": "<grid-line>",
     "computed": [
       "asSpecified"
     ],
-    "initial": "none",
+    "initial": "auto",
     "inherited": false
   },
   {
-    "name": "-webkit-flex-wrap",
+    "name": "grid-column-gap",
     "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "border-boundary",
-    "syntax": "none | parent | display",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "scroll-padding-inline-start",
-    "syntax": "auto | <length-percentage [0,∞]>",
     "computed": [
-      "asSpecified"
+      "percentageAsSpecifiedOrAbsoluteLength"
     ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "list-style-image",
-    "syntax": "<image> | none",
-    "computed": [
-      "theKeywordListStyleImageNoneOrComputedValue"
-    ],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "mask-mode",
-    "syntax": "<masking-mode>#",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "match-source",
-    "inherited": false
-  },
-  {
-    "name": "wrap-flow",
-    "syntax": "auto | both | start | end | minimum | maximum | clear",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "border-right-color",
-    "syntax": "<color> | <image-1D>",
-    "computed": [
-      "computedColor"
-    ],
-    "initial": "currentcolor",
-    "inherited": false
-  },
-  {
-    "name": "border-block-start",
-    "syntax": "<line-width> || <line-style> || <color>",
-    "computed": [
-      "border-width",
-      "border-style",
-      "border-block-start-color"
-    ],
-    "initial": [
-      "border-width",
-      "border-style",
-      "color"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "bookmark-level",
-    "syntax": "none | <integer [1,∞]>",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "ruby-align",
-    "syntax": "start | center | space-between | space-around",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "space-around",
-    "inherited": true
-  },
-  {
-    "name": "font-variant-ligatures",
-    "syntax": "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ]",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "font-variant-alternates",
-    "syntax": "normal | [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ]",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "block-step-size",
-    "syntax": "none | <length [0,∞]>",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "stroke-linecap",
-    "syntax": "butt | round | square",
-    "computed": [],
-    "initial": "butt",
-    "inherited": true
-  },
-  {
-    "name": "border-inline",
-    "syntax": "<'border-block-start'>",
-    "computed": [
-      "border-inline-width",
-      "border-inline-style",
-      "border-inline-color"
-    ],
-    "initial": [
-      "border-inline-width",
-      "border-inline-style",
-      "border-inline-color"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "border-inline-start-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-    "computed": [],
     "initial": "0",
     "inherited": false
   },
   {
-    "name": "text-box-trim",
-    "syntax": "none | trim-start | trim-end | trim-both",
-    "computed": [],
+    "name": "grid-column-start",
+    "syntax": "<grid-line>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "grid-gap",
+    "syntax": "",
+    "computed": [
+      "grid-row-gap",
+      "grid-column-gap"
+    ],
+    "initial": [
+      "grid-row-gap",
+      "grid-column-gap"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "grid-row",
+    "syntax": "<grid-line> [ / <grid-line> ]?",
+    "computed": [
+      "grid-row-start",
+      "grid-row-end"
+    ],
+    "initial": [
+      "grid-row-start",
+      "grid-row-end"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "grid-row-end",
+    "syntax": "<grid-line>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "grid-row-gap",
+    "syntax": "",
+    "computed": [
+      "percentageAsSpecifiedOrAbsoluteLength"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "grid-row-start",
+    "syntax": "<grid-line>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "grid-template",
+    "syntax": "none | [ <'grid-template-rows'> / <'grid-template-columns'> ] | [ <line-names>? <string> <track-size>? <line-names>? ]+ [ / <explicit-track-list> ]?",
+    "computed": [
+      "grid-template-columns",
+      "grid-template-rows",
+      "grid-template-areas"
+    ],
+    "initial": [
+      "grid-template-columns",
+      "grid-template-rows",
+      "grid-template-areas"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "grid-template-areas",
+    "syntax": "none | <string>+",
+    "computed": [
+      "asSpecified"
+    ],
     "initial": "none",
     "inherited": false
   },
   {
-    "name": "ry",
-    "syntax": "<length-percentage> | auto",
-    "computed": [],
+    "name": "grid-template-columns",
+    "syntax": "none | <track-list> | <auto-track-list> | subgrid <line-name-list>?",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "grid-template-rows",
+    "syntax": "none | <track-list> | <auto-track-list> | subgrid <line-name-list>?",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "hanging-punctuation",
+    "syntax": "none | [ first || [ force-end | allow-end ] || last ]",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "height",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "computed": [
+      "percentageAutoOrAbsoluteLength"
+    ],
     "initial": "auto",
     "inherited": false
+  },
+  {
+    "name": "hyphens",
+    "syntax": "none | manual | auto",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "manual",
+    "inherited": true
+  },
+  {
+    "name": "image-orientation",
+    "syntax": "from-image | none | [ <angle> || flip ]",
+    "computed": [
+      "angleRoundedToNextQuarter"
+    ],
+    "initial": "from-image",
+    "inherited": true
+  },
+  {
+    "name": "image-rendering",
+    "syntax": "auto | smooth | high-quality | pixelated | crisp-edges",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "initial-letter",
+    "syntax": "normal | <number [1,∞]> <integer [1,∞]> | <number [1,∞]> && [ drop | raise ]?",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "initial-letter-align",
+    "syntax": "[ border-box? [ alphabetic | ideographic | hanging | leading ]? ]!",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "initial-letter-wrap",
+    "syntax": "none | first | all | grid | <length-percentage>",
+    "computed": [],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "inline-size",
+    "syntax": "<'width'>",
+    "computed": [
+      "sameAsWidthAndHeight"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "inline-sizing",
+    "syntax": "normal | stretch",
+    "computed": [],
+    "initial": "normal",
+    "inherited": true
   },
   {
     "name": "input-security",
     "syntax": "auto | none",
-    "computed": [
-      "asSpecified"
-    ],
+    "computed": [],
     "initial": "auto",
     "inherited": false
   },
   {
-    "name": "font-variant-caps",
-    "syntax": "normal | small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps",
+    "name": "inset",
+    "syntax": "<'top'>{1,4}",
     "computed": [
-      "asSpecified"
+      "top",
+      "bottom",
+      "left",
+      "right"
     ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "justify-items",
-    "syntax": "normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | legacy | legacy && [ left | right | center ] | anchor-center",
-    "computed": [
-      "asSpecified"
+    "initial": [
+      "top",
+      "bottom",
+      "left",
+      "right"
     ],
-    "initial": "legacy",
-    "inherited": false
-  },
-  {
-    "name": "offset-distance",
-    "syntax": "<length-percentage>",
-    "computed": [
-      "forLengthAbsoluteValueOtherwisePercentage"
-    ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "grid-auto-flow",
-    "syntax": "[ row | column ] || dense",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "row",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-transform-origin",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "line-grid",
-    "syntax": "match-parent | create",
-    "computed": [],
-    "initial": "match-parent",
     "inherited": false
   },
   {
@@ -5051,13 +3183,398 @@
     "inherited": false
   },
   {
-    "name": "resize",
-    "syntax": "none | both | horizontal | vertical | block | inline",
+    "name": "inset-block-end",
+    "syntax": "auto | <length-percentage>",
+    "computed": [
+      "sameAsBoxOffsets"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "inset-block-start",
+    "syntax": "auto | <length-percentage>",
+    "computed": [
+      "sameAsBoxOffsets"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "inset-inline",
+    "syntax": "<'top'>{1,2}",
+    "computed": [
+      "inset-inline-start",
+      "inset-inline-end"
+    ],
+    "initial": [
+      "inset-inline-start",
+      "inset-inline-end"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "inset-inline-end",
+    "syntax": "auto | <length-percentage>",
+    "computed": [
+      "sameAsBoxOffsets"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "inset-inline-start",
+    "syntax": "auto | <length-percentage>",
+    "computed": [
+      "sameAsBoxOffsets"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "interactivity",
+    "syntax": "auto | inert",
+    "computed": [],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "isolation",
+    "syntax": "<isolation-mode>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "justify-content",
+    "syntax": "normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ]",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "justify-items",
+    "syntax": "normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | legacy | legacy && [ left | right | center ] | anchor-center",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "legacy",
+    "inherited": false
+  },
+  {
+    "name": "justify-self",
+    "syntax": "auto | normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | anchor-center",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "left",
+    "syntax": "auto | <length-percentage> | <anchor()> | <anchor-size()>",
+    "computed": [
+      "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "letter-spacing",
+    "syntax": "normal | <length>",
+    "computed": [
+      "optimumValueOfAbsoluteLengthOrNormal"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "lighting-color",
+    "syntax": "<color>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "white",
+    "inherited": false
+  },
+  {
+    "name": "line-break",
+    "syntax": "auto | loose | normal | strict | anywhere",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "line-fit-edge",
+    "syntax": "leading | <text-edge>",
+    "computed": [],
+    "initial": "leading",
+    "inherited": true
+  },
+  {
+    "name": "line-grid",
+    "syntax": "match-parent | create",
+    "computed": [],
+    "initial": "match-parent",
+    "inherited": false
+  },
+  {
+    "name": "line-height",
+    "syntax": "normal | <number [0,∞]> | <length-percentage [0,∞]>",
+    "computed": [
+      "absoluteLengthOrAsSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "line-height-step",
+    "syntax": "<length [0,∞]>",
+    "computed": [
+      "absoluteLength"
+    ],
+    "initial": "0",
+    "inherited": true
+  },
+  {
+    "name": "line-snap",
+    "syntax": "none | baseline | contain",
+    "computed": [],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "link-parameters",
+    "syntax": "none | <link-param>+",
+    "computed": [],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "list-style",
+    "syntax": "<'list-style-position'> || <'list-style-image'> || <'list-style-type'>",
+    "computed": [
+      "list-style-image",
+      "list-style-position",
+      "list-style-type"
+    ],
+    "initial": [
+      "list-style-type",
+      "list-style-position",
+      "list-style-image"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "list-style-image",
+    "syntax": "<image> | none",
+    "computed": [
+      "theKeywordListStyleImageNoneOrComputedValue"
+    ],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "list-style-position",
+    "syntax": "inside | outside",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "outside",
+    "inherited": true
+  },
+  {
+    "name": "list-style-type",
+    "syntax": "<counter-style> | <string> | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "disc",
+    "inherited": true
+  },
+  {
+    "name": "margin",
+    "syntax": "<'margin-top'>{1,4}",
+    "computed": [
+      "margin-bottom",
+      "margin-left",
+      "margin-right",
+      "margin-top"
+    ],
+    "initial": [
+      "margin-bottom",
+      "margin-left",
+      "margin-right",
+      "margin-top"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "margin-block",
+    "syntax": "<'margin-top'>{1,2}",
+    "computed": [
+      "margin-block-start",
+      "margin-block-end"
+    ],
+    "initial": [
+      "margin-block-start",
+      "margin-block-end"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "margin-block-end",
+    "syntax": "<'margin-top'>",
+    "computed": [
+      "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "margin-block-start",
+    "syntax": "<'margin-top'>",
+    "computed": [
+      "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "margin-bottom",
+    "syntax": "<length-percentage> | auto | <anchor-size()>",
+    "computed": [
+      "percentageAsSpecifiedOrAbsoluteLength"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "margin-break",
+    "syntax": "auto | keep | discard",
+    "computed": [],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "margin-inline",
+    "syntax": "<'margin-top'>{1,2}",
+    "computed": [
+      "margin-inline-start",
+      "margin-inline-end"
+    ],
+    "initial": [
+      "margin-inline-start",
+      "margin-inline-end"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "margin-inline-end",
+    "syntax": "<'margin-top'>",
+    "computed": [
+      "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "margin-inline-start",
+    "syntax": "<'margin-top'>",
+    "computed": [
+      "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "margin-left",
+    "syntax": "<length-percentage> | auto | <anchor-size()>",
+    "computed": [
+      "percentageAsSpecifiedOrAbsoluteLength"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "margin-right",
+    "syntax": "<length-percentage> | auto | <anchor-size()>",
+    "computed": [
+      "percentageAsSpecifiedOrAbsoluteLength"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "margin-top",
+    "syntax": "<length-percentage> | auto | <anchor-size()>",
+    "computed": [
+      "percentageAsSpecifiedOrAbsoluteLength"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "margin-trim",
+    "syntax": "none | [ block || inline ] | [ block-start || inline-start || block-end || inline-end ]",
     "computed": [
       "asSpecified"
     ],
     "initial": "none",
     "inherited": false
+  },
+  {
+    "name": "marker",
+    "syntax": "none | <marker-ref>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": [
+      "marker-start",
+      "marker-mid",
+      "marker-end"
+    ],
+    "inherited": true
+  },
+  {
+    "name": "marker-end",
+    "syntax": "none | <marker-ref>",
+    "computed": [
+      "asSpecifiedURLsAbsolute"
+    ],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "marker-mid",
+    "syntax": "none | <marker-ref>",
+    "computed": [
+      "asSpecifiedURLsAbsolute"
+    ],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "marker-side",
+    "syntax": "match-self | match-parent",
+    "computed": [],
+    "initial": "match-self",
+    "inherited": true
+  },
+  {
+    "name": "marker-start",
+    "syntax": "none | <marker-ref>",
+    "computed": [
+      "asSpecifiedURLsAbsolute"
+    ],
+    "initial": "none",
+    "inherited": true
   },
   {
     "name": "mask",
@@ -5085,17 +3602,483 @@
     "inherited": false
   },
   {
-    "name": "-webkit-background-origin",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "mask-border",
+    "syntax": "<'mask-border-source'> || <'mask-border-slice'> [ / <'mask-border-width'>? [ / <'mask-border-outset'> ]? ]? || <'mask-border-repeat'> || <'mask-border-mode'>",
+    "computed": [
+      "mask-border-mode",
+      "mask-border-outset",
+      "mask-border-repeat",
+      "mask-border-slice",
+      "mask-border-source",
+      "mask-border-width"
+    ],
+    "initial": [
+      "mask-border-mode",
+      "mask-border-outset",
+      "mask-border-repeat",
+      "mask-border-slice",
+      "mask-border-source",
+      "mask-border-width"
+    ],
     "inherited": false
   },
   {
-    "name": "spatial-navigation-function",
-    "syntax": "normal | grid",
-    "computed": [],
+    "name": "mask-border-mode",
+    "syntax": "luminance | alpha",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "alpha",
+    "inherited": false
+  },
+  {
+    "name": "mask-border-outset",
+    "syntax": "[ <length> | <number> ]{1,4}",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "mask-border-repeat",
+    "syntax": "[ stretch | repeat | round | space ]{1,2}",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "stretch",
+    "inherited": false
+  },
+  {
+    "name": "mask-border-slice",
+    "syntax": "[ <number> | <percentage> ]{1,4} fill?",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "mask-border-source",
+    "syntax": "none | <image>",
+    "computed": [
+      "asSpecifiedURLsAbsolute"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "mask-border-width",
+    "syntax": "[ <length-percentage> | <number> | auto ]{1,4}",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "mask-clip",
+    "syntax": "[ <coord-box> | no-clip ]#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "border-box",
+    "inherited": false
+  },
+  {
+    "name": "mask-composite",
+    "syntax": "<compositing-operator>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "add",
+    "inherited": false
+  },
+  {
+    "name": "mask-image",
+    "syntax": "<mask-reference>#",
+    "computed": [
+      "asSpecifiedURLsAbsolute"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "mask-mode",
+    "syntax": "<masking-mode>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "match-source",
+    "inherited": false
+  },
+  {
+    "name": "mask-origin",
+    "syntax": "<coord-box>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "border-box",
+    "inherited": false
+  },
+  {
+    "name": "mask-position",
+    "syntax": "<position>#",
+    "computed": [
+      "consistsOfTwoKeywordsForOriginAndOffsets"
+    ],
+    "initial": "0% 0%",
+    "inherited": false
+  },
+  {
+    "name": "mask-repeat",
+    "syntax": "<repeat-style>#",
+    "computed": [
+      "consistsOfTwoDimensionKeywords"
+    ],
+    "initial": "repeat",
+    "inherited": false
+  },
+  {
+    "name": "mask-size",
+    "syntax": "<bg-size>#",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "mask-type",
+    "syntax": "luminance | alpha",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "luminance",
+    "inherited": false
+  },
+  {
+    "name": "math-depth",
+    "syntax": "auto-add | add(<integer>) | <integer>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
+    "inherited": true
+  },
+  {
+    "name": "math-shift",
+    "syntax": "normal | compact",
+    "computed": [
+      "asSpecified"
+    ],
     "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "math-style",
+    "syntax": "normal | compact",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "max-block-size",
+    "syntax": "<'max-width'>",
+    "computed": [
+      "sameAsMaxWidthAndMaxHeight"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "max-height",
+    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "computed": [
+      "percentageAsSpecifiedAbsoluteLengthOrNone"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "max-inline-size",
+    "syntax": "<'max-width'>",
+    "computed": [
+      "sameAsMaxWidthAndMaxHeight"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "max-width",
+    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "computed": [
+      "percentageAsSpecifiedAbsoluteLengthOrNone"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "min-block-size",
+    "syntax": "<'min-width'>",
+    "computed": [
+      "sameAsMinWidthAndMinHeight"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "min-height",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "computed": [
+      "percentageAsSpecifiedOrAbsoluteLength"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "min-inline-size",
+    "syntax": "<'min-width'>",
+    "computed": [
+      "sameAsMinWidthAndMinHeight"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "min-width",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "computed": [
+      "percentageAsSpecifiedOrAbsoluteLength"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "mix-blend-mode",
+    "syntax": "<blend-mode> | plus-darker | plus-lighter",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "nav-down",
+    "syntax": "auto | <id> [ current | root | <target-name> ]?",
+    "computed": [],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "nav-left",
+    "syntax": "auto | <id> [ current | root | <target-name> ]?",
+    "computed": [],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "nav-right",
+    "syntax": "auto | <id> [ current | root | <target-name> ]?",
+    "computed": [],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "nav-up",
+    "syntax": "auto | <id> [ current | root | <target-name> ]?",
+    "computed": [],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "object-fit",
+    "syntax": "fill | contain | cover | none | scale-down",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "fill",
+    "inherited": false
+  },
+  {
+    "name": "object-position",
+    "syntax": "<position>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "50% 50%",
+    "inherited": false
+  },
+  {
+    "name": "offset",
+    "syntax": "[ <'offset-position'>? [ <'offset-path'> [ <'offset-distance'> || <'offset-rotate'> ]? ]? ]! [ / <'offset-anchor'> ]?",
+    "computed": [
+      "offset-position",
+      "offset-path",
+      "offset-distance",
+      "offset-anchor",
+      "offset-rotate"
+    ],
+    "initial": [
+      "offset-position",
+      "offset-path",
+      "offset-distance",
+      "offset-anchor",
+      "offset-rotate"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "offset-anchor",
+    "syntax": "auto | <position>",
+    "computed": [
+      "forLengthAbsoluteValueOtherwisePercentage"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "offset-distance",
+    "syntax": "<length-percentage>",
+    "computed": [
+      "forLengthAbsoluteValueOtherwisePercentage"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "offset-path",
+    "syntax": "none | <offset-path> || <coord-box>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "offset-position",
+    "syntax": "normal | auto | <position>",
+    "computed": [
+      "forLengthAbsoluteValueOtherwisePercentage"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "offset-rotate",
+    "syntax": "[ auto | reverse ] || <angle>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "opacity",
+    "syntax": "<opacity-value>",
+    "computed": [
+      "specifiedValueNumberClipped0To1"
+    ],
+    "initial": "1",
+    "inherited": false
+  },
+  {
+    "name": "order",
+    "syntax": "<integer>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "orphans",
+    "syntax": "<integer [1,∞]>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "2",
+    "inherited": true
+  },
+  {
+    "name": "outline",
+    "syntax": "<'outline-width'> || <'outline-style'> || <'outline-color'>",
+    "computed": [
+      "outline-width",
+      "outline-style",
+      "outline-color"
+    ],
+    "initial": [
+      "outline-width",
+      "outline-style",
+      "outline-color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "outline-color",
+    "syntax": "auto | <color> | <image-1D>",
+    "computed": [
+      "autoForTranslucentColorRGBAOtherwiseRGB"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "outline-offset",
+    "syntax": "<length>",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "outline-style",
+    "syntax": "auto | <outline-line-style>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "outline-width",
+    "syntax": "<line-width>",
+    "computed": [
+      "absoluteLength0ForNone"
+    ],
+    "initial": "medium",
+    "inherited": false
+  },
+  {
+    "name": "overflow",
+    "syntax": "<'overflow-block'>{1,2}",
+    "computed": [
+      "overflow-x",
+      "overflow-y"
+    ],
+    "initial": "visible",
+    "inherited": false
+  },
+  {
+    "name": "overflow-anchor",
+    "syntax": "auto | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "overflow-block",
+    "syntax": "visible | hidden | clip | scroll | auto",
+    "computed": [
+      "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
+    ],
+    "initial": "auto",
     "inherited": false
   },
   {
@@ -5108,64 +4091,122 @@
     "inherited": false
   },
   {
-    "name": "margin-inline",
-    "syntax": "<'margin-top'>{1,2}",
+    "name": "overflow-inline",
+    "syntax": "visible | hidden | clip | scroll | auto",
     "computed": [
-      "margin-inline-start",
-      "margin-inline-end"
+      "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "overflow-wrap",
+    "syntax": "normal | break-word | anywhere",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "overflow-x",
+    "syntax": "visible | hidden | clip | scroll | auto",
+    "computed": [
+      "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
+    ],
+    "initial": "visible",
+    "inherited": false
+  },
+  {
+    "name": "overflow-y",
+    "syntax": "visible | hidden | clip | scroll | auto",
+    "computed": [
+      "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
+    ],
+    "initial": "visible",
+    "inherited": false
+  },
+  {
+    "name": "overscroll-behavior",
+    "syntax": "[ contain | none | auto ]{1,2}",
+    "computed": [
+      "overscroll-behavior-x",
+      "overscroll-behavior-y"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "overscroll-behavior-block",
+    "syntax": "contain | none | auto",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "overscroll-behavior-inline",
+    "syntax": "contain | none | auto",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "overscroll-behavior-x",
+    "syntax": "contain | none | auto",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "overscroll-behavior-y",
+    "syntax": "contain | none | auto",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "padding",
+    "syntax": "<'padding-top'>{1,4}",
+    "computed": [
+      "padding-bottom",
+      "padding-left",
+      "padding-right",
+      "padding-top"
     ],
     "initial": [
-      "margin-inline-start",
-      "margin-inline-end"
+      "padding-bottom",
+      "padding-left",
+      "padding-right",
+      "padding-top"
     ],
     "inherited": false
   },
   {
-    "name": "border-width",
-    "syntax": "<line-width>{1,4}",
+    "name": "padding-block",
+    "syntax": "<'padding-top'>{1,2}",
     "computed": [
-      "border-bottom-width",
-      "border-left-width",
-      "border-right-width",
-      "border-top-width"
+      "padding-block-start",
+      "padding-block-end"
     ],
     "initial": [
-      "border-top-width",
-      "border-right-width",
-      "border-bottom-width",
-      "border-left-width"
+      "padding-block-start",
+      "padding-block-end"
     ],
     "inherited": false
   },
   {
-    "name": "grid-template",
-    "syntax": "none | [ <'grid-template-rows'> / <'grid-template-columns'> ] | [ <line-names>? <string> <track-size>? <line-names>? ]+ [ / <explicit-track-list> ]?",
+    "name": "padding-block-end",
+    "syntax": "<'padding-top'>",
     "computed": [
-      "grid-template-columns",
-      "grid-template-rows",
-      "grid-template-areas"
-    ],
-    "initial": [
-      "grid-template-columns",
-      "grid-template-rows",
-      "grid-template-areas"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "border-left-color",
-    "syntax": "<color> | <image-1D>",
-    "computed": [
-      "computedColor"
-    ],
-    "initial": "currentcolor",
-    "inherited": false
-  },
-  {
-    "name": "border-start-start-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2}",
-    "computed": [
-      "twoAbsoluteLengthOrPercentages"
+      "asLength"
     ],
     "initial": "0",
     "inherited": false
@@ -5180,177 +4221,79 @@
     "inherited": false
   },
   {
-    "name": "position-try",
-    "syntax": "<'position-try-order'>? <'position-try-fallbacks'>",
+    "name": "padding-bottom",
+    "syntax": "<length-percentage [0,∞]>",
     "computed": [
-      "position-try-fallbacks",
-      "position-try-order"
-    ],
-    "initial": [
-      "position-try-fallbacks",
-      "position-try-order"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "overscroll-behavior-inline",
-    "syntax": "contain | none | auto",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "outline-style",
-    "syntax": "auto | <outline-line-style>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "outline-offset",
-    "syntax": "<length>",
-    "computed": [
-      "asSpecifiedRelativeToAbsoluteLengths"
+      "percentageAsSpecifiedOrAbsoluteLength"
     ],
     "initial": "0",
     "inherited": false
   },
   {
-    "name": "fill-image",
-    "syntax": "<paint>#",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "text-align",
-    "syntax": "start | end | left | right | center | justify | match-parent | justify-all",
+    "name": "padding-inline",
+    "syntax": "<'padding-top'>{1,2}",
     "computed": [
-      "asSpecifiedExceptMatchParent"
-    ],
-    "initial": "startOrNamelessValueIfLTRRightIfRTL",
-    "inherited": true
-  },
-  {
-    "name": "stroke",
-    "syntax": "<paint>",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "-webkit-border-bottom-right-radius",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-order",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-perspective-origin",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "reading-flow",
-    "syntax": "normal | flex-visual | flex-flow | grid-rows | grid-columns | grid-order",
-    "computed": [],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "flex",
-    "syntax": "none | [ <'flex-grow'> <'flex-shrink'>? || <'flex-basis'> ]",
-    "computed": [
-      "flex-grow",
-      "flex-shrink",
-      "flex-basis"
+      "padding-inline-start",
+      "padding-inline-end"
     ],
     "initial": [
-      "flex-grow",
-      "flex-shrink",
-      "flex-basis"
+      "padding-inline-start",
+      "padding-inline-end"
     ],
     "inherited": false
   },
   {
-    "name": "border-limit",
-    "syntax": "all | [ sides | corners ] <length-percentage [0,∞]>? | [ top | right | bottom | left ] <length-percentage [0,∞]>",
-    "computed": [],
-    "initial": "all",
+    "name": "padding-inline-end",
+    "syntax": "<'padding-top'>",
+    "computed": [
+      "asLength"
+    ],
+    "initial": "0",
     "inherited": false
   },
   {
-    "name": "font-size-adjust",
-    "syntax": "none | <number [0,∞]>",
+    "name": "padding-inline-start",
+    "syntax": "<'padding-top'>",
     "computed": [
-      "asSpecified"
+      "asLength"
     ],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "word-break",
-    "syntax": "normal | keep-all | break-all | break-word",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "border-top-style",
-    "syntax": "<line-style>",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "none",
+    "initial": "0",
     "inherited": false
   },
   {
-    "name": "corners",
-    "syntax": "<'corner-shape'> || <'border-radius'>",
-    "computed": [],
-    "initial": "see individual properties",
+    "name": "padding-left",
+    "syntax": "<length-percentage [0,∞]>",
+    "computed": [
+      "percentageAsSpecifiedOrAbsoluteLength"
+    ],
+    "initial": "0",
     "inherited": false
   },
   {
-    "name": "shape-image-threshold",
-    "syntax": "<opacity-value>",
+    "name": "padding-right",
+    "syntax": "<length-percentage [0,∞]>",
     "computed": [
-      "specifiedValueNumberClipped0To1"
+      "percentageAsSpecifiedOrAbsoluteLength"
     ],
-    "initial": "0.0",
+    "initial": "0",
     "inherited": false
   },
   {
-    "name": "text-emphasis-style",
-    "syntax": "none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | <string>",
+    "name": "padding-top",
+    "syntax": "<length-percentage [0,∞]>",
     "computed": [
-      "asSpecified"
+      "percentageAsSpecifiedOrAbsoluteLength"
     ],
-    "initial": "none",
-    "inherited": true
+    "initial": "0",
+    "inherited": false
   },
   {
-    "name": "transform-box",
-    "syntax": "content-box | border-box | fill-box | stroke-box | view-box",
+    "name": "page",
+    "syntax": "auto | <custom-ident>",
     "computed": [
       "asSpecified"
     ],
-    "initial": "view-box",
+    "initial": "auto",
     "inherited": false
   },
   {
@@ -5363,64 +4306,64 @@
     "inherited": false
   },
   {
-    "name": "corner-shape",
-    "syntax": "[ round | angle ]{1,4}",
-    "computed": [],
-    "initial": "round",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-align-items",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-mask-repeat",
-    "syntax": "",
-    "computed": [
-      "asSpecified"
-    ],
-    "initial": "repeat",
-    "inherited": false
-  },
-  {
-    "name": "image-rendering",
-    "syntax": "auto | smooth | high-quality | pixelated | crisp-edges",
+    "name": "page-break-before",
+    "syntax": "auto | always | avoid | left | right | inherit",
     "computed": [
       "asSpecified"
     ],
     "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "color-interpolation",
-    "syntax": "auto | sRGB | linearRGB",
-    "computed": [],
-    "initial": "sRGB",
-    "inherited": true
-  },
-  {
-    "name": "scroll-padding-block",
-    "syntax": "[ auto | <length-percentage [0,∞]> ]{1,2}",
-    "computed": [
-      "scroll-padding-block-start",
-      "scroll-padding-block-end"
-    ],
-    "initial": [
-      "scroll-padding-block-start",
-      "scroll-padding-block-end"
-    ],
     "inherited": false
   },
   {
-    "name": "mask-repeat",
-    "syntax": "<repeat-style>#",
+    "name": "page-break-inside",
+    "syntax": "avoid | auto | inherit",
     "computed": [
-      "consistsOfTwoDimensionKeywords"
+      "asSpecified"
     ],
-    "initial": "repeat",
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "paint-order",
+    "syntax": "normal | [ fill || stroke || markers ]",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "pause",
+    "syntax": "<'pause-before'> <'pause-after'>?",
+    "computed": [],
+    "initial": "see individual properties",
+    "inherited": false
+  },
+  {
+    "name": "pause-after",
+    "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
+    "computed": [],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "pause-before",
+    "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
+    "computed": [],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "place-content",
+    "syntax": "<'align-content'> <'justify-content'>?",
+    "computed": [
+      "align-content",
+      "justify-content"
+    ],
+    "initial": [
+      "align-content",
+      "justify-content"
+    ],
     "inherited": false
   },
   {
@@ -5437,27 +4380,156 @@
     "inherited": false
   },
   {
-    "name": "hyphens",
-    "syntax": "none | manual | auto",
+    "name": "place-self",
+    "syntax": "<'align-self'> <'justify-self'>?",
+    "computed": [
+      "align-self",
+      "justify-self"
+    ],
+    "initial": [
+      "align-self",
+      "justify-self"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "pointer-events",
+    "syntax": "auto | bounding-box | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all | none",
     "computed": [
       "asSpecified"
     ],
-    "initial": "manual",
+    "initial": "auto",
     "inherited": true
   },
   {
-    "name": "border-block-end",
-    "syntax": "<line-width> || <line-style> || <color>",
+    "name": "position",
+    "syntax": "static | relative | absolute | sticky | fixed | <running()>",
     "computed": [
-      "border-top-width",
-      "border-top-style",
-      "border-top-color"
+      "asSpecified"
+    ],
+    "initial": "static",
+    "inherited": false
+  },
+  {
+    "name": "position-anchor",
+    "syntax": "auto | <anchor-name>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "position-area",
+    "syntax": "none | <position-area>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "position-try",
+    "syntax": "<'position-try-order'>? <'position-try-fallbacks'>",
+    "computed": [
+      "position-try-fallbacks",
+      "position-try-order"
     ],
     "initial": [
-      "border-top-width",
-      "border-top-style",
-      "border-top-color"
+      "position-try-fallbacks",
+      "position-try-order"
     ],
+    "inherited": false
+  },
+  {
+    "name": "position-try-fallbacks",
+    "syntax": "none | [ [<dashed-ident> || <try-tactic>] | <'position-area'> ]#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "position-try-order",
+    "syntax": "normal | <try-size>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "position-visibility",
+    "syntax": "always | [ anchors-valid || anchors-visible || no-overflow ]",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "anchors-visible",
+    "inherited": false
+  },
+  {
+    "name": "print-color-adjust",
+    "syntax": "economy | exact",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "economy",
+    "inherited": true
+  },
+  {
+    "name": "quotes",
+    "syntax": "auto | none | match-parent | [ <string> <string> ]+",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "dependsOnUserAgent",
+    "inherited": true
+  },
+  {
+    "name": "r",
+    "syntax": "<length-percentage>",
+    "computed": [
+      "percentageAsSpecifiedOrAbsoluteLength"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "reading-flow",
+    "syntax": "normal | source-order | flex-visual | flex-flow | grid-rows | grid-columns | grid-order",
+    "computed": [],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "reading-order",
+    "syntax": "<integer>",
+    "computed": [],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "region-fragment",
+    "syntax": "auto | break",
+    "computed": [],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "resize",
+    "syntax": "none | both | horizontal | vertical | block | inline",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "rest",
+    "syntax": "<'rest-before'> <'rest-after'>?",
+    "computed": [],
+    "initial": "see individual properties",
     "inherited": false
   },
   {
@@ -5468,32 +4540,157 @@
     "inherited": false
   },
   {
-    "name": "stroke-dashadjust",
-    "syntax": "none | [stretch | compress] [dashes | gaps]?",
+    "name": "rest-before",
+    "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
     "computed": [],
     "initial": "none",
-    "inherited": true
+    "inherited": false
   },
   {
-    "name": "forced-color-adjust",
-    "syntax": "auto | none | preserve-parent-color",
+    "name": "right",
+    "syntax": "auto | <length-percentage> | <anchor()> | <anchor-size()>",
+    "computed": [
+      "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "row-gap",
+    "syntax": "normal | <length-percentage [0,∞]>",
+    "computed": [
+      "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "row-rule",
+    "syntax": "<gap-rule-list> | <gap-auto-rule-list>",
+    "computed": [],
+    "initial": "see individual properties",
+    "inherited": false
+  },
+  {
+    "name": "row-rule-break",
+    "syntax": "none | spanning-item | intersection",
+    "computed": [],
+    "initial": "spanning-item",
+    "inherited": false
+  },
+  {
+    "name": "row-rule-color",
+    "syntax": "<line-color-list> | <auto-line-color-list>",
+    "computed": [],
+    "initial": "currentcolor",
+    "inherited": false
+  },
+  {
+    "name": "row-rule-outset",
+    "syntax": "<length-percentage>",
+    "computed": [],
+    "initial": "50%",
+    "inherited": false
+  },
+  {
+    "name": "row-rule-style",
+    "syntax": "<line-style-list> | <auto-line-style-list>",
+    "computed": [],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "row-rule-width",
+    "syntax": "<line-width-list> | <auto-line-width-list>",
+    "computed": [],
+    "initial": "medium",
+    "inherited": false
+  },
+  {
+    "name": "ruby-align",
+    "syntax": "start | center | space-between | space-around",
     "computed": [
       "asSpecified"
     ],
+    "initial": "space-around",
+    "inherited": true
+  },
+  {
+    "name": "ruby-merge",
+    "syntax": "separate | merge | auto",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "separate",
+    "inherited": true
+  },
+  {
+    "name": "ruby-overhang",
+    "syntax": "auto | none",
+    "computed": [],
     "initial": "auto",
     "inherited": true
   },
   {
-    "name": "font-variant",
-    "syntax": "normal | none | [ [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ] || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ] || [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ] || [ <east-asian-variant-values> || <east-asian-width-values> || ruby ] || [ sub | super ] || [ text | emoji | unicode ] ]",
+    "name": "ruby-position",
+    "syntax": "[ alternate || [ over | under ] ] | inter-character",
     "computed": [
       "asSpecified"
     ],
-    "initial": "normal",
+    "initial": "alternate",
     "inherited": true
   },
   {
-    "name": "margin-top",
+    "name": "rule",
+    "syntax": "<'column-rule'>",
+    "computed": [],
+    "initial": "see individual properties",
+    "inherited": false
+  },
+  {
+    "name": "rule-break",
+    "syntax": "<'column-rule-break'>",
+    "computed": [],
+    "initial": "see individual properties",
+    "inherited": false
+  },
+  {
+    "name": "rule-color",
+    "syntax": "<'column-rule-color'>",
+    "computed": [],
+    "initial": "see individual properties",
+    "inherited": false
+  },
+  {
+    "name": "rule-outset",
+    "syntax": "<'column-rule-outset'>",
+    "computed": [],
+    "initial": "see individual properties",
+    "inherited": false
+  },
+  {
+    "name": "rule-paint-order",
+    "syntax": "row-over-column | column-over-row",
+    "computed": [],
+    "initial": "row-over-column",
+    "inherited": false
+  },
+  {
+    "name": "rule-style",
+    "syntax": "<'column-rule-style'>",
+    "computed": [],
+    "initial": "see individual properties",
+    "inherited": false
+  },
+  {
+    "name": "rule-width",
+    "syntax": "<'column-rule-width'>",
+    "computed": [],
+    "initial": "see individual properties",
+    "inherited": false
+  },
+  {
+    "name": "rx",
     "syntax": "<length-percentage> | auto",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
@@ -5502,81 +4699,38 @@
     "inherited": false
   },
   {
-    "name": "gap",
-    "syntax": "<'row-gap'> <'column-gap'>?",
+    "name": "ry",
+    "syntax": "<length-percentage> | auto",
     "computed": [
-      "row-gap",
-      "column-gap"
-    ],
-    "initial": [
-      "row-gap",
-      "column-gap"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "border-end-end-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2}",
-    "computed": [
-      "twoAbsoluteLengthOrPercentages"
+      "percentageAsSpecifiedOrAbsoluteLength"
     ],
     "initial": "0",
     "inherited": false
   },
   {
-    "name": "background",
-    "syntax": "<bg-layer>#? , <final-bg-layer>",
+    "name": "scroll-behavior",
+    "syntax": "auto | smooth",
     "computed": [
-      "background-image",
-      "background-position",
-      "background-size",
-      "background-repeat",
-      "background-origin",
-      "background-clip",
-      "background-attachment",
-      "background-color"
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "scroll-margin",
+    "syntax": "<length>{1,4}",
+    "computed": [
+      "scroll-margin-bottom",
+      "scroll-margin-left",
+      "scroll-margin-right",
+      "scroll-margin-top"
     ],
     "initial": [
-      "background-image",
-      "background-position",
-      "background-size",
-      "background-repeat",
-      "background-origin",
-      "background-clip",
-      "background-attachment",
-      "background-color"
+      "scroll-margin-bottom",
+      "scroll-margin-left",
+      "scroll-margin-right",
+      "scroll-margin-top"
     ],
-    "inherited": false
-  },
-  {
-    "name": "border",
-    "syntax": "<line-width> || <line-style> || <color>",
-    "computed": [
-      "border-width",
-      "border-style",
-      "border-color"
-    ],
-    "initial": [
-      "border-width",
-      "border-style",
-      "border-color"
-    ],
-    "inherited": false
-  },
-  {
-    "name": "border-inline-end-color",
-    "syntax": "<color> | <image-1D>",
-    "computed": [
-      "computedColor"
-    ],
-    "initial": "currentcolor",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-flex-direction",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
     "inherited": false
   },
   {
@@ -5593,12 +4747,1204 @@
     "inherited": false
   },
   {
-    "name": "accent-color",
-    "syntax": "auto | <color>",
+    "name": "scroll-margin-block-end",
+    "syntax": "<length>",
     "computed": [
-      "asAutoOrColor"
+      "asSpecified"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "scroll-margin-block-start",
+    "syntax": "<length>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "scroll-margin-bottom",
+    "syntax": "<length>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "scroll-margin-inline",
+    "syntax": "<length>{1,2}",
+    "computed": [
+      "scroll-margin-inline-start",
+      "scroll-margin-inline-end"
+    ],
+    "initial": [
+      "scroll-margin-inline-start",
+      "scroll-margin-inline-end"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "scroll-margin-inline-end",
+    "syntax": "<length>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "scroll-margin-inline-start",
+    "syntax": "<length>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "scroll-margin-left",
+    "syntax": "<length>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "scroll-margin-right",
+    "syntax": "<length>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "scroll-margin-top",
+    "syntax": "<length>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "scroll-padding",
+    "syntax": "[ auto | <length-percentage [0,∞]> ]{1,4}",
+    "computed": [
+      "scroll-padding-bottom",
+      "scroll-padding-left",
+      "scroll-padding-right",
+      "scroll-padding-top"
+    ],
+    "initial": [
+      "scroll-padding-bottom",
+      "scroll-padding-left",
+      "scroll-padding-right",
+      "scroll-padding-top"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "scroll-padding-block",
+    "syntax": "[ auto | <length-percentage [0,∞]> ]{1,2}",
+    "computed": [
+      "scroll-padding-block-start",
+      "scroll-padding-block-end"
+    ],
+    "initial": [
+      "scroll-padding-block-start",
+      "scroll-padding-block-end"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "scroll-padding-block-end",
+    "syntax": "auto | <length-percentage [0,∞]>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "scroll-padding-block-start",
+    "syntax": "auto | <length-percentage [0,∞]>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "scroll-padding-bottom",
+    "syntax": "auto | <length-percentage [0,∞]>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "scroll-padding-inline",
+    "syntax": "[ auto | <length-percentage [0,∞]> ]{1,2}",
+    "computed": [
+      "scroll-padding-inline-start",
+      "scroll-padding-inline-end"
+    ],
+    "initial": [
+      "scroll-padding-inline-start",
+      "scroll-padding-inline-end"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "scroll-padding-inline-end",
+    "syntax": "auto | <length-percentage [0,∞]>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "scroll-padding-inline-start",
+    "syntax": "auto | <length-percentage [0,∞]>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "scroll-padding-left",
+    "syntax": "auto | <length-percentage [0,∞]>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "scroll-padding-right",
+    "syntax": "auto | <length-percentage [0,∞]>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "scroll-padding-top",
+    "syntax": "auto | <length-percentage [0,∞]>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "scroll-snap-align",
+    "syntax": "[ none | start | end | center ]{1,2}",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "scroll-snap-stop",
+    "syntax": "normal | always",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "scroll-snap-type",
+    "syntax": "none | [ x | y | block | inline | both ] [ mandatory | proximity ]?",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "scroll-timeline",
+    "syntax": "[ <'scroll-timeline-name'> <'scroll-timeline-axis'>? ]#",
+    "computed": [
+      "scroll-timeline-name",
+      "scroll-timeline-axis"
+    ],
+    "initial": [
+      "scroll-timeline-name",
+      "scroll-timeline-axis"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "scroll-timeline-axis",
+    "syntax": "[ block | inline | x | y ]#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "block",
+    "inherited": false
+  },
+  {
+    "name": "scroll-timeline-name",
+    "syntax": "[ none | <dashed-ident> ]#",
+    "computed": [
+      "noneOrOrderedListOfIdentifiers"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "scrollbar-color",
+    "syntax": "auto | <color>{2}",
+    "computed": [
+      "asSpecified"
     ],
     "initial": "auto",
     "inherited": true
+  },
+  {
+    "name": "scrollbar-gutter",
+    "syntax": "auto | stable && both-edges?",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "scrollbar-width",
+    "syntax": "auto | thin | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "shape-image-threshold",
+    "syntax": "<opacity-value>",
+    "computed": [
+      "specifiedValueNumberClipped0To1"
+    ],
+    "initial": "0.0",
+    "inherited": false
+  },
+  {
+    "name": "shape-margin",
+    "syntax": "<length-percentage [0,∞]>",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "shape-outside",
+    "syntax": "none | [ <basic-shape> || <shape-box> ] | <image>",
+    "computed": [
+      "asDefinedForBasicShapeWithAbsoluteURIOtherwiseAsSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "shape-rendering",
+    "syntax": "auto | optimizeSpeed | crispEdges | geometricPrecision",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "shape-subtract",
+    "syntax": "none | [ <basic-shape>| <uri> ]+",
+    "computed": [],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "slider-orientation",
+    "syntax": "auto | left-to-right | right-to-left | top-to-bottom | bottom-to-top",
+    "computed": [],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "spatial-navigation-action",
+    "syntax": "auto | focus | scroll",
+    "computed": [],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "spatial-navigation-contain",
+    "syntax": "auto | contain",
+    "computed": [],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "spatial-navigation-function",
+    "syntax": "normal | grid",
+    "computed": [],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "speak",
+    "syntax": "auto | never | always",
+    "computed": [],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "speak-as",
+    "syntax": "normal | spell-out || digits || [ literal-punctuation | no-punctuation ]",
+    "computed": [
+      "specifiedValue"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "stop-color",
+    "syntax": "",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "black",
+    "inherited": false
+  },
+  {
+    "name": "stop-opacity",
+    "syntax": "",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "black",
+    "inherited": false
+  },
+  {
+    "name": "string-set",
+    "syntax": "none | [ <custom-ident> <string>+ ]#",
+    "computed": [],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "stroke",
+    "syntax": "<paint>",
+    "computed": [
+      "asLonghands"
+    ],
+    "initial": [
+      "stroke-dasharray",
+      "stroke-dashoffset",
+      "stroke-linecap",
+      "stroke-linejoin",
+      "stroke-miterlimit",
+      "stroke-opacity",
+      "stroke-width"
+    ],
+    "inherited": true
+  },
+  {
+    "name": "stroke-align",
+    "syntax": "center | inset | outset",
+    "computed": [],
+    "initial": "center",
+    "inherited": true
+  },
+  {
+    "name": "stroke-alignment",
+    "syntax": "center | inner | outer",
+    "computed": [],
+    "initial": "center",
+    "inherited": true
+  },
+  {
+    "name": "stroke-break",
+    "syntax": "bounding-box | slice | clone",
+    "computed": [],
+    "initial": "bounding-box",
+    "inherited": false
+  },
+  {
+    "name": "stroke-color",
+    "syntax": "<color>#",
+    "computed": [],
+    "initial": "transparent",
+    "inherited": true
+  },
+  {
+    "name": "stroke-dash-corner",
+    "syntax": "none | <length>",
+    "computed": [],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "stroke-dash-justify",
+    "syntax": "none | [ stretch | compress ] || [ dashes || gaps ]",
+    "computed": [],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "stroke-dashadjust",
+    "syntax": "none | [stretch | compress] [dashes | gaps]?",
+    "computed": [],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "stroke-dasharray",
+    "syntax": "none | [<length-percentage> | <number>]+#",
+    "computed": [
+      "listEachItemConsistingOfAbsoluteLengthPercentageOrKeyword"
+    ],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "stroke-dashcorner",
+    "syntax": "none | <length>",
+    "computed": [],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "stroke-dashoffset",
+    "syntax": "<length-percentage> | <number>",
+    "computed": [
+      "absoluteLengthOrPercentageNumbersConverted"
+    ],
+    "initial": "0",
+    "inherited": true
+  },
+  {
+    "name": "stroke-image",
+    "syntax": "<paint>#",
+    "computed": [],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "stroke-linecap",
+    "syntax": "butt | round | square",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "butt",
+    "inherited": true
+  },
+  {
+    "name": "stroke-linejoin",
+    "syntax": "[ crop | arcs | miter ] || [ bevel | round | fallback ]",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "miter",
+    "inherited": true
+  },
+  {
+    "name": "stroke-miterlimit",
+    "syntax": "<number>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "4",
+    "inherited": true
+  },
+  {
+    "name": "stroke-opacity",
+    "syntax": "<'opacity'>",
+    "computed": [
+      "specifiedValueClipped0To1"
+    ],
+    "initial": "1",
+    "inherited": true
+  },
+  {
+    "name": "stroke-origin",
+    "syntax": "match-parent | fill-box | stroke-box | content-box | padding-box | border-box",
+    "computed": [],
+    "initial": "match-parent",
+    "inherited": false
+  },
+  {
+    "name": "stroke-position",
+    "syntax": "<position>#",
+    "computed": [],
+    "initial": "0% 0%",
+    "inherited": true
+  },
+  {
+    "name": "stroke-repeat",
+    "syntax": "<repeat-style>#",
+    "computed": [],
+    "initial": "repeat",
+    "inherited": true
+  },
+  {
+    "name": "stroke-size",
+    "syntax": "<bg-size>#",
+    "computed": [],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "stroke-width",
+    "syntax": "[<length-percentage> | <number>]#",
+    "computed": [
+      "absoluteLengthOrPercentageNumbersConverted"
+    ],
+    "initial": "1px",
+    "inherited": true
+  },
+  {
+    "name": "tab-size",
+    "syntax": "<number [0,∞]> | <length [0,∞]>",
+    "computed": [
+      "specifiedIntegerOrAbsoluteLength"
+    ],
+    "initial": "8",
+    "inherited": true
+  },
+  {
+    "name": "table-layout",
+    "syntax": "auto | fixed",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "text-align",
+    "syntax": "start | end | left | right | center | justify | match-parent | justify-all",
+    "computed": [
+      "asSpecifiedExceptMatchParent"
+    ],
+    "initial": "startOrNamelessValueIfLTRRightIfRTL",
+    "inherited": true
+  },
+  {
+    "name": "text-align-all",
+    "syntax": "start | end | left | right | center | justify | match-parent",
+    "computed": [],
+    "initial": "start",
+    "inherited": true
+  },
+  {
+    "name": "text-align-last",
+    "syntax": "auto | start | end | left | right | center | justify | match-parent",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "text-anchor",
+    "syntax": "start | middle | end",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "start",
+    "inherited": true
+  },
+  {
+    "name": "text-box",
+    "syntax": "normal | <'text-box-trim'> || <'text-box-edge'>",
+    "computed": [
+      "theSpecifiedKeyword"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "text-box-edge",
+    "syntax": "auto | <text-edge>",
+    "computed": [
+      "theSpecifiedKeyword"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "text-box-trim",
+    "syntax": "none | trim-start | trim-end | trim-both",
+    "computed": [
+      "theSpecifiedKeyword"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "text-combine-upright",
+    "syntax": "none | all | [ digits <integer [2,4]>? ]",
+    "computed": [
+      "keywordPlusIntegerIfDigits"
+    ],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "text-decoration",
+    "syntax": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'>",
+    "computed": [
+      "text-decoration-line",
+      "text-decoration-style",
+      "text-decoration-color",
+      "text-decoration-thickness"
+    ],
+    "initial": [
+      "text-decoration-color",
+      "text-decoration-style",
+      "text-decoration-line"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "text-decoration-color",
+    "syntax": "<color>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
+    "inherited": false
+  },
+  {
+    "name": "text-decoration-line",
+    "syntax": "none | [ underline || overline || line-through || blink ]",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "text-decoration-style",
+    "syntax": "solid | double | dotted | dashed | wavy",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "solid",
+    "inherited": false
+  },
+  {
+    "name": "text-emphasis",
+    "syntax": "<'text-emphasis-style'> || <'text-emphasis-color'>",
+    "computed": [
+      "text-emphasis-style",
+      "text-emphasis-color"
+    ],
+    "initial": [
+      "text-emphasis-style",
+      "text-emphasis-color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "text-emphasis-color",
+    "syntax": "<color>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
+    "inherited": true
+  },
+  {
+    "name": "text-emphasis-position",
+    "syntax": "[ over | under ] && [ right | left ]?",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "text-emphasis-style",
+    "syntax": "none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | <string>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "text-indent",
+    "syntax": "[ <length-percentage> ] && hanging? && each-line?",
+    "computed": [
+      "percentageOrAbsoluteLengthPlusKeywords"
+    ],
+    "initial": "0",
+    "inherited": true
+  },
+  {
+    "name": "text-justify",
+    "syntax": "auto | none | inter-word | inter-character",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "text-orientation",
+    "syntax": "mixed | upright | sideways",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "mixed",
+    "inherited": true
+  },
+  {
+    "name": "text-overflow",
+    "syntax": "clip | ellipsis",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "clip",
+    "inherited": false
+  },
+  {
+    "name": "text-rendering",
+    "syntax": "auto | optimizeSpeed | optimizeLegibility | geometricPrecision",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "text-shadow",
+    "syntax": "none | [ <color>? && <length>{2,3} ]#",
+    "computed": [
+      "colorPlusThreeAbsoluteLengths"
+    ],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "text-size-adjust",
+    "syntax": "auto | none | <percentage [0,∞]>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "autoForSmartphoneBrowsersSupportingInflation",
+    "inherited": true
+  },
+  {
+    "name": "text-transform",
+    "syntax": "none | [capitalize | uppercase | lowercase ] || full-width || full-size-kana",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "text-underline-position",
+    "syntax": "auto | [ under || [ left | right ] ]",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "timeline-scope",
+    "syntax": "none | all | <dashed-ident>#",
+    "computed": [
+      "noneOrOrderedListOfIdentifiers"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "top",
+    "syntax": "auto | <length-percentage> | <anchor()> | <anchor-size()>",
+    "computed": [
+      "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "touch-action",
+    "syntax": "auto | none | [ [ pan-x | pan-left | pan-right ] || [ pan-y | pan-up | pan-down ] || pinch-zoom ] | manipulation",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "transform",
+    "syntax": "none | <transform-list>",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "transform-box",
+    "syntax": "content-box | border-box | fill-box | stroke-box | view-box",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "view-box",
+    "inherited": false
+  },
+  {
+    "name": "transform-origin",
+    "syntax": "[ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] <length>? | [ [ center | left | right ] && [ center | top | bottom ] ] <length>?",
+    "computed": [
+      "forLengthAbsoluteValueOtherwisePercentage"
+    ],
+    "initial": "50% 50% 0",
+    "inherited": false
+  },
+  {
+    "name": "transition",
+    "syntax": "<single-transition>#",
+    "computed": [
+      "transition-delay",
+      "transition-duration",
+      "transition-property",
+      "transition-timing-function",
+      "transition-behavior"
+    ],
+    "initial": [
+      "transition-delay",
+      "transition-duration",
+      "transition-property",
+      "transition-timing-function",
+      "transition-behavior"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "transition-delay",
+    "syntax": "<time>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0s",
+    "inherited": false
+  },
+  {
+    "name": "transition-duration",
+    "syntax": "<time [0s,∞]>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0s",
+    "inherited": false
+  },
+  {
+    "name": "transition-property",
+    "syntax": "none | <single-transition-property>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "all",
+    "inherited": false
+  },
+  {
+    "name": "transition-timing-function",
+    "syntax": "<easing-function>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "ease",
+    "inherited": false
+  },
+  {
+    "name": "unicode-bidi",
+    "syntax": "normal | embed | isolate | bidi-override | isolate-override | plaintext",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "user-select",
+    "syntax": "auto | text | none | contain | all",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "vector-effect",
+    "syntax": "none | non-scaling-stroke | non-scaling-size | non-rotation | fixed-position",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "vertical-align",
+    "syntax": "[ first | last] || <'alignment-baseline'> || <'baseline-shift'>",
+    "computed": [
+      "absoluteLengthOrKeyword"
+    ],
+    "initial": "baseline",
+    "inherited": false
+  },
+  {
+    "name": "view-timeline",
+    "syntax": "[ <'view-timeline-name'> [ <'view-timeline-axis'> || <'view-timeline-inset'> ]? ]#",
+    "computed": [
+      "view-timeline-name",
+      "view-timeline-axis"
+    ],
+    "initial": [
+      "view-timeline-name",
+      "view-timeline-axis"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "view-timeline-axis",
+    "syntax": "[ block | inline | x | y ]#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "block",
+    "inherited": false
+  },
+  {
+    "name": "view-timeline-inset",
+    "syntax": "[ [ auto | <length-percentage> ]{1,2} ]#",
+    "computed": [
+      "listEachItemConsistingOfPairsOfAutoOrLengthPercentage"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "view-timeline-name",
+    "syntax": "[ none | <dashed-ident> ]#",
+    "computed": [
+      "noneOrOrderedListOfIdentifiers"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "view-transition-name",
+    "syntax": "none | <custom-ident>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "visibility",
+    "syntax": "visible | hidden | collapse",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "visible",
+    "inherited": true
+  },
+  {
+    "name": "voice-balance",
+    "syntax": "<number> | left | center | right | leftwards | rightwards",
+    "computed": [],
+    "initial": "center",
+    "inherited": true
+  },
+  {
+    "name": "voice-duration",
+    "syntax": "auto | <time [0s,∞]>",
+    "computed": [],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "voice-family",
+    "syntax": "[[<family-name> | <generic-voice>],]* [<family-name> | <generic-voice>] | preserve",
+    "computed": [],
+    "initial": "implementation-dependent",
+    "inherited": true
+  },
+  {
+    "name": "voice-pitch",
+    "syntax": "<frequency [0Hz,∞]> && absolute | [[x-low | low | medium | high | x-high] || [<frequency> | <semitones> | <percentage>]]",
+    "computed": [],
+    "initial": "medium",
+    "inherited": true
+  },
+  {
+    "name": "voice-range",
+    "syntax": "<frequency [0Hz,∞]> && absolute | [[x-low | low | medium | high | x-high] || [<frequency> | <semitones> | <percentage>]]",
+    "computed": [],
+    "initial": "medium",
+    "inherited": true
+  },
+  {
+    "name": "voice-rate",
+    "syntax": "[normal | x-slow | slow | medium | fast | x-fast] || <percentage [0,∞]>",
+    "computed": [],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "voice-stress",
+    "syntax": "normal | strong | moderate | none | reduced",
+    "computed": [],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "voice-volume",
+    "syntax": "silent | [[x-soft | soft | medium | loud | x-loud] || <decibel>]",
+    "computed": [],
+    "initial": "medium",
+    "inherited": true
+  },
+  {
+    "name": "white-space",
+    "syntax": "normal | pre | nowrap | pre-wrap | break-spaces | pre-line",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "widows",
+    "syntax": "<integer [1,∞]>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "2",
+    "inherited": true
+  },
+  {
+    "name": "width",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "computed": [
+      "percentageAutoOrAbsoluteLength"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "will-change",
+    "syntax": "auto | <animateable-feature>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "word-break",
+    "syntax": "normal | keep-all | break-all | break-word",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "word-spacing",
+    "syntax": "normal | <length>",
+    "computed": [
+      "absoluteLength"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "word-wrap",
+    "syntax": "normal | break-word | anywhere",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "wrap-flow",
+    "syntax": "auto | both | start | end | minimum | maximum | clear",
+    "computed": [],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "wrap-through",
+    "syntax": "wrap | none",
+    "computed": [],
+    "initial": "wrap",
+    "inherited": false
+  },
+  {
+    "name": "writing-mode",
+    "syntax": "horizontal-tb | vertical-rl | vertical-lr | sideways-rl | sideways-lr",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "horizontal-tb",
+    "inherited": true
+  },
+  {
+    "name": "x",
+    "syntax": "<length-percentage>",
+    "computed": [
+      "percentageAsSpecifiedOrAbsoluteLength"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "y",
+    "syntax": "<length-percentage>",
+    "computed": [
+      "percentageAsSpecifiedOrAbsoluteLength"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "z-index",
+    "syntax": "auto | <integer> | inherit",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "zoom",
+    "syntax": "<number [0,∞]> || <percentage [0,∞]>",
+    "computed": [
+      "asSpecifiedButWithPercentageConvertedToTheEquivalentNumber"
+    ],
+    "initial": "1",
+    "inherited": false
   }
 ]

--- a/crates/gosub_css3/resources/definitions/definitions_selectors.json
+++ b/crates/gosub_css3/resources/definitions/definitions_selectors.json
@@ -1,36 +1,321 @@
 [
   {
-    "name": ":volume-locked"
+    "name": "&"
   },
   {
-    "name": ":last-child"
+    "name": "+"
   },
   {
-    "name": ":hover"
+    "name": "::after"
   },
   {
-    "name": ":root"
+    "name": "::before"
+  },
+  {
+    "name": "::checkmark"
+  },
+  {
+    "name": "::clear-icon"
+  },
+  {
+    "name": "::color-swatch"
+  },
+  {
+    "name": "::column"
+  },
+  {
+    "name": "::cue"
+  },
+  {
+    "name": "::cue()"
+  },
+  {
+    "name": "::cue-region"
+  },
+  {
+    "name": "::cue-region()"
+  },
+  {
+    "name": "::details-content"
+  },
+  {
+    "name": "::field-component"
+  },
+  {
+    "name": "::field-separator"
+  },
+  {
+    "name": "::field-text"
+  },
+  {
+    "name": "::file-selector-button"
+  },
+  {
+    "name": "::first-letter"
+  },
+  {
+    "name": "::first-line"
   },
   {
     "name": "::grammar-error"
   },
   {
-    "name": ":first-line"
+    "name": "::highlight()"
   },
   {
-    "name": ":closed"
+    "name": "::marker"
+  },
+  {
+    "name": "::part()"
+  },
+  {
+    "name": "::picker()"
+  },
+  {
+    "name": "::picker-icon"
+  },
+  {
+    "name": "::placeholder"
+  },
+  {
+    "name": "::search-text"
+  },
+  {
+    "name": "::selection"
+  },
+  {
+    "name": "::slider-fill"
+  },
+  {
+    "name": "::slider-thumb"
+  },
+  {
+    "name": "::slider-track"
+  },
+  {
+    "name": "::slotted()"
+  },
+  {
+    "name": "::spelling-error"
+  },
+  {
+    "name": "::step-control"
+  },
+  {
+    "name": "::step-down"
+  },
+  {
+    "name": "::step-up"
+  },
+  {
+    "name": "::target-text"
+  },
+  {
+    "name": "::view-transition"
+  },
+  {
+    "name": "::view-transition-group()"
+  },
+  {
+    "name": "::view-transition-image-pair()"
+  },
+  {
+    "name": "::view-transition-new()"
+  },
+  {
+    "name": "::view-transition-old()"
+  },
+  {
+    "name": ":active"
+  },
+  {
+    "name": ":after"
+  },
+  {
+    "name": ":any-link"
+  },
+  {
+    "name": ":autofill"
+  },
+  {
+    "name": ":before"
+  },
+  {
+    "name": ":blank"
+  },
+  {
+    "name": ":buffering"
+  },
+  {
+    "name": ":checked"
+  },
+  {
+    "name": ":current"
+  },
+  {
+    "name": ":current()"
+  },
+  {
+    "name": ":default"
+  },
+  {
+    "name": ":defined"
+  },
+  {
+    "name": ":dir()"
+  },
+  {
+    "name": ":disabled"
+  },
+  {
+    "name": ":empty"
   },
   {
     "name": ":enabled"
   },
   {
-    "name": ":invalid"
+    "name": ":first"
+  },
+  {
+    "name": ":first-child"
+  },
+  {
+    "name": ":first-letter"
+  },
+  {
+    "name": ":first-line"
+  },
+  {
+    "name": ":first-of-type"
+  },
+  {
+    "name": ":focus"
+  },
+  {
+    "name": ":focus-visible"
+  },
+  {
+    "name": ":focus-within"
   },
   {
     "name": ":fullscreen"
   },
   {
-    "name": "~"
+    "name": ":future"
+  },
+  {
+    "name": ":has()"
+  },
+  {
+    "name": ":has-slotted"
+  },
+  {
+    "name": ":high-value"
+  },
+  {
+    "name": ":host"
+  },
+  {
+    "name": ":host()"
+  },
+  {
+    "name": ":host-context()"
+  },
+  {
+    "name": ":hover"
+  },
+  {
+    "name": ":in-range"
+  },
+  {
+    "name": ":indeterminate"
+  },
+  {
+    "name": ":invalid"
+  },
+  {
+    "name": ":is()"
+  },
+  {
+    "name": ":lang"
+  },
+  {
+    "name": ":lang()"
+  },
+  {
+    "name": ":last-child"
+  },
+  {
+    "name": ":last-of-type"
+  },
+  {
+    "name": ":left"
+  },
+  {
+    "name": ":link"
+  },
+  {
+    "name": ":local-link"
+  },
+  {
+    "name": ":low-value"
+  },
+  {
+    "name": ":matches()"
+  },
+  {
+    "name": ":modal"
+  },
+  {
+    "name": ":muted"
+  },
+  {
+    "name": ":not()"
+  },
+  {
+    "name": ":nth()"
+  },
+  {
+    "name": ":nth-child()"
+  },
+  {
+    "name": ":nth-col()"
+  },
+  {
+    "name": ":nth-last-child()"
+  },
+  {
+    "name": ":nth-last-col()"
+  },
+  {
+    "name": ":nth-last-of-type()"
+  },
+  {
+    "name": ":nth-of-type()"
+  },
+  {
+    "name": ":only-child"
+  },
+  {
+    "name": ":only-of-type"
+  },
+  {
+    "name": ":open"
+  },
+  {
+    "name": ":optimal-value"
+  },
+  {
+    "name": ":optional"
+  },
+  {
+    "name": ":out-of-range"
+  },
+  {
+    "name": ":past"
+  },
+  {
+    "name": ":paused"
   },
   {
     "name": ":picture-in-picture"
@@ -39,291 +324,69 @@
     "name": ":placeholder-shown"
   },
   {
-    "name": ":target-within"
+    "name": ":playing"
   },
   {
-    "name": ":matches()"
-  },
-  {
-    "name": ":target"
-  },
-  {
-    "name": "::view-transition"
-  },
-  {
-    "name": ":lang"
-  },
-  {
-    "name": ":open"
-  },
-  {
-    "name": "::cue()"
-  },
-  {
-    "name": ":has()"
-  },
-  {
-    "name": ":blank"
-  },
-  {
-    "name": "::placeholder"
-  },
-  {
-    "name": ":not()"
-  },
-  {
-    "name": ":disabled"
-  },
-  {
-    "name": ":nth-child()"
-  },
-  {
-    "name": ":nth-of-type()"
-  },
-  {
-    "name": ":first-letter"
-  },
-  {
-    "name": ":is()"
-  },
-  {
-    "name": ":dir()"
-  },
-  {
-    "name": ":stalled"
-  },
-  {
-    "name": ":modal"
-  },
-  {
-    "name": ":read-write"
-  },
-  {
-    "name": ":nth-col()"
-  },
-  {
-    "name": "::marker"
-  },
-  {
-    "name": "&"
-  },
-  {
-    "name": ":optional"
-  },
-  {
-    "name": "::after"
+    "name": ":popover-open"
   },
   {
     "name": ":read-only"
   },
   {
-    "name": ":out-of-range"
-  },
-  {
-    "name": "::cue-region"
-  },
-  {
-    "name": ":defined"
-  },
-  {
-    "name": ":link"
-  },
-  {
-    "name": ":visited"
-  },
-  {
-    "name": ":current"
-  },
-  {
-    "name": "::selection"
-  },
-  {
-    "name": ":nth-last-col()"
-  },
-  {
-    "name": "::cue"
-  },
-  {
-    "name": ":where()"
-  },
-  {
-    "name": ":current()"
-  },
-  {
-    "name": ":nth-last-child()"
-  },
-  {
-    "name": ":lang()"
-  },
-  {
-    "name": ":focus"
-  },
-  {
-    "name": ":buffering"
-  },
-  {
-    "name": "::view-transition-old()"
-  },
-  {
-    "name": "::before"
-  },
-  {
-    "name": ":host"
-  },
-  {
-    "name": ":any-link"
-  },
-  {
-    "name": ":playing"
-  },
-  {
-    "name": ":in-range"
-  },
-  {
-    "name": "::view-transition-image-pair()"
-  },
-  {
-    "name": ":before"
-  },
-  {
-    "name": "::spelling-error"
-  },
-  {
-    "name": "::file-selector-button"
-  },
-  {
-    "name": ":muted"
-  },
-  {
-    "name": ":first-child"
-  },
-  {
-    "name": ":first-of-type"
-  },
-  {
-    "name": ">"
-  },
-  {
-    "name": "+"
-  },
-  {
-    "name": "::cue-region()"
-  },
-  {
-    "name": ":left"
-  },
-  {
-    "name": "::part()"
-  },
-  {
-    "name": ":host-context()"
-  },
-  {
-    "name": "::target-text"
-  },
-  {
-    "name": ":host()"
-  },
-  {
-    "name": ":after"
-  },
-  {
-    "name": ":default"
-  },
-  {
-    "name": ":only-child"
-  },
-  {
-    "name": "::first-letter"
-  },
-  {
-    "name": ":active"
-  },
-  {
-    "name": ":seeking"
-  },
-  {
-    "name": ":empty"
-  },
-  {
-    "name": "::slotted()"
-  },
-  {
-    "name": ":focus-visible"
-  },
-  {
-    "name": ":valid"
-  },
-  {
-    "name": ":only-of-type"
-  },
-  {
-    "name": "||"
-  },
-  {
-    "name": ":local-link"
-  },
-  {
-    "name": ":focus-within"
-  },
-  {
-    "name": "::details-content"
-  },
-  {
-    "name": ":right"
-  },
-  {
-    "name": ":scope"
-  },
-  {
-    "name": ":paused"
-  },
-  {
-    "name": ":user-valid"
-  },
-  {
-    "name": "::view-transition-new()"
-  },
-  {
-    "name": ":nth()"
-  },
-  {
-    "name": ":first"
-  },
-  {
-    "name": ":future"
-  },
-  {
-    "name": ":indeterminate"
-  },
-  {
-    "name": "::first-line"
-  },
-  {
-    "name": ":past"
-  },
-  {
-    "name": ":user-invalid"
-  },
-  {
-    "name": ":last-of-type"
+    "name": ":read-write"
   },
   {
     "name": ":required"
   },
   {
-    "name": ":nth-last-of-type()"
+    "name": ":right"
   },
   {
-    "name": ":autofill"
+    "name": ":root"
   },
   {
-    "name": ":checked"
+    "name": ":scope"
   },
   {
-    "name": "::highlight()"
+    "name": ":seeking"
   },
   {
-    "name": "::view-transition-group()"
+    "name": ":stalled"
+  },
+  {
+    "name": ":target"
+  },
+  {
+    "name": ":target-within"
+  },
+  {
+    "name": ":user-invalid"
+  },
+  {
+    "name": ":user-valid"
+  },
+  {
+    "name": ":valid"
+  },
+  {
+    "name": ":visited"
+  },
+  {
+    "name": ":volume-locked"
+  },
+  {
+    "name": ":where()"
+  },
+  {
+    "name": ":xr-overlay"
+  },
+  {
+    "name": ">"
+  },
+  {
+    "name": "||"
+  },
+  {
+    "name": "~"
   }
 ]

--- a/crates/gosub_css3/resources/definitions/definitions_values.json
+++ b/crates/gosub_css3/resources/definitions/definitions_values.json
@@ -1,87 +1,911 @@
 [
   {
+    "name": "<alpha-value>",
+    "syntax": "<number> | <percentage>"
+  },
+  {
+    "name": "<an+b>",
+    "syntax": "odd | even | <integer> | <n-dimension> | '+'? n | -n | <ndashdigit-dimension> | '+'? <ndashdigit-ident> | <dashndashdigit-ident> | <n-dimension> <signed-integer> | '+'? n <signed-integer> | -n <signed-integer> | <ndash-dimension> <signless-integer> | '+'? n- <signless-integer> | -n- <signless-integer> | <n-dimension> ['+' | '-'] <signless-integer> | '+'? n ['+' | '-'] <signless-integer> | -n ['+' | '-'] <signless-integer>"
+  },
+  {
+    "name": "<anchor-name>",
+    "syntax": "<dashed-ident>"
+  },
+  {
+    "name": "<anchor-side>",
+    "syntax": "inside | outside | top | left | right | bottom | start | end | self-start | self-end | <percentage> | center"
+  },
+  {
+    "name": "<anchor-size>",
+    "syntax": "width | height | block | inline | self-block | self-inline"
+  },
+  {
+    "name": "<angle-percentage>",
+    "syntax": "[ <angle> | <percentage> ]"
+  },
+  {
+    "name": "<animateable-feature>",
+    "syntax": "scroll-position | contents | <custom-ident>"
+  },
+  {
+    "name": "<attachment>",
+    "syntax": "scroll | fixed | local"
+  },
+  {
+    "name": "<attr-matcher>",
+    "syntax": "[ '~' | '|' | '^' | '$' | '*' ]? '='"
+  },
+  {
+    "name": "<attr-modifier>",
+    "syntax": "i | s"
+  },
+  {
+    "name": "<attribute-selector>",
+    "syntax": "'[' <wq-name> ']' | '[' <wq-name> <attr-matcher> [ <string-token> | <ident-token> ] <attr-modifier>? ']'"
+  },
+  {
+    "name": "<auto-line-color-list>",
+    "syntax": "[ <line-color-or-repeat> ]* <auto-repeat-line-color> [ <line-color-or-repeat> ]*"
+  },
+  {
+    "name": "<auto-line-style-list>",
+    "syntax": "[ <line-style-or-repeat> ]* <auto-repeat-line-style> [ <line-style-or-repeat> ]*"
+  },
+  {
+    "name": "<auto-line-width-list>",
+    "syntax": "[ <line-width-or-repeat> ]* <auto-repeat-line-width> [ <line-width-or-repeat> ]*"
+  },
+  {
+    "name": "<auto-repeat-line-color>",
+    "syntax": "repeat( auto ',' [ <color> ]+ )"
+  },
+  {
+    "name": "<auto-repeat-line-style>",
+    "syntax": "repeat( auto ',' [ <line-style> ]+ )"
+  },
+  {
+    "name": "<auto-repeat-line-width>",
+    "syntax": "repeat( auto ',' [ <line-width> ]+ )"
+  },
+  {
+    "name": "<auto-repeat>",
+    "syntax": "repeat( [ auto-fill | auto-fit ] ',' [ <line-names>? <fixed-size> ]+ <line-names>? )"
+  },
+  {
+    "name": "<auto-track-list>",
+    "syntax": "[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>? <auto-repeat> [ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>?"
+  },
+  {
+    "name": "<axis>",
+    "syntax": "block | inline | x | y"
+  },
+  {
+    "name": "<baseline-position>",
+    "syntax": "[ first | last ]? && baseline"
+  },
+  {
     "name": "<basic-shape-rect>",
     "syntax": "<inset()> | <rect()> | <xywh()>"
   },
   {
-    "name": "<shape-box>",
-    "syntax": "<visual-box> | margin-box"
+    "name": "<bg-image>",
+    "syntax": "<image> | none"
   },
   {
-    "name": "drop-shadow()",
-    "syntax": "drop-shadow( [ <color>? && <length>{2,3} ] )"
+    "name": "<bg-layer>",
+    "syntax": "<bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <visual-box> || <visual-box>"
   },
   {
-    "name": "<try-size>",
-    "syntax": "most-width | most-height | most-block-size | most-inline-size"
+    "name": "<bg-position>",
+    "syntax": "[ [ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ center | [ left | right ] <length-percentage>? ] && [ center | [ top | bottom ] <length-percentage>? ] ]"
   },
   {
-    "name": "<color-interpolation-method>",
-    "syntax": "in [ <rectangular-color-space> | <polar-color-space> <hue-interpolation-method>? ]"
-  },
-  {
-    "name": "<color-stop-list>",
-    "syntax": "<linear-color-stop> , [ <linear-color-hint>? , <linear-color-stop> ]#?"
-  },
-  {
-    "name": "<function-name>",
-    "syntax": "<dashed-ident>"
-  },
-  {
-    "name": "<reversed-counter-name>",
-    "syntax": "reversed( <counter-name> )"
-  },
-  {
-    "name": "<color-font-tech>",
-    "syntax": "[color-COLRv0 | color-COLRv1 | color-SVG | color-sbix | color-CBDT ]"
-  },
-  {
-    "name": "<mask-source>",
-    "syntax": "<url>"
-  },
-  {
-    "name": "atan()",
-    "syntax": "atan( <calc-sum> )"
-  },
-  {
-    "name": "<counter>",
-    "syntax": "<counter()> | <counters()>"
-  },
-  {
-    "name": "snap-inline()",
-    "syntax": "snap-inline( <length> , [ left | right | near ]? )"
+    "name": "<bg-size>",
+    "syntax": "[ <length-percentage [0,∞]> | auto ]{1,2} | cover | contain"
   },
   {
     "name": "<blend-mode>",
     "syntax": "normal | multiply | screen | overlay | darken | lighten | color-dodge |color-burn | hard-light | soft-light | difference | exclusion | hue | saturation | color | luminosity"
   },
   {
-    "name": "<custom-selector>",
-    "syntax": "<custom-arg>? : <extension-name> [ ( <custom-arg>+#? ) ]? ;"
+    "name": "<calc-keyword>",
+    "syntax": "e | pi | infinity | -infinity | NaN"
   },
   {
-    "name": "<pseudo-element-selector>",
-    "syntax": "':' <pseudo-class-selector> | <legacy-pseudo-element-selector>"
+    "name": "<calc-product>",
+    "syntax": "<calc-value> [ [ '*' | / ] <calc-value> ]*"
+  },
+  {
+    "name": "<calc-sum>",
+    "syntax": "<calc-product> [ [ '+' | '-' ] <calc-product> ]*"
+  },
+  {
+    "name": "<calc-value>",
+    "syntax": "<number> | <dimension> | <percentage> | <calc-keyword> | '(' <calc-sum> ')'"
+  },
+  {
+    "name": "<class-selector>",
+    "syntax": "'.' <ident-token>"
+  },
+  {
+    "name": "<clip-source>",
+    "syntax": "<url>"
+  },
+  {
+    "name": "<color-base>",
+    "syntax": "<hex-color> | <color-function> | <named-color> | transparent"
+  },
+  {
+    "name": "<color-font-tech>",
+    "syntax": "[color-COLRv0 | color-COLRv1 | color-SVG | color-sbix | color-CBDT ]"
+  },
+  {
+    "name": "<color-function>",
+    "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <oklab()> | <oklch()> | <ictcp()> | <jzazbz()> | <jzczhz()> | <color()>"
+  },
+  {
+    "name": "<color-interpolation-method>",
+    "syntax": "in [ <rectangular-color-space> | <polar-color-space> <hue-interpolation-method>? ]"
+  },
+  {
+    "name": "<color-space>",
+    "syntax": "<rectangular-color-space> | <polar-color-space>"
+  },
+  {
+    "name": "<color-stop-list>",
+    "syntax": "<linear-color-stop> ',' [ <linear-color-hint>? ',' <linear-color-stop> ]#?"
+  },
+  {
+    "name": "<color>",
+    "syntax": "<color-base> | currentColor | <system-color>"
+  },
+  {
+    "name": "<colorspace-params>",
+    "syntax": "[ <predefined-rgb-params> | <xyz-params>]"
+  },
+  {
+    "name": "<combinator>",
+    "syntax": "'>' | '+' | '~' | [ '|' '|' ]"
+  },
+  {
+    "name": "<common-lig-values>",
+    "syntax": "[ common-ligatures | no-common-ligatures ]"
+  },
+  {
+    "name": "<compat-auto>",
+    "syntax": "searchfield | textarea | checkbox | radio | menulist | listbox | meter | progress-bar | button"
+  },
+  {
+    "name": "<compat-special>",
+    "syntax": "textfield | menulist-button"
+  },
+  {
+    "name": "<complex-real-selector-list>",
+    "syntax": "<complex-real-selector>#"
+  },
+  {
+    "name": "<complex-real-selector>",
+    "syntax": "<compound-selector> [ <combinator>? <compound-selector> ]*"
+  },
+  {
+    "name": "<complex-selector-list>",
+    "syntax": "<complex-selector>#"
+  },
+  {
+    "name": "<complex-selector-unit>",
+    "syntax": "[ <compound-selector>? <pseudo-compound-selector>* ]!"
+  },
+  {
+    "name": "<complex-selector>",
+    "syntax": "<complex-selector-unit> [ <combinator>? <complex-selector-unit> ]*"
+  },
+  {
+    "name": "<composite-mode>",
+    "syntax": "clear | copy | source-over | destination-over | source-in | destination-in | source-out | destination-out | source-atop | destination-atop | xor | lighter | plus-darker | plus-lighter"
+  },
+  {
+    "name": "<compositing-operator>",
+    "syntax": "add | subtract | intersect | exclude"
+  },
+  {
+    "name": "<compound-selector-list>",
+    "syntax": "<compound-selector>#"
+  },
+  {
+    "name": "<compound-selector>",
+    "syntax": "[ <type-selector>? <subclass-selector>* ]!"
+  },
+  {
+    "name": "<content-distribution>",
+    "syntax": "space-between | space-around | space-evenly | stretch"
+  },
+  {
+    "name": "<content-list>",
+    "syntax": "[ <string> | <counter()> | <counters()> | <content()> | <attr()> ]+"
+  },
+  {
+    "name": "<content-position>",
+    "syntax": "center | start | end | flex-start | flex-end"
+  },
+  {
+    "name": "<content-replacement>",
+    "syntax": "<image>"
+  },
+  {
+    "name": "<contextual-alt-values>",
+    "syntax": "[ contextual | no-contextual ]"
+  },
+  {
+    "name": "<coord-box>",
+    "syntax": "<paint-box> | view-box"
+  },
+  {
+    "name": "<corner-shape-value>",
+    "syntax": "round | scoop | bevel | notch | straight | squircle | superellipse(<number [0,∞]> | infinity)"
+  },
+  {
+    "name": "<counter-style>",
+    "syntax": "<counter-style-name> | <symbols()>"
+  },
+  {
+    "name": "<counter>",
+    "syntax": "<counter()> | <counters()>"
+  },
+  {
+    "name": "<css-type>",
+    "syntax": "<syntax-component> | <type()>"
+  },
+  {
+    "name": "<cubic-bezier-easing-function>",
+    "syntax": "ease | ease-in | ease-out | ease-in-out | <cubic-bezier()>"
+  },
+  {
+    "name": "<custom-arg>",
+    "syntax": "'$' <ident-token> ';'"
+  },
+  {
+    "name": "<custom-selector>",
+    "syntax": "<custom-arg>? ':' <extension-name> [ '(' <custom-arg>+#? ')' ]? ';'"
+  },
+  {
+    "name": "<dasharray>",
+    "syntax": "[ [ <length-percentage> | <number> ]+ ]#"
+  },
+  {
+    "name": "<discretionary-lig-values>",
+    "syntax": "[ discretionary-ligatures | no-discretionary-ligatures ]"
+  },
+  {
+    "name": "<display-box>",
+    "syntax": "contents | none"
+  },
+  {
+    "name": "<display-inside>",
+    "syntax": "flow | flow-root | table | flex | grid | ruby"
+  },
+  {
+    "name": "<display-internal>",
+    "syntax": "table-row-group | table-header-group | table-footer-group | table-row | table-cell | table-column-group | table-column | table-caption | ruby-base | ruby-text | ruby-base-container | ruby-text-container"
+  },
+  {
+    "name": "<display-legacy>",
+    "syntax": "inline-block | inline-table | inline-flex | inline-grid"
+  },
+  {
+    "name": "<display-listitem>",
+    "syntax": "<display-outside>? && [ flow | flow-root ]? && list-item"
+  },
+  {
+    "name": "<display-outside>",
+    "syntax": "block | inline | run-in"
+  },
+  {
+    "name": "<easing-function>",
+    "syntax": "<linear-easing-function> | <cubic-bezier-easing-function> | <step-easing-function>"
+  },
+  {
+    "name": "<east-asian-variant-values>",
+    "syntax": "[ jis78 | jis83 | jis90 | jis04 | simplified | traditional ]"
+  },
+  {
+    "name": "<east-asian-width-values>",
+    "syntax": "[ full-width | proportional-width ]"
+  },
+  {
+    "name": "<explicit-track-list>",
+    "syntax": "[ <line-names>? <track-size> ]+ <line-names>?"
+  },
+  {
+    "name": "<family-name>",
+    "syntax": "<string> | <custom-ident>+"
+  },
+  {
+    "name": "<feature-value-name>",
+    "syntax": "<ident>"
+  },
+  {
+    "name": "<filter-function>",
+    "syntax": "<blur()> | <brightness()> | <contrast()> | <drop-shadow()> | <grayscale()> | <hue-rotate()> | <invert()> | <opacity()> | <sepia()> | <saturate()>"
+  },
+  {
+    "name": "<filter-value-list>",
+    "syntax": "[ <filter-function> | <url> ]+"
+  },
+  {
+    "name": "<final-bg-layer>",
+    "syntax": "<bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <visual-box> || <visual-box> || <'background-color'>"
+  },
+  {
+    "name": "<fixed-breadth>",
+    "syntax": "<length-percentage [0,∞]>"
+  },
+  {
+    "name": "<fixed-repeat>",
+    "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-names>? <fixed-size> ]+ <line-names>? )"
+  },
+  {
+    "name": "<fixed-size>",
+    "syntax": "<fixed-breadth> | minmax( <fixed-breadth> ',' <track-breadth> ) | minmax( <inflexible-breadth> ',' <fixed-breadth> )"
+  },
+  {
+    "name": "<font-features-tech>",
+    "syntax": "[features-opentype | features-aat | features-graphite]"
+  },
+  {
+    "name": "<font-format>",
+    "syntax": "[<string> | collection | embedded-opentype | opentype | svg | truetype | woff | woff2 ]"
+  },
+  {
+    "name": "<font-src>",
+    "syntax": "<url> [ format(<font-format>)]? [ tech( <font-tech>#)]? | local(<family-name>)"
+  },
+  {
+    "name": "<font-tech>",
+    "syntax": "[<font-features-tech> | <color-font-tech> | variations | palettes | incremental ]"
+  },
+  {
+    "name": "<font-variant-css2>",
+    "syntax": "normal | small-caps"
+  },
+  {
+    "name": "<font-weight-absolute>",
+    "syntax": "[normal | bold | <number [1,1000]>]"
+  },
+  {
+    "name": "<font-width-css3>",
+    "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
   },
   {
     "name": "<frequency-percentage>",
     "syntax": "[ <frequency> | <percentage> ]"
   },
   {
-    "name": "rgba()",
-    "syntax": "[ <legacy-rgba-syntax> | <modern-rgba-syntax> ]"
+    "name": "<function-parameter>",
+    "syntax": "<custom-property-name> <css-type>? [ ':' <declaration-value> ]?"
   },
   {
-    "name": "hsla()",
-    "syntax": "[ <legacy-hsla-syntax> | <modern-hsla-syntax> ]"
+    "name": "<gap-auto-repeat-rule>",
+    "syntax": "repeat( auto ',' <gap-rule># )"
   },
   {
-    "name": "sepia()",
-    "syntax": "sepia( [ <number> | <percentage> ]? )"
+    "name": "<gap-auto-rule-list>",
+    "syntax": "<gap-rule-or-repeat>#? ',' <gap-auto-repeat-rule> ',' <gap-rule-or-repeat>#?"
   },
   {
-    "name": "<font-tech>",
-    "syntax": "[<font-features-tech> | <color-font-tech> | variations | palettes | incremental ]"
+    "name": "<gap-repeat-rule>",
+    "syntax": "repeat( <integer [1,∞]> ',' <gap-rule># )"
+  },
+  {
+    "name": "<gap-rule-list>",
+    "syntax": "<gap-rule-or-repeat>#"
+  },
+  {
+    "name": "<gap-rule-or-repeat>",
+    "syntax": "<gap-rule> | <gap-repeat-rule>"
+  },
+  {
+    "name": "<gap-rule>",
+    "syntax": "<line-width> || <line-style> || <color>"
+  },
+  {
+    "name": "<generic-complete>",
+    "syntax": "serif | sans-serif | system-ui | cursive | fantasy | math | monospace"
+  },
+  {
+    "name": "<generic-family>",
+    "syntax": "<generic-script-specific>| <generic-complete> | <generic-incomplete>"
+  },
+  {
+    "name": "<generic-incomplete>",
+    "syntax": "ui-serif | ui-sans-serif | ui-monospace | ui-rounded"
+  },
+  {
+    "name": "<generic-script-specific>",
+    "syntax": "generic(fangsong) | generic(kai) | generic(khmer-mul) | generic(nastaliq)"
+  },
+  {
+    "name": "<generic-voice>",
+    "syntax": "[<age>? <gender> <integer>?]"
+  },
+  {
+    "name": "<geometry-box>",
+    "syntax": "<shape-box> | fill-box | stroke-box | view-box"
+  },
+  {
+    "name": "<gradient>",
+    "syntax": "<linear-gradient()> | <repeating-linear-gradient()> | <radial-gradient()> | <repeating-radial-gradient()>"
+  },
+  {
+    "name": "<grid-line>",
+    "syntax": "auto | <custom-ident> | [ [ <integer [-∞,-1]> | <integer [1,∞]> ] && <custom-ident>? ] | [ span && [ <integer [1,∞]> || <custom-ident> ] ]"
+  },
+  {
+    "name": "<historical-lig-values>",
+    "syntax": "[ historical-ligatures | no-historical-ligatures ]"
+  },
+  {
+    "name": "<hue-interpolation-method>",
+    "syntax": "[ shorter | longer | increasing | decreasing ] hue"
+  },
+  {
+    "name": "<hue>",
+    "syntax": "<number> | <angle>"
+  },
+  {
+    "name": "<id-selector>",
+    "syntax": "<hash-token>"
+  },
+  {
+    "name": "<image>",
+    "syntax": "<url> | <gradient>"
+  },
+  {
+    "name": "<import-conditions>",
+    "syntax": "[ supports( [ <supports-condition> | <declaration> ] ) ]? <media-query-list>?"
+  },
+  {
+    "name": "<inflexible-breadth>",
+    "syntax": "<length-percentage [0,∞]> | min-content | max-content | auto"
+  },
+  {
+    "name": "<isolation-mode>",
+    "syntax": "auto | isolate"
+  },
+  {
+    "name": "<keyframe-block>",
+    "syntax": "<keyframe-selector># '{' <declaration-list> '}'"
+  },
+  {
+    "name": "<keyframe-selector>",
+    "syntax": "from | to | <percentage [0,100]>"
+  },
+  {
+    "name": "<keyframes-name>",
+    "syntax": "<custom-ident> | <string>"
+  },
+  {
+    "name": "<layer-name>",
+    "syntax": "<ident> [ '.' <ident> ]*"
+  },
+  {
+    "name": "<layout-box>",
+    "syntax": "<visual-box> | margin-box"
+  },
+  {
+    "name": "<leader-type>",
+    "syntax": "dotted | solid | space | <string>"
+  },
+  {
+    "name": "<legacy-hsl-syntax>",
+    "syntax": "hsl( <hue>, <percentage>, <percentage>, <alpha-value>? )"
+  },
+  {
+    "name": "<legacy-hsla-syntax>",
+    "syntax": "hsla( <hue>, <percentage>, <percentage>, <alpha-value>? )"
+  },
+  {
+    "name": "<legacy-pseudo-element-selector>",
+    "syntax": "':' [before | after | first-line | first-letter]"
+  },
+  {
+    "name": "<legacy-rgb-syntax>",
+    "syntax": "rgb( <percentage>#{3} ',' <alpha-value>? ) | rgb( <number>#{3} ',' <alpha-value>? )"
+  },
+  {
+    "name": "<legacy-rgba-syntax>",
+    "syntax": "rgba( <percentage>#{3} ',' <alpha-value>? ) | rgba( <number>#{3} ',' <alpha-value>? )"
+  },
+  {
+    "name": "<length-percentage>",
+    "syntax": "[ <length> | <percentage> ]"
+  },
+  {
+    "name": "<line-color-list>",
+    "syntax": "[ <line-color-or-repeat> ]+"
+  },
+  {
+    "name": "<line-color-or-repeat>",
+    "syntax": "[ <color> | <repeat-line-color> ]"
+  },
+  {
+    "name": "<line-name-list>",
+    "syntax": "[ <line-names> | <name-repeat> ]+"
+  },
+  {
+    "name": "<line-names>",
+    "syntax": "'[' <custom-ident>* ']'"
+  },
+  {
+    "name": "<line-style-list>",
+    "syntax": "[ <line-style-or-repeat> ]+"
+  },
+  {
+    "name": "<line-style-or-repeat>",
+    "syntax": "[ <line-style> | <repeat-line-style> ]"
+  },
+  {
+    "name": "<line-style>",
+    "syntax": "none | hidden | dotted | dashed | solid | double | groove | ridge | inset | outset"
+  },
+  {
+    "name": "<line-width-list>",
+    "syntax": "[ <line-width-or-repeat> ]+"
+  },
+  {
+    "name": "<line-width-or-repeat>",
+    "syntax": "[ <line-width> | <repeat-line-width> ]"
+  },
+  {
+    "name": "<line-width>",
+    "syntax": "<length [0,∞]> | thin | medium | thick"
+  },
+  {
+    "name": "<linear-color-hint>",
+    "syntax": "<length-percentage>"
+  },
+  {
+    "name": "<linear-color-stop>",
+    "syntax": "<color> <length-percentage>?"
+  },
+  {
+    "name": "<linear-easing-function>",
+    "syntax": "linear | <linear()>"
+  },
+  {
+    "name": "<linear-gradient-syntax>",
+    "syntax": "[ <angle> | <zero> | to <side-or-corner> ]? ',' <color-stop-list>"
+  },
+  {
+    "name": "<link-param>",
+    "syntax": "param( <custom-property-name> <declaration-value>? )"
+  },
+  {
+    "name": "<marker-ref>",
+    "syntax": "<url>"
+  },
+  {
+    "name": "<mask-layer>",
+    "syntax": "<mask-reference> || <position> [ / <bg-size> ]? || <repeat-style> || <geometry-box> || [ <geometry-box> | no-clip ] || <compositing-operator> || <masking-mode>"
+  },
+  {
+    "name": "<mask-reference>",
+    "syntax": "none | <image> | <mask-source>"
+  },
+  {
+    "name": "<mask-source>",
+    "syntax": "<url>"
+  },
+  {
+    "name": "<masking-mode>",
+    "syntax": "alpha | luminance | match-source"
+  },
+  {
+    "name": "<media-and>",
+    "syntax": "and <media-in-parens>"
+  },
+  {
+    "name": "<media-condition-without-or>",
+    "syntax": "<media-not> | <media-in-parens> <media-and>*"
+  },
+  {
+    "name": "<media-condition>",
+    "syntax": "<media-not> | <media-in-parens> [ <media-and>* | <media-or>* ]"
+  },
+  {
+    "name": "<media-feature>",
+    "syntax": "[ <mf-plain> | <mf-boolean> | <mf-range> ]"
+  },
+  {
+    "name": "<media-in-parens>",
+    "syntax": "'(' <media-condition> ')' | '(' <media-feature> ')' | <general-enclosed>"
+  },
+  {
+    "name": "<media-not>",
+    "syntax": "not <media-in-parens>"
+  },
+  {
+    "name": "<media-or>",
+    "syntax": "or <media-in-parens>"
+  },
+  {
+    "name": "<media-query>",
+    "syntax": "<media-condition> | [ not | only ]? <media-type> [ and <media-condition-without-or> ]?"
+  },
+  {
+    "name": "<media-type>",
+    "syntax": "<ident>"
+  },
+  {
+    "name": "<mf-boolean>",
+    "syntax": "<mf-name>"
+  },
+  {
+    "name": "<mf-comparison>",
+    "syntax": "<mf-lt> | <mf-gt> | <mf-eq>"
+  },
+  {
+    "name": "<mf-eq>",
+    "syntax": "'='"
+  },
+  {
+    "name": "<mf-gt>",
+    "syntax": "'>' '='?"
+  },
+  {
+    "name": "<mf-lt>",
+    "syntax": "'<' '='?"
+  },
+  {
+    "name": "<mf-name>",
+    "syntax": "<ident>"
+  },
+  {
+    "name": "<mf-plain>",
+    "syntax": "<mf-name> ':' <mf-value>"
+  },
+  {
+    "name": "<mf-range>",
+    "syntax": "<mf-name> <mf-comparison> <mf-value> | <mf-value> <mf-comparison> <mf-name> | <mf-value> <mf-lt> <mf-name> <mf-lt> <mf-value> | <mf-value> <mf-gt> <mf-name> <mf-gt> <mf-value>"
+  },
+  {
+    "name": "<mf-value>",
+    "syntax": "<number> | <dimension> | <ident> | <ratio>"
+  },
+  {
+    "name": "<modern-hsl-syntax>",
+    "syntax": "hsl( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "<modern-hsla-syntax>",
+    "syntax": "hsla( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "<modern-rgb-syntax>",
+    "syntax": "rgb( [ <number> | <percentage> | none]{3} [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "<modern-rgba-syntax>",
+    "syntax": "rgba( [ <number> | <percentage> | none]{3} [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "<mq-boolean>",
+    "syntax": "<integer [0,1]>"
+  },
+  {
+    "name": "<name-repeat>",
+    "syntax": "repeat( [ <integer [1,∞]> | auto-fill ], <line-names>+)"
+  },
+  {
+    "name": "<namespace-prefix>",
+    "syntax": "<ident>"
+  },
+  {
+    "name": "<ns-prefix>",
+    "syntax": "[ <ident-token> | '*' ]? '|'"
+  },
+  {
+    "name": "<number-optional-number>",
+    "syntax": "<number> <number>?"
+  },
+  {
+    "name": "<numeric-figure-values>",
+    "syntax": "[ lining-nums | oldstyle-nums ]"
+  },
+  {
+    "name": "<numeric-fraction-values>",
+    "syntax": "[ diagonal-fractions | stacked-fractions ]"
+  },
+  {
+    "name": "<numeric-spacing-values>",
+    "syntax": "[ proportional-nums | tabular-nums ]"
+  },
+  {
+    "name": "<offset-path>",
+    "syntax": "<ray()> | <url> | <basic-shape>"
+  },
+  {
+    "name": "<opacity-value>",
+    "syntax": "<number> | <percentage>"
+  },
+  {
+    "name": "<opentype-tag>",
+    "syntax": "<string>"
+  },
+  {
+    "name": "<overflow-position>",
+    "syntax": "unsafe | safe"
+  },
+  {
+    "name": "<page-selector-list>",
+    "syntax": "<page-selector>#"
+  },
+  {
+    "name": "<page-selector>",
+    "syntax": "[ <ident-token>? <pseudo-page>* ]!"
+  },
+  {
+    "name": "<paint-box>",
+    "syntax": "<visual-box> | fill-box | stroke-box"
+  },
+  {
+    "name": "<paint>",
+    "syntax": "none | <image> | <svg-paint>"
+  },
+  {
+    "name": "<points>",
+    "syntax": "[ <number>+ ]#"
+  },
+  {
+    "name": "<polar-color-space>",
+    "syntax": "hsl | hwb | lch | oklch"
+  },
+  {
+    "name": "<position-area>",
+    "syntax": "[ [ left | center | right | span-left | span-right | x-start | x-end | span-x-start | span-x-end | x-self-start | x-self-end | span-x-self-start | span-x-self-end | span-all ] || [ top | center | bottom | span-top | span-bottom | y-start | y-end | span-y-start | span-y-end | y-self-start | y-self-end | span-y-self-start | span-y-self-end | span-all ] | [ block-start | center | block-end | span-block-start | span-block-end | span-all ] || [ inline-start | center | inline-end | span-inline-start | span-inline-end | span-all ] | [ self-block-start | center | self-block-end | span-self-block-start | span-self-block-end | span-all ] || [ self-inline-start | center | self-inline-end | span-self-inline-start | span-self-inline-end | span-all ] | [ start | center | end | span-start | span-end | span-all ]{1,2} | [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2} ]"
+  },
+  {
+    "name": "<position>",
+    "syntax": "[ [ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right ] && [ top | center | bottom ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ] ]"
+  },
+  {
+    "name": "<predefined-rgb-params>",
+    "syntax": "<predefined-rgb> [ <number> | <percentage> | none ]{3}"
+  },
+  {
+    "name": "<predefined-rgb>",
+    "syntax": "srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020 | rec2100-pq | rec2100-hlg | rec2100-linear"
+  },
+  {
+    "name": "<pseudo-class-selector>",
+    "syntax": "':' <ident-token> | ':' <function-token> <any-value> ')'"
+  },
+  {
+    "name": "<pseudo-compound-selector>",
+    "syntax": "<pseudo-element-selector> <pseudo-class-selector>*"
+  },
+  {
+    "name": "<pseudo-element-selector>",
+    "syntax": "':' <pseudo-class-selector> | <legacy-pseudo-element-selector>"
+  },
+  {
+    "name": "<pseudo-page>",
+    "syntax": "':' [ left | right | first | blank ]"
+  },
+  {
+    "name": "<pt-name-selector>",
+    "syntax": "'*' | <custom-ident>"
+  },
+  {
+    "name": "<quote>",
+    "syntax": "open-quote | close-quote | no-open-quote | no-close-quote"
+  },
+  {
+    "name": "<radial-extent>",
+    "syntax": "closest-corner | closest-side | farthest-corner | farthest-side"
+  },
+  {
+    "name": "<radial-gradient-syntax>",
+    "syntax": "[ <radial-shape> || <radial-size> ]? [ at <position> ]? ',' <color-stop-list>"
+  },
+  {
+    "name": "<radial-shape>",
+    "syntax": "circle | ellipse"
+  },
+  {
+    "name": "<radial-size>",
+    "syntax": "<radial-extent> | <length [0,∞]> | <length-percentage [0,∞]>{2}"
+  },
+  {
+    "name": "<ratio>",
+    "syntax": "<number [0,∞]> [ / <number [0,∞]> ]?"
+  },
+  {
+    "name": "<ray-size>",
+    "syntax": "closest-side | closest-corner | farthest-side | farthest-corner | sides"
+  },
+  {
+    "name": "<rectangular-color-space>",
+    "syntax": "srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020 | lab | oklab | xyz | xyz-d50 | xyz-d65"
+  },
+  {
+    "name": "<relative-real-selector-list>",
+    "syntax": "<relative-real-selector>#"
+  },
+  {
+    "name": "<relative-real-selector>",
+    "syntax": "<combinator>? <complex-real-selector>"
+  },
+  {
+    "name": "<relative-selector-list>",
+    "syntax": "<relative-selector>#"
+  },
+  {
+    "name": "<relative-selector>",
+    "syntax": "<combinator>? <complex-selector>"
+  },
+  {
+    "name": "<repeat-line-color>",
+    "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <color> ]+ )"
+  },
+  {
+    "name": "<repeat-line-style>",
+    "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-style> ]+ )"
+  },
+  {
+    "name": "<repeat-line-width>",
+    "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-width> ]+ )"
+  },
+  {
+    "name": "<repeat-style>",
+    "syntax": "repeat-x | repeat-y | [repeat | space | round | no-repeat]{1,2}"
+  },
+  {
+    "name": "<reversed-counter-name>",
+    "syntax": "reversed( <counter-name> )"
+  },
+  {
+    "name": "<rounding-strategy>",
+    "syntax": "nearest | up | down | to-zero"
+  },
+  {
+    "name": "<scroller>",
+    "syntax": "root | nearest | self"
+  },
+  {
+    "name": "<selector-list>",
+    "syntax": "<complex-selector-list>"
+  },
+  {
+    "name": "<self-position>",
+    "syntax": "center | start | end | self-start | self-end | flex-start | flex-end"
+  },
+  {
+    "name": "<shadow>",
+    "syntax": "<color>? && [<length>{2} <length [0,∞]>? <length>?] && inset?"
+  },
+  {
+    "name": "<shape-box>",
+    "syntax": "<visual-box> | margin-box"
+  },
+  {
+    "name": "<side-or-corner>",
+    "syntax": "[left | right] || [top | bottom]"
+  },
+  {
+    "name": "<simple-selector-list>",
+    "syntax": "<simple-selector>#"
+  },
+  {
+    "name": "<simple-selector>",
+    "syntax": "<type-selector> | <subclass-selector>"
+  },
+  {
+    "name": "<single-animation-direction>",
+    "syntax": "normal | reverse | alternate | alternate-reverse"
+  },
+  {
+    "name": "<single-animation-fill-mode>",
+    "syntax": "none | forwards | backwards | both"
   },
   {
     "name": "<single-animation-iteration-count>",
@@ -92,1184 +916,388 @@
     "syntax": "running | paused"
   },
   {
-    "name": "target-counter()",
-    "syntax": "target-counter( [ <string> | <url> ] , <custom-ident> , <counter-style>? )"
-  },
-  {
-    "name": "rotate()",
-    "syntax": "rotate( [ <angle> | <zero> ] )"
-  },
-  {
-    "name": "<compat-auto>",
-    "syntax": "searchfield | textarea | checkbox | radio | menulist | listbox | meter | progress-bar | button"
-  },
-  {
-    "name": "<composite-mode>",
-    "syntax": "clear | copy | source-over | destination-over | source-in | destination-in | source-out | destination-out | source-atop | destination-atop | xor | lighter | plus-darker | plus-lighter"
-  },
-  {
-    "name": "mod()",
-    "syntax": "mod( <calc-sum>, <calc-sum> )"
-  },
-  {
-    "name": "<wq-name>",
-    "syntax": "<ns-prefix>? <ident-token>"
-  },
-  {
-    "name": "<fixed-size>",
-    "syntax": "<fixed-breadth> | minmax( <fixed-breadth> , <track-breadth> ) | minmax( <inflexible-breadth> , <fixed-breadth> )"
-  },
-  {
-    "name": "<position-area>",
-    "syntax": "[ [ left | center | right | span-left | span-right | x-start | x-end | span-x-start | span-x-end | x-self-start | x-self-end | span-x-self-start | span-x-self-end | span-all ] || [ top | center | bottom | span-top | span-bottom | y-start | y-end | span-y-start | span-y-end | y-self-start | y-self-end | span-y-self-start | span-y-self-end | span-all ] | [ block-start | center | block-end | span-block-start | span-block-end | span-all ] || [ inline-start | center | inline-end | span-inline-start | span-inline-end | span-all ] | [ self-block-start | center | self-block-end | span-self-block-start | span-self-block-end | span-all ] || [ self-inline-start | center | self-inline-end | span-self-inline-start | span-self-inline-end | span-all ] | [ start | center | end | span-start | span-end | span-all ]{1,2} | [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2} ]"
-  },
-  {
-    "name": "<display-outside>",
-    "syntax": "block | inline | run-in"
-  },
-  {
-    "name": "<simple-selector-list>",
-    "syntax": "<simple-selector>#"
-  },
-  {
-    "name": "<ratio>",
-    "syntax": "<number [0,∞]> [ / <number [0,∞]> ]?"
-  },
-  {
-    "name": "min()",
-    "syntax": "min( <calc-sum># )"
-  },
-  {
-    "name": "<legacy-rgba-syntax>",
-    "syntax": "rgba( <percentage>#{3} , <alpha-value>? ) | rgba( <number>#{3} , <alpha-value>? )"
-  },
-  {
-    "name": "<side-or-corner>",
-    "syntax": "[left | right] || [top | bottom]"
-  },
-  {
-    "name": "<contextual-alt-values>",
-    "syntax": "[ contextual | no-contextual ]"
-  },
-  {
-    "name": "<step-position>",
-    "syntax": "jump-start | jump-end | jump-none | jump-both | start | end"
-  },
-  {
-    "name": "<single-animation-fill-mode>",
-    "syntax": "none | forwards | backwards | both"
-  },
-  {
-    "name": "symbols()",
-    "syntax": "symbols( <symbols-type>? [ <string> | <image> ]+ )"
-  },
-  {
-    "name": "<supports-in-parens>",
-    "syntax": "( <supports-condition> ) | <supports-feature> | <general-enclosed>"
-  },
-  {
-    "name": "<compat-special>",
-    "syntax": "textfield | menulist-button"
-  },
-  {
-    "name": "view()",
-    "syntax": "view( [ <axis> || <'view-timeline-inset'> ]? )"
-  },
-  {
-    "name": "<display-listitem>",
-    "syntax": "<display-outside>? && [ flow | flow-root ]? && list-item"
-  },
-  {
-    "name": "fit-content()",
-    "syntax": "fit-content( <length-percentage> )"
-  },
-  {
-    "name": "<relative-real-selector-list>",
-    "syntax": "<relative-real-selector>#"
-  },
-  {
-    "name": "<track-list>",
-    "syntax": "[ <line-names>? [ <track-size> | <track-repeat> ] ]+ <line-names>?"
-  },
-  {
-    "name": "<auto-track-list>",
-    "syntax": "[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>? <auto-repeat> [ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>?"
-  },
-  {
-    "name": "<symbol>",
-    "syntax": "<string> | <image> | <custom-ident>"
-  },
-  {
-    "name": "scale()",
-    "syntax": "scale( <number> , <number>? )"
-  },
-  {
-    "name": "<shadow>",
-    "syntax": "<color>? && [<length>{2} <length [0,∞]>? <length>?] && inset?"
-  },
-  {
-    "name": "<link-param>",
-    "syntax": "param( <custom-property-name> <declaration-value>? )"
-  },
-  {
-    "name": "<compound-selector-list>",
-    "syntax": "<compound-selector>#"
-  },
-  {
-    "name": "<radial-size>",
-    "syntax": "<radial-extent> | <length [0,∞]> | <length-percentage [0,∞]>{2}"
-  },
-  {
-    "name": "<font-features-tech>",
-    "syntax": "[features-opentype | features-aat | features-graphite]"
-  },
-  {
-    "name": "running()",
-    "syntax": "running( <custom-ident> )"
-  },
-  {
-    "name": "<keyframe-selector>",
-    "syntax": "from | to | <percentage [0,100]>"
-  },
-  {
-    "name": "<linear-gradient-syntax>",
-    "syntax": "[ <angle> | to <side-or-corner> ]? , <color-stop-list>"
-  },
-  {
-    "name": "<anchor-size>",
-    "syntax": "width | height | block | inline | self-block | self-inline"
-  },
-  {
-    "name": "<linear-stop>",
-    "syntax": "<number> && <linear-stop-length>?"
-  },
-  {
-    "name": "<css-type>",
-    "syntax": "<syntax-component> | <type()>"
-  },
-  {
-    "name": "<target>",
-    "syntax": "<target-counter()> | <target-counters()> | <target-text()>"
-  },
-  {
-    "name": "<easing-function>",
-    "syntax": "linear | <linear-easing-function> | <cubic-bezier-easing-function> | <step-easing-function>"
-  },
-  {
-    "name": "<legacy-hsla-syntax>",
-    "syntax": "hsla( <hue>, <percentage>, <percentage>, <alpha-value>? )"
-  },
-  {
-    "name": "<modern-hsla-syntax>",
-    "syntax": "hsla( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
-  },
-  {
-    "name": "blur()",
-    "syntax": "blur( <length>? )"
-  },
-  {
-    "name": "filter()",
-    "syntax": "filter( [ <image> | <string> ], <filter-value-list> )"
-  },
-  {
-    "name": "<pt-name-selector>",
-    "syntax": "'*' | <custom-ident>"
+    "name": "<single-animation>",
+    "syntax": "<time [0s,∞]> || <easing-function> || <time> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ]"
   },
   {
     "name": "<single-transition-property>",
     "syntax": "all | <custom-ident>"
   },
   {
-    "name": "<visual-box>",
-    "syntax": "content-box | padding-box | border-box"
-  },
-  {
-    "name": "<length-percentage>",
-    "syntax": "[ <length> | <percentage> ]"
-  },
-  {
-    "name": "<spread-shadow>",
-    "syntax": "<'box-shadow-color'>? && [ <'box-shadow-offset'> [ <'box-shadow-blur'> <'box-shadow-spread'>? ]? ] && <'box-shadow-position'>?"
-  },
-  {
-    "name": "<predefined-rgb-params>",
-    "syntax": "<predefined-rgb> [ <number> | <percentage> | none ]{3}"
-  },
-  {
-    "name": "<symbols-type>",
-    "syntax": "cyclic | numeric | alphabetic | symbolic | fixed"
-  },
-  {
-    "name": "<scroller>",
-    "syntax": "root | nearest | self"
-  },
-  {
-    "name": "<generic-complete>",
-    "syntax": "serif | sans-serif | system-ui | cursive | fantasy | math | monospace"
-  },
-  {
-    "name": "<east-asian-width-values>",
-    "syntax": "[ full-width | proportional-width ]"
-  },
-  {
-    "name": "<geometry-box>",
-    "syntax": "<shape-box> | fill-box | stroke-box | view-box"
-  },
-  {
-    "name": "<media-not>",
-    "syntax": "not <media-in-parens>"
-  },
-  {
-    "name": "<opacity-value>",
-    "syntax": "<number> | <percentage>"
-  },
-  {
-    "name": "<hue>",
-    "syntax": "<number> | <angle>"
-  },
-  {
-    "name": "tan()",
-    "syntax": "tan( <calc-sum> )"
-  },
-  {
-    "name": "<boolean>",
-    "syntax": "<bool-not> | <bool-in-parens> [ <bool-and>* | <bool-or>* ]"
-  },
-  {
-    "name": "snap-block()",
-    "syntax": "snap-block( <length> , [ start | end | near ]? )"
-  },
-  {
-    "name": "<paint>",
-    "syntax": "none | <image> | <svg-paint>"
-  },
-  {
-    "name": "<generic-incomplete>",
-    "syntax": "ui-serif | ui-sans-serif | ui-monospace | ui-rounded"
-  },
-  {
-    "name": "exp()",
-    "syntax": "exp( <calc-sum> )"
-  },
-  {
-    "name": "<pseudo-page>",
-    "syntax": "':' [ left | right | first | blank ]"
-  },
-  {
-    "name": "<track-size>",
-    "syntax": "<track-breadth> | minmax( <inflexible-breadth> , <track-breadth> ) | fit-content( <length-percentage [0,∞]> )"
-  },
-  {
-    "name": "<hue-interpolation-method>",
-    "syntax": "[ shorter | longer | increasing | decreasing ] hue"
-  },
-  {
-    "name": "<predefined-rectangular>",
-    "syntax": "jzazbz | ictcp"
-  },
-  {
-    "name": "contrast()",
-    "syntax": "contrast( [ <number> | <percentage> ]? )"
-  },
-  {
-    "name": "<svg-paint>",
-    "syntax": "child | child( <integer> )"
-  },
-  {
-    "name": "<single-animation>",
-    "syntax": "<time [0s,∞]> || <easing-function> || <time> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ]"
-  },
-  {
-    "name": "<media-query>",
-    "syntax": "<media-condition> | [ not | only ]? <media-type> [ and <media-condition-without-or> ]?"
-  },
-  {
-    "name": "<display-legacy>",
-    "syntax": "inline-block | inline-table | inline-flex | inline-grid"
-  },
-  {
-    "name": "<complex-real-selector>",
-    "syntax": "<compound-selector> [ <combinator>? <compound-selector> ]*"
-  },
-  {
-    "name": "<generic-voice>",
-    "syntax": "[<age>? <gender> <integer>?]"
-  },
-  {
-    "name": "<points>",
-    "syntax": "[ <number>+ ]#"
-  },
-  {
-    "name": "xywh()",
-    "syntax": "xywh( <length-percentage>{2} <length-percentage [0,∞]>{2} [ round <'border-radius'> ]? )"
-  },
-  {
-    "name": "<historical-lig-values>",
-    "syntax": "[ historical-ligatures | no-historical-ligatures ]"
-  },
-  {
-    "name": "<isolation-mode>",
-    "syntax": "auto | isolate"
-  },
-  {
-    "name": "<bg-size>",
-    "syntax": "[ <length-percentage [0,∞]> | auto ]{1,2} | cover | contain"
-  },
-  {
-    "name": "<bool-not>",
-    "syntax": "not <bool-in-parens>"
-  },
-  {
-    "name": "<color-base>",
-    "syntax": "<hex-color> | <color-function> | <named-color> | transparent"
-  },
-  {
-    "name": "<image>",
-    "syntax": "<url> | <gradient>"
-  },
-  {
-    "name": "skew()",
-    "syntax": "skew( [ <angle> | <zero> ] , [ <angle> | <zero> ]? )"
-  },
-  {
-    "name": "<mf-comparison>",
-    "syntax": "<mf-lt> | <mf-gt> | <mf-eq>"
-  },
-  {
-    "name": "asin()",
-    "syntax": "asin( <calc-sum> )"
-  },
-  {
-    "name": "paint()",
-    "syntax": "paint( <ident>, <declaration-value>? )"
-  },
-  {
-    "name": "<font-format>",
-    "syntax": "[<string> | collection | embedded-opentype | opentype | svg | truetype | woff | woff2 ]"
-  },
-  {
-    "name": "<pseudo-class-selector>",
-    "syntax": "':' <ident-token> | ':' <function-token> <any-value> ')'"
-  },
-  {
-    "name": "minmax()",
-    "syntax": "minmax(min, max)"
-  },
-  {
-    "name": "sign()",
-    "syntax": "sign( <calc-sum> )"
-  },
-  {
-    "name": "<legacy-rgb-syntax>",
-    "syntax": "rgb( <percentage>#{3} , <alpha-value>? ) | rgb( <number>#{3} , <alpha-value>? )"
-  },
-  {
-    "name": "counters()",
-    "syntax": "counters( <counter-name>, <string>, <counter-style>? )"
-  },
-  {
-    "name": "<numeric-spacing-values>",
-    "syntax": "[ proportional-nums | tabular-nums ]"
-  },
-  {
-    "name": "<display-inside>",
-    "syntax": "flow | flow-root | table | flex | grid | ruby"
-  },
-  {
-    "name": "sqrt()",
-    "syntax": "sqrt( <calc-sum> )"
-  },
-  {
-    "name": "<dasharray>",
-    "syntax": "[ [ <length-percentage> | <number> ]+ ]#"
-  },
-  {
-    "name": "<an+b>",
-    "syntax": "odd | even | <integer> | <n-dimension> | '+'? n | -n | <ndashdigit-dimension> | '+'? <ndashdigit-ident> | <dashndashdigit-ident> | <n-dimension> <signed-integer> | '+'? n <signed-integer> | -n <signed-integer> | <ndash-dimension> <signless-integer> | '+'? n- <signless-integer> | -n- <signless-integer> | <n-dimension> ['+' | '-'] <signless-integer> | '+'? n ['+' | '-'] <signless-integer> | -n ['+' | '-'] <signless-integer>"
-  },
-  {
-    "name": "opacity()",
-    "syntax": "opacity( [ <number> | <percentage> ]? )"
-  },
-  {
-    "name": "<attachment>",
-    "syntax": "scroll | fixed | local"
-  },
-  {
-    "name": "<subclass-selector>",
-    "syntax": "<id-selector> | <class-selector> | <attribute-selector> | <pseudo-class-selector>"
-  },
-  {
-    "name": "atan2()",
-    "syntax": "atan2( <calc-sum>, <calc-sum> )"
-  },
-  {
-    "name": "saturate()",
-    "syntax": "saturate( [ <number> | <percentage> ]? )"
-  },
-  {
-    "name": "<filter-function>",
-    "syntax": "<blur()> | <brightness()> | <contrast()> | <drop-shadow()> | <grayscale()> | <hue-rotate()> | <invert()> | <opacity()> | <sepia()> | <saturate()>"
-  },
-  {
-    "name": "<number-optional-number>",
-    "syntax": "<number> <number>?"
-  },
-  {
-    "name": "<discretionary-lig-values>",
-    "syntax": "[ discretionary-ligatures | no-discretionary-ligatures ]"
-  },
-  {
-    "name": "<keyframe-block>",
-    "syntax": "<keyframe-selector># { <declaration-list> }"
-  },
-  {
-    "name": "<mask-layer>",
-    "syntax": "<mask-reference> || <position> [ / <bg-size> ]? || <repeat-style> || <geometry-box> || [ <geometry-box> | no-clip ] || <compositing-operator> || <masking-mode>"
-  },
-  {
-    "name": "<grid-line>",
-    "syntax": "auto | <custom-ident> | [ [ <integer [-∞,-1]> | <integer [1,∞]> ] && <custom-ident>? ] | [ span && [ <integer [1,∞]> || <custom-ident> ] ]"
-  },
-  {
-    "name": "<fixed-repeat>",
-    "syntax": "repeat( [ <integer [1,∞]> ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
-  },
-  {
-    "name": "lab()",
-    "syntax": "lab( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
-  },
-  {
-    "name": "<page-selector-list>",
-    "syntax": "<page-selector>#"
-  },
-  {
-    "name": "hue-rotate()",
-    "syntax": "hue-rotate( [ <angle> | <zero> ]? )"
-  },
-  {
-    "name": "<anchor-element>",
-    "syntax": "<dashed-ident>"
-  },
-  {
-    "name": "linear()",
-    "syntax": "linear(<linear-stop-list>)"
-  },
-  {
-    "name": "<bg-position>",
-    "syntax": "[ [ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ center | [ left | right ] <length-percentage>? ] && [ center | [ top | bottom ] <length-percentage>? ] ]"
+    "name": "<single-transition>",
+    "syntax": "[ none | <single-transition-property> ] || <time> || <easing-function> || <time>"
   },
   {
     "name": "<source-size-list>",
-    "syntax": "<source-size>#? , <source-size-value>"
-  },
-  {
-    "name": "scaleX()",
-    "syntax": "scaleX( <number> )"
-  },
-  {
-    "name": "<transform-list>",
-    "syntax": "<transform-function>+"
-  },
-  {
-    "name": "<media-feature>",
-    "syntax": "[ <mf-plain> | <mf-boolean> | <mf-range> ]"
-  },
-  {
-    "name": "src()",
-    "syntax": "src( <string> <url-modifier>* )"
-  },
-  {
-    "name": "<explicit-track-list>",
-    "syntax": "[ <line-names>? <track-size> ]+ <line-names>?"
-  },
-  {
-    "name": "<inflexible-breadth>",
-    "syntax": "<length-percentage [0,∞]> | min-content | max-content | auto"
-  },
-  {
-    "name": "<step-easing-function>",
-    "syntax": "step-start | step-end | steps(<integer> , <step-position>?)"
-  },
-  {
-    "name": "<id-selector>",
-    "syntax": "<hash-token>"
-  },
-  {
-    "name": "<auto-repeat>",
-    "syntax": "repeat( [ auto-fill | auto-fit ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
-  },
-  {
-    "name": "target-text()",
-    "syntax": "target-text( [ <string> | <url> ] , [ content | before | after | first-letter ]? )"
-  },
-  {
-    "name": "abs()",
-    "syntax": "abs( <calc-sum> )"
-  },
-  {
-    "name": "<calc-value>",
-    "syntax": "<number> | <dimension> | <percentage> | <calc-keyword> | ( <calc-sum> )"
-  },
-  {
-    "name": "<color-function>",
-    "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <oklab()> | <oklch()> | <color()>"
+    "syntax": "<source-size>#? ',' <source-size-value>"
   },
   {
     "name": "<source-size-value>",
     "syntax": "<length> | auto"
   },
   {
-    "name": "<self-position>",
-    "syntax": "center | start | end | self-start | self-end | flex-start | flex-end"
+    "name": "<source-size>",
+    "syntax": "<media-condition> <source-size-value> | auto"
   },
   {
-    "name": "<offset-path>",
-    "syntax": "<ray()> | <url> | <basic-shape>"
+    "name": "<spread-shadow>",
+    "syntax": "<'box-shadow-color'>? && [ <'box-shadow-offset'> [ <'box-shadow-blur'> <'box-shadow-spread'>? ]? ] && <'box-shadow-position'>?"
   },
   {
-    "name": "translate()",
-    "syntax": "translate( <length-percentage> , <length-percentage>? )"
+    "name": "<step-easing-function>",
+    "syntax": "step-start | step-end | <steps()>"
   },
   {
-    "name": "<media-or>",
-    "syntax": "or <media-in-parens>"
+    "name": "<step-position>",
+    "syntax": "jump-start | jump-end | jump-none | jump-both | start | end"
   },
   {
-    "name": "<xyz>",
-    "syntax": "xyz | xyz-d50 | xyz-d65"
+    "name": "<subclass-selector>",
+    "syntax": "<id-selector> | <class-selector> | <attribute-selector> | <pseudo-class-selector>"
   },
   {
-    "name": "clamp()",
-    "syntax": "clamp( [ <calc-sum> | none ], <calc-sum>, [ <calc-sum> | none ] )"
+    "name": "<supports-condition>",
+    "syntax": "not <supports-in-parens> | <supports-in-parens> [ and <supports-in-parens> ]* | <supports-in-parens> [ or <supports-in-parens> ]*"
   },
   {
-    "name": "<general-enclosed>",
-    "syntax": "[ <function-token> <any-value>? ) ] | [ ( <any-value>? ) ]"
-  },
-  {
-    "name": "<repeat-style>",
-    "syntax": "repeat-x | repeat-y | [repeat | space | round | no-repeat]{1,2}"
-  },
-  {
-    "name": "<single-animation-direction>",
-    "syntax": "normal | reverse | alternate | alternate-reverse"
-  },
-  {
-    "name": "<bool-and>",
-    "syntax": "and <bool-in-parens>"
-  },
-  {
-    "name": "target-counters()",
-    "syntax": "target-counters( [ <string> | <url> ] , <custom-ident> , <string> , <counter-style>? )"
-  },
-  {
-    "name": "<legacy-pseudo-element-selector>",
-    "syntax": "':' [before | after | first-line | first-letter]"
-  },
-  {
-    "name": "max()",
-    "syntax": "max( <calc-sum># )"
-  },
-  {
-    "name": "<class-selector>",
-    "syntax": "'.' <ident-token>"
-  },
-  {
-    "name": "<mf-range>",
-    "syntax": "<mf-name> <mf-comparison> <mf-value> | <mf-value> <mf-comparison> <mf-name> | <mf-value> <mf-lt> <mf-name> <mf-lt> <mf-value> | <mf-value> <mf-gt> <mf-name> <mf-gt> <mf-value>"
-  },
-  {
-    "name": "<calc-keyword>",
-    "syntax": "e | pi | infinity | -infinity | NaN"
-  },
-  {
-    "name": "<modern-rgba-syntax>",
-    "syntax": "rgba( [ <number> | <percentage> | none]{3} [ / [<alpha-value> | none] ]? )"
-  },
-  {
-    "name": "lch()",
-    "syntax": "lch( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )"
-  },
-  {
-    "name": "oklch()",
-    "syntax": "oklch( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )"
-  },
-  {
-    "name": "<linear-easing-function>",
-    "syntax": "linear(<linear-stop-list>)"
-  },
-  {
-    "name": "var()",
-    "syntax": "var( <custom-property-name> , <declaration-value>? )"
-  },
-  {
-    "name": "<marker-ref>",
-    "syntax": "<url>"
-  },
-  {
-    "name": "<feature-value-name>",
-    "syntax": "<ident>"
-  },
-  {
-    "name": "skewX()",
-    "syntax": "skewX( [ <angle> | <zero> ] )"
-  },
-  {
-    "name": "<predefined-polar-params>",
-    "syntax": "jzczhz [ <number> | <percentage> | none ]{2} [ <hue> | none]"
-  },
-  {
-    "name": "<linear-color-hint>",
-    "syntax": "<length-percentage>"
-  },
-  {
-    "name": "<predefined-rectangular-params>",
-    "syntax": "<predefined-rectangular> [ <number> | <percentage> | none ]{3}"
-  },
-  {
-    "name": "<quote>",
-    "syntax": "open-quote | close-quote | no-open-quote | no-close-quote"
-  },
-  {
-    "name": "<leader-type>",
-    "syntax": "dotted | solid | space | <string>"
-  },
-  {
-    "name": "<function-parameter-list>",
-    "syntax": "<function-parameter>#"
-  },
-  {
-    "name": "<radial-extent>",
-    "syntax": "closest-corner | closest-side | farthest-corner | farthest-side"
-  },
-  {
-    "name": "<numeric-figure-values>",
-    "syntax": "[ lining-nums | oldstyle-nums ]"
-  },
-  {
-    "name": "<bg-image>",
-    "syntax": "<image> | none"
-  },
-  {
-    "name": "ray()",
-    "syntax": "ray( <angle> && <ray-size>? && contain? && [at <position>]? )"
-  },
-  {
-    "name": "<east-asian-variant-values>",
-    "syntax": "[ jis78 | jis83 | jis90 | jis04 | simplified | traditional ]"
-  },
-  {
-    "name": "rgb()",
-    "syntax": "[ <legacy-rgb-syntax> | <modern-rgb-syntax> ]"
-  },
-  {
-    "name": "<syntax-combinator>",
-    "syntax": "'|'"
-  },
-  {
-    "name": "<namespace-prefix>",
-    "syntax": "<ident>"
-  },
-  {
-    "name": "<page-selector>",
-    "syntax": "[ <ident-token>? <pseudo-page>* ]!"
-  },
-  {
-    "name": "cubic-bezier()",
-    "syntax": "cubic-bezier(<number [0,1]>, <number>, <number [0,1]>, <number>)"
-  },
-  {
-    "name": "<complex-selector-unit>",
-    "syntax": "[ <compound-selector>? <pseudo-compound-selector>* ]!"
-  },
-  {
-    "name": "<media-condition-without-or>",
-    "syntax": "<media-not> | <media-in-parens> <media-and>*"
-  },
-  {
-    "name": "translateX()",
-    "syntax": "translateX( <length-percentage> )"
-  },
-  {
-    "name": "scaleY()",
-    "syntax": "scaleY( <number> )"
-  },
-  {
-    "name": "scroll()",
-    "syntax": "scroll( [ <scroller> || <axis> ]? )"
-  },
-  {
-    "name": "<font-variant-css2>",
-    "syntax": "[normal | small-caps]"
-  },
-  {
-    "name": "env()",
-    "syntax": "env( <custom-ident> <integer [0,∞]>*, <declaration-value>? )"
-  },
-  {
-    "name": "<selector-list>",
-    "syntax": "<complex-selector-list>"
-  },
-  {
-    "name": "<legacy-hsl-syntax>",
-    "syntax": "hsl( <hue>, <percentage>, <percentage>, <alpha-value>? )"
-  },
-  {
-    "name": "<mask-reference>",
-    "syntax": "none | <image> | <mask-source>"
-  },
-  {
-    "name": "<custom-arg>",
-    "syntax": "$ <ident-token> ;"
-  },
-  {
-    "name": "<gradient>",
-    "syntax": "<linear-gradient()> | <repeating-linear-gradient()> | <radial-gradient()> | <repeating-radial-gradient()>"
-  },
-  {
-    "name": "radial-gradient()",
-    "syntax": "radial-gradient( [ <radial-gradient-syntax> ] )"
-  },
-  {
-    "name": "brightness()",
-    "syntax": "brightness( [ <number> | <percentage> ]? )"
-  },
-  {
-    "name": "<family-name>",
-    "syntax": "<string> | <custom-ident>+"
-  },
-  {
-    "name": "steps()",
-    "syntax": "steps(<integer>, <step-position>?)"
-  },
-  {
-    "name": "<function-parameter>",
-    "syntax": "<custom-property-name> <css-type>? [ : <declaration-value> ]?"
-  },
-  {
-    "name": "<mq-boolean>",
-    "syntax": "<integer [0,1]>"
-  },
-  {
-    "name": "hypot()",
-    "syntax": "hypot( <calc-sum># )"
-  },
-  {
-    "name": "oklab()",
-    "syntax": "oklab( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
-  },
-  {
-    "name": "<counter-style>",
-    "syntax": "<counter-style-name> | <symbols()>"
+    "name": "<supports-decl>",
+    "syntax": "'(' <declaration> ')'"
   },
   {
     "name": "<supports-feature>",
     "syntax": "<supports-decl>"
   },
   {
-    "name": "<try-tactic>",
-    "syntax": "flip-block || flip-inline || flip-start"
+    "name": "<supports-in-parens>",
+    "syntax": "'(' <supports-condition> ')' | <supports-feature> | <general-enclosed>"
   },
   {
-    "name": "<line-width>",
-    "syntax": "<length [0,∞]> | thin | medium | thick"
+    "name": "<svg-paint>",
+    "syntax": "child | child( <integer> )"
   },
   {
-    "name": "<media-type>",
-    "syntax": "<ident>"
+    "name": "<symbol>",
+    "syntax": "<string> | <image> | <custom-ident>"
   },
   {
-    "name": "matrix()",
-    "syntax": "matrix( <number>#{6} )"
-  },
-  {
-    "name": "palette-mix()",
-    "syntax": "palette-mix(<color-interpolation-method> , [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})"
-  },
-  {
-    "name": "<complex-real-selector-list>",
-    "syntax": "<complex-real-selector>#"
-  },
-  {
-    "name": "<simple-selector>",
-    "syntax": "<type-selector> | <subclass-selector>"
-  },
-  {
-    "name": "<mf-boolean>",
-    "syntax": "<mf-name>"
-  },
-  {
-    "name": "<rectangular-color-space>",
-    "syntax": "srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020 | lab | oklab | xyz | xyz-d50 | xyz-d65"
-  },
-  {
-    "name": "dynamic-range-limit-mix()",
-    "syntax": "dynamic-range-limit-mix( [ <ident> && <percentage [0,100]>? ]#{2})"
-  },
-  {
-    "name": "<content-replacement>",
-    "syntax": "<image>"
-  },
-  {
-    "name": "<display-internal>",
-    "syntax": "table-row-group | table-header-group | table-footer-group | table-row | table-cell | table-column-group | table-column | table-caption | ruby-base | ruby-text | ruby-base-container | ruby-text-container"
-  },
-  {
-    "name": "<display-box>",
-    "syntax": "contents | none"
-  },
-  {
-    "name": "anchor()",
-    "syntax": "anchor( <anchor-element>? && <anchor-side>, <length-percentage>? )"
-  },
-  {
-    "name": "string()",
-    "syntax": "string( <custom-ident> , [ first | start | last | first-except ]? )"
-  },
-  {
-    "name": "<syntax-component-name>",
-    "syntax": "'<' <syntax-type> '>' | <custom-ident>"
-  },
-  {
-    "name": "round()",
-    "syntax": "round( <rounding-strategy>?, <calc-sum>, <calc-sum>? )"
-  },
-  {
-    "name": "rem()",
-    "syntax": "rem( <calc-sum>, <calc-sum> )"
-  },
-  {
-    "name": "sin()",
-    "syntax": "sin( <calc-sum> )"
-  },
-  {
-    "name": "<boolean-without-or>",
-    "syntax": "<bool-not> | <bool-in-parens> <bool-and>*"
-  },
-  {
-    "name": "<content-distribution>",
-    "syntax": "space-between | space-around | space-evenly | stretch"
-  },
-  {
-    "name": "<mf-name>",
-    "syntax": "<ident>"
-  },
-  {
-    "name": "ellipse()",
-    "syntax": "ellipse( <radial-size>? [ at <position> ]? )"
-  },
-  {
-    "name": "rect()",
-    "syntax": "rect( <top>, <right>, <bottom>, <left> )"
-  },
-  {
-    "name": "<complex-selector-list>",
-    "syntax": "<complex-selector>#"
-  },
-  {
-    "name": "<type()>",
-    "syntax": "type( <syntax> )"
-  },
-  {
-    "name": "counter()",
-    "syntax": "counter( <counter-name>, <counter-style>? )"
-  },
-  {
-    "name": "anchor-size()",
-    "syntax": "anchor-size( [ <anchor-element> || <anchor-size> ]? , <length-percentage>? )"
-  },
-  {
-    "name": "skewY()",
-    "syntax": "skewY( [ <angle> | <zero> ] )"
-  },
-  {
-    "name": "<content-position>",
-    "syntax": "center | start | end | flex-start | flex-end"
-  },
-  {
-    "name": "<custom-params>",
-    "syntax": "<dashed-ident> [ <number> | <percentage> | none ]+"
-  },
-  {
-    "name": "<content-list>",
-    "syntax": "[ <string> | <counter()> | <counters()> | <content()> | <attr()> ]+"
-  },
-  {
-    "name": "<filter-value-list>",
-    "syntax": "[ <filter-function> | <url> ]+"
-  },
-  {
-    "name": "<font-src>",
-    "syntax": "<url> [ format(<font-format>)]? [ tech( <font-tech>#)]? | local(<family-name>)"
-  },
-  {
-    "name": "<linear-stop-length>",
-    "syntax": "<percentage>{1,2}"
-  },
-  {
-    "name": "<track-repeat>",
-    "syntax": "repeat( [ <integer [1,∞]> ] , [ <line-names>? <track-size> ]+ <line-names>? )"
-  },
-  {
-    "name": "<polar-color-space>",
-    "syntax": "hsl | hwb | lch | oklch"
-  },
-  {
-    "name": "<font-width-css3>",
-    "syntax": "[normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded]"
-  },
-  {
-    "name": "<paint-box>",
-    "syntax": "<visual-box> | fill-box | stroke-box"
-  },
-  {
-    "name": "cos()",
-    "syntax": "cos( <calc-sum> )"
-  },
-  {
-    "name": "<mf-gt>",
-    "syntax": "'>' '='?"
-  },
-  {
-    "name": "<bool-or>",
-    "syntax": "or <bool-in-parens>"
-  },
-  {
-    "name": "<predefined-rgb>",
-    "syntax": "srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020 | rec2100-pq | rec2100-hlg | rec2100-linear"
-  },
-  {
-    "name": "<overflow-position>",
-    "syntax": "unsafe | safe"
-  },
-  {
-    "name": "<relative-selector-list>",
-    "syntax": "<relative-selector>#"
-  },
-  {
-    "name": "path()",
-    "syntax": "path( <'fill-rule'>? , <string> )"
-  },
-  {
-    "name": "<generic-family>",
-    "syntax": "<generic-script-specific>| <generic-complete> | <generic-incomplete>"
-  },
-  {
-    "name": "<attr-modifier>",
-    "syntax": "i | s"
-  },
-  {
-    "name": "<media-in-parens>",
-    "syntax": "( <media-condition> ) | ( <media-feature> ) | <general-enclosed>"
-  },
-  {
-    "name": "<alpha-value>",
-    "syntax": "<number> | <percentage>"
-  },
-  {
-    "name": "<modern-rgb-syntax>",
-    "syntax": "rgb( [ <number> | <percentage> | none]{3} [ / [<alpha-value> | none] ]? )"
-  },
-  {
-    "name": "<radial-shape>",
-    "syntax": "circle | ellipse"
-  },
-  {
-    "name": "<final-bg-layer>",
-    "syntax": "<bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <visual-box> || <visual-box> || <'background-color'>"
-  },
-  {
-    "name": "pow()",
-    "syntax": "pow( <calc-sum>, <calc-sum> )"
+    "name": "<symbols-type>",
+    "syntax": "cyclic | numeric | alphabetic | symbolic | fixed"
   },
   {
     "name": "<system-family-name>",
     "syntax": "caption | icon | menu | message-box | small-caption | status-bar"
   },
   {
-    "name": "<complex-selector>",
-    "syntax": "<complex-selector-unit> [ <combinator>? <complex-selector-unit> ]*"
+    "name": "<target>",
+    "syntax": "<target-counter()> | <target-counters()> | <target-text()>"
   },
   {
-    "name": "<xyz-space>",
-    "syntax": "xyz | xyz-d50 | xyz-d65"
+    "name": "<text-edge>",
+    "syntax": "[ text | ideographic | ideographic-ink ] | [ text | ideographic | ideographic-ink | cap | ex ] [ text | ideographic | ideographic-ink | alphabetic ]"
   },
   {
-    "name": "polygon()",
-    "syntax": "polygon( <'fill-rule'>? , [<length-percentage> <length-percentage>]# )"
-  },
-  {
-    "name": "<animateable-feature>",
-    "syntax": "scroll-position | contents | <custom-ident>"
-  },
-  {
-    "name": "<layout-box>",
-    "syntax": "<visual-box> | margin-box"
-  },
-  {
-    "name": "<combinator>",
-    "syntax": "'>' | '+' | '~' | [ '|' '|' ]"
+    "name": "<time-percentage>",
+    "syntax": "[ <time> | <percentage> ]"
   },
   {
     "name": "<track-breadth>",
     "syntax": "<length-percentage [0,∞]> | <flex [0,∞]> | min-content | max-content | auto"
   },
   {
-    "name": "<line-names>",
-    "syntax": "'[' <custom-ident>* ']'"
+    "name": "<track-list>",
+    "syntax": "[ <line-names>? [ <track-size> | <track-repeat> ] ]+ <line-names>?"
   },
   {
-    "name": "<single-transition>",
-    "syntax": "[ none | <single-transition-property> ] || <time> || <easing-function> || <time>"
+    "name": "<track-repeat>",
+    "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-names>? <track-size> ]+ <line-names>? )"
   },
   {
-    "name": "<numeric-fraction-values>",
-    "syntax": "[ diagonal-fractions | stacked-fractions ]"
+    "name": "<track-size>",
+    "syntax": "<track-breadth> | minmax( <inflexible-breadth> ',' <track-breadth> ) | fit-content( <length-percentage [0,∞]> )"
   },
   {
-    "name": "<cubic-bezier-easing-function>",
-    "syntax": "ease | ease-in | ease-out | ease-in-out | cubic-bezier(<number [0,1]>, <number>, <number [0,1]>, <number>)"
+    "name": "<transform-list>",
+    "syntax": "<transform-function>+"
   },
   {
-    "name": "<media-and>",
-    "syntax": "and <media-in-parens>"
+    "name": "<try-size>",
+    "syntax": "most-width | most-height | most-block-size | most-inline-size"
   },
   {
-    "name": "<mf-eq>",
-    "syntax": "'='"
-  },
-  {
-    "name": "<syntax-type>",
-    "syntax": "angle | color | custom-ident | image | integer | length | length-percentage | number | percentage | resolution | string | time | url | transform-function"
-  },
-  {
-    "name": "linear-gradient()",
-    "syntax": "linear-gradient( [ <linear-gradient-syntax> ] )"
-  },
-  {
-    "name": "<attribute-selector>",
-    "syntax": "'[' <wq-name> ']' | '[' <wq-name> <attr-matcher> [ <string-token> | <ident-token> ] <attr-modifier>? ']'"
-  },
-  {
-    "name": "<mf-lt>",
-    "syntax": "'<' '='?"
-  },
-  {
-    "name": "<generic-script-specific>",
-    "syntax": "generic(kai) | generic(fangsong) | generic(nastaliq)"
-  },
-  {
-    "name": "<compound-selector>",
-    "syntax": "[ <type-selector>? <subclass-selector>* ]!"
-  },
-  {
-    "name": "content()",
-    "syntax": "content( [ text | before | after | first-letter | marker ]? )"
-  },
-  {
-    "name": "hwb()",
-    "syntax": "hwb( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
-  },
-  {
-    "name": "<xyz-params>",
-    "syntax": "<xyz> [ <number> | <percentage> | none ]{3}"
-  },
-  {
-    "name": "<supports-decl>",
-    "syntax": "( <declaration> )"
-  },
-  {
-    "name": "<linear-color-stop>",
-    "syntax": "<color> <length-percentage>?"
-  },
-  {
-    "name": "translateY()",
-    "syntax": "translateY( <length-percentage> )"
+    "name": "<try-tactic>",
+    "syntax": "flip-block || flip-inline || flip-start"
   },
   {
     "name": "<type-selector>",
     "syntax": "<wq-name> | <ns-prefix>? '*'"
   },
   {
-    "name": "<angle-percentage>",
-    "syntax": "[ <angle> | <percentage> ]"
+    "name": "<type>",
+    "syntax": "'<' [ number | string ] '>'"
   },
   {
-    "name": "<modern-hsl-syntax>",
-    "syntax": "hsl( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+    "name": "<url>",
+    "syntax": "<url()> | <src()>"
   },
   {
-    "name": "<color-space>",
-    "syntax": "<rectangular-color-space> | <polar-color-space>"
+    "name": "<visual-box>",
+    "syntax": "content-box | padding-box | border-box"
   },
   {
-    "name": "<text-edge>",
-    "syntax": "[ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]?"
+    "name": "<wq-name>",
+    "syntax": "<ns-prefix>? <ident-token>"
   },
   {
-    "name": "<function-dependency-list>",
-    "syntax": "<function-parameter>#"
+    "name": "<xyz-params>",
+    "syntax": "<xyz-space> [ <number> | <percentage> | none ]{3}"
   },
   {
-    "name": "<syntax>",
-    "syntax": "'*' | <syntax-component> [ <syntax-combinator> <syntax-component> ]+"
+    "name": "<xyz-space>",
+    "syntax": "xyz | xyz-d50 | xyz-d65"
   },
   {
-    "name": "<attr-matcher>",
-    "syntax": "[ '~' | '|' | '^' | '$' | '*' ]? '='"
+    "name": "abs()",
+    "syntax": "abs( <calc-sum> )"
   },
   {
-    "name": "<ray-size>",
-    "syntax": "closest-side | closest-corner | farthest-side | farthest-corner | sides"
+    "name": "acos()",
+    "syntax": "acos( <calc-sum> )"
   },
   {
-    "name": "<syntax-component>",
-    "syntax": "<syntax-component-name> <syntax-multiplier>? | '<' transform-list '>'"
+    "name": "anchor()",
+    "syntax": "anchor( <anchor-name>? && <anchor-side>, <length-percentage>? )"
   },
   {
-    "name": "<opentype-tag>",
-    "syntax": "<string>"
+    "name": "anchor-size()",
+    "syntax": "anchor-size( [ <anchor-name> || <anchor-size> ]? ',' <length-percentage>? )"
   },
   {
-    "name": "<layer-name>",
-    "syntax": "<ident> [ '.' <ident> ]*"
+    "name": "asin()",
+    "syntax": "asin( <calc-sum> )"
   },
   {
-    "name": "<mf-plain>",
-    "syntax": "<mf-name> : <mf-value>"
+    "name": "atan()",
+    "syntax": "atan( <calc-sum> )"
   },
   {
-    "name": "<media-condition>",
-    "syntax": "<media-not> | <media-in-parens> [ <media-and>* | <media-or>* ]"
+    "name": "atan2()",
+    "syntax": "atan2( <calc-sum>, <calc-sum> )"
   },
   {
-    "name": "<position>",
-    "syntax": "[ [ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right ] && [ top | center | bottom ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ] ]"
+    "name": "blur()",
+    "syntax": "blur( <length>? )"
   },
   {
-    "name": "<rounding-strategy>",
-    "syntax": "nearest | up | down | to-zero"
+    "name": "brightness()",
+    "syntax": "brightness( [ <number> | <percentage> ]? )"
   },
   {
-    "name": "<coord-box>",
-    "syntax": "<paint-box> | view-box"
+    "name": "calc()",
+    "syntax": "calc( <calc-sum> )"
   },
   {
-    "name": "<import-conditions>",
-    "syntax": "[ supports( [ <supports-condition> | <declaration> ] ) ]? <media-query-list>?"
+    "name": "circle()",
+    "syntax": "circle( <radial-size>? [ at <position> ]? )"
   },
   {
-    "name": "url()",
-    "syntax": "url( <string> <url-modifier>* ) | <url-token>"
+    "name": "clamp()",
+    "syntax": "clamp( [ <calc-sum> | none ], <calc-sum>, [ <calc-sum> | none ] )"
   },
   {
-    "name": "<fixed-breadth>",
-    "syntax": "<length-percentage [0,∞]>"
+    "name": "content()",
+    "syntax": "content( [ text | before | after | first-letter | marker ]? )"
   },
   {
-    "name": "<color>",
-    "syntax": "<color-base> | currentColor | <system-color>"
+    "name": "contrast()",
+    "syntax": "contrast( [ <number> | <percentage> ]? )"
+  },
+  {
+    "name": "control-value()",
+    "syntax": "control-value( <type>? )"
+  },
+  {
+    "name": "cos()",
+    "syntax": "cos( <calc-sum> )"
+  },
+  {
+    "name": "counter()",
+    "syntax": "counter( <counter-name>, <counter-style>? )"
+  },
+  {
+    "name": "counters()",
+    "syntax": "counters( <counter-name>, <string>, <counter-style>? )"
+  },
+  {
+    "name": "cubic-bezier()",
+    "syntax": "cubic-bezier( [ <number [0,1]>, <number> ]#{2} )"
+  },
+  {
+    "name": "drop-shadow()",
+    "syntax": "drop-shadow( [ <color>? && <length>{2,3} ] )"
+  },
+  {
+    "name": "dynamic-range-limit-mix()",
+    "syntax": "dynamic-range-limit-mix( [ <'dynamic-range-limit'> && <percentage [0,100]> ]#{2,} )"
+  },
+  {
+    "name": "ellipse()",
+    "syntax": "ellipse( <radial-size>? [ at <position> ]? )"
+  },
+  {
+    "name": "env()",
+    "syntax": "env( <custom-ident> <integer [0,∞]>*, <declaration-value>? )"
+  },
+  {
+    "name": "exp()",
+    "syntax": "exp( <calc-sum> )"
+  },
+  {
+    "name": "filter()",
+    "syntax": "filter( [ <image> | <string> ], <filter-value-list> )"
+  },
+  {
+    "name": "fit-content()",
+    "syntax": "fit-content( <length-percentage> )"
+  },
+  {
+    "name": "grayscale()",
+    "syntax": "grayscale( [ <number> | <percentage> ]? )"
+  },
+  {
+    "name": "hdr-color()",
+    "syntax": "color-hdr([ <color> && <number [0,∞]>? ]#{2})"
+  },
+  {
+    "name": "hsl()",
+    "syntax": "[ <legacy-hsl-syntax> | <modern-hsl-syntax> ]"
+  },
+  {
+    "name": "hsla()",
+    "syntax": "[ <legacy-hsla-syntax> | <modern-hsla-syntax> ]"
+  },
+  {
+    "name": "hue-rotate()",
+    "syntax": "hue-rotate( [ <angle> | <zero> ]? )"
+  },
+  {
+    "name": "hwb()",
+    "syntax": "hwb( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "hypot()",
+    "syntax": "hypot( <calc-sum># )"
+  },
+  {
+    "name": "ictcp()",
+    "syntax": "ictcp([from <color>]? [<percentage> | <number> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "inset()",
+    "syntax": "inset( <length-percentage>{1,4} [ round <'border-radius'> ]? )"
+  },
+  {
+    "name": "invert()",
+    "syntax": "invert( [ <number> | <percentage> ]? )"
+  },
+  {
+    "name": "jzazbz()",
+    "syntax": "jzazbz([from <color>]? [<percentage> | <number> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "jzczhz()",
+    "syntax": "jzczhz([from <color>]? [<percentage> | <number> | none] [<percentage> | <number> | none] [<hue> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "lab()",
+    "syntax": "lab( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "lch()",
+    "syntax": "lch( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "leader()",
+    "syntax": "leader( <leader-type> )"
+  },
+  {
+    "name": "linear()",
+    "syntax": "linear( [ <number> && <percentage>{0,2} ]# )"
+  },
+  {
+    "name": "linear-gradient()",
+    "syntax": "linear-gradient( [ <linear-gradient-syntax> ] )"
+  },
+  {
+    "name": "log()",
+    "syntax": "log( <calc-sum>, <calc-sum>? )"
+  },
+  {
+    "name": "matrix()",
+    "syntax": "matrix( <number>#{6} )"
+  },
+  {
+    "name": "max()",
+    "syntax": "max( <calc-sum># )"
+  },
+  {
+    "name": "min()",
+    "syntax": "min( <calc-sum># )"
+  },
+  {
+    "name": "minmax()",
+    "syntax": "minmax(min, max)"
+  },
+  {
+    "name": "mod()",
+    "syntax": "mod( <calc-sum>, <calc-sum> )"
+  },
+  {
+    "name": "oklab()",
+    "syntax": "oklab( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "oklch()",
+    "syntax": "oklch( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "opacity()",
+    "syntax": "opacity( [ <number> | <percentage> ]? )"
+  },
+  {
+    "name": "paint()",
+    "syntax": "paint( <ident>, <declaration-value>? )"
+  },
+  {
+    "name": "palette-mix()",
+    "syntax": "palette-mix(<color-interpolation-method> ',' [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})"
+  },
+  {
+    "name": "path()",
+    "syntax": "path( <'fill-rule'>? ',' <string> )"
+  },
+  {
+    "name": "polygon()",
+    "syntax": "polygon( <'fill-rule'>? [ round <length> ]? ',' [<length-percentage> <length-percentage>]# )"
+  },
+  {
+    "name": "pow()",
+    "syntax": "pow( <calc-sum>, <calc-sum> )"
+  },
+  {
+    "name": "radial-gradient()",
+    "syntax": "radial-gradient( [ <radial-gradient-syntax> ] )"
+  },
+  {
+    "name": "ray()",
+    "syntax": "ray( <angle> && <ray-size>? && contain? && [at <position>]? )"
+  },
+  {
+    "name": "rect()",
+    "syntax": "rect( <top>, <right>, <bottom>, <left> )"
+  },
+  {
+    "name": "rem()",
+    "syntax": "rem( <calc-sum>, <calc-sum> )"
   },
   {
     "name": "repeating-linear-gradient()",
@@ -1280,159 +1308,143 @@
     "syntax": "repeating-radial-gradient( [ <radial-gradient-syntax> ] )"
   },
   {
-    "name": "inset()",
-    "syntax": "inset( <length-percentage>{1,4} [ round <'border-radius'> ]? )"
+    "name": "rgb()",
+    "syntax": "[ <legacy-rgb-syntax> | <modern-rgb-syntax> ]"
   },
   {
-    "name": "<keyframes-name>",
-    "syntax": "<custom-ident> | <string>"
+    "name": "rgba()",
+    "syntax": "[ <legacy-rgba-syntax> | <modern-rgba-syntax> ]"
   },
   {
-    "name": "<ns-prefix>",
-    "syntax": "[ <ident-token> | '*' ]? '|'"
+    "name": "rotate()",
+    "syntax": "rotate( [ <angle> | <zero> ] )"
   },
   {
-    "name": "<font-weight-absolute>",
-    "syntax": "[normal | bold | <number [1,1000]>]"
+    "name": "round()",
+    "syntax": "round( <rounding-strategy>?, <calc-sum>, <calc-sum>? )"
   },
   {
-    "name": "<common-lig-values>",
-    "syntax": "[ common-ligatures | no-common-ligatures ]"
+    "name": "running()",
+    "syntax": "running( <custom-ident> )"
   },
   {
-    "name": "<bool-in-parens>",
-    "syntax": "( <boolean> ) | <bool-test> | <general-enclosed>"
+    "name": "saturate()",
+    "syntax": "saturate( [ <number> | <percentage> ]? )"
   },
   {
-    "name": "<name-repeat>",
-    "syntax": "repeat( [ <integer [1,∞]> | auto-fill ], <line-names>+)"
+    "name": "scale()",
+    "syntax": "scale( <number> ',' <number>? )"
   },
   {
-    "name": "<radial-gradient-syntax>",
-    "syntax": "[ <radial-shape> || <radial-size> ]? [ at <position> ]? , <color-stop-list>"
+    "name": "scaleX()",
+    "syntax": "scaleX( <number> )"
   },
   {
-    "name": "<bg-layer>",
-    "syntax": "<bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <visual-box> || <visual-box>"
+    "name": "scaleY()",
+    "syntax": "scaleY( <number> )"
   },
   {
-    "name": "acos()",
-    "syntax": "acos( <calc-sum> )"
+    "name": "scroll()",
+    "syntax": "scroll( [ <scroller> || <axis> ]? )"
   },
   {
-    "name": "<url>",
-    "syntax": "<url()> | <src()>"
+    "name": "sepia()",
+    "syntax": "sepia( [ <number> | <percentage> ]? )"
   },
   {
-    "name": "log()",
-    "syntax": "log( <calc-sum>, <calc-sum>? )"
+    "name": "sign()",
+    "syntax": "sign( <calc-sum> )"
   },
   {
-    "name": "<calc-sum>",
-    "syntax": "<calc-product> [ [ '+' | '-' ] <calc-product> ]*"
+    "name": "sin()",
+    "syntax": "sin( <calc-sum> )"
   },
   {
-    "name": "<syntax-multiplier>",
-    "syntax": "[ '#' | '+' ]"
+    "name": "skew()",
+    "syntax": "skew( [ <angle> | <zero> ] ',' [ <angle> | <zero> ]? )"
   },
   {
-    "name": "circle()",
-    "syntax": "circle( <radial-size>? [ at <position> ]? )"
+    "name": "skewX()",
+    "syntax": "skewX( [ <angle> | <zero> ] )"
   },
   {
-    "name": "grayscale()",
-    "syntax": "grayscale( [ <number> | <percentage> ]? )"
+    "name": "skewY()",
+    "syntax": "skewY( [ <angle> | <zero> ] )"
   },
   {
-    "name": "<masking-mode>",
-    "syntax": "alpha | luminance | match-source"
+    "name": "snap-block()",
+    "syntax": "snap-block( <length> ',' [ start | end | near ]? )"
   },
   {
-    "name": "<mf-value>",
-    "syntax": "<number> | <dimension> | <ident> | <ratio>"
+    "name": "snap-inline()",
+    "syntax": "snap-inline( <length> ',' [ left | right | near ]? )"
   },
   {
-    "name": "<anchor-side>",
-    "syntax": "inside | outside | top | left | right | bottom | start | end | self-start | self-end | <percentage> | center"
+    "name": "sqrt()",
+    "syntax": "sqrt( <calc-sum> )"
   },
   {
-    "name": "<time-percentage>",
-    "syntax": "[ <time> | <percentage> ]"
+    "name": "src()",
+    "syntax": "src( <string> <url-modifier>* )"
   },
   {
-    "name": "<calc-product>",
-    "syntax": "<calc-value> [ [ '*' | '/' ] <calc-value> ]*"
+    "name": "steps()",
+    "syntax": "steps( <integer>, <step-position>?)"
   },
   {
-    "name": "<colorspace-params>",
-    "syntax": "[<custom-params> | <predefined-rgb-params> | <predefined-polar-params> | <predefined-rectangular-params> | <xyz-params>]"
+    "name": "string()",
+    "syntax": "string( <custom-ident> ',' [ first | start | last | first-except ]? )"
   },
   {
-    "name": "<supports-condition>",
-    "syntax": "not <supports-in-parens> | <supports-in-parens> [ and <supports-in-parens> ]* | <supports-in-parens> [ or <supports-in-parens> ]*"
+    "name": "superellipse()",
+    "syntax": "superellipse( <number> | infinity )"
   },
   {
-    "name": "<relative-selector>",
-    "syntax": "<combinator>? <complex-selector>"
+    "name": "symbols()",
+    "syntax": "symbols( <symbols-type>? [ <string> | <image> ]+ )"
   },
   {
-    "name": "<relative-real-selector>",
-    "syntax": "<combinator>? <complex-real-selector>"
+    "name": "tan()",
+    "syntax": "tan( <calc-sum> )"
   },
   {
-    "name": "<baseline-position>",
-    "syntax": "[ first | last ]? && baseline"
+    "name": "target-counter()",
+    "syntax": "target-counter( [ <string> | <url> ] ',' <custom-ident> ',' <counter-style>? )"
   },
   {
-    "name": "<pseudo-compound-selector>",
-    "syntax": "<pseudo-element-selector> <pseudo-class-selector>*"
+    "name": "target-counters()",
+    "syntax": "target-counters( [ <string> | <url> ] ',' <custom-ident> ',' <string> ',' <counter-style>? )"
   },
   {
-    "name": "<line-name-list>",
-    "syntax": "[ <line-names> | <name-repeat> ]+"
+    "name": "target-text()",
+    "syntax": "target-text( [ <string> | <url> ] ',' [ content | before | after | first-letter ]? )"
   },
   {
-    "name": "hsl()",
-    "syntax": "[ <legacy-hsl-syntax> | <modern-hsl-syntax> ]"
+    "name": "translate()",
+    "syntax": "translate( <length-percentage> ',' <length-percentage>? )"
   },
   {
-    "name": "leader()",
-    "syntax": "leader( <leader-type> )"
+    "name": "translateX()",
+    "syntax": "translateX( <length-percentage> )"
   },
   {
-    "name": "<axis>",
-    "syntax": "block | inline | x | y"
+    "name": "translateY()",
+    "syntax": "translateY( <length-percentage> )"
   },
   {
-    "name": "<line-style>",
-    "syntax": "none | hidden | dotted | dashed | solid | double | groove | ridge | inset | outset"
+    "name": "url()",
+    "syntax": "url( <string> <url-modifier>* ) | <url-token>"
   },
   {
-    "name": "<clip-source>",
-    "syntax": "<url>"
+    "name": "var()",
+    "syntax": "var( <custom-property-name> ',' <declaration-value>? )"
   },
   {
-    "name": "calc()",
-    "syntax": "calc( <calc-sum> )"
+    "name": "view()",
+    "syntax": "view( [ <axis> || <'view-timeline-inset'> ]? )"
   },
   {
-    "name": "invert()",
-    "syntax": "invert( [ <number> | <percentage> ]? )"
-  },
-  {
-    "name": "color()",
-    "syntax": "color( [from <color>]? <colorspace-params> [ / [ <alpha-value> | none ] ]? )"
-  },
-  {
-    "name": "<source-size>",
-    "syntax": "<media-condition> <source-size-value> | auto"
-  },
-  {
-    "name": "<linear-stop-list>",
-    "syntax": "[ <linear-stop> ]#"
-  },
-  {
-    "name": "<compositing-operator>",
-    "syntax": "add | subtract | intersect | exclude"
+    "name": "xywh()",
+    "syntax": "xywh( <length-percentage>{2} <length-percentage [0,∞]>{2} [ round <'border-radius'> ]? )"
   }
 ]

--- a/crates/gosub_css3/src/matcher/property_definitions.rs
+++ b/crates/gosub_css3/src/matcher/property_definitions.rs
@@ -12,7 +12,7 @@ use crate::stylesheet::CssValue;
 
 /// List of elements that are built-in data types in the CSS specification. These will be handled
 /// by the syntax matcher as built-in types.
-const BUILTIN_DATA_TYPES: [&str; 41] = [
+const BUILTIN_DATA_TYPES: [&str; 43] = [
     "absolute-size",
     "age",
     "angle",
@@ -54,6 +54,8 @@ const BUILTIN_DATA_TYPES: [&str; 41] = [
     "color()",
     "attr()",    //TODO: this is not a builtin!
     "element()", //TODO: this is not a builtin!
+    "dynamic-range-limit-mix()",
+    "palette-mix()",
 ];
 
 /// A CSS property definition including its type and initial value and optional expanded values if it's a shorthand property
@@ -584,7 +586,12 @@ mod tests {
 
     #[test]
     fn test_parse_definition_file() {
-        assert_eq!(CSS_DEFINITIONS.len(), 620);
+        // set the log level to WARN
+        simple_logger::SimpleLogger::new()
+            .with_level(log::LevelFilter::Warn)
+            .init()
+            .unwrap();
+        assert_eq!(CSS_DEFINITIONS.len(), 656);
     }
 
     #[test]

--- a/crates/gosub_css3/src/matcher/syntax.rs
+++ b/crates/gosub_css3/src/matcher/syntax.rs
@@ -273,7 +273,6 @@ impl CssSyntax {
                 Ok(CssSyntaxTree::new(vec![components]))
             }
             Err(e) => {
-                dbg!(&self.source);
                 Err(CssError::new(e.to_string().as_str()))
             }
         }

--- a/crates/gosub_css3/src/matcher/syntax.rs
+++ b/crates/gosub_css3/src/matcher/syntax.rs
@@ -272,9 +272,7 @@ impl CssSyntax {
                 }
                 Ok(CssSyntaxTree::new(vec![components]))
             }
-            Err(e) => {
-                Err(CssError::new(e.to_string().as_str()))
-            }
+            Err(e) => Err(CssError::new(e.to_string().as_str())),
         }
     }
 }

--- a/crates/gosub_css3/src/matcher/syntax.rs
+++ b/crates/gosub_css3/src/matcher/syntax.rs
@@ -7,7 +7,7 @@ use nom::character::complete::{alpha1, alphanumeric1, char, digit0, digit1, mult
 use nom::combinator::{map, map_res, opt, recognize};
 use nom::multi::{fold_many1, many0, many1, separated_list0, separated_list1};
 use nom::number::complete::float;
-use nom::sequence::{delimited, pair, preceded, separated_pair};
+use nom::sequence::{delimited, pair, preceded, separated_pair, terminated};
 use nom::Err;
 use nom::IResult;
 use nom::Parser;
@@ -18,7 +18,7 @@ use crate::stylesheet::CssValue;
 // When debugging the parser, it's nice to have some additional information ready. This should maybe
 // be inside a cfg setting, but for now (un)commenting the appropriate line is good enough.
 macro_rules! debug_print {
-    // ($($x:tt)*) => { println!($($x)*) }
+    // ($($x:tt)*) => { println!($($x)*) };
     ($($x:tt)*) => {{}};
 }
 
@@ -272,7 +272,10 @@ impl CssSyntax {
                 }
                 Ok(CssSyntaxTree::new(vec![components]))
             }
-            Err(e) => Err(CssError::new(e.to_string().as_str())),
+            Err(e) => {
+                dbg!(&self.source);
+                Err(CssError::new(e.to_string().as_str()))
+            }
         }
     }
 }
@@ -341,8 +344,9 @@ fn parse_curly_braces_multiplier(input: &str) -> IResult<&str, SyntaxComponentMu
 
 fn parse_comma_separated_multiplier(input: &str) -> IResult<&str, SyntaxComponentMultiplier> {
     let range = alt((
-        separated_pair(ws(integer), ws(tag(",")), ws(integer)),
-        map(ws(integer), |num| (num, num)),
+        separated_pair(ws(integer), ws(tag(",")), ws(integer)), // "2,5"
+        map(terminated(ws(integer), ws(tag(","))), |num| (num, u32::MAX)), // "3,"
+        map(ws(integer), |num| (num, num)),                     // "3"
     ));
 
     let (input, minmax) = alt((
@@ -367,8 +371,8 @@ fn parse_multipliers(input: &str) -> IResult<&str, Vec<SyntaxComponentMultiplier
         map(tag("+"), |_| SyntaxComponentMultiplier::OneOrMore),
         map(tag("?"), |_| SyntaxComponentMultiplier::Optional),
         map(tag("!"), |_| SyntaxComponentMultiplier::AtLeastOneValue),
-        parse_comma_separated_multiplier,
-        parse_curly_braces_multiplier,
+        parse_comma_separated_multiplier, // Deals with # and #{x,y}
+        parse_curly_braces_multiplier,    // Deals with {x,y}
     )))
     .parse(input)?;
 
@@ -794,7 +798,7 @@ fn parse_component(input: &str) -> IResult<&str, SyntaxComponent> {
 
     component.update_multipliers(multipliers.clone());
 
-    debug_print!("<- Parsed component_type: {:#?} {}", component, multipliers);
+    debug_print!("<- Parsed component_type: {:#?} {:?}", component, multipliers);
 
     Ok((input, component))
 }

--- a/crates/gosub_css3/tools/generate_definitions/.gitignore
+++ b/crates/gosub_css3/tools/generate_definitions/.gitignore
@@ -1,0 +1,2 @@
+.css_cache
+.output

--- a/crates/gosub_css3/tools/generate_definitions/utils/utils.go
+++ b/crates/gosub_css3/tools/generate_definitions/utils/utils.go
@@ -10,9 +10,9 @@ const (
 	REPO             = "w3c/webref"
 	LOCATION         = "ed/css"
 	PATCH_LOCATION   = "ed/csspatches"
-	CACHE_DIR        = "crates/gosub_css3/resources/cache"
+	CACHE_DIR        = ".css_cache"
 	CACHE_INDEX_FILE = CACHE_DIR + "/index/cache_index.json"
-	CUSTOM_PATCH_DIR = "crates/gosub_css3/resources/patches"
+	CUSTOM_PATCH_DIR = ".css_cache/patches"
 	BRANCH           = "curated"
 )
 


### PR DESCRIPTION
- Fixed css parsing as there was a minor issue with multipliers
- Fixed the definition generator to deal with literals like , ; ()
- Fixed the output sorting of the definition generator so elements are
  always correctly ordered, which makes it easier to use in version
  control.