### PR TITLE
Updated the DocumentFragment

### DIFF
--- a/crates/gosub_html5/src/document/builder.rs
+++ b/crates/gosub_html5/src/document/builder.rs
@@ -1,6 +1,5 @@
 use gosub_interface::config::HasDocument;
 use gosub_interface::document::{Document, DocumentType};
-use gosub_interface::node::QuirksMode;
 use url::Url;
 
 pub struct DocumentBuilderImpl;
@@ -8,9 +7,5 @@ pub struct DocumentBuilderImpl;
 impl DocumentBuilderImpl {
     pub fn new_document<C: HasDocument>(url: Option<Url>) -> C::Document {
         C::Document::new(DocumentType::HTML, url)
-    }
-
-    pub fn new_document_fragment<C: HasDocument>(quirks_mode: QuirksMode) -> C::Document {
-        C::Document::new_fragment(quirks_mode)
     }
 }

--- a/crates/gosub_html5/src/document/document_impl.rs
+++ b/crates/gosub_html5/src/document/document_impl.rs
@@ -14,7 +14,6 @@ use crate::node::data::doctype::DocTypeData;
 use crate::node::data::element::{ClassListImpl, ElementData};
 use crate::node::node_impl::{NodeDataTypeInternal, NodeImpl};
 use crate::node::visitor::Visitor;
-use crate::node::HTML_NAMESPACE;
 use gosub_interface::config::HasDocument;
 use gosub_interface::node::{NodeType, QuirksMode};
 use gosub_shared::byte_stream::Location;
@@ -56,20 +55,6 @@ impl<C: HasDocument<Document = Self>> Document<C> for DocumentImpl<C> {
         };
         let root = NodeImpl::new_document(Location::default(), QuirksMode::NoQuirks);
         doc.arena.register_node(root);
-        doc
-    }
-
-    fn new_fragment(quirks_mode: QuirksMode) -> Self {
-        let mut doc = Self {
-            url: None,
-            arena: NodeArena::new(),
-            named_id_elements: HashMap::new(),
-            doctype: DocumentType::HTML,
-            quirks_mode,
-            stylesheets: Vec::new(),
-        };
-        let html_node = NodeImpl::new_element(Location::default(), "html", Some(HTML_NAMESPACE), HashMap::new());
-        doc.arena.register_node(html_node);
         doc
     }
 
@@ -574,23 +559,6 @@ impl<C: HasDocument<Document = Self>> DocumentImpl<C> {
             location,
             NodeDataTypeInternal::Element(ElementData::new(name, namespace, attributes, class_list)),
         )
-    }
-
-    /// Creates a fragment document with an html element as root (at NodeId::root()).
-    /// Used by DocumentBuilderImpl::new_document_fragment. parse_fragment expects
-    /// NodeId::root() to be the html element, not a Document node.
-    pub fn new_fragment(quirks_mode: QuirksMode) -> Self {
-        let mut doc = Self {
-            url: None,
-            arena: NodeArena::new(),
-            named_id_elements: HashMap::new(),
-            doctype: DocumentType::HTML,
-            quirks_mode,
-            stylesheets: Vec::new(),
-        };
-        let html_node = NodeImpl::new_element(Location::default(), "html", Some(HTML_NAMESPACE), HashMap::new());
-        doc.register_node(html_node);
-        doc
     }
 
     // ── display helper ─────────────────────────────────────────────────────

--- a/crates/gosub_html5/src/parser.rs
+++ b/crates/gosub_html5/src/parser.rs
@@ -326,11 +326,14 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
         // 4. / 12.
         parser.initialize_fragment_case(context_node_id);
 
-        // 5. / 6.
-        // Not needed, as the document should have been created with DocumentBuilderImpl::new_document_fragment(), and already got an HTML root node.
+        // 5. / 6. Create a new html element and append it to the Document node.
+        let html_id = parser
+            .document
+            .create_element("html", Some(HTML_NAMESPACE), HashMap::new(), start_location);
+        parser.document.attach(html_id, parser.document.root(), None);
 
         // 7.
