### PR TITLE
all code and examples are now using the gosub_net fetcher system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3664,6 +3664,7 @@ name = "gosub_net"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "cookie",
  "cow-utils",
  "gosub_engine",
  "gosub_shared",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,7 +1547,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -1570,7 +1570,7 @@ checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
 dependencies = [
  "core-foundation 0.9.4",
  "core-graphics",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -2677,21 +2677,12 @@ dependencies = [
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -2704,12 +2695,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -3444,7 +3429,6 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rand 0.9.4",
- "reqwest 0.13.3",
  "simple_logger",
  "slotmap",
  "test-case",
@@ -3566,7 +3550,7 @@ dependencies = [
  "rand 0.9.4",
  "raw-window-handle",
  "regex",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "serde_json",
  "skia-safe",
@@ -3624,6 +3608,7 @@ dependencies = [
  "criterion",
  "gosub_css3",
  "gosub_interface",
+ "gosub_net",
  "gosub_shared",
  "lazy_static",
  "log",
@@ -3631,7 +3616,6 @@ dependencies = [
  "nom_locate",
  "phf 0.13.1",
  "regex",
- "reqwest 0.13.3",
  "serde",
  "serde_json",
  "test-case",
@@ -3680,9 +3664,10 @@ name = "gosub_net"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "cow-utils",
  "gosub_engine",
  "gosub_shared",
- "reqwest 0.13.3",
+ "reqwest",
  "tokio",
  "url",
 ]
@@ -3700,6 +3685,7 @@ dependencies = [
  "gosub_css3",
  "gosub_html5",
  "gosub_interface",
+ "gosub_net",
  "gosub_shared",
  "gtk4",
  "hex",
@@ -3710,7 +3696,6 @@ dependencies = [
  "pollster",
  "rand 0.9.4",
  "regex",
- "reqwest 0.12.28",
  "resvg",
  "rstar",
  "serde",
@@ -4356,22 +4341,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -5112,7 +5081,7 @@ dependencies = [
  "bitflags 2.11.1",
  "block",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "log",
  "objc",
  "paste",
@@ -5232,23 +5201,6 @@ dependencies = [
  "spirv 0.4.0+sdk-1.4.341.0",
  "thiserror 2.0.18",
  "unicode-ident",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -5820,47 +5772,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.115"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -7080,48 +6995,6 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "encoding_rs",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
@@ -7567,18 +7440,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -8453,16 +8314,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,6 @@ getrandom = "0.4.2"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 gosub_v8 = { version = "0.1.1", path = "./crates/gosub_v8", features = [], registry = "gosub" }
 gosub_webexecutor = { version = "0.1.1", path = "./crates/gosub_webexecutor", features = [], registry = "gosub" }
-reqwest = { version = "0.13.3", features = ["blocking", "rustls"] }
 futures = "0.3.32"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/gosub_html5/Cargo.toml
+++ b/crates/gosub_html5/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 cow-utils = "0.1.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-reqwest = { version = "0.13.3", features = ["blocking", "rustls"] }
+gosub_net = { version = "0.1.1", registry = "gosub", path = "../gosub_net" }
 
 [dev-dependencies]
 test-case = "3.3.1"

--- a/crates/gosub_html5/src/parser.rs
+++ b/crates/gosub_html5/src/parser.rs
@@ -4104,7 +4104,7 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
 
             match response.headers.get("content-type") {
                 Some(ct) if !ct.starts_with("text/css") => {
-                    warn!("External stylesheet has no text/css content type: {ct}");
+                    warn!("External stylesheet has unexpected content type: {ct}");
                 }
                 None => warn!("External stylesheet has no content type: {url}"),
                 _ => {}

--- a/crates/gosub_html5/src/parser.rs
+++ b/crates/gosub_html5/src/parser.rs
@@ -4086,36 +4086,31 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
     #[cfg(not(target_arch = "wasm32"))]
     fn load_external_stylesheet(&self, origin: CssOrigin, url: Url) -> Option<<C::CssSystem as CssSystem>::Stylesheet> {
         let css = if url.scheme() == "http" || url.scheme() == "https" {
-            // Fetch the html from the url
-            let response = reqwest::blocking::get(url.as_str());
-            if let Err(err) = response {
-                warn!("Could not load external stylesheet from {}. Error: {}", url, err);
-                return None;
-            }
-            let response = response.unwrap();
+            let response = match gosub_net::http::blocking::get(&url) {
+                Ok(r) => r,
+                Err(err) => {
+                    warn!("Could not load external stylesheet from {}. Error: {}", url, err);
+                    return None;
+                }
+            };
 
-            if response.status().as_u16() != 200 {
+            if response.status != 200 {
                 warn!(
-                    "Could not load external stylesheet from {}. Status code {} ",
-                    url,
-                    response.status()
+                    "Could not load external stylesheet from {}. Status code {}",
+                    url, response.status
                 );
                 return None;
             }
-            let content_type = response.headers().get("Content-Type");
-            match content_type {
-                Some(content_type) => {
-                    let content_type = content_type.to_str().unwrap_or("");
-                    if !content_type.starts_with("text/css") {
-                        warn!("External stylesheet has no text/css content type: {content_type} ");
-                    }
+
+            match response.headers.get("content-type") {
+                Some(ct) if !ct.starts_with("text/css") => {
+                    warn!("External stylesheet has no text/css content type: {ct}");
                 }
-                None => {
-                    warn!("External stylesheet has no content type: {url} ");
-                }
+                None => warn!("External stylesheet has no content type: {url}"),
+                _ => {}
             }
 
-            match response.text() {
+            match String::from_utf8(response.body) {
                 Ok(css) => css,
                 Err(err) => {
                     warn!("Could not load external stylesheet from {url}. Error: {err}");

--- a/crates/gosub_net/Cargo.toml
+++ b/crates/gosub_net/Cargo.toml
@@ -11,6 +11,7 @@ gosub_shared = { version = "0.1.1", registry = "gosub", path = "../gosub_shared"
 anyhow = "1.0.102"
 url = "2.5.8"
 cow-utils = "0.1"
+cookie = "0.18.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 gosub_engine = { version = "0.1.0", path = "../gosub_engine" }

--- a/crates/gosub_net/Cargo.toml
+++ b/crates/gosub_net/Cargo.toml
@@ -10,11 +10,12 @@ description = "Network utitilies"
 gosub_shared = { version = "0.1.1", registry = "gosub", path = "../gosub_shared", features = [] }
 anyhow = "1.0.102"
 url = "2.5.8"
+cow-utils = "0.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 gosub_engine = { version = "0.1.0", path = "../gosub_engine" }
 tokio = { version = "1.52.3", features = ["rt"] }
-reqwest = { version = "0.13.3", features = ["rustls", "stream"] }
+reqwest = { version = "0.13.3", features = ["rustls", "stream", "blocking"] }
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/gosub_net/src/http.rs
+++ b/crates/gosub_net/src/http.rs
@@ -1,2 +1,4 @@
+#[cfg(not(target_arch = "wasm32"))]
+pub mod blocking;
 pub mod fetcher;
 pub mod response;

--- a/crates/gosub_net/src/http/blocking.rs
+++ b/crates/gosub_net/src/http/blocking.rs
@@ -3,6 +3,7 @@ use cookie::Cookie;
 use cow_utils::CowUtils;
 use gosub_shared::types::Result;
 use std::collections::HashMap;
+use std::io::Read;
 use std::sync::OnceLock;
 use std::time::Duration;
 use url::Url;
@@ -26,14 +27,20 @@ fn get_client() -> &'static reqwest::blocking::Client {
 /// Headers in the returned [`Response`] are stored with lowercase keys.
 pub fn get(url: &Url) -> Result<Response> {
     if url.scheme() == "file" {
-        let path = url
-            .to_file_path()
-            .map_err(|_| anyhow::anyhow!("Invalid file URL: {}", url))?;
-        let metadata = std::fs::metadata(&path)?;
-        if metadata.len() > MAX_BODY_SIZE {
+        // to_file_path() handles well-formed file:///absolute/path URLs.
+        // For relative-style file://relative/path URLs the host holds the first
+        // path segment, so we fall back to concatenating host + path.
+        let path = url.to_file_path().unwrap_or_else(|_| {
+            let host = url.host_str().unwrap_or("");
+            std::path::PathBuf::from(format!("{}{}", host, url.path()))
+        });
+        let mut body = Vec::new();
+        std::fs::File::open(&path)?
+            .take(MAX_BODY_SIZE + 1)
+            .read_to_end(&mut body)?;
+        if body.len() as u64 > MAX_BODY_SIZE {
             anyhow::bail!("File size exceeds maximum size of {} bytes", MAX_BODY_SIZE);
         }
-        let body = std::fs::read(&path)?;
         return Ok(Response::from(body));
     }
 
@@ -80,13 +87,11 @@ pub fn get(url: &Url) -> Result<Response> {
         })
         .collect();
 
-    let mut reader = resp.take(MAX_BODY_SIZE + 1);
     let mut body = Vec::new();
-    reader.read_to_end(&mut body)?;
+    resp.take(MAX_BODY_SIZE + 1).read_to_end(&mut body)?;
     if body.len() as u64 > MAX_BODY_SIZE {
         anyhow::bail!("Response body exceeds maximum size of {} bytes", MAX_BODY_SIZE);
     }
-    let body = bytes.to_vec();
 
     Ok(Response {
         status,

--- a/crates/gosub_net/src/http/blocking.rs
+++ b/crates/gosub_net/src/http/blocking.rs
@@ -1,0 +1,48 @@
+use crate::http::response::Response;
+use cow_utils::CowUtils;
+use gosub_shared::types::Result;
+use std::collections::HashMap;
+use std::time::Duration;
+use url::Url;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Performs a blocking HTTP GET, handling both `file://` and `http(s)://` URLs.
+/// Headers in the returned [`Response`] are stored with lowercase keys.
+pub fn get(url: &Url) -> Result<Response> {
+    if url.scheme() == "file" {
+        let path = &url.as_str()[7..];
+        let body = std::fs::read(path)?;
+        return Ok(Response::from(body));
+    }
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(DEFAULT_TIMEOUT)
+        .use_rustls_tls()
+        .build()?;
+
+    let resp = client.get(url.as_str()).send()?;
+    let status = resp.status().as_u16();
+    let status_text = resp.status().canonical_reason().unwrap_or("").to_string();
+
+    let headers: HashMap<String, String> = resp
+        .headers()
+        .iter()
+        .filter_map(|(k, v)| {
+            v.to_str()
+                .ok()
+                .map(|v| (k.as_str().cow_to_lowercase().into_owned(), v.to_string()))
+        })
+        .collect();
+
+    let body = resp.bytes()?.to_vec();
+
+    Ok(Response {
+        status,
+        status_text,
+        version: "HTTP/1.1".to_string(),
+        headers,
+        cookies: HashMap::new(),
+        body,
+    })
+}

--- a/crates/gosub_net/src/http/blocking.rs
+++ b/crates/gosub_net/src/http/blocking.rs
@@ -80,8 +80,10 @@ pub fn get(url: &Url) -> Result<Response> {
         })
         .collect();
 
-    let bytes = resp.bytes()?;
-    if bytes.len() as u64 > MAX_BODY_SIZE {
+    let mut reader = resp.take(MAX_BODY_SIZE + 1);
+    let mut body = Vec::new();
+    reader.read_to_end(&mut body)?;
+    if body.len() as u64 > MAX_BODY_SIZE {
         anyhow::bail!("Response body exceeds maximum size of {} bytes", MAX_BODY_SIZE);
     }
     let body = bytes.to_vec();

--- a/crates/gosub_net/src/http/blocking.rs
+++ b/crates/gosub_net/src/http/blocking.rs
@@ -6,13 +6,16 @@ use std::time::Duration;
 use url::Url;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_BODY_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
 
 /// Performs a blocking HTTP GET, handling both `file://` and `http(s)://` URLs.
 /// Headers in the returned [`Response`] are stored with lowercase keys.
 pub fn get(url: &Url) -> Result<Response> {
     if url.scheme() == "file" {
-        let path = &url.as_str()[7..];
-        let body = std::fs::read(path)?;
+        let path = url
+            .to_file_path()
+            .map_err(|_| anyhow::anyhow!("Invalid file URL: {}", url))?;
+        let body = std::fs::read(&path)?;
         return Ok(Response::from(body));
     }
 
@@ -24,6 +27,14 @@ pub fn get(url: &Url) -> Result<Response> {
     let resp = client.get(url.as_str()).send()?;
     let status = resp.status().as_u16();
     let status_text = resp.status().canonical_reason().unwrap_or("").to_string();
+    let version = match resp.version() {
+        reqwest::Version::HTTP_10 => "HTTP/1.0",
+        reqwest::Version::HTTP_11 => "HTTP/1.1",
+        reqwest::Version::HTTP_2 => "HTTP/2",
+        reqwest::Version::HTTP_3 => "HTTP/3",
+        _ => "HTTP/1.1",
+    }
+    .to_string();
 
     let headers: HashMap<String, String> = resp
         .headers()
@@ -35,14 +46,30 @@ pub fn get(url: &Url) -> Result<Response> {
         })
         .collect();
 
-    let body = resp.bytes()?.to_vec();
+    let cookies: HashMap<String, String> = resp
+        .headers()
+        .get_all("set-cookie")
+        .iter()
+        .filter_map(|v| {
+            let s = v.to_str().ok()?;
+            let kv = s.split(';').next()?;
+            let (name, value) = kv.split_once('=')?;
+            Some((name.trim().to_string(), value.trim().to_string()))
+        })
+        .collect();
+
+    let bytes = resp.bytes()?;
+    if bytes.len() as u64 > MAX_BODY_SIZE {
+        anyhow::bail!("Response body exceeds maximum size of {} bytes", MAX_BODY_SIZE);
+    }
+    let body = bytes.to_vec();
 
     Ok(Response {
         status,
         status_text,
-        version: "HTTP/1.1".to_string(),
+        version,
         headers,
-        cookies: HashMap::new(),
+        cookies,
         body,
     })
 }

--- a/crates/gosub_net/src/http/blocking.rs
+++ b/crates/gosub_net/src/http/blocking.rs
@@ -1,12 +1,26 @@
 use crate::http::response::Response;
+use cookie::Cookie;
 use cow_utils::CowUtils;
 use gosub_shared::types::Result;
 use std::collections::HashMap;
+use std::sync::OnceLock;
 use std::time::Duration;
 use url::Url;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_BODY_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
+
+static HTTP_CLIENT: OnceLock<reqwest::blocking::Client> = OnceLock::new();
+
+fn get_client() -> &'static reqwest::blocking::Client {
+    HTTP_CLIENT.get_or_init(|| {
+        reqwest::blocking::Client::builder()
+            .timeout(DEFAULT_TIMEOUT)
+            .use_rustls_tls()
+            .build()
+            .expect("Failed to build HTTP client")
+    })
+}
 
 /// Performs a blocking HTTP GET, handling both `file://` and `http(s)://` URLs.
 /// Headers in the returned [`Response`] are stored with lowercase keys.
@@ -15,16 +29,15 @@ pub fn get(url: &Url) -> Result<Response> {
         let path = url
             .to_file_path()
             .map_err(|_| anyhow::anyhow!("Invalid file URL: {}", url))?;
+        let metadata = std::fs::metadata(&path)?;
+        if metadata.len() > MAX_BODY_SIZE {
+            anyhow::bail!("File size exceeds maximum size of {} bytes", MAX_BODY_SIZE);
+        }
         let body = std::fs::read(&path)?;
         return Ok(Response::from(body));
     }
 
-    let client = reqwest::blocking::Client::builder()
-        .timeout(DEFAULT_TIMEOUT)
-        .use_rustls_tls()
-        .build()?;
-
-    let resp = client.get(url.as_str()).send()?;
+    let resp = get_client().get(url.as_str()).send()?;
     let status = resp.status().as_u16();
     let status_text = resp.status().canonical_reason().unwrap_or("").to_string();
     let version = match resp.version() {
@@ -35,6 +48,15 @@ pub fn get(url: &Url) -> Result<Response> {
         _ => "HTTP/1.1",
     }
     .to_string();
+
+    // Reject early if Content-Length declares an oversized body.
+    if let Some(cl) = resp.headers().get("content-length") {
+        if let Ok(size) = cl.to_str().unwrap_or("").parse::<u64>() {
+            if size > MAX_BODY_SIZE {
+                anyhow::bail!("Response body exceeds maximum size of {} bytes", MAX_BODY_SIZE);
+            }
+        }
+    }
 
     let headers: HashMap<String, String> = resp
         .headers()
@@ -52,9 +74,9 @@ pub fn get(url: &Url) -> Result<Response> {
         .iter()
         .filter_map(|v| {
             let s = v.to_str().ok()?;
-            let kv = s.split(';').next()?;
-            let (name, value) = kv.split_once('=')?;
-            Some((name.trim().to_string(), value.trim().to_string()))
+            Cookie::parse(s.to_owned())
+                .ok()
+                .map(|c| (c.name().to_owned(), c.value().to_owned()))
         })
         .collect();
 

--- a/crates/gosub_pipeline/Cargo.toml
+++ b/crates/gosub_pipeline/Cargo.toml
@@ -27,7 +27,8 @@ serde_json = "1.0.138"
 csscolorparser = "0.7.0"
 regex = "1.11.1"
 rstar = "0.12.2"
-reqwest = { version = "0.12.22", features = ["blocking"] }
+gosub_net = { version = "0.1.1", path = "../gosub_net", registry = "gosub" }
+url = "2.5.8"
 resvg = "0.47.0"
 bytes = "1.10.1"
 file_type = { version = "0.8.1", features = ["httpd"] }

--- a/crates/gosub_pipeline/examples/rendertree.rs
+++ b/crates/gosub_pipeline/examples/rendertree.rs
@@ -80,14 +80,10 @@ fn main() {
     }
 }
 
-fn fetch_html(url: &str) -> Result<String, reqwest::Error> {
-    reqwest::blocking::Client::builder()
-        .user_agent("GosubBrowser/0.1 rendertree-example")
-        .timeout(std::time::Duration::from_secs(15))
-        .build()?
-        .get(url)
-        .send()?
-        .text()
+fn fetch_html(url: &str) -> anyhow::Result<String> {
+    let parsed = url::Url::parse(url)?;
+    let response = gosub_net::http::blocking::get(&parsed)?;
+    Ok(String::from_utf8_lossy(&response.body).into_owned())
 }
 
 fn print_subtree(rt: &RenderTree, id: RenderNodeId, depth: usize) {

--- a/crates/gosub_pipeline/src/common/media/media_store.rs
+++ b/crates/gosub_pipeline/src/common/media/media_store.rs
@@ -3,12 +3,11 @@ use crate::common::media::Svg;
 use crate::common::media::{Media, MediaId, MediaImage, MediaSvg, MediaType};
 use bytes::Bytes;
 use file_type::FileType;
-use reqwest::header::HeaderValue;
 use resvg::usvg;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock, RwLock};
-use std::time::Duration;
+use url::Url;
 
 const DEFAULT_SVG_ID: MediaId = MediaId::new(0);
 const DEFAULT_IMAGE_ID: MediaId = MediaId::new(1);
@@ -274,32 +273,19 @@ impl MediaStore {
     /// Fetch resource from the web (or local file system, depending on the src) and returns the media type and raw
     /// bytes. This is blocking.
     fn fetch_resource(&self, src: &str) -> anyhow::Result<(MediaType, bytes::Bytes)> {
-        let client = reqwest::blocking::Client::builder()
-            .timeout(Duration::from_secs(10))
-            .build()?;
-        let response = client
-            .get(src)
-            .send()
-            .map_err(|e| anyhow::anyhow!("Failed to fetch resource: {e}"))?;
+        let url = Url::parse(src)?;
+        let response = gosub_net::http::blocking::get(&url)?;
 
-        if !response.status().is_success() {
-            anyhow::bail!("HTTP {} fetching resource", response.status());
+        if !response.is_ok() {
+            anyhow::bail!("HTTP {} fetching resource", response.status);
         }
 
         // Detect through content type
-        let detected_content_type = detect_content_type(
-            response
-                .headers()
-                .get("content-type")
-                .unwrap_or(&HeaderValue::from_static(""))
-                .to_str()
-                .unwrap_or(""),
-        );
+        let detected_content_type =
+            detect_content_type(response.headers.get("content-type").map(String::as_str).unwrap_or(""));
 
         // Detect through content bytes
-        let raw_bytes = response
-            .bytes()
-            .map_err(|e| anyhow::anyhow!("Failed to read response body: {e}"))?;
+        let raw_bytes = bytes::Bytes::from(response.body);
         let detected_file_type = detect_file_type(&raw_bytes);
 
         if detected_content_type.is_none() && detected_file_type.is_none() {

--- a/src/bin/css3-parser.rs
+++ b/src/bin/css3-parser.rs
@@ -51,7 +51,11 @@ fn main() -> Result<()> {
     let url: String = matches.get_one::<String>("url").expect("url").to_string();
     let display_tokenizer = matches.get_flag("tokenizer");
 
-    let parsed_url = url::Url::parse(&url)?;
+    let parsed_url = match url::Url::parse(&url) {
+        Ok(u) => u,
+        Err(_) => url::Url::from_file_path(std::path::Path::new(&url))
+            .map_err(|_| anyhow!("Invalid URL or file path: {url}"))?,
+    };
     let response = gosub_net::http::blocking::get(&parsed_url)?;
     if !response.is_ok() {
         bail!("Could not get url. Status code {}", response.status);

--- a/src/bin/css3-parser.rs
+++ b/src/bin/css3-parser.rs
@@ -7,7 +7,6 @@ use gosub_shared::byte_stream::{ByteStream, Encoding, Location};
 use gosub_shared::config::ParserConfig;
 use gosub_shared::errors::CssError;
 use simple_logger::SimpleLogger;
-use std::fs;
 use std::time::Instant;
 
 fn main() -> Result<()> {
@@ -52,19 +51,17 @@ fn main() -> Result<()> {
     let url: String = matches.get_one::<String>("url").expect("url").to_string();
     let display_tokenizer = matches.get_flag("tokenizer");
 
-    let css = if url.starts_with("http://") || url.starts_with("https://") {
-        // Fetch the html from the url
-        let response = reqwest::blocking::get(&url)?;
-        if response.status().as_u16() != 200 {
-            bail!("Could not get url. Status code {}", response.status());
+    let parsed_url = url::Url::parse(&url)?;
+    let response = gosub_net::http::blocking::get(&parsed_url)?;
+    if !response.is_ok() {
+        bail!("Could not get url. Status code {}", response.status);
+    }
+    if let Some(ct) = response.headers.get("content-type") {
+        if !ct.contains("css") && !ct.contains("text/plain") {
+            bail!("URL does not appear to be a CSS resource (content-type: {ct})");
         }
-        response.text()?
-    } else if url.starts_with("file://") {
-        let path = url.trim_start_matches("file://");
-        fs::read_to_string(path)?
-    } else {
-        bail!("Unsupported url scheme: {}", url);
-    };
+    }
+    let css = String::from_utf8_lossy(&response.body).into_owned();
 
     if debug {
         SimpleLogger::new().init().unwrap();

--- a/src/bin/display-text-tree.rs
+++ b/src/bin/display-text-tree.rs
@@ -35,12 +35,13 @@ fn main() -> Result<()> {
         .unwrap();
 
     // Fetch the html from the url
-    let response = reqwest::blocking::get(&url)?;
-    if response.status().as_u16() != 200 {
-        println!("could not get url. Status code {}", response.status());
+    let parsed_url = url::Url::parse(&url)?;
+    let response = gosub_net::http::blocking::get(&parsed_url)?;
+    if !response.is_ok() {
+        println!("could not get url. Status code {}", response.status);
         exit(1);
     }
-    let html = response.text()?;
+    let html = String::from_utf8_lossy(&response.body).into_owned();
 
     let mut stream = ByteStream::from_str(&html, Encoding::UTF8);
 

--- a/src/bin/gosub-parser.rs
+++ b/src/bin/gosub-parser.rs
@@ -8,7 +8,6 @@ use gosub_shared::byte_stream::{ByteStream, Encoding};
 use gosub_shared::timing::Scale;
 use gosub_shared::timing_display;
 use gosub_shared::types::Result;
-use std::fs;
 use std::process::exit;
 use std::str::FromStr;
 use url::Url;
@@ -52,19 +51,11 @@ fn main() -> Result<()> {
 
     println!("Parsing url: {url:?}");
 
-    let html = if url.scheme() == "http" || url.scheme() == "https" {
-        // Fetch the html from the url
-        let response = reqwest::blocking::get(url.as_str())?;
-        if response.status().as_u16() != 200 {
-            bail!("Could not get url. Status code {}", response.status());
-        }
-        response.text()?
-    } else if url.scheme() == "file" {
-        // Get html from the file
-        fs::read_to_string(url.to_string().trim_start_matches("file://"))?
-    } else {
-        fatal("Invalid url scheme");
-    };
+    let response = gosub_net::http::blocking::get(&url)?;
+    if !response.is_ok() {
+        bail!("Could not get url. Status code {}", response.status);
+    }
+    let html = String::from_utf8_lossy(&response.body).into_owned();
 
     let mut stream = ByteStream::from_str(&html, Encoding::UTF8);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Unified HTTP fetching behind a single internal network layer used by CLIs, examples, and libraries; dependency updates to support this.

* **Bug Fixes**
  * More consistent HTTP error handling, clearer failures on non-OK responses, and safer UTF‑8/body handling with logged warnings.

* **New Features**
  * Blocking fetch support for file:// and http(s) inputs, cookie extraction, header normalization, and enforced max response size (10MB).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gosub-io/gosub-engine/pull/966)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->