### PR TITLE
Html5 parser fixes

### DIFF
--- a/crates/gosub_html5/src/parser.rs
+++ b/crates/gosub_html5/src/parser.rs
@@ -244,7 +244,6 @@ fn meta_charset_encoding(token: &Token) -> Option<Encoding> {
                     }
                     Some(v.trim())
                 })?;
-                })?;
                 return charset_label_to_encoding(charset);
             }
         }

--- a/crates/gosub_html5/src/parser.rs
+++ b/crates/gosub_html5/src/parser.rs
@@ -24,7 +24,7 @@ use gosub_interface::node::NodeType;
 
 use gosub_interface::html5::ParserOptions;
 use gosub_interface::node::QuirksMode;
-use gosub_shared::byte_stream::{ByteStream, Location};
+use gosub_shared::byte_stream::{ByteStream, Encoding, Location};
 use gosub_shared::config::{Context, ParserConfig};
 use gosub_shared::node::NodeId;
 use gosub_shared::types::{ParseError, Result};
@@ -218,6 +218,51 @@ enum Scope {
 enum DispatcherMode {
     Foreign,
     Html,
+}
+
+/// Extracts the encoding declared by a `<meta charset="…">` or
+/// `<meta http-equiv="Content-Type" content="…; charset=…">` token.
+/// Returns `None` when no valid/supported encoding is found.
+fn meta_charset_encoding(token: &Token) -> Option<Encoding> {
+    let Token::StartTag { attributes, .. } = token else {
+        return None;
+    };
+
+    if let Some(charset) = attributes.get("charset") {
+        return charset_label_to_encoding(charset.trim());
+    }
+
+    // http-equiv="Content-Type" with a content attribute
+    if let Some(http_equiv) = attributes.get("http-equiv") {
+        if http_equiv.eq_ignore_ascii_case("content-type") {
+            if let Some(content) = attributes.get("content") {
+                let charset = content.split(';').find_map(|part| {
+                    let part = part.trim();
+                    let rest = part.strip_prefix("charset")?;
+                    let rest = rest.trim_start_matches(|c: char| c.is_ascii_whitespace());
+                    let rest = rest.strip_prefix('=')?;
+                    Some(rest.trim())
+                })?;
+                return charset_label_to_encoding(charset);
+            }
+        }
+    }
+
+    None
+}
+
+/// Maps a charset label string to our `Encoding` enum.
+/// Per WHATWG spec §13.2.3.5, a UTF-16 label from a meta element must be
+/// treated as UTF-8 (a truly UTF-16 document would have a BOM detected earlier).
+fn charset_label_to_encoding(label: &str) -> Option<Encoding> {
+    match label.to_ascii_lowercase().as_str() {
+        "utf-8" | "utf8" | "unicode-1-1-utf-8" => Some(Encoding::UTF8),
+        "us-ascii" | "ascii" | "ansi_x3.4-1968" | "iso-ir-6" | "iso646-us" | "latin1"
+        | "iso-8859-1" => Some(Encoding::ASCII),
+        // UTF-16 from meta → treat as UTF-8 per spec
+        "utf-16" | "utf-16le" | "utf-16be" => Some(Encoding::UTF8),
+        _ => None,
+    }
 }
 
 impl<'a, C: HasDocument> Html5Parser<'a, C> {
@@ -2948,8 +2993,13 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
                 self.insert_html_element(&self.current_token.clone());
                 self.open_elements.pop();
 
-                // @TODO: if active speculative html parser is null then...
-                // we probably want to change the encoding if the element has a charset attribute and the current encoding is "tentative"
+                // The speculative parser is not implemented, so we always proceed.
+                // Update the stream encoding if the meta element declares one.
+                // Note: a fully spec-compliant implementation would also restart the parse
+                // when the encoding changes (WHATWG §13.2.3.5); that is not yet supported.
+                if let Some(enc) = meta_charset_encoding(&self.current_token) {
+                    self.tokenizer.stream.set_encoding(enc);
+                }
             }
             Token::StartTag { name, .. } if name == "title" => {
                 self.parse_rcdata();

--- a/crates/gosub_html5/src/parser.rs
+++ b/crates/gosub_html5/src/parser.rs
@@ -256,7 +256,7 @@ fn meta_charset_encoding(token: &Token) -> Option<Encoding> {
 /// Per WHATWG spec §13.2.3.5, a UTF-16 label from a meta element must be
 /// treated as UTF-8 (a truly UTF-16 document would have a BOM detected earlier).
 fn charset_label_to_encoding(label: &str) -> Option<Encoding> {
-    match label.to_ascii_lowercase().as_str() {
+    match label.cow_to_ascii_lowercase().as_ref() {
         "utf-8" | "utf8" | "unicode-1-1-utf-8" => Some(Encoding::UTF8),
         "us-ascii" | "ascii" | "ansi_x3.4-1968" | "iso-ir-6" | "iso646-us" | "latin1" | "iso-8859-1" => {
             Some(Encoding::ASCII)

--- a/crates/gosub_html5/src/parser.rs
+++ b/crates/gosub_html5/src/parser.rs
@@ -1779,6 +1779,23 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
         self.error_logger.borrow().get_errors().clone()
     }
 
+    /// Emits a parse error if any open element (in the HTML namespace) is not in the set of
+    /// elements that are allowed to remain open at body/EOF close time (spec §13.2.6.4.7).
+    fn check_open_elements_at_body_end(&self) {
+        const ALLOWED: &[&str] = &[
+            "dd", "dt", "li", "optgroup", "option", "p", "rb", "rp", "rt", "rtc", "tbody", "td",
+            "tfoot", "th", "thead", "tr", "body", "html",
+        ];
+        for &node_id in &self.open_elements {
+            let tag = self.document.tag_name(node_id).unwrap_or_default();
+            let ns = self.document.namespace(node_id);
+            if ns == Some(HTML_NAMESPACE) && !ALLOWED.contains(&tag) {
+                self.parse_error("open element not allowed at end of body");
+                return;
+            }
+        }
+    }
+
     /// Send a parse error to the error logger
     fn parse_error(&self, message: &str) {
         self.error_logger
@@ -1826,11 +1843,6 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
                 panic!("EOF token not allowed");
             }
         }
-    }
-
-    #[allow(dead_code)]
-    fn flush_pending_table_character_tokens(&mut self) {
-        todo!()
     }
 
     /// This function will pop elements off the stack until it reaches the first element that matches
@@ -2209,7 +2221,7 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
             }
             Token::Eof { .. } => {
                 if self.template_insertion_mode.is_empty() {
-                    // @TODO: do stuff
+                    self.check_open_elements_at_body_end();
                     self.stop_parsing();
                 } else {
                     self.handle_in_template();
@@ -2222,8 +2234,7 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
                     return;
                 }
 
-                // @TODO: Other stuff
-
+                self.check_open_elements_at_body_end();
                 self.insertion_mode = InsertionMode::AfterBody;
             }
             Token::EndTag { name, .. } if name == "html" => {
@@ -2233,8 +2244,7 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
                     return;
                 }
 
-                // @TODO: Other stuff
-
+                self.check_open_elements_at_body_end();
                 self.insertion_mode = InsertionMode::AfterBody;
                 self.reprocess_token = true;
             }

--- a/crates/gosub_html5/src/parser.rs
+++ b/crates/gosub_html5/src/parser.rs
@@ -238,10 +238,12 @@ fn meta_charset_encoding(token: &Token) -> Option<Encoding> {
             if let Some(content) = attributes.get("content") {
                 let charset = content.split(';').find_map(|part| {
                     let part = part.trim();
-                    let rest = part.strip_prefix("charset")?;
-                    let rest = rest.trim_start_matches(|c: char| c.is_ascii_whitespace());
-                    let rest = rest.strip_prefix('=')?;
-                    Some(rest.trim())
+                    let (k, v) = part.split_once('=')?;
+                    if !k.trim().eq_ignore_ascii_case("charset") {
+                        return None;
+                    }
+                    Some(v.trim())
+                })?;
                 })?;
                 return charset_label_to_encoding(charset);
             }

--- a/crates/gosub_html5/src/parser.rs
+++ b/crates/gosub_html5/src/parser.rs
@@ -257,8 +257,9 @@ fn meta_charset_encoding(token: &Token) -> Option<Encoding> {
 fn charset_label_to_encoding(label: &str) -> Option<Encoding> {
     match label.to_ascii_lowercase().as_str() {
         "utf-8" | "utf8" | "unicode-1-1-utf-8" => Some(Encoding::UTF8),
-        "us-ascii" | "ascii" | "ansi_x3.4-1968" | "iso-ir-6" | "iso646-us" | "latin1"
-        | "iso-8859-1" => Some(Encoding::ASCII),
+        "us-ascii" | "ascii" | "ansi_x3.4-1968" | "iso-ir-6" | "iso646-us" | "latin1" | "iso-8859-1" => {
+            Some(Encoding::ASCII)
+        }
         // UTF-16 from meta → treat as UTF-8 per spec
         "utf-16" | "utf-16le" | "utf-16be" => Some(Encoding::UTF8),
         _ => None,
@@ -1828,8 +1829,8 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
     /// elements that are allowed to remain open at body/EOF close time (spec §13.2.6.4.7).
     fn check_open_elements_at_body_end(&self) {
         const ALLOWED: &[&str] = &[
-            "dd", "dt", "li", "optgroup", "option", "p", "rb", "rp", "rt", "rtc", "tbody", "td",
-            "tfoot", "th", "thead", "tr", "body", "html",
+            "dd", "dt", "li", "optgroup", "option", "p", "rb", "rp", "rt", "rtc", "tbody", "td", "tfoot", "th",
+            "thead", "tr", "body", "html",
         ];
         for &node_id in &self.open_elements {
             let tag = self.document.tag_name(node_id).unwrap_or_default();

--- a/crates/gosub_html5/src/parser/helper.rs
+++ b/crates/gosub_html5/src/parser/helper.rs
@@ -231,7 +231,11 @@ impl<C: HasDocument> Html5Parser<'_, C> {
         self.insert_text_helper(insertion_position, token);
     }
 
-    // @todo: where is the fragment case handled? (sub step 4: https://html.spec.whatwg.org/multipage/parsing.html#appropriate-place-for-inserting-a-node)
+    // Implements the "appropriate place for inserting a node" algorithm.
+    // https://html.spec.whatwg.org/multipage/parsing.html#appropriate-place-for-inserting-a-node
+    //
+    // The "no last table" sub-step (fragment case) is handled by the fallthrough at the
+    // bottom of this function, which returns the first element in the open elements stack.
     pub fn appropriate_place_insert(&self, override_node: Option<NodeId>) -> InsertionPositionMode<NodeId> {
         let current_node_id = *self.open_elements.last().unwrap_or(&NodeId::root());
         let target_id = override_node.unwrap_or(current_node_id);
@@ -241,21 +245,25 @@ impl<C: HasDocument> Html5Parser<'_, C> {
 
         if !(self.foster_parenting && ["table", "tbody", "thead", "tfoot", "tr"].contains(&target_tag)) {
             if target_tag == "template" && target_ns == Some(HTML_NAMESPACE) {
-                if self.document.template_contents(target_id).is_some() {
-                    return InsertionPositionMode::LastChild { parent_id: target_id };
+                // Spec step 3: redirect inside template to its template contents.
+                if let Some(contents_id) = self.document.template_contents(target_id) {
+                    return InsertionPositionMode::LastChild { parent_id: contents_id };
                 }
             } else {
                 return InsertionPositionMode::LastChild { parent_id: target_id };
             }
         }
 
+        // Foster-parenting path: scan open elements from top, looking for the last
+        // template or table element (whichever is more recently pushed).
         let mut iter = self.open_elements.iter().rev().peekable();
         while let Some(node_id) = iter.next() {
             let node_tag = self.document.tag_name(*node_id).unwrap_or_default();
 
             if node_tag == "template" {
-                if self.document.template_contents(*node_id).is_some() {
-                    return InsertionPositionMode::LastChild { parent_id: *node_id };
+                // Spec step 3: redirect inside template to its template contents.
+                if let Some(contents_id) = self.document.template_contents(*node_id) {
+                    return InsertionPositionMode::LastChild { parent_id: contents_id };
                 }
             } else if node_tag == "table" {
                 if let Some(parent_id) = self.document.parent(*node_id) {
@@ -269,6 +277,8 @@ impl<C: HasDocument> Html5Parser<'_, C> {
                 };
             }
         }
+        // No table found: use the first element in the stack (the html element, or in the
+        // fragment case, the context element). This covers spec sub-step 4.
         InsertionPositionMode::LastChild {
             parent_id: *self.open_elements.first().unwrap(),
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of meta charset declarations so documents use the correct text encoding.
  * Insertions into HTML template elements now place content into the template's internal contents.
  * Parser now reports structural errors for unexpected open elements at body/EOF boundaries, improving spec conformance.

* **Chores**
  * Removed an obsolete stub implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->