### PR TITLE
only depend on x11 and wayland things on linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3568,6 +3568,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "gosub_render_runtime"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "gosub_shared",
+]
+
+[[package]]
 name = "gosub_renderer"
 version = "0.1.1"
 dependencies = [
@@ -3596,6 +3604,26 @@ dependencies = [
  "gosub_shared",
  "log",
  "rstar",
+]
+
+[[package]]
+name = "gosub_runtime"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "gosub_interface",
+ "gosub_net",
+ "gosub_render_runtime",
+ "gosub_shared",
+ "http",
+ "num_cpus",
+ "reqwest",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "url",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/gosub_engine/Cargo.toml
+++ b/crates/gosub_engine/Cargo.toml
@@ -47,10 +47,6 @@ wgpu = { version = "29.0.0", optional = true }
 
 winit = { version = "0.30.12", optional = true }
 
-gdk4-wayland = { version = "0.11", optional = true, features = [
-    "wayland_crate",
-] }
-gdk4-x11 = { version = "0.11", optional = true }
 raw-window-handle = "0.6"
 
 eframe = { version = "0.34.2", optional = true, features = ["wgpu"] }
@@ -85,6 +81,12 @@ image = "0.25.8"
 async-trait = "0.1.89"
 async-channel = "2.5.0"
 smallvec = "1.15.1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+gdk4-wayland = { version = "0.11", optional = true, features = [
+    "wayland_crate",
+] }
+gdk4-x11 = { version = "0.11", optional = true }
 
 [features]
 default = ["sqlite_cookie_store", "parley_layout"]


### PR DESCRIPTION
We couldn't use the `--all-features` on anything else than linux since it would enable x11/wayland specifics. Now we are gating those deps behind an OS-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized platform-specific build dependencies for improved system compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gosub-io/gosub-engine/pull/979?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->