-        parser.open_elements.push(NodeId::root());
+        parser.open_elements.push(html_id);
 
         // 8.
         if parser.document.tag_name(context_node_id).unwrap_or_default() == "template" {

--- a/crates/gosub_html5/src/testing/tree_construction.rs
+++ b/crates/gosub_html5/src/testing/tree_construction.rs
@@ -88,14 +88,21 @@ impl Harness {
         self.test = test;
         self.next_document_line = 0;
 
-        let (actual_document, actual_errors) = self.do_parse::<C>(scripting_enabled)?;
-        let result = self.generate_test_result::<C>(actual_document, &actual_errors);
+        let (actual_document, actual_errors, tree_root) = self.do_parse::<C>(scripting_enabled)?;
+        let result = self.generate_test_result::<C>(actual_document, &actual_errors, tree_root);
 
         Ok(result)
     }
 
-    /// Run the html5 parser and return the document tree and errors
-    fn do_parse<C: HasHtmlParser + HasDocument>(&mut self, scripting_enabled: bool) -> ParseResult<C::Document> {
+    /// Run the html5 parser and return the document tree, errors, and the NodeId to start tree
+    /// generation from (document root for full documents, the html element for fragment parses).
+    fn do_parse<C: HasHtmlParser + HasDocument>(
+        &mut self,
+        scripting_enabled: bool,
+    ) -> Result<(C::Document, Vec<ParseError>, gosub_shared::node::NodeId)> {
+        use gosub_interface::document::Document;
+        use gosub_shared::node::NodeId;
+
         let options = <<C::HtmlParser as Html5Parser<C>>::Options as ParserOptions>::new(scripting_enabled);
         let mut stream = ByteStream::new(
             Encoding::UTF8,
@@ -108,16 +115,20 @@ impl Harness {
         stream.read_from_str(self.test.spec_data(), None);
         stream.close();
 
-        let (document, parse_errors) = if let Some(fragment) = self.test.spec.document_fragment.clone() {
-            self.parse_fragment::<C>(fragment, stream, options, Location::default())?
+        if let Some(fragment) = self.test.spec.document_fragment.clone() {
+            let (document, parse_errors) = self.parse_fragment::<C>(fragment, stream, options, Location::default())?;
+            // The html element is the first child of the document root.
+            let html_id = document
+                .children(document.root())
+                .first()
+                .copied()
+                .unwrap_or(NodeId::root());
+            Ok((document, parse_errors, html_id))
         } else {
             let mut document = DocumentBuilderImpl::new_document::<C>(None);
             let parser_errors = C::HtmlParser::parse(&mut stream, &mut document, Some(options))?;
-
-            (document, parser_errors)
-        };
-
-        Ok((document, parse_errors))
+            Ok((document, parser_errors, NodeId::root()))
+        }
     }
 
     fn parse_fragment<C: HasHtmlParser + HasDocument>(
@@ -135,7 +146,7 @@ impl Harness {
             (fragment, HTML_NAMESPACE)
         };
 
-        let mut document = DocumentBuilderImpl::new_document_fragment::<C>(gosub_interface::node::QuirksMode::NoQuirks);
+        let mut document = DocumentBuilderImpl::new_document::<C>(None);
 
         // Register the context element in the fragment document so that parse_fragment
         // can look it up by NodeId. It is only used for parser initialization (tokenizer
@@ -201,11 +212,12 @@ impl Harness {
         &mut self,
         document: C::Document,
         _parse_errors: &[ParseError],
+        tree_root: gosub_shared::node::NodeId,
     ) -> TestResult {
         let mut result = TestResult::default();
 
         let generator = TreeOutputGenerator::<C>::new(document);
-        let actual = generator.generate();
+        let actual = generator.generate_from(tree_root);
 
         let mut line_idx = 1;
         for actual_line in actual {

--- a/crates/gosub_html5/src/testing/tree_construction/generator.rs
+++ b/crates/gosub_html5/src/testing/tree_construction/generator.rs
@@ -16,9 +16,9 @@ impl<C: HasDocument> TreeOutputGenerator<C> {
         Self { document }
     }
 
-    /// Generates a tree
-    pub fn generate(&self) -> Vec<String> {
-        self.output_treeline(self.document.root(), 0)
+    /// Generates a tree starting from `start`, treating it as the implicit root (not printed).
+    pub fn generate_from(&self, start: NodeId) -> Vec<String> {
+        self.output_treeline(start, 0)
     }
 
     /// Generates an array of indented tree lines for a node and its children.

--- a/crates/gosub_interface/src/document.rs
+++ b/crates/gosub_interface/src/document.rs
@@ -28,9 +28,6 @@ pub trait Document<C: HasCssSystem>: Sized + Display + Debug + PartialEq + 'stat
     /// Create a new empty document of the given type.
     fn new(document_type: DocumentType, url: Option<Url>) -> Self;
 
-    /// Create an HTML fragment document with a root `<html>` node.
-    fn new_fragment(quirks_mode: QuirksMode) -> Self;
-
     // -----------------------------------------------------------------------
     // Node creation — each returns the NodeId of the new node
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Stacked on top of #929 

Removed the new_fragment from the document trait and made the system
more consistent with the regular Docuemnt creation. The parse_fragment
now owns the html root creation.