### PR TITLE
use taffy's calc integration

### DIFF
--- a/crates/gosub_css3/src/functions.rs
+++ b/crates/gosub_css3/src/functions.rs
@@ -1,7 +1,5 @@
 // pub use attr::*;
-// pub use calc::*;
 // pub use var::*;
 
 pub mod attr;
-pub mod calc;
 pub mod var;

--- a/crates/gosub_css3/src/functions/calc.rs
+++ b/crates/gosub_css3/src/functions/calc.rs
@@ -1,7 +1,0 @@
-use crate::stylesheet::CssValue;
-
-#[allow(dead_code)]
-pub fn resolve_calc(values: &[CssValue]) -> Vec<CssValue> {
-    println!("Calc called with {values:?}");
-    vec![CssValue::None]
-}

--- a/crates/gosub_css3/src/stylesheet.rs
+++ b/crates/gosub_css3/src/stylesheet.rs
@@ -496,7 +496,14 @@ impl CssValue {
                 Ok(CssValue::String(value))
             }
             crate::node::NodeType::Operator(_) => Ok(CssValue::None),
-            crate::node::NodeType::Calc { .. } => Ok(CssValue::Function("calc".to_string(), vec![])),
+            crate::node::NodeType::Calc { expr } => {
+                // Preserve the raw body of calc(...) so the layout engine can evaluate it later.
+                let body = match *expr.node_type {
+                    crate::node::NodeType::Raw { value } => value,
+                    _ => String::new(),
+                };
+                Ok(CssValue::Function("calc".to_string(), vec![CssValue::String(body)]))
+            }
             crate::node::NodeType::Url { url } => {
                 Ok(CssValue::Function("url".to_string(), vec![CssValue::String(url)]))
             }

--- a/crates/gosub_css3/src/system.rs
+++ b/crates/gosub_css3/src/system.rs
@@ -1,5 +1,4 @@
 use crate::functions::attr::resolve_attr;
-use crate::functions::calc::resolve_calc;
 use crate::functions::var::resolve_var;
 use crate::matcher::property_definitions::get_css_definitions;
 use crate::matcher::shorthands::FixList;
