### PR TITLE
Added custom Result<> structure for config crate.

### DIFF
--- a/crates/gosub_config/src/errors.rs
+++ b/crates/gosub_config/src/errors.rs
@@ -1,21 +1,7 @@
 //! Error results that can be returned from the engine
 use thiserror::Error;
 
-/// Parser error that defines an error (message) on the given position
-#[derive(Clone, Debug, PartialEq)]
-#[allow(dead_code)]
-pub struct ParseError {
-    /// Parse error message
-    pub message: String,
-    /// Line number (1-based) of the error
-    pub line: usize,
-    // Column (1-based) of the line of the error
-    pub col: usize,
-    // Position (0-based) of the error in the input stream
-    pub offset: usize,
-}
-
-/// Serious errors and errors from third-party libraries
+/// Errors returned by the config crate
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("config error: {0}")]

--- a/crates/gosub_config/src/errors.rs
+++ b/crates/gosub_config/src/errors.rs
@@ -27,6 +27,10 @@ pub enum Error {
     #[error("json parsing error: {0}")]
     JsonSerde(#[from] serde_json::Error),
 
+    #[cfg(not(target_arch = "wasm32"))]
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+
     #[error("there was a problem: {0}")]
     Generic(String),
 }

--- a/crates/gosub_config/src/lib.rs
+++ b/crates/gosub_config/src/lib.rs
@@ -69,35 +69,50 @@ macro_rules! config {
         match config_store().get($key) {
             Ok(Some(setting)) => setting.to_string(),
             Ok(None) => String::new(),
-            Err(err) => { log::warn!("config error: {err}"); String::new() }
+            Err(err) => {
+                log::warn!("config error: {err}");
+                String::new()
+            }
         }
     };
     (bool $key:expr) => {
         match config_store().get($key) {
             Ok(Some(setting)) => setting.to_bool(),
             Ok(None) => false,
-            Err(err) => { log::warn!("config error: {err}"); false }
+            Err(err) => {
+                log::warn!("config error: {err}");
+                false
+            }
         }
     };
     (uint $key:expr) => {
         match config_store().get($key) {
             Ok(Some(setting)) => setting.to_uint(),
             Ok(None) => 0,
-            Err(err) => { log::warn!("config error: {err}"); 0 }
+            Err(err) => {
+                log::warn!("config error: {err}");
+                0
+            }
         }
     };
     (sint $key:expr) => {
         match config_store().get($key) {
             Ok(Some(setting)) => setting.to_sint(),
             Ok(None) => 0,
-            Err(err) => { log::warn!("config error: {err}"); 0 }
+            Err(err) => {
+                log::warn!("config error: {err}");
+                0
+            }
         }
     };
     (map $key:expr) => {
         match config_store().get($key) {
             Ok(Some(setting)) => setting.to_map(),
             Ok(None) => Vec::new(),
-            Err(err) => { log::warn!("config error: {err}"); Vec::new() }
+            Err(err) => {
+                log::warn!("config error: {err}");
+                Vec::new()
+            }
         }
     };
 }