@@ -234,7 +233,6 @@ pub fn resolve_functions<C: HasDocument>(value: &CssValue, doc: &C::Document, id
         match val {
             CssValue::Function(func, values) => {
                 let resolved = match func.as_str() {
-                    "calc" => resolve_calc(values),
                     "attr" => resolve_attr::<C>(values, doc, id),
                     "var" => resolve_var::<C>(values, doc, id),
                     _ => vec![val.clone()],

--- a/crates/gosub_taffy/Cargo.toml
+++ b/crates/gosub_taffy/Cargo.toml
@@ -11,7 +11,7 @@ gosub_shared = { version = "0.1.1", registry = "gosub", path = "../gosub_shared"
 parking_lot = "0.12"
 gosub_interface = { version = "0.1.1", registry = "gosub", path = "../gosub_interface" }
 gosub_fontmanager = { version = "0.1.0", path = "../gosub_fontmanager", registry = "gosub" }
-taffy = { version = "0.9.2", default-features = false, features = ["std", "flexbox", "grid", "block_layout", "content_size"] }
+taffy = { version = "0.9.2", default-features = false, features = ["std", "flexbox", "grid", "block_layout", "content_size", "calc"] }
 anyhow = "1.0.102"
 regex = "1.12.3"
 log = "0.4.29"

--- a/crates/gosub_taffy/src/calc.rs
+++ b/crates/gosub_taffy/src/calc.rs
@@ -1,0 +1,318 @@
+//! Parsing and evaluation of CSS `calc()` expressions for the Taffy layouter.
+//!
+//! Taffy's `calc` feature lets us encode a `calc()` value as an opaque pointer in the
+//! [`Dimension`]/[`LengthPercentage`]/[`LengthPercentageAuto`] tagged-pointer types. Taffy then
+//! calls back into [`LayoutPartialTree::resolve_calc_value`] with that pointer and a basis size
+//! when it needs a concrete f32. The pointer must be non-null and 8-byte aligned (Taffy uses the
+//! low 3 bits as a tag).
+//!
+//! We parse the calc expression once (when styles are converted to Taffy [`Style`]s), box it
+//! into a [`CalcExpr`] (which is forced to 8-byte alignment), and store the box in the per-node
+//! layout cache so the pointer stays valid for the duration of layout.
+//!
+//! [`Dimension`]: taffy::Dimension
+//! [`LengthPercentage`]: taffy::LengthPercentage
+//! [`LengthPercentageAuto`]: taffy::LengthPercentageAuto
+//! [`LayoutPartialTree::resolve_calc_value`]: taffy::LayoutPartialTree::resolve_calc_value
+//! [`Style`]: taffy::Style
+
+use std::iter::Peekable;
+use std::str::Chars;
+
+/// A parsed CSS `calc()` expression.
+///
+/// Forced to 8-byte alignment so the raw pointer we hand to Taffy has its low 3 bits clear,
+/// satisfying the contract on `Dimension::calc(ptr)` and friends.
+#[repr(C, align(8))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct CalcExpr(pub CalcNode);
+
+impl CalcExpr {
+    /// Evaluate the expression against `basis` (the size used to resolve percentages).
+    pub fn resolve(&self, basis: f32) -> f32 {
+        self.0.resolve(basis)
+    }
+}
+
+/// A node in a parsed calc expression tree.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CalcNode {
+    /// An absolute length, already converted to pixels.
+    Length(f32),
+    /// A percentage of the basis, stored as a fraction in `[0.0, 1.0]`.
+    Percent(f32),
+    /// A dimensionless number (used as a multiplier).
+    Number(f32),
+    Add(Box<CalcNode>, Box<CalcNode>),
+    Sub(Box<CalcNode>, Box<CalcNode>),
+    Mul(Box<CalcNode>, Box<CalcNode>),
+    Div(Box<CalcNode>, Box<CalcNode>),
+}
+
+impl CalcNode {
+    fn resolve(&self, basis: f32) -> f32 {
+        match self {
+            CalcNode::Length(v) => *v,
+            CalcNode::Percent(p) => p * basis,
+            CalcNode::Number(n) => *n,
+            CalcNode::Add(l, r) => l.resolve(basis) + r.resolve(basis),
+            CalcNode::Sub(l, r) => l.resolve(basis) - r.resolve(basis),
+            CalcNode::Mul(l, r) => l.resolve(basis) * r.resolve(basis),
+            CalcNode::Div(l, r) => {
+                let rhs = r.resolve(basis);
+                if rhs == 0.0 {
+                    0.0
+                } else {
+                    l.resolve(basis) / rhs
+                }
+            }
+        }
+    }
+}
+
+/// Parse a calc body (the contents of `calc(...)`, with or without the wrapper).
+///
+/// Returns `None` if the input cannot be parsed into a valid calc expression.
+pub fn parse(input: &str) -> Option<CalcExpr> {
+    let body = strip_wrapper(input);
+    let mut tokens = Tokenizer::new(body).peekable();
+    let node = parse_expr(&mut tokens)?;
+    if tokens.peek().is_some() {
+        return None;
+    }
+    Some(CalcExpr(node))
+}
+
+/// Resolve a raw pointer (as passed to Taffy via `Dimension::calc(ptr)`) back to a value.
+///
+/// # Safety
+/// The pointer must originate from a live [`CalcExpr`] (one boxed and kept alive by the layout
+/// cache). Callers receive these pointers only from `LayoutPartialTree::resolve_calc_value`
+/// during layout, where this invariant holds.
+#[allow(unsafe_code)]
+pub fn resolve(ptr: *const (), basis: f32) -> f32 {
+    if ptr.is_null() {
+        return 0.0;
+    }
+    let expr = unsafe { &*(ptr as *const CalcExpr) };
+    expr.resolve(basis)
+}
+
+fn strip_wrapper(input: &str) -> &str {
+    let trimmed = input.trim();
+    // Be lenient: the body we receive may or may not include the surrounding `calc(...)`,
+    // and our css3 parser is known to slice through the closing paren.
+    let without_prefix = trimmed
+        .strip_prefix("calc(")
+        .or_else(|| trimmed.strip_prefix("CALC("))
+        .unwrap_or(trimmed);
+    without_prefix.strip_suffix(')').unwrap_or(without_prefix).trim()
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Token {
+    Number(f32, Unit),
+    Plus,
+    Minus,
+    Star,
+    Slash,
+    LParen,
+    RParen,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Unit {
+    None,
+    Px,
+    Em,
+    Rem,
+    Percent,
+    /// Any other unit we don't yet handle (treated as a unitless number).
+    Other,
+}
+
+struct Tokenizer<'a> {
+    chars: Peekable<Chars<'a>>,
+}
+
+impl<'a> Tokenizer<'a> {
+    fn new(input: &'a str) -> Self {
+        Self {
+            chars: input.chars().peekable(),
+        }
+    }
+
+    fn tokenize_number(&mut self, first: char) -> Option<Token> {
+        let mut num_str = String::new();
+        num_str.push(first);
+        while let Some(&c) = self.chars.peek() {
+            if c.is_ascii_digit() || c == '.' {
+                num_str.push(c);
+                self.chars.next();
+            } else {
+                break;
+            }
+        }
+        let value: f32 = num_str.parse().ok()?;
+
+        let mut unit_str = String::new();
+        while let Some(&c) = self.chars.peek() {
+            if c.is_ascii_alphabetic() || c == '%' {
+                unit_str.push(c);
+                self.chars.next();
+            } else {
+                break;
+            }
+        }
+        let unit = match unit_str.as_str() {
+            "" => Unit::None,
+            "px" => Unit::Px,
+            "em" => Unit::Em,
+            "rem" => Unit::Rem,
+            "%" => Unit::Percent,
+            _ => Unit::Other,
+        };
+        Some(Token::Number(value, unit))
+    }
+}
+
+impl Iterator for Tokenizer<'_> {
+    type Item = Token;
+
+    fn next(&mut self) -> Option<Token> {
+        loop {
+            let c = self.chars.next()?;
+            if c.is_ascii_whitespace() {
+                continue;
+            }
+            return Some(match c {
+                '+' => Token::Plus,
+                '-' => Token::Minus,
+                '*' => Token::Star,
+                '/' => Token::Slash,
+                '(' => Token::LParen,
+                ')' => Token::RParen,
+                c if c.is_ascii_digit() || c == '.' => self.tokenize_number(c)?,
+                _ => continue,
+            });
+        }
+    }
+}
+
+type TokenIter<'a> = Peekable<Tokenizer<'a>>;
+
+fn parse_expr(tokens: &mut TokenIter<'_>) -> Option<CalcNode> {
+    let mut lhs = parse_term(tokens)?;
+    while let Some(token) = tokens.peek() {
+        let op = match token {
+            Token::Plus => Token::Plus,
+            Token::Minus => Token::Minus,
+            _ => break,
+        };
+        tokens.next();
+        let rhs = parse_term(tokens)?;
+        lhs = match op {
+            Token::Plus => CalcNode::Add(Box::new(lhs), Box::new(rhs)),
+            Token::Minus => CalcNode::Sub(Box::new(lhs), Box::new(rhs)),
+            _ => unreachable!(),
+        };
+    }
+    Some(lhs)
+}
+
+fn parse_term(tokens: &mut TokenIter<'_>) -> Option<CalcNode> {
+    let mut lhs = parse_atom(tokens)?;
+    while let Some(token) = tokens.peek() {
+        let op = match token {
+            Token::Star => Token::Star,
+            Token::Slash => Token::Slash,
+            _ => break,
+        };
+        tokens.next();
+        let rhs = parse_atom(tokens)?;
+        lhs = match op {
+            Token::Star => CalcNode::Mul(Box::new(lhs), Box::new(rhs)),
+            Token::Slash => CalcNode::Div(Box::new(lhs), Box::new(rhs)),
+            _ => unreachable!(),
+        };
+    }
+    Some(lhs)
+}
+
+fn parse_atom(tokens: &mut TokenIter<'_>) -> Option<CalcNode> {
+    match tokens.next()? {
+        Token::Number(value, unit) => Some(match unit {
+            Unit::Px | Unit::Other => CalcNode::Length(value),
+            Unit::Em | Unit::Rem => CalcNode::Length(value * 16.0),
+            Unit::Percent => CalcNode::Percent(value / 100.0),
+            Unit::None => CalcNode::Number(value),
+        }),
+        Token::LParen => {
+            let inner = parse_expr(tokens)?;
+            match tokens.next()? {
+                Token::RParen => Some(inner),
+                _ => None,
+            }
+        }
+        // Unary minus: parse as `0 - atom`.
+        Token::Minus => {
+            let inner = parse_atom(tokens)?;
+            Some(CalcNode::Sub(Box::new(CalcNode::Number(0.0)), Box::new(inner)))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn r(input: &str, basis: f32) -> f32 {
+        parse(input).expect("parse failed").resolve(basis)
+    }
+
+    #[test]
+    fn plain_length() {
+        assert_eq!(r("calc(10px)", 100.0), 10.0);
+    }
+
+    #[test]
+    fn addition() {
+        assert_eq!(r("calc(10px + 20px)", 0.0), 30.0);
+    }
+
+    #[test]
+    fn percentage_against_basis() {
+        assert_eq!(r("calc(50%)", 200.0), 100.0);
+    }
+
+    #[test]
+    fn mixed_percentage_and_length() {
+        assert_eq!(r("calc(50% - 10px)", 200.0), 90.0);
+    }
+
+    #[test]
+    fn precedence() {
+        // 10px + 2 * 5px = 20px
+        assert_eq!(r("calc(10px + 2 * 5px)", 0.0), 20.0);
+    }
+
+    #[test]
+    fn parentheses() {
+        // (10px + 2) * 5px = 12 * 5 = 60
+        assert_eq!(r("calc((10px + 2) * 5px)", 0.0), 60.0);
+    }
+
+    #[test]
+    fn alignment_is_eight() {
+        let boxed = Box::new(CalcExpr(CalcNode::Length(1.0)));
+        let ptr = (&*boxed) as *const CalcExpr as usize;
+        assert_eq!(ptr & 0b111, 0, "CalcExpr pointer must be 8-byte aligned");
+    }
+
+    #[test]
+    fn body_without_wrapper() {
+        // We accept the body alone as well.
+        assert_eq!(r("10px + 20px", 0.0), 30.0);
+    }
+}

--- a/crates/gosub_taffy/src/lib.rs
+++ b/crates/gosub_taffy/src/lib.rs
@@ -13,10 +13,12 @@ use gosub_interface::layout::{Layout as TLayout, LayoutCache, LayoutNode, Layout
 use gosub_shared::geo::{Point, Rect, Size, SizeU32};
 use gosub_shared::types::Result;
 
+use crate::calc::CalcExpr;
 use crate::compute::inline::compute_inline_layout;
 use crate::style::get_style_from_node;
 use crate::text::TextLayout;
 
+pub mod calc;
 mod compute;
 pub mod style;
 mod text;
@@ -110,6 +112,12 @@ pub struct Cache {
     taffy: TaffyCache,
     style: Style,
     display: Display,
+    /// Boxed `calc()` expressions referenced by `style` via raw pointers (see [`calc`]).
+    /// Kept alive here so those pointers remain valid for the lifetime of the cache.
+    /// The `Box` indirection is required: `Vec<CalcExpr>` would move elements on reallocation
+    /// and invalidate the raw pointers we handed to Taffy.
+    #[allow(clippy::vec_box)]
+    calc_storage: Vec<Box<CalcExpr>>,
 }
 
 unsafe impl Send for Cache {}
@@ -240,11 +248,14 @@ impl<C: HasLayouter<Layouter = TaffyLayouter>> LayoutDocument<'_, C> {
             return;
         };
 
-        let (style, display) = get_style_from_node(node);
+        let (style, display, calc_storage) = get_style_from_node(node);
 
         if let Some(cache) = self.0.get_cache_mut(node_id) {
             cache.style = style;
             cache.display = display;
+            // Replace any previous calc expressions atomically with the new style so the raw
+            // pointers in `cache.style` always refer to boxes we still own.
+            cache.calc_storage = calc_storage;
         }
     }
 
@@ -333,6 +344,10 @@ impl<C: HasLayouter<Layouter = TaffyLayouter>> LayoutPartialTree for LayoutDocum
 
     fn get_core_container_style(&self, node_id: TaffyId) -> Self::CoreContainerStyle<'_> {
         self.get_taffy_style_no_update(<C::LayoutTree as LayoutTree<C>>::NodeId::from(node_id.into()))
+    }
+
+    fn resolve_calc_value(&self, val: *const (), basis: f32) -> f32 {
+        crate::calc::resolve(val, basis)
     }
 
     fn set_unrounded_layout(&mut self, node_id: TaffyId, layout: &TaffyLayout) {

--- a/crates/gosub_taffy/src/style.rs
+++ b/crates/gosub_taffy/src/style.rs
@@ -1,38 +1,45 @@
 use taffy::Style;
 
+use crate::style::parse::CalcStorage;
 use crate::Display;
 use gosub_interface::config::HasLayouter;
 use gosub_interface::layout::LayoutNode;
 
-mod parse;
+pub mod parse;
 mod parse_properties;
 
 const SCROLLBAR_WIDTH: f32 = 16.0;
 
 // This function will convert a node into a Style object with Taffy properties.
-pub fn get_style_from_node<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> (Style, Display) {
+//
+// Returns the [`Style`], the gosub-side [`Display`] and the boxed `calc()` expressions referenced
+// by the style. The caller must keep `CalcStorage` alive for as long as the style is in use,
+// since the style contains raw pointers into those boxes.
+pub fn get_style_from_node<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> (Style, Display, CalcStorage) {
     //TODO: theoretically we should limit this to the taffy layouter, since it doesn't make any sense otherwise
+    let mut calc_storage = CalcStorage::new();
+
     let (display, disp) = parse_properties::parse_display(node);
     let overflow = parse_properties::parse_overflow(node);
     let position = parse_properties::parse_position(node);
-    let inset = parse_properties::parse_inset(node);
-    let size = parse_properties::parse_size(node);
-    let min_size = parse_properties::parse_min_size(node);
-    let max_size = parse_properties::parse_max_size(node);
+    let inset = parse_properties::parse_inset(node, &mut calc_storage);
+    let size = parse_properties::parse_size(node, &mut calc_storage);
+    let min_size = parse_properties::parse_min_size(node, &mut calc_storage);
+    let max_size = parse_properties::parse_max_size(node, &mut calc_storage);
     let aspect_ratio = parse_properties::parse_aspect_ratio(node);
-    let margin = parse_properties::parse_margin(node);
-    let padding = parse_properties::parse_padding(node);
-    let border = parse_properties::parse_border(node);
+    let margin = parse_properties::parse_margin(node, &mut calc_storage);
+    let padding = parse_properties::parse_padding(node, &mut calc_storage);
+    let border = parse_properties::parse_border(node, &mut calc_storage);
     let align_items = parse_properties::parse_align_items(node);
     let align_self = parse_properties::parse_align_self(node);
     let justify_items = parse_properties::parse_justify_items(node);
     let justify_self = parse_properties::parse_justify_self(node);
     let align_content = parse_properties::parse_align_content(node);
     let justify_content = parse_properties::parse_justify_content(node);
-    let gap = parse_properties::parse_gap(node);
+    let gap = parse_properties::parse_gap(node, &mut calc_storage);
     let flex_direction = parse_properties::parse_flex_direction(node);
     let flex_wrap = parse_properties::parse_flex_wrap(node);
-    let flex_basis = parse_properties::parse_flex_basis(node);
+    let flex_basis = parse_properties::parse_flex_basis(node, &mut calc_storage);
     let flex_grow = parse_properties::parse_flex_grow(node);
     let flex_shrink = parse_properties::parse_flex_shrink(node);
     let grid_template_rows = parse_properties::parse_grid_template_rows(node);
@@ -89,5 +96,6 @@ pub fn get_style_from_node<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> (St
             ..Style::default()
         },
         disp,
+        calc_storage,
     )
 }

--- a/crates/gosub_taffy/src/style/parse.rs
+++ b/crates/gosub_taffy/src/style/parse.rs
@@ -4,17 +4,54 @@ use taffy::{
 };
 
 use gosub_interface::config::HasLayouter;
-use gosub_interface::css3::CssProperty;
+use gosub_interface::css3::{CssProperty, CssSystem, CssValue};
 use gosub_interface::layout::LayoutNode;
+
+use crate::calc::{self, CalcExpr};
+
+/// Storage for parsed `calc()` expressions tied to a single Taffy `Style`.
+///
+/// Taffy encodes a calc value as a raw pointer; we keep the underlying boxes alive here so those
+/// pointers stay valid for the duration of layout. Heap addresses of the boxed `CalcExpr`s don't
+/// move when the vec reallocates — only the `Box` slots themselves do. (`Vec<CalcExpr>` would
+/// move elements on reallocation and invalidate the raw pointers we handed to Taffy.)
+#[allow(clippy::vec_box)]
+pub type CalcStorage = Vec<Box<CalcExpr>>;
+
+/// Box up a parsed calc expression and return a stable, 8-byte-aligned pointer to it.
+fn store_calc(storage: &mut CalcStorage, expr: CalcExpr) -> *const () {
+    let boxed = Box::new(expr);
+    let ptr = (&*boxed) as *const CalcExpr as *const ();
+    storage.push(boxed);
+    ptr
+}
+
+/// If `property` is a `calc(...)` function, parse its body.
+fn take_calc<C: HasLayouter>(property: &<C::CssSystem as CssSystem>::Property) -> Option<CalcExpr> {
+    let (name, args) = property.as_function()?;
+    if !name.eq_ignore_ascii_case("calc") {
+        return None;
+    }
+    let body = args.first().and_then(CssValue::as_string)?;
+    calc::parse(body)
+}
 
 // Parse functions that will parse a CSS property and converts it into a Taffy type so it can be used
 // in the taffy layout engine. This step is needed since our CSS properties are not directly compatible
 // with the Taffy layout engine.
 
-pub fn parse_len<C: HasLayouter>(node: &mut impl LayoutNode<C>, name: &str) -> LengthPercentage {
+pub fn parse_len<C: HasLayouter>(
+    node: &mut impl LayoutNode<C>,
+    name: &str,
+    calc_storage: &mut CalcStorage,
+) -> LengthPercentage {
     let Some(property) = node.get_property(name) else {
         return LengthPercentage::length(0.0);
     };
+
+    if let Some(expr) = take_calc::<C>(property) {
+        return LengthPercentage::calc(store_calc(calc_storage, expr));
+    }
 
     if let Some(percent) = property.as_percentage() {
         return LengthPercentage::percent(percent / 100.0);
@@ -23,7 +60,11 @@ pub fn parse_len<C: HasLayouter>(node: &mut impl LayoutNode<C>, name: &str) -> L
     LengthPercentage::length(property.unit_to_px())
 }
 
-pub fn parse_len_auto<C: HasLayouter>(node: &mut impl LayoutNode<C>, name: &str) -> LengthPercentageAuto {
+pub fn parse_len_auto<C: HasLayouter>(
+    node: &mut impl LayoutNode<C>,
+    name: &str,
+    calc_storage: &mut CalcStorage,
+) -> LengthPercentageAuto {
     let Some(property) = node.get_property(name) else {
         return LengthPercentageAuto::length(0.0);
     };
@@ -34,6 +75,10 @@ pub fn parse_len_auto<C: HasLayouter>(node: &mut impl LayoutNode<C>, name: &str)
         }
     }
 
+    if let Some(expr) = take_calc::<C>(property) {
+        return LengthPercentageAuto::calc(store_calc(calc_storage, expr));
+    }
+
     if let Some(percent) = property.as_percentage() {
         return LengthPercentageAuto::percent(percent / 100.0);
     }
@@ -41,7 +86,11 @@ pub fn parse_len_auto<C: HasLayouter>(node: &mut impl LayoutNode<C>, name: &str)
     LengthPercentageAuto::length(property.unit_to_px())
 }
 
-pub fn parse_dimension<C: HasLayouter>(node: &mut impl LayoutNode<C>, name: &str) -> Dimension {
+pub fn parse_dimension<C: HasLayouter>(
+    node: &mut impl LayoutNode<C>,
+    name: &str,
+    calc_storage: &mut CalcStorage,
+) -> Dimension {
     let Some(property) = node.get_property(name) else {
         return Dimension::auto();
     };
@@ -50,6 +99,10 @@ pub fn parse_dimension<C: HasLayouter>(node: &mut impl LayoutNode<C>, name: &str
         if str == "auto" {
             return Dimension::auto();
         }
+    }
+
+    if let Some(expr) = take_calc::<C>(property) {
+        return Dimension::calc(store_calc(calc_storage, expr));
     }
 
     if let Some(percent) = property.as_percentage() {

--- a/crates/gosub_taffy/src/style/parse_properties.rs
+++ b/crates/gosub_taffy/src/style/parse_properties.rs
@@ -4,7 +4,7 @@ use taffy::{Overflow, Point, TextAlign};
 
 use crate::style::parse::{
     parse_align_c, parse_align_i, parse_dimension, parse_grid_auto, parse_grid_placement, parse_len, parse_len_auto,
-    parse_tracking_sizing_function,
+    parse_tracking_sizing_function, CalcStorage,
 };
 use gosub_interface::config::HasLayouter;
 use gosub_interface::css3::CssProperty;
@@ -79,33 +79,42 @@ pub fn parse_position<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> Position
     }
 }
 
-pub fn parse_inset<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> Rect<LengthPercentageAuto> {
+pub fn parse_inset<C: HasLayouter>(
+    node: &mut impl LayoutNode<C>,
+    calc_storage: &mut CalcStorage,
+) -> Rect<LengthPercentageAuto> {
     Rect {
-        top: parse_len_auto(node, "top"),
-        right: parse_len_auto(node, "right"),
-        bottom: parse_len_auto(node, "bottom"),
-        left: parse_len_auto(node, "left"),
+        top: parse_len_auto(node, "top", calc_storage),
+        right: parse_len_auto(node, "right", calc_storage),
+        bottom: parse_len_auto(node, "bottom", calc_storage),
+        left: parse_len_auto(node, "left", calc_storage),
     }
 }
 
-pub fn parse_size<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> Size<Dimension> {
+pub fn parse_size<C: HasLayouter>(node: &mut impl LayoutNode<C>, calc_storage: &mut CalcStorage) -> Size<Dimension> {
     Size {
-        width: parse_dimension(node, "width"),
-        height: parse_dimension(node, "height"),
+        width: parse_dimension(node, "width", calc_storage),
+        height: parse_dimension(node, "height", calc_storage),
     }
 }
 
-pub fn parse_min_size<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> Size<Dimension> {
+pub fn parse_min_size<C: HasLayouter>(
+    node: &mut impl LayoutNode<C>,
+    calc_storage: &mut CalcStorage,
+) -> Size<Dimension> {
     Size {
-        width: parse_dimension(node, "min-width"),
-        height: parse_dimension(node, "min-height"),
+        width: parse_dimension(node, "min-width", calc_storage),
+        height: parse_dimension(node, "min-height", calc_storage),
     }
 }
 
-pub fn parse_max_size<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> Size<Dimension> {
+pub fn parse_max_size<C: HasLayouter>(
+    node: &mut impl LayoutNode<C>,
+    calc_storage: &mut CalcStorage,
+) -> Size<Dimension> {
     Size {
-        width: parse_dimension(node, "max-width"),
-        height: parse_dimension(node, "max-height"),
+        width: parse_dimension(node, "max-width", calc_storage),
+        height: parse_dimension(node, "max-height", calc_storage),
     }
 }
 
@@ -144,30 +153,39 @@ pub fn parse_aspect_ratio<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> Opti
     None
 }
 
-pub fn parse_margin<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> Rect<LengthPercentageAuto> {
+pub fn parse_margin<C: HasLayouter>(
+    node: &mut impl LayoutNode<C>,
+    calc_storage: &mut CalcStorage,
+) -> Rect<LengthPercentageAuto> {
     Rect {
-        top: parse_len_auto(node, "margin-top"),
-        right: parse_len_auto(node, "margin-right"),
-        bottom: parse_len_auto(node, "margin-bottom"),
-        left: parse_len_auto(node, "margin-left"),
+        top: parse_len_auto(node, "margin-top", calc_storage),
+        right: parse_len_auto(node, "margin-right", calc_storage),
+        bottom: parse_len_auto(node, "margin-bottom", calc_storage),
+        left: parse_len_auto(node, "margin-left", calc_storage),
     }
 }
 
-pub fn parse_padding<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> Rect<LengthPercentage> {
+pub fn parse_padding<C: HasLayouter>(
+    node: &mut impl LayoutNode<C>,
+    calc_storage: &mut CalcStorage,
+) -> Rect<LengthPercentage> {
     Rect {
-        top: parse_len(node, "padding-top"),
-        right: parse_len(node, "padding-right"),
-        bottom: parse_len(node, "padding-bottom"),
-        left: parse_len(node, "padding-left"),
+        top: parse_len(node, "padding-top", calc_storage),
+        right: parse_len(node, "padding-right", calc_storage),
+        bottom: parse_len(node, "padding-bottom", calc_storage),
+        left: parse_len(node, "padding-left", calc_storage),
     }
 }
 
-pub fn parse_border<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> Rect<LengthPercentage> {
+pub fn parse_border<C: HasLayouter>(
+    node: &mut impl LayoutNode<C>,
+    calc_storage: &mut CalcStorage,
+) -> Rect<LengthPercentage> {
     Rect {
-        top: parse_len(node, "border-top-width"),
-        right: parse_len(node, "border-right-width"),
-        bottom: parse_len(node, "border-bottom-width"),
-        left: parse_len(node, "border-left-width"),
+        top: parse_len(node, "border-top-width", calc_storage),
+        right: parse_len(node, "border-right-width", calc_storage),
+        bottom: parse_len(node, "border-bottom-width", calc_storage),
+        left: parse_len(node, "border-left-width", calc_storage),
     }
 }
 
@@ -208,10 +226,13 @@ pub fn parse_justify_content<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> O
     parse_align_c(node, "justify-content")
 }
 
-pub fn parse_gap<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> Size<LengthPercentage> {
+pub fn parse_gap<C: HasLayouter>(
+    node: &mut impl LayoutNode<C>,
+    calc_storage: &mut CalcStorage,
+) -> Size<LengthPercentage> {
     Size {
-        width: parse_len(node, "column-gap"),
-        height: parse_len(node, "row-gap"),
+        width: parse_len(node, "column-gap", calc_storage),
+        height: parse_len(node, "row-gap", calc_storage),
     }
 }
 
@@ -250,8 +271,8 @@ pub fn parse_flex_wrap<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> FlexWra
     }
 }
 
-pub fn parse_flex_basis<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> Dimension {
-    parse_dimension(node, "flex-basis")
+pub fn parse_flex_basis<C: HasLayouter>(node: &mut impl LayoutNode<C>, calc_storage: &mut CalcStorage) -> Dimension {
+    parse_dimension(node, "flex-basis", calc_storage)
 }
 
 pub fn parse_flex_grow<C: HasLayouter>(node: &mut impl LayoutNode<C>) -> f32 {


### PR DESCRIPTION
This is how it looks now with the calc:
<img width="2012" height="1205" alt="image" src="https://github.com/user-attachments/assets/31674147-220a-45e2-9d5b-0c2cee65797c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full support for CSS `calc()` expressions in layout properties including widths, heights, margins, padding, borders, gaps, and flex-basis. The system now properly parses and evaluates calculation expressions during layout rendering.

* **Refactor**
  * Moved and enhanced CSS `calc()` functionality from the CSS parser to the layout system for proper evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->