@@ -252,7 +267,9 @@ impl ConfigStore {
 
         if mem::discriminant(&info.default) != mem::discriminant(&value) {
             warn!("config: Setting {key} is of different type than setting expects");
-            return Err(Error::Config(format!("Setting {key} is of different type than expected")));
+            return Err(Error::Config(format!(
+                "Setting {key} is of different type than expected"
+            )));
         }
 
         self.settings.lock().borrow_mut().insert(key.to_owned(), value.clone());
@@ -266,8 +283,7 @@ impl ConfigStore {
 
         if let Value::Object(data) = json_data {
             for (section_prefix, section_entries) in &data {
-                let section_entries: Vec<JsonEntry> =
-                    serde_json::from_value(section_entries.clone())?;
+                let section_entries: Vec<JsonEntry> = serde_json::from_value(section_entries.clone())?;
 
                 for entry in section_entries {
                     let key = format!("{}.{}", section_prefix, entry.key);
@@ -305,7 +321,9 @@ mod test {
         let setting = config_store().get("dns.local.enabled").unwrap().unwrap();
         assert_eq!(setting, Setting::Bool(true));
 
-        config_store_write().set("dns.local.enabled", Setting::Bool(false)).unwrap();
+        config_store_write()
+            .set("dns.local.enabled", Setting::Bool(false))
+            .unwrap();
         let setting = config_store().get("dns.local.enabled").unwrap().unwrap();
         assert_eq!(setting, Setting::Bool(false));
     }

--- a/crates/gosub_config/src/lib.rs
+++ b/crates/gosub_config/src/lib.rs
@@ -1,10 +1,12 @@
-mod errors;
+pub mod errors;
 pub mod settings;
 pub mod storage;
 
+pub use errors::Error;
+pub(crate) type Result<T> = std::result::Result<T, Error>;
+
 use crate::settings::{Setting, SettingInfo};
 use crate::storage::MemoryStorageAdapter;
-use gosub_shared::types::Result;
 use lazy_static::lazy_static;
 use log::warn;
 use parking_lot::RwLock;
@@ -23,13 +25,13 @@ const SETTINGS_JSON: &str = include_str!("./settings.json");
 /// Note that we need to implement Send so we can send the storage adapter
 /// to other threads.
 pub trait StorageAdapter: Send + Sync {
-    /// Retrieves a setting from the storage
-    fn get(&self, key: &str) -> Option<Setting>;
+    /// Retrieves a setting from the storage. Returns `Ok(None)` when the key does not exist.
+    fn get(&self, key: &str) -> Result<Option<Setting>>;
 
     /// Stores a given setting to the storage. Note that "self" is self and not "mut self". We need to be able
     /// to storage settings in a non-mutable way. That is mostly possible it seems with a mutex lock that we
     /// can get mutable.
-    fn set(&self, key: &str, value: Setting);
+    fn set(&self, key: &str, value: Setting) -> Result<()>;
 
     /// Retrieves all the settings in the storage in one go. This is used for preloading the settings
     /// into the `ConfigStore` and is more performant normally than calling `get_setting` manually for each
@@ -65,32 +67,37 @@ pub fn config_store_write() -> parking_lot::RwLockWriteGuard<'static, ConfigStor
 macro_rules! config {
     (string $key:expr) => {
         match config_store().get($key) {
-            Some(setting) => setting.to_string(),
-            None => String::new(),
+            Ok(Some(setting)) => setting.to_string(),
+            Ok(None) => String::new(),
+            Err(err) => { log::warn!("config error: {err}"); String::new() }
         }
     };
     (bool $key:expr) => {
         match config_store().get($key) {
-            Some(setting) => setting.to_bool(),
-            None => false,
+            Ok(Some(setting)) => setting.to_bool(),
+            Ok(None) => false,
+            Err(err) => { log::warn!("config error: {err}"); false }
         }
     };
     (uint $key:expr) => {
         match config_store().get($key) {
-            Some(setting) => setting.to_uint(),
-            None => 0,
+            Ok(Some(setting)) => setting.to_uint(),
+            Ok(None) => 0,
+            Err(err) => { log::warn!("config error: {err}"); 0 }
         }
     };
     (sint $key:expr) => {
         match config_store().get($key) {
-            Some(setting) => setting.to_sint(),
-            None => 0,
+            Ok(Some(setting)) => setting.to_sint(),
+            Ok(None) => 0,
+            Err(err) => { log::warn!("config error: {err}"); 0 }
         }
     };
     (map $key:expr) => {
         match config_store().get($key) {
-            Some(setting) => setting.to_map(),
-            None => Vec::new(),
+            Ok(Some(setting)) => setting.to_map(),
+            Ok(None) => Vec::new(),
+            Err(err) => { log::warn!("config error: {err}"); Vec::new() }
         }
     };
 }
@@ -98,21 +105,31 @@ macro_rules! config {
 #[allow(clippy::crate_in_macro_def)]
 #[macro_export]
 macro_rules! config_set {
-    (string $key:expr, $val:expr) => {
-        config_store().set($key, Setting::String($val))
-    };
-    (bool $key:expr, $val:expr) => {
-        config_store().set($key, Setting::Bool($val))
-    };
-    (uint $key:expr, $val:expr) => {
-        config_store().set($key, Setting::UInt($val))
-    };
-    (sint $key:expr, $val:expr) => {
-        config_store().set($key, Setting::SInt($val))
-    };
-    (map $key:expr, $val:expr) => {
-        config_store().set($key, Setting::Map($val))
-    };
+    (string $key:expr, $val:expr) => {{
+        if let Err(err) = config_store().set($key, Setting::String($val)) {
+            log::warn!("config error: {err}");
+        }
+    }};
+    (bool $key:expr, $val:expr) => {{
+        if let Err(err) = config_store().set($key, Setting::Bool($val)) {
+            log::warn!("config error: {err}");
+        }
+    }};
+    (uint $key:expr, $val:expr) => {{
+        if let Err(err) = config_store().set($key, Setting::UInt($val)) {
+            log::warn!("config error: {err}");
+        }
+    }};
+    (sint $key:expr, $val:expr) => {{
+        if let Err(err) = config_store().set($key, Setting::SInt($val)) {
+            log::warn!("config error: {err}");
+        }
+    }};
+    (map $key:expr, $val:expr) => {{
+        if let Err(err) = config_store().set($key, Setting::Map($val)) {
+            log::warn!("config error: {err}");
+        }
+    }};
 }
 
 /// `JsonEntry` is used for parsing the settings.json file
@@ -199,61 +216,58 @@ impl ConfigStore {
 
     /// Returns the setting with the given key. If the setting is not found in the current
     /// storage, it will load the key from the storage. If the key is still not found, it will
-    /// return the default value for the given key. Note that if the key is not found and no
-    /// default value is specified, this function will panic.
-    pub fn get(&self, key: &str) -> Option<Setting> {
+    /// return the default value for the given key. Returns `Ok(None)` when the key is unknown.
+    pub fn get(&self, key: &str) -> Result<Option<Setting>> {
         if let Some(setting) = self.settings.lock().borrow().get(key) {
-            return Some(setting.clone());
+            return Ok(Some(setting.clone()));
         }
 
         // Setting not found, try and load it from the storage adapter
-        if let Some(setting) = self.storage.get(key) {
+        if let Some(setting) = self.storage.get(key)? {
             self.settings
                 .lock()
                 .borrow_mut()
                 .insert(key.to_string(), setting.clone());
-            return Some(setting.clone());
+            return Ok(Some(setting.clone()));
         }
 
         // Return the default value for the setting when nothing is found
         if let Some(info) = self.settings_info.get(key) {
-            return Some(info.default.clone());
+            return Ok(Some(info.default.clone()));
         }
 
-        // At this point we haven't found the key in the store, we haven't found it in storage, and we
-        // don't have a default value. This is a programming error, so we panic.
-        panic!("config: Setting {key} is not known");
+        Ok(None)
     }
 
     /// Sets the given setting to the given value. Will persist the setting to the
     /// storage. Note that the setting MUST have a settings-info entry, otherwise
     /// this function will not store the setting.
-    pub fn set(&self, key: &str, value: Setting) {
+    pub fn set(&self, key: &str, value: Setting) -> Result<()> {
         let info = if let Some(info) = self.settings_info.get(key) {
             info
         } else {
             warn!("config: Setting {key} is not known");
-            return;
+            return Err(Error::Config(format!("Setting {key} is not known")));
         };
 
         if mem::discriminant(&info.default) != mem::discriminant(&value) {
             warn!("config: Setting {key} is of different type than setting expects");
-            return;
+            return Err(Error::Config(format!("Setting {key} is of different type than expected")));
         }
 
         self.settings.lock().borrow_mut().insert(key.to_owned(), value.clone());
-
-        self.storage.set(key, value);
+        self.storage.set(key, value)?;
+        Ok(())
     }
 
     /// Populates the settings in the storage from the settings.json file
     fn populate_default_settings(&mut self) -> Result<()> {
-        let json_data: Value = serde_json::from_str(SETTINGS_JSON).expect("Failed to parse settings.json");
+        let json_data: Value = serde_json::from_str(SETTINGS_JSON)?;
 
         if let Value::Object(data) = json_data {
             for (section_prefix, section_entries) in &data {
                 let section_entries: Vec<JsonEntry> =
-                    serde_json::from_value(section_entries.clone()).expect("Failed to parse settings.json");
+                    serde_json::from_value(section_entries.clone())?;
 
                 for entry in section_entries {
                     let key = format!("{}.{}", section_prefix, entry.key);
@@ -288,11 +302,11 @@ mod test {
     fn test_config_store() {
         config_store_write().set_storage(Box::new(MemoryStorageAdapter::new()));
 
-        let setting = config_store().get("dns.local.enabled").unwrap();
+        let setting = config_store().get("dns.local.enabled").unwrap().unwrap();
         assert_eq!(setting, Setting::Bool(true));
 
-        config_store_write().set("dns.local.enabled", Setting::Bool(false));
-        let setting = config_store().get("dns.local.enabled").unwrap();
+        config_store_write().set("dns.local.enabled", Setting::Bool(false)).unwrap();
+        let setting = config_store().get("dns.local.enabled").unwrap().unwrap();
         assert_eq!(setting, Setting::Bool(false));
     }
 
@@ -304,7 +318,8 @@ mod test {
             assert_eq!(captured_logs.len(), 0);
         });
 
-        config_store_write().set("dns.local.enabled", Setting::String("wont accept strings".into()));
+        let result = config_store_write().set("dns.local.enabled", Setting::String("wont accept strings".into()));
+        assert!(result.is_err());
 
         testing_logger::validate(|captured_logs| {
             assert_eq!(captured_logs.len(), 1);
@@ -322,8 +337,13 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn macro_usage_with_panic() {
+    fn unknown_key_returns_none() {
+        let result = config_store().get("this.key.doesnt.exist");
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn unknown_key_in_macro_returns_default() {
         config_set!(string "this.key.doesnt.exist", "yesitdoes".into());
         let s = config!(string "this.key.doesnt.exist");
         assert_eq!(s, "");

--- a/crates/gosub_config/src/lib.rs
+++ b/crates/gosub_config/src/lib.rs
@@ -55,13 +55,13 @@ pub fn config_store_write() -> parking_lot::RwLockWriteGuard<'static, ConfigStor
     CONFIG_STORE.write()
 }
 
-/// These macro's can be used to simplify the calls to the config store. You can simply do:
+/// Reads a setting from the config store, returning a type-appropriate default when the key is
+/// unknown or a storage error occurs.
 ///
-/// let enabled = config!(bool "`dns.local.enabled").unwrap()`;
-/// `config_set!(bool` "dns.local.enabled", false);
-///
-/// Note that when you cannot find the key, it will return a default value. This is not always
-/// what you want, but you can test for existence of the key with `config_store().has("key`")
+/// ```ignore
+/// let enabled = config!(bool "dns.local.enabled");
+/// let max     = config!(uint "dns.cache.max_entries");
+/// ```
 #[allow(clippy::crate_in_macro_def)]
 #[macro_export]
 macro_rules! config {

--- a/crates/gosub_config/src/settings.rs
+++ b/crates/gosub_config/src/settings.rs
@@ -160,7 +160,9 @@ impl FromStr for Setting {
 
     /// Converts a string to a setting or None when the string is invalid
     fn from_str(key: &str) -> Result<Setting, crate::errors::Error> {
-        let (key_type, key_value) = key.split_once(':').expect("");
+        let (key_type, key_value) = key
+            .split_once(':')
+            .ok_or_else(|| Error::Config(format!("invalid setting format, missing ':' in {key:?}")))?;
 
         let setting = match key_type {
             "b" => Setting::Bool(

--- a/crates/gosub_config/src/settings.rs
+++ b/crates/gosub_config/src/settings.rs
@@ -158,7 +158,9 @@ impl FromStr for Setting {
     //   s:hello world
     //   m:foo,bar,baz
 
-    /// Converts a string to a setting or None when the string is invalid
+    /// Parses a prefixed string into a `Setting`. The format is `<type>:<value>`,
+    /// e.g. `b:true`, `i:-1`, `u:42`, `s:hello`, `m:foo,bar`. Returns an error
+    /// when the prefix is missing or the value cannot be parsed.
     fn from_str(key: &str) -> Result<Setting, crate::errors::Error> {
         let (key_type, key_value) = key
             .split_once(':')

--- a/crates/gosub_config/src/storage/json.rs
+++ b/crates/gosub_config/src/storage/json.rs
@@ -8,6 +8,9 @@ use std::fs;
 use std::fs::File;
 use std::io::{Read, Seek, Write};
 
+/// JSON file-backed storage adapter. All settings are held in memory and written to a JSON
+/// file on the filesystem. Note: `set` currently only updates the in-memory cache; call
+/// `write_file` explicitly to persist changes to disk.
 pub struct JsonStorageAdapter {
     path: String,
     elements: Mutex<HashMap<String, Setting>>,

--- a/crates/gosub_config/src/storage/json.rs
+++ b/crates/gosub_config/src/storage/json.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::fs;
 use std::fs::File;
-use std::io::{Read, Seek, Write};
+use std::io::{Read, Write};
 
 /// JSON file-backed storage adapter. All settings are held in memory and written to a JSON
 /// file on the filesystem. Note: `set` currently only updates the in-memory cache; call
@@ -88,10 +88,8 @@ impl JsonStorageAdapter {
 
     #[allow(dead_code)]
     fn write_file(&mut self) -> Result<()> {
-        let mut file = File::open(&self.path)?;
+        let mut file = File::options().write(true).truncate(true).open(&self.path)?;
         let json = serde_json::to_string_pretty(&*self.elements.lock())?;
-        file.set_len(0)?;
-        file.seek(std::io::SeekFrom::Start(0))?;
         file.write_all(json.as_bytes())?;
         Ok(())
     }

--- a/crates/gosub_config/src/storage/json.rs
+++ b/crates/gosub_config/src/storage/json.rs
@@ -1,6 +1,5 @@
 use crate::settings::Setting;
-use crate::StorageAdapter;
-use gosub_shared::types::Result;
+use crate::{Result, StorageAdapter};
 use log::warn;
 use parking_lot::Mutex;
 use serde_json::Value;
@@ -15,72 +14,60 @@ pub struct JsonStorageAdapter {
 }
 
 impl TryFrom<&String> for JsonStorageAdapter {
-    type Error = anyhow::Error;
+    type Error = crate::errors::Error;
 
     fn try_from(path: &String) -> Result<Self> {
-        let _ = if let Ok(metadata) = fs::metadata(path) {
-            assert!(metadata.is_file(), "json file is not a regular file");
-
-            File::options()
-                .read(true)
-                .write(true)
-                .open(path)
-                .expect("failed to open json file")
+        if let Ok(metadata) = fs::metadata(path) {
+            if !metadata.is_file() {
+                return Err(crate::errors::Error::Config(format!("{path} is not a regular file")));
+            }
+            File::options().read(true).write(true).open(path)?;
         } else {
-            let json = "{}";
-
-            let mut file = File::create(path).expect("cannot create json file");
-            file.write_all(json.as_bytes())?;
-
-            file
-        };
+            let mut file = File::create(path)?;
+            file.write_all(b"{}")?;
+        }
 
         let mut adapter = JsonStorageAdapter {
             path: path.to_string(),
             elements: Mutex::new(HashMap::new()),
         };
 
-        adapter.read_file();
+        adapter.read_file()?;
 
         Ok(adapter)
     }
 }
 
 impl StorageAdapter for JsonStorageAdapter {
-    fn get(&self, key: &str) -> Option<Setting> {
+    fn get(&self, key: &str) -> Result<Option<Setting>> {
         let lock = self.elements.lock();
-        lock.get(key).cloned()
+        Ok(lock.get(key).cloned())
     }
 
-    fn set(&self, key: &str, value: Setting) {
+    fn set(&self, key: &str, value: Setting) -> Result<()> {
         let mut lock = self.elements.lock();
         lock.insert(key.to_owned(), value);
-
-        // self.write_file()
+        Ok(())
     }
 
     fn all(&self) -> Result<HashMap<String, Setting>> {
         let lock = self.elements.lock();
-
         Ok(lock.clone())
     }
 }
 
 impl JsonStorageAdapter {
-    /// Read whole json file and stores the data into self.elements
-    fn read_file(&mut self) {
-        // @TODO: We should have some kind of OS file lock here
-        let mut file = File::open(&self.path).expect("failed to open json file");
+    fn read_file(&mut self) -> Result<()> {
+        let mut file = File::open(&self.path)?;
 
         let mut buf = String::new();
-        _ = file.read_to_string(&mut buf);
+        file.read_to_string(&mut buf)?;
 
-        let parsed_json: Value = serde_json::from_str(&buf).expect("Failed to parse json");
+        let parsed_json: Value = serde_json::from_str(&buf)?;
 
         if let Value::Object(settings) = parsed_json {
-            self.elements = Mutex::new(HashMap::new());
-
             let mut lock = self.elements.lock();
+            lock.clear();
             for (key, value) in &settings {
                 match serde_json::from_value(value.clone()) {
                     Ok(setting) => {
@@ -92,20 +79,17 @@ impl JsonStorageAdapter {
                 }
             }
         }
+
+        Ok(())
     }
 
-    /// Write the self.elements hashmap back to the file by truncating the file and writing the
-    /// data again.
     #[allow(dead_code)]
-    fn write_file(&mut self) {
-        // @TODO: We need some kind of OS lock file here. We should protect against concurrent threads but also
-        // against concurrent processes.
-        let mut file = File::open(&self.path).expect("failed to open json file");
-
-        let json = serde_json::to_string_pretty(&*self.elements.lock()).expect("failed to serialize");
-
-        file.set_len(0).expect("failed to truncate file");
-        file.seek(std::io::SeekFrom::Start(0)).expect("failed to seek");
-        file.write_all(json.as_bytes()).expect("failed to write file");
+    fn write_file(&mut self) -> Result<()> {
+        let mut file = File::open(&self.path)?;
+        let json = serde_json::to_string_pretty(&*self.elements.lock())?;
+        file.set_len(0)?;
+        file.seek(std::io::SeekFrom::Start(0))?;
+        file.write_all(json.as_bytes())?;
+        Ok(())
     }
 }

--- a/crates/gosub_config/src/storage/memory.rs
+++ b/crates/gosub_config/src/storage/memory.rs
@@ -1,6 +1,5 @@
 use crate::settings::Setting;
-use crate::StorageAdapter;
-use gosub_shared::types::Result;
+use crate::{Result, StorageAdapter};
 use parking_lot::Mutex;
 use std::collections::HashMap;
 
@@ -19,15 +18,15 @@ impl MemoryStorageAdapter {
 }
 
 impl StorageAdapter for MemoryStorageAdapter {
-    fn get(&self, key: &str) -> Option<Setting> {
+    fn get(&self, key: &str) -> Result<Option<Setting>> {
         let lock = self.settings.lock();
-        let v = lock.get(key);
-        v.cloned()
+        Ok(lock.get(key).cloned())
     }
 
-    fn set(&self, key: &str, value: Setting) {
+    fn set(&self, key: &str, value: Setting) -> Result<()> {
         let mut lock = self.settings.lock();
         lock.insert(key.to_owned(), value);
+        Ok(())
     }
 
     fn all(&self) -> Result<HashMap<String, Setting>> {

--- a/crates/gosub_config/src/storage/memory.rs
+++ b/crates/gosub_config/src/storage/memory.rs
@@ -3,6 +3,8 @@ use crate::{Result, StorageAdapter};
 use parking_lot::Mutex;
 use std::collections::HashMap;
 
+/// In-memory storage adapter. Settings are lost when the process exits.
+/// Useful for testing and for the default state before a persistent adapter is attached.
 #[derive(Default)]
 pub struct MemoryStorageAdapter {
     settings: Mutex<HashMap<String, Setting>>,

--- a/crates/gosub_config/src/storage/sqlite.rs
+++ b/crates/gosub_config/src/storage/sqlite.rs
@@ -1,7 +1,6 @@
 use crate::errors::Error;
 use crate::settings::Setting;
 use crate::{Result, StorageAdapter};
-use log::warn;
 use parking_lot::Mutex;
 use rusqlite::{named_params, Connection};
 use std::collections::HashMap;
@@ -21,7 +20,7 @@ impl TryFrom<&String> for SqliteStorageAdapter {
 
         let query = "CREATE TABLE IF NOT EXISTS settings (
             id INTEGER PRIMARY KEY,
-            key TEXT NOT NULL,
+            key TEXT NOT NULL UNIQUE,
             value TEXT NOT NULL
         )";
         conn.execute(query, [])?;
@@ -39,13 +38,7 @@ impl StorageAdapter for SqliteStorageAdapter {
         let mut statement = db_lock.prepare(query)?;
 
         match statement.query_row(named_params! { ":key": key }, |row| row.get::<_, String>(0)) {
-            Ok(val) => match Setting::from_str(&val) {
-                Ok(setting) => Ok(Some(setting)),
-                Err(err) => {
-                    warn!("problem reading from sqlite: {err}");
-                    Ok(None)
-                }
-            },
+            Ok(val) => Setting::from_str(&val).map(Some),
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
             Err(err) => Err(Error::Sqlite(err)),
         }

--- a/crates/gosub_config/src/storage/sqlite.rs
+++ b/crates/gosub_config/src/storage/sqlite.rs
@@ -7,6 +7,8 @@ use rusqlite::{named_params, Connection};
 use std::collections::HashMap;
 use std::str::FromStr;
 
+/// SQLite-backed storage adapter. Each `get` and `set` call hits the database directly,
+/// so settings are persisted immediately without a separate flush step.
 pub struct SqliteStorageAdapter {
     connection: Mutex<Connection>,
 }

--- a/crates/gosub_config/src/storage/sqlite.rs
+++ b/crates/gosub_config/src/storage/sqlite.rs
@@ -1,6 +1,6 @@
+use crate::errors::Error;
 use crate::settings::Setting;
-use crate::StorageAdapter;
-use gosub_shared::types::Result;
+use crate::{Result, StorageAdapter};
 use log::warn;
 use parking_lot::Mutex;
 use rusqlite::{named_params, Connection};
@@ -12,10 +12,10 @@ pub struct SqliteStorageAdapter {
 }
 
 impl TryFrom<&String> for SqliteStorageAdapter {
-    type Error = anyhow::Error;
+    type Error = Error;
 
     fn try_from(path: &String) -> Result<Self> {
-        let conn = Connection::open(path).expect("cannot open db file");
+        let conn = Connection::open(path)?;
 
         let query = "CREATE TABLE IF NOT EXISTS settings (
             id INTEGER PRIMARY KEY,
@@ -31,35 +31,33 @@ impl TryFrom<&String> for SqliteStorageAdapter {
 }
 
 impl StorageAdapter for SqliteStorageAdapter {
-    fn get(&self, key: &str) -> Option<Setting> {
+    fn get(&self, key: &str) -> Result<Option<Setting>> {
         let db_lock = self.connection.lock();
-
         let query = "SELECT value FROM settings WHERE key = :key";
-        let mut statement = db_lock.prepare(query).unwrap();
-        let val: String = statement
-            .query_row(named_params! { ":key": key }, |row| row.get(0))
-            .unwrap();
+        let mut statement = db_lock.prepare(query)?;
 
-        match Setting::from_str(&val) {
-            Ok(setting) => Some(setting),
-            Err(err) => {
-                warn!("problem reading from sqlite: {err}");
-                None
-            }
+        match statement.query_row(named_params! { ":key": key }, |row| row.get::<_, String>(0)) {
+            Ok(val) => match Setting::from_str(&val) {
+                Ok(setting) => Ok(Some(setting)),
+                Err(err) => {
+                    warn!("problem reading from sqlite: {err}");
+                    Ok(None)
+                }
+            },
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(err) => Err(Error::Sqlite(err)),
         }
     }
 
-    fn set(&self, key: &str, value: Setting) {
+    fn set(&self, key: &str, value: Setting) -> Result<()> {
         let db_lock = self.connection.lock();
-
         let query = "INSERT OR REPLACE INTO settings (key, value) VALUES (:key, :value)";
-        let mut statement = db_lock.prepare(query).unwrap();
-        let _ = statement
-            .execute(named_params! {
-                ":key": &key.to_string(),
-                ":value": &value.to_string(),
-            })
-            .unwrap();
+        let mut statement = db_lock.prepare(query)?;
+        statement.execute(named_params! {
+            ":key": key,
+            ":value": value.to_string(),
+        })?;
+        Ok(())
     }
 
     fn all(&self) -> Result<HashMap<String, Setting>> {
@@ -67,12 +65,12 @@ impl StorageAdapter for SqliteStorageAdapter {
 
         let db_lock = self.connection.lock();
         let query = "SELECT id,key,value FROM settings";
-        let mut statement = db_lock.prepare(query).unwrap();
+        let mut statement = db_lock.prepare(query)?;
 
-        let mut rows = statement.query([]).unwrap();
+        let mut rows = statement.query([])?;
         while let Some(row) = rows.next()? {
-            let key: String = row.get(1).unwrap();
-            let val: String = row.get(2).unwrap();
+            let key: String = row.get(1)?;
+            let val: String = row.get(2)?;
             settings.insert(key, Setting::from_str(&val)?);
         }
 

--- a/src/bin/config-store.rs
+++ b/src/bin/config-store.rs
@@ -92,17 +92,21 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::List => {
             for key in config_store().find("*") {
-                if let Some(value) = config_store().get(&key)? {
+                let value = config_store().get(&key)?
+                    .or_else(|| config_store().get_info(&key).map(|i| i.default));
+                if let Some(value) = value {
                     println!("{key:40}: {value}");
                 }
             }
         }
         Commands::Set { key, value } => {
-            config_store().set(&key, Setting::from_str(&value).expect("incorrect value"))?;
+            config_store().set(&key, Setting::from_str(&value)?)?;
         }
         Commands::Search { key } => {
             for key in config_store().find(&key) {
-                if let Some(value) = config_store().get(&key)? {
+                let value = config_store().get(&key)?
+                    .or_else(|| config_store().get_info(&key).map(|i| i.default));
+                if let Some(value) = value {
                     println!("{key:40}: {value}");
                 }
             }

--- a/src/bin/config-store.rs
+++ b/src/bin/config-store.rs
@@ -83,7 +83,7 @@ fn main() -> anyhow::Result<()> {
             }
 
             let info = config_store().get_info(&key).unwrap();
-            let value = config_store().get(&key).unwrap();
+            let value = config_store().get(&key)?.unwrap_or(info.default.clone());
 
             println!("Key            : {key}");
             println!("Current Value  : {value}");
@@ -92,17 +92,19 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::List => {
             for key in config_store().find("*") {
-                let value = config_store().get(&key).unwrap();
-                println!("{key:40}: {value}");
+                if let Some(value) = config_store().get(&key)? {
+                    println!("{key:40}: {value}");
+                }
             }
         }
         Commands::Set { key, value } => {
-            config_store().set(&key, Setting::from_str(&value).expect("incorrect value"));
+            config_store().set(&key, Setting::from_str(&value).expect("incorrect value"))?;
         }
         Commands::Search { key } => {
             for key in config_store().find(&key) {
-                let value = config_store().get(&key).unwrap();
-                println!("{key:40}: {value}");
+                if let Some(value) = config_store().get(&key)? {
+                    println!("{key:40}: {value}");
+                }
             }
         }
     }

--- a/src/bin/config-store.rs
+++ b/src/bin/config-store.rs
@@ -92,7 +92,8 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::List => {
             for key in config_store().find("*") {
-                let value = config_store().get(&key)?
+                let value = config_store()
+                    .get(&key)?
                     .or_else(|| config_store().get_info(&key).map(|i| i.default));
                 if let Some(value) = value {
                     println!("{key:40}: {value}");
@@ -104,7 +105,8 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::Search { key } => {
             for key in config_store().find(&key) {
-                let value = config_store().get(&key)?
+                let value = config_store()
+                    .get(&key)?
                     .or_else(|| config_store().get_info(&key).map(|i| i.default));
                 if let Some(value) = value {
                     println!("{key:40}: {value}");


### PR DESCRIPTION
This is an initial setup for all crates to use Result<>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reads/writes, parsing, and storage I/O now return structured errors instead of panicking; CLI falls back to defaults or skips absent values.

* **Refactor**
  * Configuration storage APIs are now fallible end-to-end and propagate errors; macros/logging report failures rather than crashing.

* **Tests**
  * Updated/added tests covering unknown-key handling and new error paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gosub-io/gosub-engine/pull/964)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->