### PR TITLE
Update css definitions

### DIFF
--- a/crates/gosub_css3/resources/definitions/definitions.json
+++ b/crates/gosub_css3/resources/definitions/definitions.json
@@ -1,92 +1,17 @@
 {
   "properties": [
     {
-      "name": "-webkit-align-content",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
+      "name": "--*",
+      "syntax": "<declaration-value>",
+      "computed": [
+        "asSpecifiedWithVarsSubstituted"
+      ],
+      "initial": "seeProse",
+      "inherited": true
     },
     {
-      "name": "-webkit-align-items",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-align-self",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-animation",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-animation-delay",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-animation-direction",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-animation-duration",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-animation-fill-mode",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-animation-iteration-count",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-animation-name",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-animation-play-state",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-animation-timing-function",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-appearance",
-      "syntax": "",
+      "name": "-moz-appearance",
+      "syntax": "none | button | button-arrow-down | button-arrow-next | button-arrow-previous | button-arrow-up | button-bevel | button-focus | caret | checkbox | checkbox-container | checkbox-label | checkmenuitem | dualbutton | groupbox | listbox | listitem | menuarrow | menubar | menucheckbox | menuimage | menuitem | menuitemtext | menulist | menulist-button | menulist-text | menulist-textfield | menupopup | menuradio | menuseparator | meterbar | meterchunk | progressbar | progressbar-vertical | progresschunk | progresschunk-vertical | radio | radio-container | radio-label | radiomenuitem | range | range-thumb | resizer | resizerpanel | scale-horizontal | scalethumbend | scalethumb-horizontal | scalethumbstart | scalethumbtick | scalethumb-vertical | scale-vertical | scrollbarbutton-down | scrollbarbutton-left | scrollbarbutton-right | scrollbarbutton-up | scrollbarthumb-horizontal | scrollbarthumb-vertical | scrollbartrack-horizontal | scrollbartrack-vertical | searchfield | separator | sheet | spinner | spinner-downbutton | spinner-textfield | spinner-upbutton | splitter | statusbar | statusbarpanel | tab | tabpanel | tabpanels | tab-scroll-arrow-back | tab-scroll-arrow-forward | textfield | textfield-multiline | toolbar | toolbarbutton | toolbarbutton-dropdown | toolbargripper | toolbox | tooltip | treeheader | treeheadercell | treeheadersortarrow | treeitem | treeline | treetwisty | treetwistyopen | treeview | -moz-mac-unified-toolbar | -moz-win-borderless-glass | -moz-win-browsertabbar-toolbox | -moz-win-communicationstext | -moz-win-communications-toolbox | -moz-win-exclude-glass | -moz-win-glass | -moz-win-mediatext | -moz-win-media-toolbox | -moz-window-button-box | -moz-window-button-box-maximized | -moz-window-button-close | -moz-window-button-maximize | -moz-window-button-minimize | -moz-window-button-restore | -moz-window-frame-bottom | -moz-window-frame-left | -moz-window-frame-right | -moz-window-titlebar | -moz-window-titlebar-maximized",
       "computed": [
         "asSpecified"
       ],
@@ -94,183 +19,856 @@
       "inherited": false
     },
     {
-      "name": "-webkit-backface-visibility",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-moz-binding",
+      "syntax": "<url> | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
       "inherited": false
     },
     {
-      "name": "-webkit-background-clip",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-moz-border-bottom-colors",
+      "syntax": "<color>+ | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
       "inherited": false
     },
     {
-      "name": "-webkit-background-origin",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-moz-border-left-colors",
+      "syntax": "<color>+ | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
       "inherited": false
     },
     {
-      "name": "-webkit-background-size",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-moz-border-right-colors",
+      "syntax": "<color>+ | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
       "inherited": false
     },
     {
-      "name": "-webkit-border-bottom-left-radius",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-moz-border-top-colors",
+      "syntax": "<color>+ | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
       "inherited": false
     },
     {
-      "name": "-webkit-border-bottom-right-radius",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-moz-context-properties",
+      "syntax": "none | [ fill | fill-opacity | stroke | stroke-opacity ]#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "-moz-float-edge",
+      "syntax": "border-box | content-box | margin-box | padding-box",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "content-box",
       "inherited": false
     },
     {
-      "name": "-webkit-border-radius",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-moz-force-broken-image-icon",
+      "syntax": "0 | 1",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
       "inherited": false
     },
     {
-      "name": "-webkit-border-top-left-radius",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-moz-orient",
+      "syntax": "inline | block | horizontal | vertical",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "inline",
       "inherited": false
     },
     {
-      "name": "-webkit-border-top-right-radius",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-moz-outline-radius",
+      "syntax": "<outline-radius>{1,4} [ / <outline-radius>{1,4} ]?",
+      "computed": [
+        "-moz-outline-radius-topleft",
+        "-moz-outline-radius-topright",
+        "-moz-outline-radius-bottomright",
+        "-moz-outline-radius-bottomleft"
+      ],
+      "initial": [
+        "-moz-outline-radius-topleft",
+        "-moz-outline-radius-topright",
+        "-moz-outline-radius-bottomright",
+        "-moz-outline-radius-bottomleft"
+      ],
       "inherited": false
     },
     {
-      "name": "-webkit-box-align",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-moz-outline-radius-bottomleft",
+      "syntax": "<outline-radius>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
       "inherited": false
     },
     {
-      "name": "-webkit-box-flex",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-moz-outline-radius-bottomright",
+      "syntax": "<outline-radius>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
       "inherited": false
     },
     {
-      "name": "-webkit-box-ordinal-group",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-moz-outline-radius-topleft",
+      "syntax": "<outline-radius>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
       "inherited": false
     },
     {
-      "name": "-webkit-box-orient",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-moz-outline-radius-topright",
+      "syntax": "<outline-radius>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
       "inherited": false
     },
     {
-      "name": "-webkit-box-pack",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-moz-stack-sizing",
+      "syntax": "ignore | stretch-to-fit",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "stretch-to-fit",
+      "inherited": true
+    },
+    {
+      "name": "-moz-text-blink",
+      "syntax": "none | blink",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
       "inherited": false
     },
     {
-      "name": "-webkit-box-shadow",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-moz-user-focus",
+      "syntax": "ignore | normal | select-after | select-before | select-menu | select-same | select-all | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
       "inherited": false
     },
     {
-      "name": "-webkit-box-sizing",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-moz-user-input",
+      "syntax": "auto | none | enabled | disabled",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "-moz-user-modify",
+      "syntax": "read-only | read-write | write-only",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "read-only",
+      "inherited": true
+    },
+    {
+      "name": "-moz-window-dragging",
+      "syntax": "drag | no-drag",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "drag",
       "inherited": false
     },
     {
-      "name": "-webkit-filter",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-moz-window-shadow",
+      "syntax": "default | menu | tooltip | sheet | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "default",
       "inherited": false
     },
     {
-      "name": "-webkit-flex",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-ms-accelerator",
+      "syntax": "false | true",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "false",
       "inherited": false
     },
     {
-      "name": "-webkit-flex-basis",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-ms-block-progression",
+      "syntax": "tb | rl | bt | lr",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "tb",
       "inherited": false
     },
     {
-      "name": "-webkit-flex-direction",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-ms-content-zoom-chaining",
+      "syntax": "none | chained",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
       "inherited": false
     },
     {
-      "name": "-webkit-flex-flow",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-ms-content-zoom-limit",
+      "syntax": "<'-ms-content-zoom-limit-min'> <'-ms-content-zoom-limit-max'>",
+      "computed": [
+        "-ms-content-zoom-limit-max",
+        "-ms-content-zoom-limit-min"
+      ],
+      "initial": [
+        "-ms-content-zoom-limit-max",
+        "-ms-content-zoom-limit-min"
+      ],
       "inherited": false
     },
     {
-      "name": "-webkit-flex-grow",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-ms-content-zoom-limit-max",
+      "syntax": "<percentage>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "400%",
       "inherited": false
     },
     {
-      "name": "-webkit-flex-shrink",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-ms-content-zoom-limit-min",
+      "syntax": "<percentage>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "100%",
       "inherited": false
     },
     {
-      "name": "-webkit-flex-wrap",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-ms-content-zoom-snap",
+      "syntax": "<'-ms-content-zoom-snap-type'> || <'-ms-content-zoom-snap-points'>",
+      "computed": [
+        "-ms-content-zoom-snap-type",
+        "-ms-content-zoom-snap-points"
+      ],
+      "initial": [
+        "-ms-content-zoom-snap-type",
+        "-ms-content-zoom-snap-points"
+      ],
       "inherited": false
     },
     {
-      "name": "-webkit-justify-content",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-ms-content-zoom-snap-points",
+      "syntax": "snapInterval( <percentage>, <percentage> ) | snapList( <percentage># )",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "snapInterval(0%, 100%)",
+      "inherited": false
+    },
+    {
+      "name": "-ms-content-zoom-snap-type",
+      "syntax": "none | proximity | mandatory",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "-ms-content-zooming",
+      "syntax": "none | zoom",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "zoomForTheTopLevelNoneForTheRest",
+      "inherited": false
+    },
+    {
+      "name": "-ms-filter",
+      "syntax": "<string>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "\"\"",
+      "inherited": false
+    },
+    {
+      "name": "-ms-flow-from",
+      "syntax": "[ none | <custom-ident> ]#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "-ms-flow-into",
+      "syntax": "[ none | <custom-ident> ]#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "-ms-grid-columns",
+      "syntax": "none | <track-list> | <auto-track-list>",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "-ms-grid-rows",
+      "syntax": "none | <track-list> | <auto-track-list>",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "-ms-high-contrast-adjust",
+      "syntax": "auto | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "-ms-hyphenate-limit-chars",
+      "syntax": "auto | <integer>{1,3}",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "-ms-hyphenate-limit-lines",
+      "syntax": "no-limit | <integer>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "no-limit",
+      "inherited": true
+    },
+    {
+      "name": "-ms-hyphenate-limit-zone",
+      "syntax": "<percentage> | <length>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
+      "inherited": true
+    },
+    {
+      "name": "-ms-ime-align",
+      "syntax": "auto | after",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "-ms-overflow-style",
+      "syntax": "auto | none | scrollbar | -ms-autohiding-scrollbar",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "-ms-scroll-chaining",
+      "syntax": "chained | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "chained",
+      "inherited": false
+    },
+    {
+      "name": "-ms-scroll-limit",
+      "syntax": "<'-ms-scroll-limit-x-min'> <'-ms-scroll-limit-y-min'> <'-ms-scroll-limit-x-max'> <'-ms-scroll-limit-y-max'>",
+      "computed": [
+        "-ms-scroll-limit-x-min",
+        "-ms-scroll-limit-y-min",
+        "-ms-scroll-limit-x-max",
+        "-ms-scroll-limit-y-max"
+      ],
+      "initial": [
+        "-ms-scroll-limit-x-min",
+        "-ms-scroll-limit-y-min",
+        "-ms-scroll-limit-x-max",
+        "-ms-scroll-limit-y-max"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "-ms-scroll-limit-x-max",
+      "syntax": "auto | <length>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "-ms-scroll-limit-x-min",
+      "syntax": "<length>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "-ms-scroll-limit-y-max",
+      "syntax": "auto | <length>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "-ms-scroll-limit-y-min",
+      "syntax": "<length>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "-ms-scroll-rails",
+      "syntax": "none | railed",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "railed",
+      "inherited": false
+    },
+    {
+      "name": "-ms-scroll-snap-points-x",
+      "syntax": "snapInterval( <length-percentage>, <length-percentage> ) | snapList( <length-percentage># )",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "snapInterval(0px, 100%)",
+      "inherited": false
+    },
+    {
+      "name": "-ms-scroll-snap-points-y",
+      "syntax": "snapInterval( <length-percentage>, <length-percentage> ) | snapList( <length-percentage># )",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "snapInterval(0px, 100%)",
+      "inherited": false
+    },
+    {
+      "name": "-ms-scroll-snap-type",
+      "syntax": "none | proximity | mandatory",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "-ms-scroll-snap-x",
+      "syntax": "<'-ms-scroll-snap-type'> <'-ms-scroll-snap-points-x'>",
+      "computed": [
+        "-ms-scroll-snap-type",
+        "-ms-scroll-snap-points-x"
+      ],
+      "initial": [
+        "-ms-scroll-snap-type",
+        "-ms-scroll-snap-points-x"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "-ms-scroll-snap-y",
+      "syntax": "<'-ms-scroll-snap-type'> <'-ms-scroll-snap-points-y'>",
+      "computed": [
+        "-ms-scroll-snap-type",
+        "-ms-scroll-snap-points-y"
+      ],
+      "initial": [
+        "-ms-scroll-snap-type",
+        "-ms-scroll-snap-points-y"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "-ms-scroll-translation",
+      "syntax": "none | vertical-to-horizontal",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": true
+    },
+    {
+      "name": "-ms-scrollbar-3dlight-color",
+      "syntax": "<color>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "dependsOnUserAgent",
+      "inherited": true
+    },
+    {
+      "name": "-ms-scrollbar-arrow-color",
+      "syntax": "<color>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "ButtonText",
+      "inherited": true
+    },
+    {
+      "name": "-ms-scrollbar-base-color",
+      "syntax": "<color>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "dependsOnUserAgent",
+      "inherited": true
+    },
+    {
+      "name": "-ms-scrollbar-darkshadow-color",
+      "syntax": "<color>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "ThreeDDarkShadow",
+      "inherited": true
+    },
+    {
+      "name": "-ms-scrollbar-face-color",
+      "syntax": "<color>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "ThreeDFace",
+      "inherited": true
+    },
+    {
+      "name": "-ms-scrollbar-highlight-color",
+      "syntax": "<color>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "ThreeDHighlight",
+      "inherited": true
+    },
+    {
+      "name": "-ms-scrollbar-shadow-color",
+      "syntax": "<color>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "ThreeDDarkShadow",
+      "inherited": true
+    },
+    {
+      "name": "-ms-scrollbar-track-color",
+      "syntax": "<color>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "Scrollbar",
+      "inherited": true
+    },
+    {
+      "name": "-ms-text-autospace",
+      "syntax": "none | ideograph-alpha | ideograph-numeric | ideograph-parenthesis | ideograph-space",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "-ms-touch-select",
+      "syntax": "grippers | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "grippers",
+      "inherited": true
+    },
+    {
+      "name": "-ms-user-select",
+      "syntax": "none | element | text",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "text",
+      "inherited": false
+    },
+    {
+      "name": "-ms-wrap-flow",
+      "syntax": "auto | both | start | end | maximum | clear",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "-ms-wrap-margin",
+      "syntax": "<length>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "-ms-wrap-through",
+      "syntax": "wrap | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "wrap",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-appearance",
+      "syntax": "none | button | button-bevel | caret | checkbox | default-button | inner-spin-button | listbox | listitem | media-controls-background | media-controls-fullscreen-background | media-current-time-display | media-enter-fullscreen-button | media-exit-fullscreen-button | media-fullscreen-button | media-mute-button | media-overlay-play-button | media-play-button | media-seek-back-button | media-seek-forward-button | media-slider | media-sliderthumb | media-time-remaining-display | media-toggle-closed-captions-button | media-volume-slider | media-volume-slider-container | media-volume-sliderthumb | menulist | menulist-button | menulist-text | menulist-textfield | meter | progress-bar | progress-bar-value | push-button | radio | searchfield | searchfield-cancel-button | searchfield-decoration | searchfield-results-button | searchfield-results-decoration | slider-horizontal | slider-vertical | sliderthumb-horizontal | sliderthumb-vertical | square-button | textarea | textfield | -apple-pay-button",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "noneButOverriddenInUserAgentCSS",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-after",
+      "syntax": "<'border-top'>",
+      "computed": [
+        "border-block-end-width",
+        "border-block-end-style",
+        "border-block-end-color"
+      ],
+      "initial": [
+        "border-block-end-width",
+        "border-block-end-style",
+        "border-block-end-color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-after-color",
+      "syntax": "<'border-top-color'>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-after-style",
+      "syntax": "<'border-top-style'>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-after-width",
+      "syntax": "<'border-top-width'>",
+      "computed": [
+        "absoluteLength"
+      ],
+      "initial": "medium",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-before",
+      "syntax": "<'border-top'>",
+      "computed": [
+        "border-block-start-width",
+        "border-block-start-style",
+        "border-block-start-color"
+      ],
+      "initial": [
+        "border-block-start-width",
+        "border-block-start-style",
+        "border-block-start-color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-before-color",
+      "syntax": "<'border-top-color'>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-before-style",
+      "syntax": "<'border-top-style'>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-before-width",
+      "syntax": "<'border-top-width'>",
+      "computed": [
+        "absoluteLength"
+      ],
+      "initial": "medium",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-end",
+      "syntax": "<'border-top'>",
+      "computed": [
+        "border-inline-end-width",
+        "border-inline-end-style",
+        "border-inline-end-color"
+      ],
+      "initial": [
+        "border-inline-end-width",
+        "border-inline-end-style",
+        "border-inline-end-color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-end-color",
+      "syntax": "<'border-top-color'>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-end-style",
+      "syntax": "<'border-top-style'>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-end-width",
+      "syntax": "<'border-top-width'>",
+      "computed": [
+        "absoluteLength"
+      ],
+      "initial": "medium",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-start",
+      "syntax": "<'border-top'>",
+      "computed": [
+        "border-inline-start-width",
+        "border-inline-start-style",
+        "border-inline-start-color"
+      ],
+      "initial": [
+        "border-inline-start-width",
+        "border-inline-start-style",
+        "border-inline-start-color"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-start-color",
+      "syntax": "<'border-top-color'>",
+      "computed": [
+        "computedColor"
+      ],
+      "initial": "currentcolor",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-start-style",
+      "syntax": "<'border-top-style'>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-border-start-width",
+      "syntax": "<'border-top-width'>",
+      "computed": [
+        "absoluteLength"
+      ],
+      "initial": "medium",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-box-reflect",
+      "syntax": "[ above | below | right | left ]? <length>? <image>?",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-line-clamp",
+      "syntax": "none | <integer>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
       "inherited": false
     },
     {
       "name": "-webkit-mask",
-      "syntax": "",
+      "syntax": "[ <mask-reference> || <position> [ / <bg-size> ]? || <repeat-style> || [ <visual-box> | border | padding | content | text ] || [ <visual-box> | border | padding | content ] ]#",
       "computed": [
         "-webkit-mask-image",
         "-webkit-mask-repeat",
@@ -290,50 +888,17 @@
       "inherited": false
     },
     {
-      "name": "-webkit-mask-box-image",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-mask-box-image-outset",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-mask-box-image-repeat",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-mask-box-image-slice",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-mask-box-image-source",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-mask-box-image-width",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
+      "name": "-webkit-mask-attachment",
+      "syntax": "<attachment>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "scroll",
       "inherited": false
     },
     {
       "name": "-webkit-mask-clip",
-      "syntax": "",
+      "syntax": "[ <coord-box> | no-clip | border | padding | content | text ]#",
       "computed": [
         "asSpecified"
       ],
@@ -342,7 +907,7 @@
     },
     {
       "name": "-webkit-mask-composite",
-      "syntax": "",
+      "syntax": "<composite-style>#",
       "computed": [
         "asSpecified"
       ],
@@ -351,7 +916,7 @@
     },
     {
       "name": "-webkit-mask-image",
-      "syntax": "",
+      "syntax": "<mask-reference>#",
       "computed": [
         "absoluteURIOrNone"
       ],
@@ -360,7 +925,7 @@
     },
     {
       "name": "-webkit-mask-origin",
-      "syntax": "",
+      "syntax": "[ <coord-box> | border | padding | content ]#",
       "computed": [
         "asSpecified"
       ],
@@ -369,7 +934,7 @@
     },
     {
       "name": "-webkit-mask-position",
-      "syntax": "",
+      "syntax": "<position>#",
       "computed": [
         "absoluteLengthOrPercentage"
       ],
@@ -377,8 +942,26 @@
       "inherited": false
     },
     {
+      "name": "-webkit-mask-position-x",
+      "syntax": "[ <length-percentage> | left | center | right ]#",
+      "computed": [
+        "absoluteLengthOrPercentage"
+      ],
+      "initial": "0%",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-mask-position-y",
+      "syntax": "[ <length-percentage> | top | center | bottom ]#",
+      "computed": [
+        "absoluteLengthOrPercentage"
+      ],
+      "initial": "0%",
+      "inherited": false
+    },
+    {
       "name": "-webkit-mask-repeat",
-      "syntax": "",
+      "syntax": "<repeat-style>#",
       "computed": [
         "asSpecified"
       ],
@@ -386,8 +969,26 @@
       "inherited": false
     },
     {
+      "name": "-webkit-mask-repeat-x",
+      "syntax": "repeat | no-repeat | space | round",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "repeat",
+      "inherited": false
+    },
+    {
+      "name": "-webkit-mask-repeat-y",
+      "syntax": "repeat | no-repeat | space | round",
+      "computed": [
+        "absoluteLengthOrPercentage"
+      ],
+      "initial": "repeat",
+      "inherited": false
+    },
+    {
       "name": "-webkit-mask-size",
-      "syntax": "",
+      "syntax": "<bg-size>#",
       "computed": [
         "asSpecified"
       ],
@@ -395,25 +996,22 @@
       "inherited": false
     },
     {
-      "name": "-webkit-order",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
+      "name": "-webkit-overflow-scrolling",
+      "syntax": "auto | touch",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
     },
     {
-      "name": "-webkit-perspective",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-perspective-origin",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
+      "name": "-webkit-tap-highlight-color",
+      "syntax": "<color>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "black",
+      "inherited": true
     },
     {
       "name": "-webkit-text-fill-color",
@@ -425,15 +1023,8 @@
       "inherited": true
     },
     {
-      "name": "-webkit-text-size-adjust",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
       "name": "-webkit-text-stroke",
-      "syntax": "<line-width> || <color>",
+      "syntax": "<length> || <color>",
       "computed": [
         "-webkit-text-stroke-width",
         "-webkit-text-stroke-color"
@@ -455,7 +1046,7 @@
     },
     {
       "name": "-webkit-text-stroke-width",
-      "syntax": "<line-width>",
+      "syntax": "<length>",
       "computed": [
         "absoluteLength"
       ],
@@ -463,64 +1054,26 @@
       "inherited": true
     },
     {
-      "name": "-webkit-transform",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
+      "name": "-webkit-touch-callout",
+      "syntax": "default | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "default",
+      "inherited": true
     },
     {
-      "name": "-webkit-transform-origin",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-transform-style",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-transition",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-transition-delay",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-transition-duration",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-transition-property",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
-    },
-    {
-      "name": "-webkit-transition-timing-function",
-      "syntax": "",
-      "computed": [],
-      "initial": "",
-      "inherited": false
+      "name": "-webkit-user-modify",
+      "syntax": "read-only | read-write | read-write-plaintext-only",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "read-only",
+      "inherited": true
     },
     {
       "name": "-webkit-user-select",
-      "syntax": "",
+      "syntax": "auto | text | none | all",
       "computed": [
         "asSpecified"
       ],
@@ -564,8 +1117,17 @@
       "inherited": false
     },
     {
+      "name": "align-tracks",
+      "syntax": "[ normal | <baseline-position> | <content-distribution> | <overflow-position>? <content-position> ]#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
       "name": "alignment-baseline",
-      "syntax": "baseline | text-bottom | alphabetic | ideographic | middle | central | mathematical | text-top",
+      "syntax": "baseline | alphabetic | ideographic | middle | central | mathematical | text-before-edge | text-after-edge",
       "computed": [
         "theSpecifiedKeyword"
       ],
@@ -627,6 +1189,15 @@
       "inherited": false
     },
     {
+      "name": "animation-composition",
+      "syntax": "<single-animation-composition>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "replace",
+      "inherited": false
+    },
+    {
       "name": "animation-delay",
       "syntax": "<time>#",
       "computed": [
@@ -646,7 +1217,7 @@
     },
     {
       "name": "animation-duration",
-      "syntax": "<time [0s,∞]>#",
+      "syntax": "[ auto | <time [0s,∞]> ]#",
       "computed": [
         "asSpecified"
       ],
@@ -721,6 +1292,15 @@
       "inherited": false
     },
     {
+      "name": "animation-timeline",
+      "syntax": "<single-animation-timeline>#",
+      "computed": [
+        "listEachItemIdentifierOrNoneAuto"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
       "name": "animation-timing-function",
       "syntax": "<easing-function>#",
       "computed": [
@@ -730,12 +1310,48 @@
       "inherited": false
     },
     {
-      "name": "appearance",
-      "syntax": "none | auto | base | <compat-auto> | <compat-special> | base",
+      "name": "animation-trigger",
+      "syntax": "[ none | [ <dashed-ident> <animation-action>+ ]+ ]#",
       "computed": [
         "asSpecified"
       ],
       "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "appearance",
+      "syntax": "none | auto | <compat-auto> | <compat-special>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "aspect-ratio",
+      "syntax": "auto || <ratio>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "backdrop-filter",
+      "syntax": "none | <filter-value-list>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "backface-visibility",
+      "syntax": "visible | hidden",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "visible",
       "inherited": false
     },
     {
@@ -774,7 +1390,7 @@
     },
     {
       "name": "background-blend-mode",
-      "syntax": "<mix-blend-mode>#",
+      "syntax": "<blend-mode>#",
       "computed": [
         "asSpecified"
       ],
@@ -783,7 +1399,7 @@
     },
     {
       "name": "background-clip",
-      "syntax": "<visual-box>#",
+      "syntax": "<bg-clip>#",
       "computed": [
         "asSpecified"
       ],
@@ -828,6 +1444,24 @@
       "inherited": false
     },
     {
+      "name": "background-position-x",
+      "syntax": "[ center | [ [ left | right | x-start | x-end ]? <length-percentage>? ]! ]#",
+      "computed": [
+        "listEachItemConsistingOfAbsoluteLengthPercentageAndOrigin"
+      ],
+      "initial": "0%",
+      "inherited": false
+    },
+    {
+      "name": "background-position-y",
+      "syntax": "[ center | [ [ top | bottom | y-start | y-end ]? <length-percentage>? ]! ]#",
+      "computed": [
+        "listEachItemConsistingOfAbsoluteLengthPercentageAndOrigin"
+      ],
+      "initial": "0%",
+      "inherited": false
+    },
+    {
       "name": "background-repeat",
       "syntax": "<repeat-style>#",
       "computed": [
@@ -847,7 +1481,7 @@
     },
     {
       "name": "baseline-shift",
-      "syntax": "<length-percentage> | sub | super | top | center | bottom",
+      "syntax": "<length-percentage> | sub | super | baseline",
       "computed": [
         "theSpecifiedKeywordOrAComputedLengthPercentageValue"
       ],
@@ -857,7 +1491,9 @@
     {
       "name": "baseline-source",
       "syntax": "auto | first | last",
-      "computed": [],
+      "computed": [
+        "asSpecified"
+      ],
       "initial": "auto",
       "inherited": false
     },
@@ -868,62 +1504,6 @@
         "sameAsWidthAndHeight"
       ],
       "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "block-step",
-      "syntax": "<'block-step-size'> || <'block-step-insert'> || <'block-step-align'> || <'block-step-round'>",
-      "computed": [],
-      "initial": "see individual properties",
-      "inherited": false
-    },
-    {
-      "name": "block-step-align",
-      "syntax": "auto | center | start | end",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "block-step-insert",
-      "syntax": "margin-box | padding-box | content-box",
-      "computed": [],
-      "initial": "margin-box",
-      "inherited": false
-    },
-    {
-      "name": "block-step-round",
-      "syntax": "up | down | nearest",
-      "computed": [],
-      "initial": "up",
-      "inherited": false
-    },
-    {
-      "name": "block-step-size",
-      "syntax": "none | <length [0,∞]>",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "bookmark-label",
-      "syntax": "<content-list>",
-      "computed": [],
-      "initial": "content(text)",
-      "inherited": false
-    },
-    {
-      "name": "bookmark-level",
-      "syntax": "none | <integer [1,∞]>",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "bookmark-state",
-      "syntax": "open | closed",
-      "computed": [],
-      "initial": "open",
       "inherited": false
     },
     {
@@ -943,7 +1523,7 @@
     },
     {
       "name": "border-block",
-      "syntax": "<'border-block-start'>",
+      "syntax": "<'border-top'>",
       "computed": [
         "border-block-width",
         "border-block-style",
@@ -960,29 +1540,33 @@
       "name": "border-block-color",
       "syntax": "<'border-top-color'>{1,2}",
       "computed": [
-        "computedColor"
+        "border-block-start-color",
+        "border-block-end-color"
       ],
-      "initial": "currentcolor",
+      "initial": [
+        "border-block-start-color",
+        "border-block-end-color"
+      ],
       "inherited": false
     },
     {
       "name": "border-block-end",
-      "syntax": "<line-width> || <line-style> || <color>",
+      "syntax": "<'border-top'>",
       "computed": [
-        "border-top-width",
-        "border-top-style",
-        "border-top-color"
+        "border-block-end-width",
+        "border-block-end-style",
+        "border-block-end-color"
       ],
       "initial": [
-        "border-top-width",
-        "border-top-style",
-        "border-top-color"
+        "border-block-end-width",
+        "border-block-end-style",
+        "border-block-end-color"
       ],
       "inherited": false
     },
     {
       "name": "border-block-end-color",
-      "syntax": "<color> | <image-1D>",
+      "syntax": "<'border-top-color'>",
       "computed": [
         "computedColor"
       ],
@@ -990,15 +1574,8 @@
       "inherited": false
     },
     {
-      "name": "border-block-end-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
       "name": "border-block-end-style",
-      "syntax": "<line-style>",
+      "syntax": "<'border-top-style'>",
       "computed": [
         "asSpecified"
       ],
@@ -1007,7 +1584,7 @@
     },
     {
       "name": "border-block-end-width",
-      "syntax": "<line-width>",
+      "syntax": "<'border-top-width'>",
       "computed": [
         "absoluteLengthZeroIfBorderStyleNoneOrHidden"
       ],
@@ -1016,22 +1593,22 @@
     },
     {
       "name": "border-block-start",
-      "syntax": "<line-width> || <line-style> || <color>",
+      "syntax": "<'border-top'>",
       "computed": [
-        "border-width",
-        "border-style",
+        "border-block-start-width",
+        "border-block-start-style",
         "border-block-start-color"
       ],
       "initial": [
-        "border-width",
-        "border-style",
-        "color"
+        "border-block-start-width",
+        "border-block-start-style",
+        "border-block-start-color"
       ],
       "inherited": false
     },
     {
       "name": "border-block-start-color",
-      "syntax": "<color> | <image-1D>",
+      "syntax": "<'border-top-color'>",
       "computed": [
         "computedColor"
       ],
@@ -1039,15 +1616,8 @@
       "inherited": false
     },
     {
-      "name": "border-block-start-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
       "name": "border-block-start-style",
-      "syntax": "<line-style>",
+      "syntax": "<'border-top-style'>",
       "computed": [
         "asSpecified"
       ],
@@ -1056,7 +1626,7 @@
     },
     {
       "name": "border-block-start-width",
-      "syntax": "<line-width>",
+      "syntax": "<'border-top-width'>",
       "computed": [
         "absoluteLengthZeroIfBorderStyleNoneOrHidden"
       ],
@@ -1067,18 +1637,26 @@
       "name": "border-block-style",
       "syntax": "<'border-top-style'>{1,2}",
       "computed": [
-        "asSpecified"
+        "border-block-start-style",
+        "border-block-end-style"
       ],
-      "initial": "none",
+      "initial": [
+        "border-block-start-style",
+        "border-block-end-style"
+      ],
       "inherited": false
     },
     {
       "name": "border-block-width",
       "syntax": "<'border-top-width'>{1,2}",
       "computed": [
-        "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+        "border-block-start-width",
+        "border-block-end-width"
       ],
-      "initial": "medium",
+      "initial": [
+        "border-block-start-width",
+        "border-block-end-width"
+      ],
       "inherited": false
     },
     {
@@ -1098,7 +1676,7 @@
     },
     {
       "name": "border-bottom-color",
-      "syntax": "<color> | <image-1D>",
+      "syntax": "<'border-top-color'>",
       "computed": [
         "computedColor"
       ],
@@ -1111,13 +1689,6 @@
       "computed": [
         "twoAbsoluteLengthOrPercentages"
       ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "border-bottom-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-      "computed": [],
       "initial": "0",
       "inherited": false
     },
@@ -1149,48 +1720,6 @@
       "inherited": false
     },
     {
-      "name": "border-boundary",
-      "syntax": "none | parent | display",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "border-clip",
-      "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
-      "computed": [],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "border-clip-bottom",
-      "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
-      "computed": [],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "border-clip-left",
-      "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
-      "computed": [],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "border-clip-right",
-      "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
-      "computed": [],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "border-clip-top",
-      "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
-      "computed": [],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
       "name": "border-collapse",
       "syntax": "separate | collapse",
       "computed": [
@@ -1201,12 +1730,12 @@
     },
     {
       "name": "border-color",
-      "syntax": "[ <color> | <image-1D> ]{1,4}",
+      "syntax": "<color>{1,4}",
       "computed": [
-        "border-bottom-color",
-        "border-left-color",
+        "border-top-color",
         "border-right-color",
-        "border-top-color"
+        "border-bottom-color",
+        "border-left-color"
       ],
       "initial": [
         "border-top-color",
@@ -1218,7 +1747,7 @@
     },
     {
       "name": "border-end-end-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2}",
+      "syntax": "<'border-top-left-radius'>",
       "computed": [
         "twoAbsoluteLengthOrPercentages"
       ],
@@ -1227,7 +1756,7 @@
     },
     {
       "name": "border-end-start-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2}",
+      "syntax": "<'border-top-left-radius'>",
       "computed": [
         "twoAbsoluteLengthOrPercentages"
       ],
@@ -1238,11 +1767,11 @@
       "name": "border-image",
       "syntax": "<'border-image-source'> || <'border-image-slice'> [ / <'border-image-width'> | / <'border-image-width'>? / <'border-image-outset'> ]? || <'border-image-repeat'>",
       "computed": [
-        "border-image-outset",
-        "border-image-repeat",
-        "border-image-slice",
         "border-image-source",
-        "border-image-width"
+        "border-image-slice",
+        "border-image-width",
+        "border-image-outset",
+        "border-image-repeat"
       ],
       "initial": [
         "border-image-source",
@@ -1273,7 +1802,7 @@
     },
     {
       "name": "border-image-slice",
-      "syntax": "[<number [0,∞]> | <percentage [0,∞]>]{1,4} && fill?",
+      "syntax": "[ <number [0,∞]> | <percentage [0,∞]> ]{1,4} && fill?",
       "computed": [
         "oneToFourPercentagesOrAbsoluteLengthsPlusFill"
       ],
@@ -1300,7 +1829,7 @@
     },
     {
       "name": "border-inline",
-      "syntax": "<'border-block-start'>",
+      "syntax": "<'border-top'>",
       "computed": [
         "border-inline-width",
         "border-inline-style",
@@ -1317,29 +1846,33 @@
       "name": "border-inline-color",
       "syntax": "<'border-top-color'>{1,2}",
       "computed": [
-        "computedColor"
+        "border-inline-start-color",
+        "border-inline-end-color"
       ],
-      "initial": "currentcolor",
+      "initial": [
+        "border-inline-start-color",
+        "border-inline-end-color"
+      ],
       "inherited": false
     },
     {
       "name": "border-inline-end",
-      "syntax": "<line-width> || <line-style> || <color>",
+      "syntax": "<'border-top'>",
       "computed": [
-        "border-width",
-        "border-style",
+        "border-inline-end-width",
+        "border-inline-end-style",
         "border-inline-end-color"
       ],
       "initial": [
-        "border-width",
-        "border-style",
-        "color"
+        "border-inline-end-width",
+        "border-inline-end-style",
+        "border-inline-end-color"
       ],
       "inherited": false
     },
     {
       "name": "border-inline-end-color",
-      "syntax": "<color> | <image-1D>",
+      "syntax": "<'border-top-color'>",
       "computed": [
         "computedColor"
       ],
@@ -1347,15 +1880,8 @@
       "inherited": false
     },
     {
-      "name": "border-inline-end-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
       "name": "border-inline-end-style",
-      "syntax": "<line-style>",
+      "syntax": "<'border-top-style'>",
       "computed": [
         "asSpecified"
       ],
@@ -1364,7 +1890,7 @@
     },
     {
       "name": "border-inline-end-width",
-      "syntax": "<line-width>",
+      "syntax": "<'border-top-width'>",
       "computed": [
         "absoluteLengthZeroIfBorderStyleNoneOrHidden"
       ],
@@ -1373,22 +1899,22 @@
     },
     {
       "name": "border-inline-start",
-      "syntax": "<line-width> || <line-style> || <color>",
+      "syntax": "<'border-top'>",
       "computed": [
-        "border-width",
-        "border-style",
+        "border-inline-start-width",
+        "border-inline-start-style",
         "border-inline-start-color"
       ],
       "initial": [
-        "border-width",
-        "border-style",
-        "color"
+        "border-inline-start-width",
+        "border-inline-start-style",
+        "border-inline-start-color"
       ],
       "inherited": false
     },
     {
       "name": "border-inline-start-color",
-      "syntax": "<color> | <image-1D>",
+      "syntax": "<'border-top-color'>",
       "computed": [
         "computedColor"
       ],
@@ -1396,15 +1922,8 @@
       "inherited": false
     },
     {
-      "name": "border-inline-start-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
       "name": "border-inline-start-style",
-      "syntax": "<line-style>",
+      "syntax": "<'border-top-style'>",
       "computed": [
         "asSpecified"
       ],
@@ -1413,7 +1932,7 @@
     },
     {
       "name": "border-inline-start-width",
-      "syntax": "<line-width>",
+      "syntax": "<'border-top-width'>",
       "computed": [
         "absoluteLengthZeroIfBorderStyleNoneOrHidden"
       ],
@@ -1424,18 +1943,26 @@
       "name": "border-inline-style",
       "syntax": "<'border-top-style'>{1,2}",
       "computed": [
-        "asSpecified"
+        "border-inline-start-style",
+        "border-inline-end-style"
       ],
-      "initial": "none",
+      "initial": [
+        "border-inline-start-style",
+        "border-inline-end-style"
+      ],
       "inherited": false
     },
     {
       "name": "border-inline-width",
       "syntax": "<'border-top-width'>{1,2}",
       "computed": [
-        "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+        "border-inline-start-width",
+        "border-inline-end-width"
       ],
-      "initial": "medium",
+      "initial": [
+        "border-inline-start-width",
+        "border-inline-end-width"
+      ],
       "inherited": false
     },
     {
@@ -1455,18 +1982,11 @@
     },
     {
       "name": "border-left-color",
-      "syntax": "<color> | <image-1D>",
+      "syntax": "<color>",
       "computed": [
         "computedColor"
       ],
       "initial": "currentcolor",
-      "inherited": false
-    },
-    {
-      "name": "border-left-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-      "computed": [],
-      "initial": "0",
       "inherited": false
     },
     {
@@ -1488,20 +2008,13 @@
       "inherited": false
     },
     {
-      "name": "border-limit",
-      "syntax": "all | [ sides | corners ] <length-percentage [0,∞]>? | [ top | right | bottom | left ] <length-percentage [0,∞]>",
-      "computed": [],
-      "initial": "all",
-      "inherited": false
-    },
-    {
       "name": "border-radius",
       "syntax": "<length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?",
       "computed": [
-        "border-bottom-left-radius",
-        "border-bottom-right-radius",
         "border-top-left-radius",
-        "border-top-right-radius"
+        "border-top-right-radius",
+        "border-bottom-right-radius",
+        "border-bottom-left-radius"
       ],
       "initial": [
         "border-top-left-radius",
@@ -1528,18 +2041,11 @@
     },
     {
       "name": "border-right-color",
-      "syntax": "<color> | <image-1D>",
+      "syntax": "<color>",
       "computed": [
         "computedColor"
       ],
       "initial": "currentcolor",
-      "inherited": false
-    },
-    {
-      "name": "border-right-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-      "computed": [],
-      "initial": "0",
       "inherited": false
     },
     {
@@ -1563,7 +2069,9 @@
     {
       "name": "border-shape",
       "syntax": "none | [ <basic-shape> <geometry-box>?]{1,2}",
-      "computed": [],
+      "computed": [
+        "asSpecified"
+      ],
       "initial": "none",
       "inherited": false
     },
@@ -1578,7 +2086,7 @@
     },
     {
       "name": "border-start-end-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2}",
+      "syntax": "<'border-top-left-radius'>",
       "computed": [
         "twoAbsoluteLengthOrPercentages"
       ],
@@ -1587,7 +2095,7 @@
     },
     {
       "name": "border-start-start-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2}",
+      "syntax": "<'border-top-left-radius'>",
       "computed": [
         "twoAbsoluteLengthOrPercentages"
       ],
@@ -1598,10 +2106,10 @@
       "name": "border-style",
       "syntax": "<line-style>{1,4}",
       "computed": [
-        "border-bottom-style",
-        "border-left-style",
+        "border-top-style",
         "border-right-style",
-        "border-top-style"
+        "border-bottom-style",
+        "border-left-style"
       ],
       "initial": [
         "border-top-style",
@@ -1628,7 +2136,7 @@
     },
     {
       "name": "border-top-color",
-      "syntax": "<color> | <image-1D>",
+      "syntax": "<color>",
       "computed": [
         "computedColor"
       ],
@@ -1641,13 +2149,6 @@
       "computed": [
         "twoAbsoluteLengthOrPercentages"
       ],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "border-top-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-      "computed": [],
       "initial": "0",
       "inherited": false
     },
@@ -1682,10 +2183,10 @@
       "name": "border-width",
       "syntax": "<line-width>{1,4}",
       "computed": [
-        "border-bottom-width",
-        "border-left-width",
+        "border-top-width",
         "border-right-width",
-        "border-top-width"
+        "border-bottom-width",
+        "border-left-width"
       ],
       "initial": [
         "border-top-width",
@@ -1705,6 +2206,15 @@
       "inherited": false
     },
     {
+      "name": "box-align",
+      "syntax": "start | center | end | baseline | stretch",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "stretch",
+      "inherited": false
+    },
+    {
       "name": "box-decoration-break",
       "syntax": "slice | clone",
       "computed": [
@@ -1714,47 +2224,75 @@
       "inherited": false
     },
     {
+      "name": "box-direction",
+      "syntax": "normal | reverse | inherit",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "box-flex",
+      "syntax": "<number>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
+      "name": "box-flex-group",
+      "syntax": "<integer>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "1",
+      "inherited": false
+    },
+    {
+      "name": "box-lines",
+      "syntax": "single | multiple",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "single",
+      "inherited": false
+    },
+    {
+      "name": "box-ordinal-group",
+      "syntax": "<integer>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "1",
+      "inherited": false
+    },
+    {
+      "name": "box-orient",
+      "syntax": "horizontal | vertical | inline-axis | block-axis | inherit",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "inline-axis",
+      "inherited": false
+    },
+    {
+      "name": "box-pack",
+      "syntax": "start | center | end | justify",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "start",
+      "inherited": false
+    },
+    {
       "name": "box-shadow",
-      "syntax": "<spread-shadow>#",
+      "syntax": "none | <shadow>#",
       "computed": [
         "absoluteLengthsSpecifiedColorAsSpecified"
       ],
       "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "box-shadow-blur",
-      "syntax": "<length [0,∞]>#",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "box-shadow-color",
-      "syntax": "<color>#",
-      "computed": [],
-      "initial": "currentcolor",
-      "inherited": false
-    },
-    {
-      "name": "box-shadow-offset",
-      "syntax": "[ none | <length>{2} ]#",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "box-shadow-position",
-      "syntax": "[ outset | inset ]#",
-      "computed": [],
-      "initial": "outset",
-      "inherited": false
-    },
-    {
-      "name": "box-shadow-spread",
-      "syntax": "<length>#",
-      "computed": [],
-      "initial": "0",
       "inherited": false
     },
     {
@@ -1765,13 +2303,6 @@
       ],
       "initial": "content-box",
       "inherited": false
-    },
-    {
-      "name": "box-snap",
-      "syntax": "none | block-start | block-end | center | baseline | last-baseline",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
     },
     {
       "name": "break-after",
@@ -1814,10 +2345,12 @@
       "syntax": "<'caret-color'> || <'caret-animation'> || <'caret-shape'>",
       "computed": [
         "caret-color",
+        "caret-animation",
         "caret-shape"
       ],
       "initial": [
         "caret-color",
+        "caret-animation",
         "caret-shape"
       ],
       "inherited": true
@@ -1825,7 +2358,9 @@
     {
       "name": "caret-animation",
       "syntax": "auto | manual",
-      "computed": [],
+      "computed": [
+        "asSpecified"
+      ],
       "initial": "auto",
       "inherited": true
     },
@@ -1849,7 +2384,7 @@
     },
     {
       "name": "clear",
-      "syntax": "inline-start | inline-end | block-start | block-end | left | right | top | bottom | both-inline | both-block | both | none",
+      "syntax": "none | left | right | both | inline-start | inline-end",
       "computed": [
         "asSpecified"
       ],
@@ -1858,7 +2393,7 @@
     },
     {
       "name": "clip",
-      "syntax": "<rect()> | auto",
+      "syntax": "<shape> | auto",
       "computed": [
         "autoOrRectangle"
       ],
@@ -1893,20 +2428,6 @@
       "inherited": true
     },
     {
-      "name": "color-adjust",
-      "syntax": "<'print-color-adjust'>",
-      "computed": [],
-      "initial": "see individual properties",
-      "inherited": false
-    },
-    {
-      "name": "color-interpolation",
-      "syntax": "auto | sRGB | linearRGB",
-      "computed": [],
-      "initial": "sRGB",
-      "inherited": true
-    },
-    {
       "name": "color-interpolation-filters",
       "syntax": "auto | sRGB | linearRGB",
       "computed": [
@@ -1926,7 +2447,7 @@
     },
     {
       "name": "column-count",
-      "syntax": "auto | <integer [1,∞]>",
+      "syntax": "<integer> | auto",
       "computed": [
         "asSpecified"
       ],
@@ -1935,7 +2456,7 @@
     },
     {
       "name": "column-fill",
-      "syntax": "auto | balance | balance-all",
+      "syntax": "auto | balance",
       "computed": [
         "asSpecified"
       ],
@@ -1944,7 +2465,7 @@
     },
     {
       "name": "column-gap",
-      "syntax": "normal | <length-percentage [0,∞]>",
+      "syntax": "normal | <length-percentage>",
       "computed": [
         "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn"
       ],
@@ -1954,17 +2475,19 @@
     {
       "name": "column-height",
       "syntax": "auto | <length [0,∞]>",
-      "computed": [],
+      "computed": [
+        "autoOrAbsoluteLength"
+      ],
       "initial": "auto",
       "inherited": false
     },
     {
       "name": "column-rule",
-      "syntax": "<gap-rule-list> | <gap-auto-rule-list>",
+      "syntax": "<'column-rule-width'> || <'column-rule-style'> || <'column-rule-color'>",
       "computed": [
-        "column-rule-color",
+        "column-rule-width",
         "column-rule-style",
-        "column-rule-width"
+        "column-rule-color"
       ],
       "initial": [
         "column-rule-width",
@@ -1974,15 +2497,8 @@
       "inherited": false
     },
     {
-      "name": "column-rule-break",
-      "syntax": "none | spanning-item | intersection",
-      "computed": [],
-      "initial": "spanning-item",
-      "inherited": false
-    },
-    {
       "name": "column-rule-color",
-      "syntax": "<line-color-list> | <auto-line-color-list>",
+      "syntax": "<color>",
       "computed": [
         "computedColor"
       ],
@@ -1990,15 +2506,8 @@
       "inherited": false
     },
     {
-      "name": "column-rule-outset",
-      "syntax": "<length-percentage>",
-      "computed": [],
-      "initial": "50%",
-      "inherited": false
-    },
-    {
       "name": "column-rule-style",
-      "syntax": "<line-style-list> | <auto-line-style-list>",
+      "syntax": "<line-style>",
       "computed": [
         "asSpecified"
       ],
@@ -2007,7 +2516,7 @@
     },
     {
       "name": "column-rule-width",
-      "syntax": "<line-width-list> | <auto-line-width-list>",
+      "syntax": "<line-width>",
       "computed": [
         "absoluteLength0IfColumnRuleStyleNoneOrHidden"
       ],
@@ -2016,7 +2525,7 @@
     },
     {
       "name": "column-span",
-      "syntax": "none | <integer [1,∞]> | all | auto",
+      "syntax": "none | all",
       "computed": [
         "asSpecified"
       ],
@@ -2025,9 +2534,9 @@
     },
     {
       "name": "column-width",
-      "syntax": "auto | <length [0,∞]> | min-content | max-content | fit-content(<length-percentage>)",
+      "syntax": "auto | <length [0,∞]>",
       "computed": [
-        "absoluteLengthZeroOrLarger"
+        "autoOrAbsoluteLength"
       ],
       "initial": "auto",
       "inherited": false
@@ -2035,26 +2544,30 @@
     {
       "name": "column-wrap",
       "syntax": "auto | nowrap | wrap",
-      "computed": [],
+      "computed": [
+        "asSpecified"
+      ],
       "initial": "auto",
       "inherited": false
     },
     {
       "name": "columns",
-      "syntax": "<'column-width'> || <'column-count'> [ / <'column-height'> ]?",
+      "syntax": "[ <'column-width'> || <'column-count'> ] [ / <'column-height'> ]?",
       "computed": [
         "column-width",
-        "column-count"
+        "column-count",
+        "column-height"
       ],
       "initial": [
         "column-width",
-        "column-count"
+        "column-count",
+        "column-height"
       ],
       "inherited": false
     },
     {
       "name": "contain",
-      "syntax": "none | strict | content | [ [size | inline-size] || layout || style || paint ]",
+      "syntax": "none | strict | content | [ [ size || inline-size ] || layout || style || paint ]",
       "computed": [
         "asSpecified"
       ],
@@ -2062,8 +2575,88 @@
       "inherited": false
     },
     {
+      "name": "contain-intrinsic-block-size",
+      "syntax": "auto? [ none | <length> ]",
+      "computed": [
+        "asSpecifiedWithLengthValuesComputed"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "contain-intrinsic-height",
+      "syntax": "auto? [ none | <length> ]",
+      "computed": [
+        "asSpecifiedWithLengthValuesComputed"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "contain-intrinsic-inline-size",
+      "syntax": "auto? [ none | <length> ]",
+      "computed": [
+        "asSpecifiedWithLengthValuesComputed"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "contain-intrinsic-size",
+      "syntax": "[ auto? [ none | <length> ] ]{1,2}",
+      "computed": [
+        "contain-intrinsic-width",
+        "contain-intrinsic-height"
+      ],
+      "initial": [
+        "contain-intrinsic-width",
+        "contain-intrinsic-height"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "contain-intrinsic-width",
+      "syntax": "auto? [ none | <length> ]",
+      "computed": [
+        "asSpecifiedWithLengthValuesComputed"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "container",
+      "syntax": "<'container-name'> [ / <'container-type'> ]?",
+      "computed": [
+        "container-name",
+        "container-type"
+      ],
+      "initial": [
+        "container-name",
+        "container-type"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "container-name",
+      "syntax": "none | <custom-ident>+",
+      "computed": [
+        "noneOrOrderedListOfIdentifiers"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "container-type",
+      "syntax": "normal | [ [ size | inline-size ] || scroll-state ]",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
       "name": "content",
-      "syntax": "normal | none | [ <content-replacement> | <content-list> ] [/ [ <string> | <counter> | <attr()> ]+ ]? | <element()>",
+      "syntax": "normal | none | [ <content-replacement> | <content-list> ] [ / [ <string> | <counter> | <attr()> ]+ ]?",
       "computed": [
         "normalOnElementsForPseudosNoneAbsoluteURIStringOrAsSpecified"
       ],
@@ -2081,121 +2674,195 @@
     },
     {
       "name": "corner-block-end-shape",
-      "syntax": "<corner-shape-value>",
-      "computed": [],
-      "initial": "round",
+      "syntax": "<corner-shape-value>{1,2}",
+      "computed": [
+        "corner-end-start-shape",
+        "corner-end-end-shape"
+      ],
+      "initial": [
+        "corner-end-start-shape",
+        "corner-end-end-shape"
+      ],
       "inherited": false
     },
     {
       "name": "corner-block-start-shape",
-      "syntax": "<corner-shape-value>",
-      "computed": [],
-      "initial": "round",
+      "syntax": "<corner-shape-value>{1,2}",
+      "computed": [
+        "corner-start-start-shape",
+        "corner-start-end-shape"
+      ],
+      "initial": [
+        "corner-start-start-shape",
+        "corner-start-end-shape"
+      ],
       "inherited": false
     },
     {
       "name": "corner-bottom-left-shape",
       "syntax": "<corner-shape-value>",
-      "computed": [],
+      "computed": [
+        "correspondingSuperellipse"
+      ],
       "initial": "round",
       "inherited": false
     },
     {
       "name": "corner-bottom-right-shape",
       "syntax": "<corner-shape-value>",
-      "computed": [],
+      "computed": [
+        "correspondingSuperellipse"
+      ],
       "initial": "round",
       "inherited": false
     },
     {
       "name": "corner-bottom-shape",
-      "syntax": "<corner-shape-value>",
-      "computed": [],
-      "initial": "round",
+      "syntax": "<corner-shape-value>{1,2}",
+      "computed": [
+        "corner-bottom-left-shape",
+        "corner-bottom-right-shape"
+      ],
+      "initial": [
+        "corner-bottom-left-shape",
+        "corner-bottom-right-shape"
+      ],
       "inherited": false
     },
     {
       "name": "corner-end-end-shape",
       "syntax": "<corner-shape-value>",
-      "computed": [],
+      "computed": [
+        "correspondingSuperellipse"
+      ],
       "initial": "round",
       "inherited": false
     },
     {
       "name": "corner-end-start-shape",
       "syntax": "<corner-shape-value>",
-      "computed": [],
+      "computed": [
+        "correspondingSuperellipse"
+      ],
       "initial": "round",
       "inherited": false
     },
     {
       "name": "corner-inline-end-shape",
-      "syntax": "<corner-shape-value>",
-      "computed": [],
-      "initial": "round",
+      "syntax": "<corner-shape-value>{1,2}",
+      "computed": [
+        "corner-start-end-shape",
+        "corner-end-end-shape"
+      ],
+      "initial": [
+        "corner-start-end-shape",
+        "corner-end-end-shape"
+      ],
       "inherited": false
     },
     {
       "name": "corner-inline-start-shape",
-      "syntax": "<corner-shape-value>",
-      "computed": [],
-      "initial": "round",
+      "syntax": "<corner-shape-value>{1,2}",
+      "computed": [
+        "corner-start-start-shape",
+        "corner-start-end-shape"
+      ],
+      "initial": [
+        "corner-start-start-shape",
+        "corner-start-end-shape"
+      ],
       "inherited": false
     },
     {
       "name": "corner-left-shape",
-      "syntax": "<corner-shape-value>",
-      "computed": [],
-      "initial": "round",
+      "syntax": "<corner-shape-value>{1,2}",
+      "computed": [
+        "corner-top-left-shape",
+        "corner-bottom-left-shape"
+      ],
+      "initial": [
+        "corner-top-left-shape",
+        "corner-bottom-left-shape"
+      ],
       "inherited": false
     },
     {
       "name": "corner-right-shape",
-      "syntax": "<corner-shape-value>",
-      "computed": [],
-      "initial": "round",
+      "syntax": "<corner-shape-value>{1,2}",
+      "computed": [
+        "corner-top-right-shape",
+        "corner-bottom-right-shape"
+      ],
+      "initial": [
+        "corner-top-right-shape",
+        "corner-bottom-right-shape"
+      ],
       "inherited": false
     },
     {
       "name": "corner-shape",
       "syntax": "<corner-shape-value>{1,4}",
-      "computed": [],
-      "initial": "round",
+      "computed": [
+        "corner-top-left-shape",
+        "corner-top-right-shape",
+        "corner-bottom-left-shape",
+        "corner-bottom-right-shape"
+      ],
+      "initial": [
+        "corner-top-left-shape",
+        "corner-top-right-shape",
+        "corner-bottom-left-shape",
+        "corner-bottom-right-shape"
+      ],
       "inherited": false
     },
     {
       "name": "corner-start-end-shape",
       "syntax": "<corner-shape-value>",
-      "computed": [],
+      "computed": [
+        "correspondingSuperellipse"
+      ],
       "initial": "round",
       "inherited": false
     },
     {
       "name": "corner-start-start-shape",
       "syntax": "<corner-shape-value>",
-      "computed": [],
+      "computed": [
+        "correspondingSuperellipse"
+      ],
       "initial": "round",
       "inherited": false
     },
     {
       "name": "corner-top-left-shape",
       "syntax": "<corner-shape-value>",
-      "computed": [],
+      "computed": [
+        "correspondingSuperellipse"
+      ],
       "initial": "round",
       "inherited": false
     },
     {
       "name": "corner-top-right-shape",
       "syntax": "<corner-shape-value>",
-      "computed": [],
+      "computed": [
+        "correspondingSuperellipse"
+      ],
       "initial": "round",
       "inherited": false
     },
     {
       "name": "corner-top-shape",
-      "syntax": "<corner-shape-value>",
-      "computed": [],
-      "initial": "round",
+      "syntax": "<corner-shape-value>{1,2}",
+      "computed": [
+        "corner-top-left-shape",
+        "corner-top-right-shape"
+      ],
+      "initial": [
+        "corner-top-left-shape",
+        "corner-top-right-shape"
+      ],
       "inherited": false
     },
     {
@@ -2226,29 +2893,8 @@
       "inherited": false
     },
     {
-      "name": "cue",
-      "syntax": "<'cue-before'> <'cue-after'>?",
-      "computed": [],
-      "initial": "see individual properties",
-      "inherited": false
-    },
-    {
-      "name": "cue-after",
-      "syntax": "<uri> <decibel>? | none",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "cue-before",
-      "syntax": "<uri> <decibel>? | none",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
       "name": "cursor",
-      "syntax": "[ [ <url> | <url-set> ] [<x> <y>]? ]#? [ auto | default | none | context-menu | help | pointer | progress | wait | cell | crosshair | text | vertical-text | alias | copy | move | no-drop | not-allowed | grab | grabbing | e-resize | n-resize | ne-resize | nw-resize | s-resize | se-resize | sw-resize | w-resize | ew-resize | ns-resize | nesw-resize | nwse-resize | col-resize | row-resize | all-scroll | zoom-in | zoom-out ]",
+      "syntax": "[ [ <url> [ <x> <y> ]? , ]* <cursor-predefined> ]",
       "computed": [
         "asSpecifiedURLsAbsolute"
       ],
@@ -2257,7 +2903,7 @@
     },
     {
       "name": "cx",
-      "syntax": "<length-percentage>",
+      "syntax": "<length> | <percentage>",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
@@ -2266,7 +2912,7 @@
     },
     {
       "name": "cy",
-      "syntax": "<length-percentage>",
+      "syntax": "<length> | <percentage>",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
@@ -2275,7 +2921,7 @@
     },
     {
       "name": "d",
-      "syntax": "none | <string>",
+      "syntax": "none | path(<string>)",
       "computed": [
         "asSpecified"
       ],
@@ -2293,7 +2939,7 @@
     },
     {
       "name": "display",
-      "syntax": "[ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy> | <display-outside> || [ <display-inside> | math ]",
+      "syntax": "[ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy>",
       "computed": [
         "asSpecifiedExceptPositionedFloatingAndRootElementsKeywordMaybeDifferent"
       ],
@@ -2311,8 +2957,10 @@
     },
     {
       "name": "dynamic-range-limit",
-      "syntax": "standard | no-limit | constrained-high | <dynamic-range-limit-mix()>",
-      "computed": [],
+      "syntax": "standard | no-limit | constrained | <dynamic-range-limit-mix()>",
+      "computed": [
+        "computedValueForDynamicRangeLimit"
+      ],
       "initial": "no-limit",
       "inherited": true
     },
@@ -2327,7 +2975,7 @@
     },
     {
       "name": "field-sizing",
-      "syntax": "fixed | content",
+      "syntax": "content | fixed",
       "computed": [
         "asSpecified"
       ],
@@ -2344,27 +2992,6 @@
       "inherited": true
     },
     {
-      "name": "fill-break",
-      "syntax": "bounding-box | slice | clone",
-      "computed": [],
-      "initial": "bounding-box",
-      "inherited": false
-    },
-    {
-      "name": "fill-color",
-      "syntax": "<color>",
-      "computed": [],
-      "initial": "currentcolor",
-      "inherited": true
-    },
-    {
-      "name": "fill-image",
-      "syntax": "<paint>#",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
       "name": "fill-opacity",
       "syntax": "<'opacity'>",
       "computed": [
@@ -2374,40 +3001,12 @@
       "inherited": true
     },
     {
-      "name": "fill-origin",
-      "syntax": "match-parent | fill-box | stroke-box | content-box | padding-box | border-box",
-      "computed": [],
-      "initial": "match-parent",
-      "inherited": false
-    },
-    {
-      "name": "fill-position",
-      "syntax": "<position>#",
-      "computed": [],
-      "initial": "0% 0%",
-      "inherited": true
-    },
-    {
-      "name": "fill-repeat",
-      "syntax": "<repeat-style>#",
-      "computed": [],
-      "initial": "repeat",
-      "inherited": true
-    },
-    {
       "name": "fill-rule",
       "syntax": "nonzero | evenodd",
       "computed": [
         "asSpecified"
       ],
       "initial": "nonzero",
-      "inherited": true
-    },
-    {
-      "name": "fill-size",
-      "syntax": "<bg-size>#",
-      "computed": [],
-      "initial": "auto",
       "inherited": true
     },
     {
@@ -2467,7 +3066,7 @@
     },
     {
       "name": "flex-grow",
-      "syntax": "<number [0,∞]>",
+      "syntax": "<number>",
       "computed": [
         "asSpecified"
       ],
@@ -2476,7 +3075,7 @@
     },
     {
       "name": "flex-shrink",
-      "syntax": "<number [0,∞]>",
+      "syntax": "<number>",
       "computed": [
         "asSpecified"
       ],
@@ -2494,32 +3093,11 @@
     },
     {
       "name": "float",
-      "syntax": "block-start | block-end | inline-start | inline-end | snap-block | <snap-block()> | snap-inline | <snap-inline()> | left | right | top | bottom | none | footnote",
+      "syntax": "left | right | none | inline-start | inline-end",
       "computed": [
         "asSpecified"
       ],
       "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "float-defer",
-      "syntax": "<integer> | last | none",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "float-offset",
-      "syntax": "<length-percentage>",
-      "computed": [],
-      "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "float-reference",
-      "syntax": "inline | column | region | page",
-      "computed": [],
-      "initial": "inline",
       "inherited": false
     },
     {
@@ -2538,20 +3116,6 @@
         "specifiedValueClipped0To1"
       ],
       "initial": "black",
-      "inherited": false
-    },
-    {
-      "name": "flow-from",
-      "syntax": "<ident> | none",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "flow-into",
-      "syntax": "none | <ident> [element | content]?",
-      "computed": [],
-      "initial": "none",
       "inherited": false
     },
     {
@@ -2642,7 +3206,7 @@
     },
     {
       "name": "font-size-adjust",
-      "syntax": "none | <number [0,∞]>",
+      "syntax": "none | [ ex-height | cap-height | ch-width | ic-width | ic-height ]? [ from-font | <number> ]",
       "computed": [
         "asSpecified"
       ],
@@ -2650,17 +3214,26 @@
       "inherited": true
     },
     {
+      "name": "font-smooth",
+      "syntax": "auto | never | always | <absolute-size> | <length>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
       "name": "font-stretch",
-      "syntax": "",
+      "syntax": "<font-stretch-absolute>",
       "computed": [
         "asSpecified"
       ],
       "initial": "normal",
-      "inherited": false
+      "inherited": true
     },
     {
       "name": "font-style",
-      "syntax": "normal | italic | oblique <angle [-90deg,90deg]>?",
+      "syntax": "normal | italic | oblique <angle>?",
       "computed": [
         "asSpecified"
       ],
@@ -2696,7 +3269,7 @@
     },
     {
       "name": "font-synthesis-style",
-      "syntax": "auto | none | oblique-only",
+      "syntax": "auto | none",
       "computed": [
         "asSpecified"
       ],
@@ -2714,7 +3287,7 @@
     },
     {
       "name": "font-variant",
-      "syntax": "normal | none | [ [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ] || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ] || [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ] || [ <east-asian-variant-values> || <east-asian-width-values> || ruby ] || [ sub | super ] || [ text | emoji | unicode ] ]",
+      "syntax": "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> || stylistic( <feature-value-name> ) || historical-forms || styleset( <feature-value-name># ) || character-variant( <feature-value-name># ) || swash( <feature-value-name> ) || ornaments( <feature-value-name> ) || annotation( <feature-value-name> ) || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero || <east-asian-variant-values> || <east-asian-width-values> || ruby ]",
       "computed": [
         "asSpecified"
       ],
@@ -2723,7 +3296,7 @@
     },
     {
       "name": "font-variant-alternates",
-      "syntax": "normal | [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ]",
+      "syntax": "normal | [ stylistic( <feature-value-name> ) || historical-forms || styleset( <feature-value-name># ) || character-variant( <feature-value-name># ) || swash( <feature-value-name> ) || ornaments( <feature-value-name> ) || annotation( <feature-value-name> ) ]",
       "computed": [
         "asSpecified"
       ],
@@ -2786,7 +3359,7 @@
     },
     {
       "name": "font-variation-settings",
-      "syntax": "normal | [ <opentype-tag> <number>]#",
+      "syntax": "normal | [ <string> <number> ]#",
       "computed": [
         "asSpecified"
       ],
@@ -2805,23 +3378,11 @@
     {
       "name": "font-width",
       "syntax": "normal | <percentage [0,∞]> | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded",
-      "computed": [],
+      "computed": [
+        "percentage"
+      ],
       "initial": "normal",
       "inherited": true
-    },
-    {
-      "name": "footnote-display",
-      "syntax": "block | inline | compact",
-      "computed": [],
-      "initial": "block",
-      "inherited": false
-    },
-    {
-      "name": "footnote-policy",
-      "syntax": "auto | line | block",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
     },
     {
       "name": "forced-color-adjust",
@@ -2843,13 +3404,6 @@
         "row-gap",
         "column-gap"
       ],
-      "inherited": false
-    },
-    {
-      "name": "glyph-orientation-vertical",
-      "syntax": "auto | 0deg | 90deg | 0 | 90",
-      "computed": [],
-      "initial": "n/a",
       "inherited": false
     },
     {
@@ -2949,7 +3503,7 @@
     },
     {
       "name": "grid-column-gap",
-      "syntax": "",
+      "syntax": "<length-percentage>",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
@@ -2967,7 +3521,7 @@
     },
     {
       "name": "grid-gap",
-      "syntax": "",
+      "syntax": "<'grid-row-gap'> <'grid-column-gap'>?",
       "computed": [
         "grid-row-gap",
         "grid-column-gap"
@@ -3002,7 +3556,7 @@
     },
     {
       "name": "grid-row-gap",
-      "syntax": "",
+      "syntax": "<length-percentage>",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
@@ -3071,12 +3625,30 @@
     },
     {
       "name": "height",
-      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
       "computed": [
         "percentageAutoOrAbsoluteLength"
       ],
       "initial": "auto",
       "inherited": false
+    },
+    {
+      "name": "hyphenate-character",
+      "syntax": "auto | <string>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "hyphenate-limit-chars",
+      "syntax": "[ auto | <integer> ]{1,3}",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
     },
     {
       "name": "hyphens",
@@ -3089,7 +3661,7 @@
     },
     {
       "name": "image-orientation",
-      "syntax": "from-image | none | [ <angle> || flip ]",
+      "syntax": "from-image | <angle> | [ <angle>? flip ]",
       "computed": [
         "angleRoundedToNextQuarter"
       ],
@@ -3098,7 +3670,7 @@
     },
     {
       "name": "image-rendering",
-      "syntax": "auto | smooth | high-quality | pixelated | crisp-edges",
+      "syntax": "auto | crisp-edges | pixelated | smooth",
       "computed": [
         "asSpecified"
       ],
@@ -3106,8 +3678,26 @@
       "inherited": true
     },
     {
+      "name": "image-resolution",
+      "syntax": "[ from-image || <resolution> ] && snap?",
+      "computed": [
+        "asSpecifiedWithExceptionOfResolution"
+      ],
+      "initial": "1dppx",
+      "inherited": true
+    },
+    {
+      "name": "ime-mode",
+      "syntax": "auto | normal | active | inactive | disabled",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
       "name": "initial-letter",
-      "syntax": "normal | <number [1,∞]> <integer [1,∞]> | <number [1,∞]> && [ drop | raise ]?",
+      "syntax": "normal | [ <number> <integer>? ]",
       "computed": [
         "asSpecified"
       ],
@@ -3116,19 +3706,12 @@
     },
     {
       "name": "initial-letter-align",
-      "syntax": "[ border-box? [ alphabetic | ideographic | hanging | leading ]? ]!",
+      "syntax": "[ auto | alphabetic | hanging | ideographic ]",
       "computed": [
         "asSpecified"
       ],
       "initial": "auto",
-      "inherited": true
-    },
-    {
-      "name": "initial-letter-wrap",
-      "syntax": "none | first | all | grid | <length-percentage>",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
+      "inherited": false
     },
     {
       "name": "inline-size",
@@ -3136,20 +3719,6 @@
       "computed": [
         "sameAsWidthAndHeight"
       ],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "inline-sizing",
-      "syntax": "normal | stretch",
-      "computed": [],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "input-security",
-      "syntax": "auto | none",
-      "computed": [],
       "initial": "auto",
       "inherited": false
     },
@@ -3185,7 +3754,7 @@
     },
     {
       "name": "inset-block-end",
-      "syntax": "auto | <length-percentage>",
+      "syntax": "<'top'>",
       "computed": [
         "sameAsBoxOffsets"
       ],
@@ -3194,7 +3763,7 @@
     },
     {
       "name": "inset-block-start",
-      "syntax": "auto | <length-percentage>",
+      "syntax": "<'top'>",
       "computed": [
         "sameAsBoxOffsets"
       ],
@@ -3216,7 +3785,7 @@
     },
     {
       "name": "inset-inline-end",
-      "syntax": "auto | <length-percentage>",
+      "syntax": "<'top'>",
       "computed": [
         "sameAsBoxOffsets"
       ],
@@ -3225,7 +3794,7 @@
     },
     {
       "name": "inset-inline-start",
-      "syntax": "auto | <length-percentage>",
+      "syntax": "<'top'>",
       "computed": [
         "sameAsBoxOffsets"
       ],
@@ -3235,13 +3804,55 @@
     {
       "name": "interactivity",
       "syntax": "auto | inert",
-      "computed": [],
+      "computed": [
+        "asSpecified"
+      ],
       "initial": "auto",
       "inherited": true
     },
     {
+      "name": "interest-delay",
+      "syntax": "<'interest-delay-start'>{1,2}",
+      "computed": [
+        "interest-delay-start",
+        "interest-delay-end"
+      ],
+      "initial": [
+        "interest-delay-start",
+        "interest-delay-end"
+      ],
+      "inherited": true
+    },
+    {
+      "name": "interest-delay-end",
+      "syntax": "normal | <time>",
+      "computed": [
+        "normalOrComputedTime"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "interest-delay-start",
+      "syntax": "normal | <time>",
+      "computed": [
+        "normalOrComputedTime"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
+      "name": "interpolate-size",
+      "syntax": "numeric-only | allow-keywords",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "numeric-only",
+      "inherited": true
+    },
+    {
       "name": "isolation",
-      "syntax": "<isolation-mode>",
+      "syntax": "auto | isolate",
       "computed": [
         "asSpecified"
       ],
@@ -3273,6 +3884,15 @@
         "asSpecified"
       ],
       "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "justify-tracks",
+      "syntax": "[ normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ] ]#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
       "inherited": false
     },
     {
@@ -3312,22 +3932,17 @@
       "inherited": true
     },
     {
-      "name": "line-fit-edge",
-      "syntax": "leading | <text-edge>",
-      "computed": [],
-      "initial": "leading",
-      "inherited": true
-    },
-    {
-      "name": "line-grid",
-      "syntax": "match-parent | create",
-      "computed": [],
-      "initial": "match-parent",
+      "name": "line-clamp",
+      "syntax": "none | <integer>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
       "inherited": false
     },
     {
       "name": "line-height",
-      "syntax": "normal | <number [0,∞]> | <length-percentage [0,∞]>",
+      "syntax": "normal | <number> | <length> | <percentage>",
       "computed": [
         "absoluteLengthOrAsSpecified"
       ],
@@ -3336,7 +3951,7 @@
     },
     {
       "name": "line-height-step",
-      "syntax": "<length [0,∞]>",
+      "syntax": "<length>",
       "computed": [
         "absoluteLength"
       ],
@@ -3344,22 +3959,8 @@
       "inherited": true
     },
     {
-      "name": "line-snap",
-      "syntax": "none | baseline | contain",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "link-parameters",
-      "syntax": "none | <link-param>+",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
       "name": "list-style",
-      "syntax": "<'list-style-position'> || <'list-style-image'> || <'list-style-type'>",
+      "syntax": "<'list-style-type'> || <'list-style-position'> || <'list-style-image'>",
       "computed": [
         "list-style-image",
         "list-style-position",
@@ -3370,7 +3971,7 @@
         "list-style-position",
         "list-style-image"
       ],
-      "inherited": false
+      "inherited": true
     },
     {
       "name": "list-style-image",
@@ -3457,13 +4058,6 @@
       "inherited": false
     },
     {
-      "name": "margin-break",
-      "syntax": "auto | keep | discard",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
       "name": "margin-inline",
       "syntax": "<'margin-top'>{1,2}",
       "computed": [
@@ -3523,7 +4117,7 @@
     },
     {
       "name": "margin-trim",
-      "syntax": "none | [ block || inline ] | [ block-start || inline-start || block-end || inline-end ]",
+      "syntax": "none | in-flow | all",
       "computed": [
         "asSpecified"
       ],
@@ -3532,7 +4126,7 @@
     },
     {
       "name": "marker",
-      "syntax": "none | <marker-ref>",
+      "syntax": "none | <url>",
       "computed": [
         "asSpecified"
       ],
@@ -3545,7 +4139,7 @@
     },
     {
       "name": "marker-end",
-      "syntax": "none | <marker-ref>",
+      "syntax": "none | <url>",
       "computed": [
         "asSpecifiedURLsAbsolute"
       ],
@@ -3554,7 +4148,7 @@
     },
     {
       "name": "marker-mid",
-      "syntax": "none | <marker-ref>",
+      "syntax": "none | <url>",
       "computed": [
         "asSpecifiedURLsAbsolute"
       ],
@@ -3562,15 +4156,8 @@
       "inherited": true
     },
     {
-      "name": "marker-side",
-      "syntax": "match-self | match-parent",
-      "computed": [],
-      "initial": "match-self",
-      "inherited": true
-    },
-    {
       "name": "marker-start",
-      "syntax": "none | <marker-ref>",
+      "syntax": "none | <url>",
       "computed": [
         "asSpecifiedURLsAbsolute"
       ],
@@ -3652,7 +4239,7 @@
     },
     {
       "name": "mask-border-slice",
-      "syntax": "[ <number> | <percentage> ]{1,4} fill?",
+      "syntax": "<number-percentage>{1,4} fill?",
       "computed": [
         "asSpecified"
       ],
@@ -3759,6 +4346,15 @@
       "inherited": false
     },
     {
+      "name": "masonry-auto-flow",
+      "syntax": "[ pack | next ] || [ definite-first | ordered ]",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "pack",
+      "inherited": false
+    },
+    {
       "name": "math-depth",
       "syntax": "auto-add | add(<integer>) | <integer>",
       "computed": [
@@ -3796,7 +4392,7 @@
     },
     {
       "name": "max-height",
-      "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+      "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
       "computed": [
         "percentageAsSpecifiedAbsoluteLengthOrNone"
       ],
@@ -3813,8 +4409,17 @@
       "inherited": false
     },
     {
+      "name": "max-lines",
+      "syntax": "none | <integer>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
       "name": "max-width",
-      "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+      "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
       "computed": [
         "percentageAsSpecifiedAbsoluteLengthOrNone"
       ],
@@ -3832,7 +4437,7 @@
     },
     {
       "name": "min-height",
-      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
@@ -3850,7 +4455,7 @@
     },
     {
       "name": "min-width",
-      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
@@ -3864,34 +4469,6 @@
         "asSpecified"
       ],
       "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "nav-down",
-      "syntax": "auto | <id> [ current | root | <target-name> ]?",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "nav-left",
-      "syntax": "auto | <id> [ current | root | <target-name> ]?",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "nav-right",
-      "syntax": "auto | <id> [ current | root | <target-name> ]?",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "nav-up",
-      "syntax": "auto | <id> [ current | root | <target-name> ]?",
-      "computed": [],
-      "initial": "auto",
       "inherited": false
     },
     {
@@ -3910,6 +4487,15 @@
         "asSpecified"
       ],
       "initial": "50% 50%",
+      "inherited": true
+    },
+    {
+      "name": "object-view-box",
+      "syntax": "none | <basic-shape-rect>",
+      "computed": [
+        "specifiedKeywordOrComputedFunction"
+      ],
+      "initial": "none",
       "inherited": false
     },
     {
@@ -3996,7 +4582,7 @@
     },
     {
       "name": "orphans",
-      "syntax": "<integer [1,∞]>",
+      "syntax": "<integer>",
       "computed": [
         "asSpecified"
       ],
@@ -4020,7 +4606,7 @@
     },
     {
       "name": "outline-color",
-      "syntax": "auto | <color> | <image-1D>",
+      "syntax": "auto | <color>",
       "computed": [
         "autoForTranslucentColorRGBAOtherwiseRGB"
       ],
@@ -4056,7 +4642,7 @@
     },
     {
       "name": "overflow",
-      "syntax": "<'overflow-block'>{1,2}",
+      "syntax": "[ visible | hidden | clip | scroll | auto ]{1,2}",
       "computed": [
         "overflow-x",
         "overflow-y"
@@ -4080,6 +4666,15 @@
         "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
       ],
       "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "overflow-clip-box",
+      "syntax": "padding-box | content-box",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "padding-box",
       "inherited": false
     },
     {
@@ -4125,6 +4720,15 @@
         "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
       ],
       "initial": "visible",
+      "inherited": false
+    },
+    {
+      "name": "overlay",
+      "syntax": "none | auto",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
       "inherited": false
     },
     {
@@ -4299,7 +4903,7 @@
     },
     {
       "name": "page-break-after",
-      "syntax": "auto | always | avoid | left | right | inherit",
+      "syntax": "auto | always | avoid | left | right | recto | verso",
       "computed": [
         "asSpecified"
       ],
@@ -4308,7 +4912,7 @@
     },
     {
       "name": "page-break-before",
-      "syntax": "auto | always | avoid | left | right | inherit",
+      "syntax": "auto | always | avoid | left | right | recto | verso",
       "computed": [
         "asSpecified"
       ],
@@ -4317,7 +4921,7 @@
     },
     {
       "name": "page-break-inside",
-      "syntax": "avoid | auto | inherit",
+      "syntax": "auto | avoid",
       "computed": [
         "asSpecified"
       ],
@@ -4334,24 +4938,21 @@
       "inherited": true
     },
     {
-      "name": "pause",
-      "syntax": "<'pause-before'> <'pause-after'>?",
-      "computed": [],
-      "initial": "see individual properties",
-      "inherited": false
-    },
-    {
-      "name": "pause-after",
-      "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
-      "computed": [],
+      "name": "perspective",
+      "syntax": "none | <length>",
+      "computed": [
+        "absoluteLengthOrNone"
+      ],
       "initial": "none",
       "inherited": false
     },
     {
-      "name": "pause-before",
-      "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
-      "computed": [],
-      "initial": "none",
+      "name": "perspective-origin",
+      "syntax": "<position>",
+      "computed": [
+        "forLengthAbsoluteValueOtherwisePercentage"
+      ],
+      "initial": "50% 50%",
       "inherited": false
     },
     {
@@ -4395,7 +4996,7 @@
     },
     {
       "name": "pointer-events",
-      "syntax": "auto | bounding-box | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all | none",
+      "syntax": "auto | none | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all | inherit",
       "computed": [
         "asSpecified"
       ],
@@ -4404,7 +5005,7 @@
     },
     {
       "name": "position",
-      "syntax": "static | relative | absolute | sticky | fixed | <running()>",
+      "syntax": "static | relative | absolute | sticky | fixed",
       "computed": [
         "asSpecified"
       ],
@@ -4413,11 +5014,11 @@
     },
     {
       "name": "position-anchor",
-      "syntax": "auto | <anchor-name>",
+      "syntax": "normal | auto | none | <anchor-name> | match-parent",
       "computed": [
         "asSpecified"
       ],
-      "initial": "auto",
+      "initial": "normal",
       "inherited": false
     },
     {
@@ -4480,7 +5081,7 @@
     },
     {
       "name": "quotes",
-      "syntax": "auto | none | match-parent | [ <string> <string> ]+",
+      "syntax": "none | auto | [ <string> <string> ]+",
       "computed": [
         "asSpecified"
       ],
@@ -4489,7 +5090,7 @@
     },
     {
       "name": "r",
-      "syntax": "<length-percentage>",
+      "syntax": "<length> | <percentage>",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
@@ -4499,22 +5100,19 @@
     {
       "name": "reading-flow",
       "syntax": "normal | source-order | flex-visual | flex-flow | grid-rows | grid-columns | grid-order",
-      "computed": [],
+      "computed": [
+        "asSpecified"
+      ],
       "initial": "normal",
       "inherited": false
     },
     {
       "name": "reading-order",
       "syntax": "<integer>",
-      "computed": [],
+      "computed": [
+        "specifiedInteger"
+      ],
       "initial": "0",
-      "inherited": false
-    },
-    {
-      "name": "region-fragment",
-      "syntax": "auto | break",
-      "computed": [],
-      "initial": "auto",
       "inherited": false
     },
     {
@@ -4523,27 +5121,6 @@
       "computed": [
         "asSpecified"
       ],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "rest",
-      "syntax": "<'rest-before'> <'rest-after'>?",
-      "computed": [],
-      "initial": "see individual properties",
-      "inherited": false
-    },
-    {
-      "name": "rest-after",
-      "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "rest-before",
-      "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
-      "computed": [],
       "initial": "none",
       "inherited": false
     },
@@ -4557,54 +5134,21 @@
       "inherited": false
     },
     {
-      "name": "row-gap",
-      "syntax": "normal | <length-percentage [0,∞]>",
+      "name": "rotate",
+      "syntax": "none | <angle> | [ x | y | z | <number>{3} ] && <angle>",
       "computed": [
-        "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn"
+        "asSpecified"
       ],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "row-rule",
-      "syntax": "<gap-rule-list> | <gap-auto-rule-list>",
-      "computed": [],
-      "initial": "see individual properties",
-      "inherited": false
-    },
-    {
-      "name": "row-rule-break",
-      "syntax": "none | spanning-item | intersection",
-      "computed": [],
-      "initial": "spanning-item",
-      "inherited": false
-    },
-    {
-      "name": "row-rule-color",
-      "syntax": "<line-color-list> | <auto-line-color-list>",
-      "computed": [],
-      "initial": "currentcolor",
-      "inherited": false
-    },
-    {
-      "name": "row-rule-outset",
-      "syntax": "<length-percentage>",
-      "computed": [],
-      "initial": "50%",
-      "inherited": false
-    },
-    {
-      "name": "row-rule-style",
-      "syntax": "<line-style-list> | <auto-line-style-list>",
-      "computed": [],
       "initial": "none",
       "inherited": false
     },
     {
-      "name": "row-rule-width",
-      "syntax": "<line-width-list> | <auto-line-width-list>",
-      "computed": [],
-      "initial": "medium",
+      "name": "row-gap",
+      "syntax": "normal | <length-percentage>",
+      "computed": [
+        "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn"
+      ],
+      "initial": "normal",
       "inherited": false
     },
     {
@@ -4618,7 +5162,7 @@
     },
     {
       "name": "ruby-merge",
-      "syntax": "separate | merge | auto",
+      "syntax": "separate | collapse | auto",
       "computed": [
         "asSpecified"
       ],
@@ -4628,7 +5172,9 @@
     {
       "name": "ruby-overhang",
       "syntax": "auto | none",
-      "computed": [],
+      "computed": [
+        "theSpecifiedKeyword"
+      ],
       "initial": "auto",
       "inherited": true
     },
@@ -4642,61 +5188,12 @@
       "inherited": true
     },
     {
-      "name": "rule",
-      "syntax": "<'column-rule'>",
-      "computed": [],
-      "initial": "see individual properties",
-      "inherited": false
-    },
-    {
-      "name": "rule-break",
-      "syntax": "<'column-rule-break'>",
-      "computed": [],
-      "initial": "see individual properties",
-      "inherited": false
-    },
-    {
-      "name": "rule-color",
-      "syntax": "<'column-rule-color'>",
-      "computed": [],
-      "initial": "see individual properties",
-      "inherited": false
-    },
-    {
-      "name": "rule-outset",
-      "syntax": "<'column-rule-outset'>",
-      "computed": [],
-      "initial": "see individual properties",
-      "inherited": false
-    },
-    {
-      "name": "rule-paint-order",
-      "syntax": "row-over-column | column-over-row",
-      "computed": [],
-      "initial": "row-over-column",
-      "inherited": false
-    },
-    {
-      "name": "rule-style",
-      "syntax": "<'column-rule-style'>",
-      "computed": [],
-      "initial": "see individual properties",
-      "inherited": false
-    },
-    {
-      "name": "rule-width",
-      "syntax": "<'column-rule-width'>",
-      "computed": [],
-      "initial": "see individual properties",
-      "inherited": false
-    },
-    {
       "name": "rx",
       "syntax": "<length-percentage> | auto",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
-      "initial": "0",
+      "initial": "auto",
       "inherited": false
     },
     {
@@ -4705,7 +5202,16 @@
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
-      "initial": "0",
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "scale",
+      "syntax": "none | [ <number> | <percentage> ]{1,3}",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
       "inherited": false
     },
     {
@@ -4715,6 +5221,15 @@
         "asSpecified"
       ],
       "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "scroll-initial-target",
+      "syntax": "none | nearest",
+      "computed": [
+        "theSpecifiedKeyword"
+      ],
+      "initial": "none",
       "inherited": false
     },
     {
@@ -4833,8 +5348,17 @@
       "inherited": false
     },
     {
+      "name": "scroll-marker-group",
+      "syntax": "none | before | after",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
       "name": "scroll-padding",
-      "syntax": "[ auto | <length-percentage [0,∞]> ]{1,4}",
+      "syntax": "[ auto | <length-percentage> ]{1,4}",
       "computed": [
         "scroll-padding-bottom",
         "scroll-padding-left",
@@ -4851,7 +5375,7 @@
     },
     {
       "name": "scroll-padding-block",
-      "syntax": "[ auto | <length-percentage [0,∞]> ]{1,2}",
+      "syntax": "[ auto | <length-percentage> ]{1,2}",
       "computed": [
         "scroll-padding-block-start",
         "scroll-padding-block-end"
@@ -4864,7 +5388,7 @@
     },
     {
       "name": "scroll-padding-block-end",
-      "syntax": "auto | <length-percentage [0,∞]>",
+      "syntax": "auto | <length-percentage>",
       "computed": [
         "asSpecified"
       ],
@@ -4873,7 +5397,7 @@
     },
     {
       "name": "scroll-padding-block-start",
-      "syntax": "auto | <length-percentage [0,∞]>",
+      "syntax": "auto | <length-percentage>",
       "computed": [
         "asSpecified"
       ],
@@ -4882,7 +5406,7 @@
     },
     {
       "name": "scroll-padding-bottom",
-      "syntax": "auto | <length-percentage [0,∞]>",
+      "syntax": "auto | <length-percentage>",
       "computed": [
         "asSpecified"
       ],
@@ -4891,7 +5415,7 @@
     },
     {
       "name": "scroll-padding-inline",
-      "syntax": "[ auto | <length-percentage [0,∞]> ]{1,2}",
+      "syntax": "[ auto | <length-percentage> ]{1,2}",
       "computed": [
         "scroll-padding-inline-start",
         "scroll-padding-inline-end"
@@ -4904,7 +5428,7 @@
     },
     {
       "name": "scroll-padding-inline-end",
-      "syntax": "auto | <length-percentage [0,∞]>",
+      "syntax": "auto | <length-percentage>",
       "computed": [
         "asSpecified"
       ],
@@ -4913,7 +5437,7 @@
     },
     {
       "name": "scroll-padding-inline-start",
-      "syntax": "auto | <length-percentage [0,∞]>",
+      "syntax": "auto | <length-percentage>",
       "computed": [
         "asSpecified"
       ],
@@ -4922,7 +5446,7 @@
     },
     {
       "name": "scroll-padding-left",
-      "syntax": "auto | <length-percentage [0,∞]>",
+      "syntax": "auto | <length-percentage>",
       "computed": [
         "asSpecified"
       ],
@@ -4931,7 +5455,7 @@
     },
     {
       "name": "scroll-padding-right",
-      "syntax": "auto | <length-percentage [0,∞]>",
+      "syntax": "auto | <length-percentage>",
       "computed": [
         "asSpecified"
       ],
@@ -4940,7 +5464,7 @@
     },
     {
       "name": "scroll-padding-top",
-      "syntax": "auto | <length-percentage [0,∞]>",
+      "syntax": "auto | <length-percentage>",
       "computed": [
         "asSpecified"
       ],
@@ -4957,6 +5481,42 @@
       "inherited": false
     },
     {
+      "name": "scroll-snap-coordinate",
+      "syntax": "none | <position>#",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "scroll-snap-destination",
+      "syntax": "<position>",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "0px 0px",
+      "inherited": false
+    },
+    {
+      "name": "scroll-snap-points-x",
+      "syntax": "none | repeat( <length-percentage> )",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "scroll-snap-points-y",
+      "syntax": "none | repeat( <length-percentage> )",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
       "name": "scroll-snap-stop",
       "syntax": "normal | always",
       "computed": [
@@ -4968,6 +5528,33 @@
     {
       "name": "scroll-snap-type",
       "syntax": "none | [ x | y | block | inline | both ] [ mandatory | proximity ]?",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "scroll-snap-type-x",
+      "syntax": "none | mandatory | proximity",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "scroll-snap-type-y",
+      "syntax": "none | mandatory | proximity",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "scroll-target-group",
+      "syntax": "none | auto",
       "computed": [
         "asSpecified"
       ],
@@ -5043,7 +5630,7 @@
     },
     {
       "name": "shape-margin",
-      "syntax": "<length-percentage [0,∞]>",
+      "syntax": "<length-percentage>",
       "computed": [
         "asSpecifiedRelativeToAbsoluteLengths"
       ],
@@ -5052,7 +5639,7 @@
     },
     {
       "name": "shape-outside",
-      "syntax": "none | [ <basic-shape> || <shape-box> ] | <image>",
+      "syntax": "none | [ <shape-box> || <basic-shape> ] | <image>",
       "computed": [
         "asDefinedForBasicShapeWithAbsoluteURIOtherwiseAsSpecified"
       ],
@@ -5069,48 +5656,6 @@
       "inherited": true
     },
     {
-      "name": "shape-subtract",
-      "syntax": "none | [ <basic-shape>| <uri> ]+",
-      "computed": [],
-      "initial": "none",
-      "inherited": false
-    },
-    {
-      "name": "slider-orientation",
-      "syntax": "auto | left-to-right | right-to-left | top-to-bottom | bottom-to-top",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "spatial-navigation-action",
-      "syntax": "auto | focus | scroll",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "spatial-navigation-contain",
-      "syntax": "auto | contain",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "spatial-navigation-function",
-      "syntax": "normal | grid",
-      "computed": [],
-      "initial": "normal",
-      "inherited": false
-    },
-    {
-      "name": "speak",
-      "syntax": "auto | never | always",
-      "computed": [],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
       "name": "speak-as",
       "syntax": "normal | spell-out || digits || [ literal-punctuation | no-punctuation ]",
       "computed": [
@@ -5121,7 +5666,7 @@
     },
     {
       "name": "stop-color",
-      "syntax": "",
+      "syntax": "<'color'>",
       "computed": [
         "asSpecified"
       ],
@@ -5130,18 +5675,11 @@
     },
     {
       "name": "stop-opacity",
-      "syntax": "",
+      "syntax": "<'opacity'>",
       "computed": [
         "asSpecified"
       ],
       "initial": "black",
-      "inherited": false
-    },
-    {
-      "name": "string-set",
-      "syntax": "none | [ <custom-ident> <string>+ ]#",
-      "computed": [],
-      "initial": "none",
       "inherited": false
     },
     {
@@ -5162,67 +5700,20 @@
       "inherited": true
     },
     {
-      "name": "stroke-align",
-      "syntax": "center | inset | outset",
-      "computed": [],
-      "initial": "center",
-      "inherited": true
-    },
-    {
-      "name": "stroke-alignment",
-      "syntax": "center | inner | outer",
-      "computed": [],
-      "initial": "center",
-      "inherited": true
-    },
-    {
-      "name": "stroke-break",
-      "syntax": "bounding-box | slice | clone",
-      "computed": [],
-      "initial": "bounding-box",
-      "inherited": false
-    },
-    {
       "name": "stroke-color",
-      "syntax": "<color>#",
-      "computed": [],
+      "syntax": "<color>",
+      "computed": [
+        "computedColor"
+      ],
       "initial": "transparent",
       "inherited": true
     },
     {
-      "name": "stroke-dash-corner",
-      "syntax": "none | <length>",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "stroke-dash-justify",
-      "syntax": "none | [ stretch | compress ] || [ dashes || gaps ]",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "stroke-dashadjust",
-      "syntax": "none | [stretch | compress] [dashes | gaps]?",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
       "name": "stroke-dasharray",
-      "syntax": "none | [<length-percentage> | <number>]+#",
+      "syntax": "none | <dasharray>",
       "computed": [
         "listEachItemConsistingOfAbsoluteLengthPercentageOrKeyword"
       ],
-      "initial": "none",
-      "inherited": true
-    },
-    {
-      "name": "stroke-dashcorner",
-      "syntax": "none | <length>",
-      "computed": [],
       "initial": "none",
       "inherited": true
     },
@@ -5236,13 +5727,6 @@
       "inherited": true
     },
     {
-      "name": "stroke-image",
-      "syntax": "<paint>#",
-      "computed": [],
-      "initial": "none",
-      "inherited": true
-    },
-    {
       "name": "stroke-linecap",
       "syntax": "butt | round | square",
       "computed": [
@@ -5253,7 +5737,7 @@
     },
     {
       "name": "stroke-linejoin",
-      "syntax": "[ crop | arcs | miter ] || [ bevel | round | fallback ]",
+      "syntax": "miter | miter-clip | round | bevel | arcs",
       "computed": [
         "asSpecified"
       ],
@@ -5279,36 +5763,8 @@
       "inherited": true
     },
     {
-      "name": "stroke-origin",
-      "syntax": "match-parent | fill-box | stroke-box | content-box | padding-box | border-box",
-      "computed": [],
-      "initial": "match-parent",
-      "inherited": false
-    },
-    {
-      "name": "stroke-position",
-      "syntax": "<position>#",
-      "computed": [],
-      "initial": "0% 0%",
-      "inherited": true
-    },
-    {
-      "name": "stroke-repeat",
-      "syntax": "<repeat-style>#",
-      "computed": [],
-      "initial": "repeat",
-      "inherited": true
-    },
-    {
-      "name": "stroke-size",
-      "syntax": "<bg-size>#",
-      "computed": [],
-      "initial": "auto",
-      "inherited": true
-    },
-    {
       "name": "stroke-width",
-      "syntax": "[<length-percentage> | <number>]#",
+      "syntax": "<length-percentage> | <number>",
       "computed": [
         "absoluteLengthOrPercentageNumbersConverted"
       ],
@@ -5317,7 +5773,7 @@
     },
     {
       "name": "tab-size",
-      "syntax": "<number [0,∞]> | <length [0,∞]>",
+      "syntax": "<integer> | <length>",
       "computed": [
         "specifiedIntegerOrAbsoluteLength"
       ],
@@ -5335,7 +5791,7 @@
     },
     {
       "name": "text-align",
-      "syntax": "start | end | left | right | center | justify | match-parent | justify-all",
+      "syntax": "start | end | left | right | center | justify | match-parent",
       "computed": [
         "asSpecifiedExceptMatchParent"
       ],
@@ -5343,15 +5799,8 @@
       "inherited": true
     },
     {
-      "name": "text-align-all",
-      "syntax": "start | end | left | right | center | justify | match-parent",
-      "computed": [],
-      "initial": "start",
-      "inherited": true
-    },
-    {
       "name": "text-align-last",
-      "syntax": "auto | start | end | left | right | center | justify | match-parent",
+      "syntax": "auto | start | end | left | right | center | justify",
       "computed": [
         "asSpecified"
       ],
@@ -5365,6 +5814,15 @@
         "asSpecified"
       ],
       "initial": "start",
+      "inherited": true
+    },
+    {
+      "name": "text-autospace",
+      "syntax": "normal | <autospace> | auto",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
       "inherited": true
     },
     {
@@ -5383,7 +5841,7 @@
         "theSpecifiedKeyword"
       ],
       "initial": "auto",
-      "inherited": true
+      "inherited": false
     },
     {
       "name": "text-box-trim",
@@ -5396,7 +5854,7 @@
     },
     {
       "name": "text-combine-upright",
-      "syntax": "none | all | [ digits <integer [2,4]>? ]",
+      "syntax": "none | all | [ digits <integer>? ]",
       "computed": [
         "keywordPlusIntegerIfDigits"
       ],
@@ -5405,7 +5863,7 @@
     },
     {
       "name": "text-decoration",
-      "syntax": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'>",
+      "syntax": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'> || <'text-decoration-thickness'>",
       "computed": [
         "text-decoration-line",
         "text-decoration-style",
@@ -5429,13 +5887,40 @@
       "inherited": false
     },
     {
+      "name": "text-decoration-inset",
+      "syntax": "<length>{1,2} | auto",
+      "computed": [
+        "absoluteLengthOrKeyword"
+      ],
+      "initial": "0",
+      "inherited": false
+    },
+    {
       "name": "text-decoration-line",
-      "syntax": "none | [ underline || overline || line-through || blink ]",
+      "syntax": "none | [ underline || overline || line-through || blink ] | spelling-error | grammar-error",
       "computed": [
         "asSpecified"
       ],
       "initial": "none",
       "inherited": false
+    },
+    {
+      "name": "text-decoration-skip",
+      "syntax": "none | [ objects || [ spaces | [ leading-spaces || trailing-spaces ] ] || edges || box-decoration ]",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "objects",
+      "inherited": true
+    },
+    {
+      "name": "text-decoration-skip-ink",
+      "syntax": "auto | all | none",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
     },
     {
       "name": "text-decoration-style",
@@ -5444,6 +5929,15 @@
         "asSpecified"
       ],
       "initial": "solid",
+      "inherited": false
+    },
+    {
+      "name": "text-decoration-thickness",
+      "syntax": "auto | from-font | <length> | <percentage>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
       "inherited": false
     },
     {
@@ -5457,7 +5951,7 @@
         "text-emphasis-style",
         "text-emphasis-color"
       ],
-      "inherited": false
+      "inherited": true
     },
     {
       "name": "text-emphasis-color",
@@ -5470,7 +5964,7 @@
     },
     {
       "name": "text-emphasis-position",
-      "syntax": "[ over | under ] && [ right | left ]?",
+      "syntax": "auto | [ over | under ] && [ right | left ]?",
       "computed": [
         "asSpecified"
       ],
@@ -5488,7 +5982,7 @@
     },
     {
       "name": "text-indent",
-      "syntax": "[ <length-percentage> ] && hanging? && each-line?",
+      "syntax": "<length-percentage> && hanging? && each-line?",
       "computed": [
         "percentageOrAbsoluteLengthPlusKeywords"
       ],
@@ -5497,7 +5991,7 @@
     },
     {
       "name": "text-justify",
-      "syntax": "auto | none | inter-word | inter-character",
+      "syntax": "auto | inter-character | inter-word | none",
       "computed": [
         "asSpecified"
       ],
@@ -5515,7 +6009,7 @@
     },
     {
       "name": "text-overflow",
-      "syntax": "clip | ellipsis",
+      "syntax": "[ clip | ellipsis | <string> ]{1,2}",
       "computed": [
         "asSpecified"
       ],
@@ -5533,7 +6027,7 @@
     },
     {
       "name": "text-shadow",
-      "syntax": "none | [ <color>? && <length>{2,3} ]#",
+      "syntax": "none | <shadow-t>#",
       "computed": [
         "colorPlusThreeAbsoluteLengths"
       ],
@@ -5542,7 +6036,7 @@
     },
     {
       "name": "text-size-adjust",
-      "syntax": "auto | none | <percentage [0,∞]>",
+      "syntax": "none | auto | <percentage>",
       "computed": [
         "asSpecified"
       ],
@@ -5550,8 +6044,17 @@
       "inherited": true
     },
     {
+      "name": "text-spacing-trim",
+      "syntax": "space-all | normal | space-first | trim-start",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": true
+    },
+    {
       "name": "text-transform",
-      "syntax": "none | [capitalize | uppercase | lowercase ] || full-width || full-size-kana",
+      "syntax": "none | [ capitalize | uppercase | lowercase ] || full-width || full-size-kana | math-auto",
       "computed": [
         "asSpecified"
       ],
@@ -5559,8 +6062,45 @@
       "inherited": true
     },
     {
+      "name": "text-underline-offset",
+      "syntax": "auto | <length> | <percentage>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
       "name": "text-underline-position",
-      "syntax": "auto | [ under || [ left | right ] ]",
+      "syntax": "auto | from-font | [ under || [ left | right ] ]",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": true
+    },
+    {
+      "name": "text-wrap",
+      "syntax": "<'text-wrap-mode'> || <'text-wrap-style'>",
+      "computed": [
+        "text-wrap-mode",
+        "text-wrap-style"
+      ],
+      "initial": "wrap",
+      "inherited": true
+    },
+    {
+      "name": "text-wrap-mode",
+      "syntax": "wrap | nowrap",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "wrap",
+      "inherited": true
+    },
+    {
+      "name": "text-wrap-style",
+      "syntax": "auto | balance | stable | pretty",
       "computed": [
         "asSpecified"
       ],
@@ -5569,11 +6109,108 @@
     },
     {
       "name": "timeline-scope",
-      "syntax": "none | all | <dashed-ident>#",
+      "syntax": "none | <dashed-ident>#",
       "computed": [
         "noneOrOrderedListOfIdentifiers"
       ],
       "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "timeline-trigger",
+      "syntax": "none | [ <'timeline-trigger-name'> <'timeline-trigger-source'> <'timeline-trigger-activation-range'> [ '/' <'timeline-trigger-active-range'> ]? ]#",
+      "computed": [
+        "timeline-trigger-name",
+        "timeline-trigger-source",
+        "timeline-trigger-activation-range",
+        "timeline-trigger-active-range"
+      ],
+      "initial": [
+        "timeline-trigger-name",
+        "timeline-trigger-source",
+        "timeline-trigger-activation-range",
+        "timeline-trigger-active-range"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "timeline-trigger-activation-range",
+      "syntax": "[ <'timeline-trigger-activation-range-start'> <'timeline-trigger-activation-range-end'>? ]#",
+      "computed": [
+        "timeline-trigger-activation-range-start",
+        "timeline-trigger-activation-range-end"
+      ],
+      "initial": [
+        "timeline-trigger-activation-range-start",
+        "timeline-trigger-activation-range-end"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "timeline-trigger-activation-range-end",
+      "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+      "computed": [
+        "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "timeline-trigger-activation-range-start",
+      "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+      "computed": [
+        "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
+      "name": "timeline-trigger-active-range",
+      "syntax": "[ <'timeline-trigger-active-range-start'> <'timeline-trigger-active-range-end'>? ]#",
+      "computed": [
+        "timeline-trigger-active-range-start",
+        "timeline-trigger-active-range-end"
+      ],
+      "initial": [
+        "timeline-trigger-active-range-start",
+        "timeline-trigger-active-range-end"
+      ],
+      "inherited": false
+    },
+    {
+      "name": "timeline-trigger-active-range-end",
+      "syntax": "[ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+      "computed": [
+        "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "timeline-trigger-active-range-start",
+      "syntax": "[ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+      "computed": [
+        "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage"
+      ],
+      "initial": "auto",
+      "inherited": false
+    },
+    {
+      "name": "timeline-trigger-name",
+      "syntax": "none | <dashed-ident>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "timeline-trigger-source",
+      "syntax": "<single-animation-timeline>#",
+      "computed": [
+        "listOfNoneAutoIdentScrollOrView"
+      ],
+      "initial": "auto",
       "inherited": false
     },
     {
@@ -5614,11 +6251,20 @@
     },
     {
       "name": "transform-origin",
-      "syntax": "[ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] <length>? | [ [ center | left | right ] && [ center | top | bottom ] ] <length>?",
+      "syntax": "[ <length-percentage> | left | center | right | top | bottom ] | [ [ <length-percentage> | left | center | right ] && [ <length-percentage> | top | center | bottom ] ] <length>?",
       "computed": [
         "forLengthAbsoluteValueOtherwisePercentage"
       ],
       "initial": "50% 50% 0",
+      "inherited": false
+    },
+    {
+      "name": "transform-style",
+      "syntax": "flat | preserve-3d",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "flat",
       "inherited": false
     },
     {
@@ -5641,6 +6287,15 @@
       "inherited": false
     },
     {
+      "name": "transition-behavior",
+      "syntax": "<transition-behavior-value>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "normal",
+      "inherited": false
+    },
+    {
       "name": "transition-delay",
       "syntax": "<time>#",
       "computed": [
@@ -5651,7 +6306,7 @@
     },
     {
       "name": "transition-duration",
-      "syntax": "<time [0s,∞]>#",
+      "syntax": "<time>#",
       "computed": [
         "asSpecified"
       ],
@@ -5677,6 +6332,24 @@
       "inherited": false
     },
     {
+      "name": "translate",
+      "syntax": "none | <length-percentage> [ <length-percentage> <length>? ]?",
+      "computed": [
+        "asSpecifiedRelativeToAbsoluteLengths"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "trigger-scope",
+      "syntax": "none | all | <dashed-ident>#",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
       "name": "unicode-bidi",
       "syntax": "normal | embed | isolate | bidi-override | isolate-override | plaintext",
       "computed": [
@@ -5687,7 +6360,7 @@
     },
     {
       "name": "user-select",
-      "syntax": "auto | text | none | contain | all",
+      "syntax": "auto | text | none | all",
       "computed": [
         "asSpecified"
       ],
@@ -5705,9 +6378,9 @@
     },
     {
       "name": "vertical-align",
-      "syntax": "[ first | last] || <'alignment-baseline'> || <'baseline-shift'>",
+      "syntax": "baseline | sub | super | text-top | text-bottom | middle | top | bottom | <percentage> | <length>",
       "computed": [
-        "absoluteLengthOrKeyword"
+        "asLonghands"
       ],
       "initial": "baseline",
       "inherited": false
@@ -5753,8 +6426,17 @@
       "inherited": false
     },
     {
+      "name": "view-transition-class",
+      "syntax": "none | <custom-ident>+",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
       "name": "view-transition-name",
-      "syntax": "none | <custom-ident>",
+      "syntax": "none | <custom-ident> | match-element",
       "computed": [
         "asSpecified"
       ],
@@ -5771,64 +6453,8 @@
       "inherited": true
     },
     {
-      "name": "voice-balance",
-      "syntax": "<number> | left | center | right | leftwards | rightwards",
-      "computed": [],
-      "initial": "center",
-      "inherited": true
-    },
-    {
-      "name": "voice-duration",
-      "syntax": "auto | <time [0s,∞]>",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "voice-family",
-      "syntax": "[[<family-name> | <generic-voice>],]* [<family-name> | <generic-voice>] | preserve",
-      "computed": [],
-      "initial": "implementation-dependent",
-      "inherited": true
-    },
-    {
-      "name": "voice-pitch",
-      "syntax": "<frequency [0Hz,∞]> && absolute | [[x-low | low | medium | high | x-high] || [<frequency> | <semitones> | <percentage>]]",
-      "computed": [],
-      "initial": "medium",
-      "inherited": true
-    },
-    {
-      "name": "voice-range",
-      "syntax": "<frequency [0Hz,∞]> && absolute | [[x-low | low | medium | high | x-high] || [<frequency> | <semitones> | <percentage>]]",
-      "computed": [],
-      "initial": "medium",
-      "inherited": true
-    },
-    {
-      "name": "voice-rate",
-      "syntax": "[normal | x-slow | slow | medium | fast | x-fast] || <percentage [0,∞]>",
-      "computed": [],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "voice-stress",
-      "syntax": "normal | strong | moderate | none | reduced",
-      "computed": [],
-      "initial": "normal",
-      "inherited": true
-    },
-    {
-      "name": "voice-volume",
-      "syntax": "silent | [[x-soft | soft | medium | loud | x-loud] || <decibel>]",
-      "computed": [],
-      "initial": "medium",
-      "inherited": true
-    },
-    {
       "name": "white-space",
-      "syntax": "normal | pre | nowrap | pre-wrap | break-spaces | pre-line",
+      "syntax": "normal | pre | pre-wrap | pre-line | <'white-space-collapse'> || <'text-wrap-mode'>",
       "computed": [
         "asSpecified"
       ],
@@ -5836,8 +6462,17 @@
       "inherited": true
     },
     {
+      "name": "white-space-collapse",
+      "syntax": "collapse | preserve | preserve-breaks | preserve-spaces | break-spaces",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "collapse",
+      "inherited": true
+    },
+    {
       "name": "widows",
-      "syntax": "<integer [1,∞]>",
+      "syntax": "<integer>",
       "computed": [
         "asSpecified"
       ],
@@ -5846,7 +6481,7 @@
     },
     {
       "name": "width",
-      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
       "computed": [
         "percentageAutoOrAbsoluteLength"
       ],
@@ -5864,7 +6499,7 @@
     },
     {
       "name": "word-break",
-      "syntax": "normal | keep-all | break-all | break-word",
+      "syntax": "normal | break-all | keep-all | break-word | auto-phrase",
       "computed": [
         "asSpecified"
       ],
@@ -5882,26 +6517,12 @@
     },
     {
       "name": "word-wrap",
-      "syntax": "normal | break-word | anywhere",
+      "syntax": "normal | break-word",
       "computed": [
         "asSpecified"
       ],
       "initial": "normal",
       "inherited": true
-    },
-    {
-      "name": "wrap-flow",
-      "syntax": "auto | both | start | end | minimum | maximum | clear",
-      "computed": [],
-      "initial": "auto",
-      "inherited": false
-    },
-    {
-      "name": "wrap-through",
-      "syntax": "wrap | none",
-      "computed": [],
-      "initial": "wrap",
-      "inherited": false
     },
     {
       "name": "writing-mode",
@@ -5914,7 +6535,7 @@
     },
     {
       "name": "x",
-      "syntax": "<length-percentage>",
+      "syntax": "<length> | <percentage>",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
@@ -5923,7 +6544,7 @@
     },
     {
       "name": "y",
-      "syntax": "<length-percentage>",
+      "syntax": "<length> | <percentage>",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
@@ -5932,7 +6553,7 @@
     },
     {
       "name": "z-index",
-      "syntax": "auto | <integer> | inherit",
+      "syntax": "auto | <integer>",
       "computed": [
         "asSpecified"
       ],
@@ -5941,7 +6562,7 @@
     },
     {
       "name": "zoom",
-      "syntax": "<number [0,∞]> || <percentage [0,∞]>",
+      "syntax": "normal | reset | <number [0,∞]> || <percentage [0,∞]>",
       "computed": [
         "asSpecifiedButWithPercentageConvertedToTheEquivalentNumber"
       ],
@@ -5950,6 +6571,10 @@
     }
   ],
   "values": [
+    {
+      "name": "<absolute-size>",
+      "syntax": "xx-small | x-small | small | medium | large | x-large | xx-large | xxx-large"
+    },
     {
       "name": "<alpha-value>",
       "syntax": "<number> | <percentage>"
@@ -5972,11 +6597,31 @@
     },
     {
       "name": "<angle-percentage>",
-      "syntax": "[ <angle> | <percentage> ]"
+      "syntax": "<angle> | <percentage>"
+    },
+    {
+      "name": "<angle>",
+      "syntax": ""
+    },
+    {
+      "name": "<angular-color-hint>",
+      "syntax": "<angle-percentage> | <zero>"
+    },
+    {
+      "name": "<angular-color-stop-list>",
+      "syntax": "<angular-color-stop> , [ <angular-color-hint>? , <angular-color-stop> ]#?"
+    },
+    {
+      "name": "<angular-color-stop>",
+      "syntax": "<color> <color-stop-angle>?"
     },
     {
       "name": "<animateable-feature>",
       "syntax": "scroll-position | contents | <custom-ident>"
+    },
+    {
+      "name": "<animation-action>",
+      "syntax": "none | play | play-once | play-forwards | play-backwards | pause | reset | replay"
     },
     {
       "name": "<attachment>",
@@ -5991,40 +6636,20 @@
       "syntax": "i | s"
     },
     {
+      "name": "<attr-type>",
+      "syntax": "type( <syntax> ) | raw-string | number | <attr-unit>"
+    },
+    {
       "name": "<attribute-selector>",
       "syntax": "'[' <wq-name> ']' | '[' <wq-name> <attr-matcher> [ <string-token> | <ident-token> ] <attr-modifier>? ']'"
     },
     {
-      "name": "<auto-line-color-list>",
-      "syntax": "[ <line-color-or-repeat> ]* <auto-repeat-line-color> [ <line-color-or-repeat> ]*"
-    },
-    {
-      "name": "<auto-line-style-list>",
-      "syntax": "[ <line-style-or-repeat> ]* <auto-repeat-line-style> [ <line-style-or-repeat> ]*"
-    },
-    {
-      "name": "<auto-line-width-list>",
-      "syntax": "[ <line-width-or-repeat> ]* <auto-repeat-line-width> [ <line-width-or-repeat> ]*"
-    },
-    {
-      "name": "<auto-repeat-line-color>",
-      "syntax": "repeat( auto ',' [ <color> ]+ )"
-    },
-    {
-      "name": "<auto-repeat-line-style>",
-      "syntax": "repeat( auto ',' [ <line-style> ]+ )"
-    },
-    {
-      "name": "<auto-repeat-line-width>",
-      "syntax": "repeat( auto ',' [ <line-width> ]+ )"
-    },
-    {
       "name": "<auto-repeat>",
-      "syntax": "repeat( [ auto-fill | auto-fit ] ',' [ <line-names>? <fixed-size> ]+ <line-names>? )"
+      "syntax": "repeat( [ auto-fill | auto-fit ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
     },
     {
       "name": "<auto-track-list>",
-      "syntax": "[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>? <auto-repeat> [ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>?"
+      "syntax": "[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>? <auto-repeat>\n[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>?"
     },
     {
       "name": "<axis>",
@@ -6032,11 +6657,19 @@
     },
     {
       "name": "<baseline-position>",
-      "syntax": "[ first | last ]? && baseline"
+      "syntax": "[ first | last ]? baseline"
     },
     {
       "name": "<basic-shape-rect>",
       "syntax": "<inset()> | <rect()> | <xywh()>"
+    },
+    {
+      "name": "<basic-shape>",
+      "syntax": "<inset()> | <xywh()> | <rect()> | <circle()> | <ellipse()> | <polygon()> | <path()> | shape()"
+    },
+    {
+      "name": "<bg-clip>",
+      "syntax": "<visual-box> | border-area | text"
     },
     {
       "name": "<bg-image>",
@@ -6056,15 +6689,19 @@
     },
     {
       "name": "<blend-mode>",
-      "syntax": "normal | multiply | screen | overlay | darken | lighten | color-dodge |color-burn | hard-light | soft-light | difference | exclusion | hue | saturation | color | luminosity"
+      "syntax": "normal | multiply | screen | overlay | darken | lighten | color-dodge | color-burn | hard-light | soft-light | difference | exclusion | hue | saturation | color | luminosity"
     },
     {
-      "name": "<calc-keyword>",
+      "name": "<calc-constant>",
       "syntax": "e | pi | infinity | -infinity | NaN"
     },
     {
       "name": "<calc-product>",
-      "syntax": "<calc-value> [ [ '*' | / ] <calc-value> ]*"
+      "syntax": "<calc-value> [ '*' <calc-value> | '/' <number> ]*"
+    },
+    {
+      "name": "<calc-size-basis>",
+      "syntax": "<intrinsic-size-keyword> | <calc-size()> | any | <calc-sum>"
     },
     {
       "name": "<calc-sum>",
@@ -6072,7 +6709,15 @@
     },
     {
       "name": "<calc-value>",
-      "syntax": "<number> | <dimension> | <percentage> | <calc-keyword> | '(' <calc-sum> ')'"
+      "syntax": "<number> | <dimension> | <percentage> | <calc-constant> | ( <calc-sum> )"
+    },
+    {
+      "name": "<cf-final-image>",
+      "syntax": "<image> | <color>"
+    },
+    {
+      "name": "<cf-mixing-image>",
+      "syntax": "<percentage>? && <image>"
     },
     {
       "name": "<class-selector>",
@@ -6084,39 +6729,43 @@
     },
     {
       "name": "<color-base>",
-      "syntax": "<hex-color> | <color-function> | <named-color> | transparent"
-    },
-    {
-      "name": "<color-font-tech>",
-      "syntax": "[color-COLRv0 | color-COLRv1 | color-SVG | color-sbix | color-CBDT ]"
+      "syntax": "<hex-color> | <color-function> | <named-color> | <color-mix()> | transparent"
     },
     {
       "name": "<color-function>",
-      "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <oklab()> | <oklch()> | <ictcp()> | <jzazbz()> | <jzczhz()> | <color()>"
+      "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <oklab()> | <oklch()> | <color()>"
     },
     {
       "name": "<color-interpolation-method>",
-      "syntax": "in [ <rectangular-color-space> | <polar-color-space> <hue-interpolation-method>? ]"
+      "syntax": "in [ <rectangular-color-space> | <polar-color-space> <hue-interpolation-method>? | <custom-color-space> ]"
     },
     {
-      "name": "<color-space>",
-      "syntax": "<rectangular-color-space> | <polar-color-space>"
+      "name": "<color-stop-angle>",
+      "syntax": "[ <angle-percentage> | <zero> ]{1,2}"
+    },
+    {
+      "name": "<color-stop-length>",
+      "syntax": "<length-percentage>{1,2}"
     },
     {
       "name": "<color-stop-list>",
-      "syntax": "<linear-color-stop> ',' [ <linear-color-hint>? ',' <linear-color-stop> ]#?"
+      "syntax": "<linear-color-stop> , [ <linear-color-hint>? , <linear-color-stop> ]#?"
+    },
+    {
+      "name": "<color-stop>",
+      "syntax": "<color-stop-length> | <color-stop-angle>"
     },
     {
       "name": "<color>",
-      "syntax": "<color-base> | currentColor | <system-color>"
+      "syntax": "<color-base> | currentColor | <system-color> | <light-dark()> | <deprecated-system-color>"
     },
     {
       "name": "<colorspace-params>",
-      "syntax": "[ <predefined-rgb-params> | <xyz-params>]"
+      "syntax": "[<custom-params> | <predefined-rgb-params> | <xyz-params>]"
     },
     {
       "name": "<combinator>",
-      "syntax": "'>' | '+' | '~' | [ '|' '|' ]"
+      "syntax": "'>' | '+' | '~' | [ '||' ]"
     },
     {
       "name": "<common-lig-values>",
@@ -6131,28 +6780,16 @@
       "syntax": "textfield | menulist-button"
     },
     {
-      "name": "<complex-real-selector-list>",
-      "syntax": "<complex-real-selector>#"
-    },
-    {
-      "name": "<complex-real-selector>",
-      "syntax": "<compound-selector> [ <combinator>? <compound-selector> ]*"
-    },
-    {
       "name": "<complex-selector-list>",
       "syntax": "<complex-selector>#"
     },
     {
-      "name": "<complex-selector-unit>",
-      "syntax": "[ <compound-selector>? <pseudo-compound-selector>* ]!"
-    },
-    {
       "name": "<complex-selector>",
-      "syntax": "<complex-selector-unit> [ <combinator>? <complex-selector-unit> ]*"
+      "syntax": "<compound-selector> [ <combinator>? <compound-selector> ]*"
     },
     {
-      "name": "<composite-mode>",
-      "syntax": "clear | copy | source-over | destination-over | source-in | destination-in | source-out | destination-out | source-atop | destination-atop | xor | lighter | plus-darker | plus-lighter"
+      "name": "<composite-style>",
+      "syntax": "clear | copy | source-over | source-in | source-out | source-atop | destination-over | destination-in | destination-out | destination-atop | xor"
     },
     {
       "name": "<compositing-operator>",
@@ -6164,7 +6801,23 @@
     },
     {
       "name": "<compound-selector>",
-      "syntax": "[ <type-selector>? <subclass-selector>* ]!"
+      "syntax": "[ <type-selector>? <subclass-selector>* [ <pseudo-element-selector> <pseudo-class-selector>* ]* ]!"
+    },
+    {
+      "name": "<conic-gradient-syntax>",
+      "syntax": "[ [ [ from [ <angle> | <zero> ] ]? [ at <position> ]? ] || <color-interpolation-method> ]? , <angular-color-stop-list>"
+    },
+    {
+      "name": "<container-condition>",
+      "syntax": "[ <container-name>? <container-query>? ]!"
+    },
+    {
+      "name": "<container-name>",
+      "syntax": "<custom-ident>"
+    },
+    {
+      "name": "<container-query>",
+      "syntax": "not <query-in-parens> | <query-in-parens> [ [ and <query-in-parens> ]* | [ or <query-in-parens> ]* ]"
     },
     {
       "name": "<content-distribution>",
@@ -6172,7 +6825,7 @@
     },
     {
       "name": "<content-list>",
-      "syntax": "[ <string> | <counter()> | <counters()> | <content()> | <attr()> ]+"
+      "syntax": "[ <string> | <image> | <attr()> | <quote> | <counter> ]+"
     },
     {
       "name": "<content-position>",
@@ -6192,35 +6845,63 @@
     },
     {
       "name": "<corner-shape-value>",
-      "syntax": "round | scoop | bevel | notch | straight | squircle | superellipse(<number [0,∞]> | infinity)"
+      "syntax": "round | scoop | bevel | notch | square | squircle | <superellipse()>"
+    },
+    {
+      "name": "<counter-name>",
+      "syntax": "<custom-ident>"
+    },
+    {
+      "name": "<counter-style-name>",
+      "syntax": "<custom-ident>"
     },
     {
       "name": "<counter-style>",
-      "syntax": "<counter-style-name> | <symbols()>"
+      "syntax": "<counter-style-name> | symbols()"
     },
     {
       "name": "<counter>",
       "syntax": "<counter()> | <counters()>"
     },
     {
-      "name": "<css-type>",
-      "syntax": "<syntax-component> | <type()>"
-    },
-    {
       "name": "<cubic-bezier-easing-function>",
       "syntax": "ease | ease-in | ease-out | ease-in-out | <cubic-bezier()>"
     },
     {
-      "name": "<custom-arg>",
-      "syntax": "'$' <ident-token> ';'"
+      "name": "<cursor-predefined>",
+      "syntax": "auto | default | none | context-menu | help | pointer | progress | wait | cell | crosshair | text | vertical-text | alias | copy | move | no-drop | not-allowed | e-resize | n-resize | ne-resize | nw-resize | s-resize | se-resize | sw-resize | w-resize | ew-resize | ns-resize | nesw-resize | nwse-resize | col-resize | row-resize | all-scroll | zoom-in | zoom-out | grab | grabbing"
     },
     {
-      "name": "<custom-selector>",
-      "syntax": "<custom-arg>? ':' <extension-name> [ '(' <custom-arg>+#? ')' ]? ';'"
+      "name": "<custom-color-space>",
+      "syntax": "<dashed-ident>"
+    },
+    {
+      "name": "<custom-ident>",
+      "syntax": ""
+    },
+    {
+      "name": "<custom-params>",
+      "syntax": "<dashed-ident> [ <number> | <percentage> | none ]+"
     },
     {
       "name": "<dasharray>",
       "syntax": "[ [ <length-percentage> | <number> ]+ ]#"
+    },
+    {
+      "name": "<dashed-ident>",
+      "syntax": ""
+    },
+    {
+      "name": "<dashndashdigit-ident>",
+      "syntax": "<ident-token>"
+    },
+    {
+      "name": "<deprecated-system-color>",
+      "syntax": "ActiveBorder | ActiveCaption | AppWorkspace | Background | ButtonHighlight | ButtonShadow | CaptionText | InactiveBorder | InactiveCaption | InactiveCaptionText | InfoBackground | InfoText | Menu | MenuText | Scrollbar | ThreeDDarkShadow | ThreeDFace | ThreeDHighlight | ThreeDLightShadow | ThreeDShadow | Window | WindowFrame | WindowText"
+    },
+    {
+      "name": "<dimension>",
+      "syntax": ""
     },
     {
       "name": "<discretionary-lig-values>",
@@ -6240,7 +6921,7 @@
     },
     {
       "name": "<display-legacy>",
-      "syntax": "inline-block | inline-table | inline-flex | inline-grid"
+      "syntax": "inline-block | inline-list-item | inline-table | inline-flex | inline-grid"
     },
     {
       "name": "<display-listitem>",
@@ -6271,12 +6952,36 @@
       "syntax": "<string> | <custom-ident>+"
     },
     {
+      "name": "<feature-tag-value>",
+      "syntax": "<string> [ <integer> | on | off ]?"
+    },
+    {
+      "name": "<feature-type>",
+      "syntax": "@stylistic | @historical-forms | @styleset | @character-variant | @swash | @ornaments | @annotation"
+    },
+    {
+      "name": "<feature-value-block-list>",
+      "syntax": "<feature-value-block>+"
+    },
+    {
+      "name": "<feature-value-block>",
+      "syntax": "<feature-type> '{' <feature-value-declaration-list> '}'"
+    },
+    {
+      "name": "<feature-value-declaration-list>",
+      "syntax": "<feature-value-declaration>"
+    },
+    {
+      "name": "<feature-value-declaration>",
+      "syntax": "<custom-ident>: <integer>+;"
+    },
+    {
       "name": "<feature-value-name>",
-      "syntax": "<ident>"
+      "syntax": "<custom-ident>"
     },
     {
       "name": "<filter-function>",
-      "syntax": "<blur()> | <brightness()> | <contrast()> | <drop-shadow()> | <grayscale()> | <hue-rotate()> | <invert()> | <opacity()> | <sepia()> | <saturate()>"
+      "syntax": "<blur()> | <brightness()> | <contrast()> | <drop-shadow()> | <grayscale()> | <hue-rotate()> | <invert()> | <opacity()> | <saturate()> | <sepia()>"
     },
     {
       "name": "<filter-value-list>",
@@ -6288,31 +6993,23 @@
     },
     {
       "name": "<fixed-breadth>",
-      "syntax": "<length-percentage [0,∞]>"
+      "syntax": "<length-percentage>"
     },
     {
       "name": "<fixed-repeat>",
-      "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-names>? <fixed-size> ]+ <line-names>? )"
+      "syntax": "repeat( [ <integer [1,∞]> ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
     },
     {
       "name": "<fixed-size>",
-      "syntax": "<fixed-breadth> | minmax( <fixed-breadth> ',' <track-breadth> ) | minmax( <inflexible-breadth> ',' <fixed-breadth> )"
+      "syntax": "<fixed-breadth> | minmax( <fixed-breadth> , <track-breadth> ) | minmax( <inflexible-breadth> , <fixed-breadth> )"
     },
     {
-      "name": "<font-features-tech>",
-      "syntax": "[features-opentype | features-aat | features-graphite]"
+      "name": "<flex>",
+      "syntax": ""
     },
     {
-      "name": "<font-format>",
-      "syntax": "[<string> | collection | embedded-opentype | opentype | svg | truetype | woff | woff2 ]"
-    },
-    {
-      "name": "<font-src>",
-      "syntax": "<url> [ format(<font-format>)]? [ tech( <font-tech>#)]? | local(<family-name>)"
-    },
-    {
-      "name": "<font-tech>",
-      "syntax": "[<font-features-tech> | <color-font-tech> | variations | palettes | incremental ]"
+      "name": "<font-stretch-absolute>",
+      "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded | <percentage>"
     },
     {
       "name": "<font-variant-css2>",
@@ -6320,43 +7017,27 @@
     },
     {
       "name": "<font-weight-absolute>",
-      "syntax": "[normal | bold | <number [1,1000]>]"
+      "syntax": "normal | bold | <number [1,1000]>"
     },
     {
       "name": "<font-width-css3>",
       "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
     },
     {
+      "name": "<form-control-identifier>",
+      "syntax": "select"
+    },
+    {
       "name": "<frequency-percentage>",
-      "syntax": "[ <frequency> | <percentage> ]"
+      "syntax": "<frequency> | <percentage>"
     },
     {
-      "name": "<function-parameter>",
-      "syntax": "<custom-property-name> <css-type>? [ ':' <declaration-value> ]?"
+      "name": "<frequency>",
+      "syntax": ""
     },
     {
-      "name": "<gap-auto-repeat-rule>",
-      "syntax": "repeat( auto ',' <gap-rule># )"
-    },
-    {
-      "name": "<gap-auto-rule-list>",
-      "syntax": "<gap-rule-or-repeat>#? ',' <gap-auto-repeat-rule> ',' <gap-rule-or-repeat>#?"
-    },
-    {
-      "name": "<gap-repeat-rule>",
-      "syntax": "repeat( <integer [1,∞]> ',' <gap-rule># )"
-    },
-    {
-      "name": "<gap-rule-list>",
-      "syntax": "<gap-rule-or-repeat>#"
-    },
-    {
-      "name": "<gap-rule-or-repeat>",
-      "syntax": "<gap-rule> | <gap-repeat-rule>"
-    },
-    {
-      "name": "<gap-rule>",
-      "syntax": "<line-width> || <line-style> || <color>"
+      "name": "<general-enclosed>",
+      "syntax": "[ <function-token> <any-value> ) ] | ( <ident> <any-value> )"
     },
     {
       "name": "<generic-complete>",
@@ -6364,19 +7045,11 @@
     },
     {
       "name": "<generic-family>",
-      "syntax": "<generic-script-specific>| <generic-complete> | <generic-incomplete>"
+      "syntax": "<generic-complete> | <generic-incomplete> | emoji | fangsong"
     },
     {
       "name": "<generic-incomplete>",
       "syntax": "ui-serif | ui-sans-serif | ui-monospace | ui-rounded"
-    },
-    {
-      "name": "<generic-script-specific>",
-      "syntax": "generic(fangsong) | generic(kai) | generic(khmer-mul) | generic(nastaliq)"
-    },
-    {
-      "name": "<generic-voice>",
-      "syntax": "[<age>? <gender> <integer>?]"
     },
     {
       "name": "<geometry-box>",
@@ -6384,11 +7057,11 @@
     },
     {
       "name": "<gradient>",
-      "syntax": "<linear-gradient()> | <repeating-linear-gradient()> | <radial-gradient()> | <repeating-radial-gradient()>"
+      "syntax": "<linear-gradient()> | <repeating-linear-gradient()> | <radial-gradient()> | <repeating-radial-gradient()> | <conic-gradient()> | <repeating-conic-gradient()>"
     },
     {
       "name": "<grid-line>",
-      "syntax": "auto | <custom-ident> | [ [ <integer [-∞,-1]> | <integer [1,∞]> ] && <custom-ident>? ] | [ span && [ <integer [1,∞]> || <custom-ident> ] ]"
+      "syntax": "auto | <custom-ident> | [ <integer> && <custom-ident>? ] | [ span && [ <integer> || <custom-ident> ] ]"
     },
     {
       "name": "<historical-lig-values>",
@@ -6407,28 +7080,40 @@
       "syntax": "<hash-token>"
     },
     {
-      "name": "<image>",
-      "syntax": "<url> | <gradient>"
+      "name": "<ident>",
+      "syntax": ""
     },
     {
-      "name": "<import-conditions>",
-      "syntax": "[ supports( [ <supports-condition> | <declaration> ] ) ]? <media-query-list>?"
+      "name": "<image-set-option>",
+      "syntax": "[ <image> | <string> ] [ <resolution> || type(<string>) ]"
+    },
+    {
+      "name": "<image-src>",
+      "syntax": "<url> | <string>"
+    },
+    {
+      "name": "<image-tags>",
+      "syntax": "ltr | rtl"
+    },
+    {
+      "name": "<image>",
+      "syntax": "<url> | <image()> | <image-set()> | <element()> | <paint()> | <cross-fade()> | <gradient>"
     },
     {
       "name": "<inflexible-breadth>",
-      "syntax": "<length-percentage [0,∞]> | min-content | max-content | auto"
+      "syntax": "<length-percentage> | min-content | max-content | auto"
     },
     {
-      "name": "<isolation-mode>",
-      "syntax": "auto | isolate"
+      "name": "<integer>",
+      "syntax": "<number-token>"
     },
     {
       "name": "<keyframe-block>",
-      "syntax": "<keyframe-selector># '{' <declaration-list> '}'"
+      "syntax": "<keyframe-selector># {\n  <declaration-list>\n}"
     },
     {
       "name": "<keyframe-selector>",
-      "syntax": "from | to | <percentage [0,100]>"
+      "syntax": "from | to | <percentage [0,100]> | <timeline-range-name> <percentage>"
     },
     {
       "name": "<keyframes-name>",
@@ -6439,44 +7124,16 @@
       "syntax": "<ident> [ '.' <ident> ]*"
     },
     {
-      "name": "<layout-box>",
-      "syntax": "<visual-box> | margin-box"
-    },
-    {
       "name": "<leader-type>",
       "syntax": "dotted | solid | space | <string>"
     },
     {
-      "name": "<legacy-hsl-syntax>",
-      "syntax": "hsl( <hue>, <percentage>, <percentage>, <alpha-value>? )"
-    },
-    {
-      "name": "<legacy-hsla-syntax>",
-      "syntax": "hsla( <hue>, <percentage>, <percentage>, <alpha-value>? )"
-    },
-    {
-      "name": "<legacy-pseudo-element-selector>",
-      "syntax": "':' [before | after | first-line | first-letter]"
-    },
-    {
-      "name": "<legacy-rgb-syntax>",
-      "syntax": "rgb( <percentage>#{3} ',' <alpha-value>? ) | rgb( <number>#{3} ',' <alpha-value>? )"
-    },
-    {
-      "name": "<legacy-rgba-syntax>",
-      "syntax": "rgba( <percentage>#{3} ',' <alpha-value>? ) | rgba( <number>#{3} ',' <alpha-value>? )"
-    },
-    {
       "name": "<length-percentage>",
-      "syntax": "[ <length> | <percentage> ]"
+      "syntax": "<length> | <percentage>"
     },
     {
-      "name": "<line-color-list>",
-      "syntax": "[ <line-color-or-repeat> ]+"
-    },
-    {
-      "name": "<line-color-or-repeat>",
-      "syntax": "[ <color> | <repeat-line-color> ]"
+      "name": "<length>",
+      "syntax": ""
     },
     {
       "name": "<line-name-list>",
@@ -6487,28 +7144,12 @@
       "syntax": "'[' <custom-ident>* ']'"
     },
     {
-      "name": "<line-style-list>",
-      "syntax": "[ <line-style-or-repeat> ]+"
-    },
-    {
-      "name": "<line-style-or-repeat>",
-      "syntax": "[ <line-style> | <repeat-line-style> ]"
-    },
-    {
       "name": "<line-style>",
       "syntax": "none | hidden | dotted | dashed | solid | double | groove | ridge | inset | outset"
     },
     {
-      "name": "<line-width-list>",
-      "syntax": "[ <line-width-or-repeat> ]+"
-    },
-    {
-      "name": "<line-width-or-repeat>",
-      "syntax": "[ <line-width> | <repeat-line-width> ]"
-    },
-    {
       "name": "<line-width>",
-      "syntax": "<length [0,∞]> | thin | medium | thick"
+      "syntax": "<length> | thin | medium | thick"
     },
     {
       "name": "<linear-color-hint>",
@@ -6516,7 +7157,7 @@
     },
     {
       "name": "<linear-color-stop>",
-      "syntax": "<color> <length-percentage>?"
+      "syntax": "<color> <color-stop-length>?"
     },
     {
       "name": "<linear-easing-function>",
@@ -6524,19 +7165,15 @@
     },
     {
       "name": "<linear-gradient-syntax>",
-      "syntax": "[ <angle> | <zero> | to <side-or-corner> ]? ',' <color-stop-list>"
-    },
-    {
-      "name": "<link-param>",
-      "syntax": "param( <custom-property-name> <declaration-value>? )"
-    },
-    {
-      "name": "<marker-ref>",
-      "syntax": "<url>"
+      "syntax": "[ [ <angle> | <zero> | to <side-or-corner> ] || <color-interpolation-method> ]? , <color-stop-list>"
     },
     {
       "name": "<mask-layer>",
       "syntax": "<mask-reference> || <position> [ / <bg-size> ]? || <repeat-style> || <geometry-box> || [ <geometry-box> | no-clip ] || <compositing-operator> || <masking-mode>"
+    },
+    {
+      "name": "<mask-position>",
+      "syntax": "[ <length-percentage> | left | center | right ] [ <length-percentage> | top | center | bottom ]?"
     },
     {
       "name": "<mask-reference>",
@@ -6552,23 +7189,23 @@
     },
     {
       "name": "<media-and>",
-      "syntax": "and <media-in-parens>"
+      "syntax": "<media-in-parens> [ and <media-in-parens> ]+"
     },
     {
       "name": "<media-condition-without-or>",
-      "syntax": "<media-not> | <media-in-parens> <media-and>*"
+      "syntax": "<media-not> | <media-and> | <media-in-parens>"
     },
     {
       "name": "<media-condition>",
-      "syntax": "<media-not> | <media-in-parens> [ <media-and>* | <media-or>* ]"
+      "syntax": "<media-not> | <media-and> | <media-or> | <media-in-parens>"
     },
     {
       "name": "<media-feature>",
-      "syntax": "[ <mf-plain> | <mf-boolean> | <mf-range> ]"
+      "syntax": "( [ <mf-plain> | <mf-boolean> | <mf-range> ] )"
     },
     {
       "name": "<media-in-parens>",
-      "syntax": "'(' <media-condition> ')' | '(' <media-feature> ')' | <general-enclosed>"
+      "syntax": "( <media-condition> ) | <media-feature> | <general-enclosed>"
     },
     {
       "name": "<media-not>",
@@ -6576,7 +7213,11 @@
     },
     {
       "name": "<media-or>",
-      "syntax": "or <media-in-parens>"
+      "syntax": "<media-in-parens> [ or <media-in-parens> ]+"
+    },
+    {
+      "name": "<media-query-list>",
+      "syntax": "<media-query>#"
     },
     {
       "name": "<media-query>",
@@ -6591,72 +7232,60 @@
       "syntax": "<mf-name>"
     },
     {
-      "name": "<mf-comparison>",
-      "syntax": "<mf-lt> | <mf-gt> | <mf-eq>"
-    },
-    {
-      "name": "<mf-eq>",
-      "syntax": "'='"
-    },
-    {
-      "name": "<mf-gt>",
-      "syntax": "'>' '='?"
-    },
-    {
-      "name": "<mf-lt>",
-      "syntax": "'<' '='?"
-    },
-    {
       "name": "<mf-name>",
       "syntax": "<ident>"
     },
     {
       "name": "<mf-plain>",
-      "syntax": "<mf-name> ':' <mf-value>"
+      "syntax": "<mf-name> : <mf-value>"
     },
     {
       "name": "<mf-range>",
-      "syntax": "<mf-name> <mf-comparison> <mf-value> | <mf-value> <mf-comparison> <mf-name> | <mf-value> <mf-lt> <mf-name> <mf-lt> <mf-value> | <mf-value> <mf-gt> <mf-name> <mf-gt> <mf-value>"
+      "syntax": "<mf-name> [ '<' | '>' ]? '='? <mf-value>\n| <mf-value> [ '<' | '>' ]? '='? <mf-name>\n| <mf-value> '<' '='? <mf-name> '<' '='? <mf-value>\n| <mf-value> '>' '='? <mf-name> '>' '='? <mf-value>"
     },
     {
       "name": "<mf-value>",
       "syntax": "<number> | <dimension> | <ident> | <ratio>"
     },
     {
-      "name": "<modern-hsl-syntax>",
-      "syntax": "hsl( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
-    },
-    {
-      "name": "<modern-hsla-syntax>",
-      "syntax": "hsla( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
-    },
-    {
-      "name": "<modern-rgb-syntax>",
-      "syntax": "rgb( [ <number> | <percentage> | none]{3} [ / [<alpha-value> | none] ]? )"
-    },
-    {
-      "name": "<modern-rgba-syntax>",
-      "syntax": "rgba( [ <number> | <percentage> | none]{3} [ / [<alpha-value> | none] ]? )"
-    },
-    {
-      "name": "<mq-boolean>",
-      "syntax": "<integer [0,1]>"
+      "name": "<n-dimension>",
+      "syntax": "<dimension-token>"
     },
     {
       "name": "<name-repeat>",
-      "syntax": "repeat( [ <integer [1,∞]> | auto-fill ], <line-names>+)"
+      "syntax": "repeat( [ <integer [1,∞]> | auto-fill ], <line-names>+ )"
+    },
+    {
+      "name": "<named-color>",
+      "syntax": "aliceblue | antiquewhite | aqua | aquamarine | azure | beige | bisque | black | blanchedalmond | blue | blueviolet | brown | burlywood | cadetblue | chartreuse | chocolate | coral | cornflowerblue | cornsilk | crimson | cyan | darkblue | darkcyan | darkgoldenrod | darkgray | darkgreen | darkgrey | darkkhaki | darkmagenta | darkolivegreen | darkorange | darkorchid | darkred | darksalmon | darkseagreen | darkslateblue | darkslategray | darkslategrey | darkturquoise | darkviolet | deeppink | deepskyblue | dimgray | dimgrey | dodgerblue | firebrick | floralwhite | forestgreen | fuchsia | gainsboro | ghostwhite | gold | goldenrod | gray | green | greenyellow | grey | honeydew | hotpink | indianred | indigo | ivory | khaki | lavender | lavenderblush | lawngreen | lemonchiffon | lightblue | lightcoral | lightcyan | lightgoldenrodyellow | lightgray | lightgreen | lightgrey | lightpink | lightsalmon | lightseagreen | lightskyblue | lightslategray | lightslategrey | lightsteelblue | lightyellow | lime | limegreen | linen | magenta | maroon | mediumaquamarine | mediumblue | mediumorchid | mediumpurple | mediumseagreen | mediumslateblue | mediumspringgreen | mediumturquoise | mediumvioletred | midnightblue | mintcream | mistyrose | moccasin | navajowhite | navy | oldlace | olive | olivedrab | orange | orangered | orchid | palegoldenrod | palegreen | paleturquoise | palevioletred | papayawhip | peachpuff | peru | pink | plum | powderblue | purple | rebeccapurple | red | rosybrown | royalblue | saddlebrown | salmon | sandybrown | seagreen | seashell | sienna | silver | skyblue | slateblue | slategray | slategrey | snow | springgreen | steelblue | tan | teal | thistle | tomato | turquoise | violet | wheat | white | whitesmoke | yellow | yellowgreen"
     },
     {
       "name": "<namespace-prefix>",
       "syntax": "<ident>"
     },
     {
+      "name": "<ndash-dimension>",
+      "syntax": "<dimension-token>"
+    },
+    {
+      "name": "<ndashdigit-dimension>",
+      "syntax": "<dimension-token>"
+    },
+    {
+      "name": "<ndashdigit-ident>",
+      "syntax": "<ident-token>"
+    },
+    {
       "name": "<ns-prefix>",
       "syntax": "[ <ident-token> | '*' ]? '|'"
     },
     {
-      "name": "<number-optional-number>",
-      "syntax": "<number> <number>?"
+      "name": "<number-percentage>",
+      "syntax": "<number> | <percentage>"
+    },
+    {
+      "name": "<number>",
+      "syntax": ""
     },
     {
       "name": "<numeric-figure-values>",
@@ -6679,20 +7308,44 @@
       "syntax": "<number> | <percentage>"
     },
     {
-      "name": "<opentype-tag>",
-      "syntax": "<string>"
+      "name": "<outline-line-style>",
+      "syntax": "none | dotted | dashed | solid | double | groove | ridge | inset | outset"
+    },
+    {
+      "name": "<outline-radius>",
+      "syntax": "<length> | <percentage>"
     },
     {
       "name": "<overflow-position>",
       "syntax": "unsafe | safe"
     },
     {
+      "name": "<overflow>",
+      "syntax": ""
+    },
+    {
+      "name": "<page-body>",
+      "syntax": "<declaration>? [ ; <page-body> ]? | <page-margin-box> <page-body>"
+    },
+    {
+      "name": "<page-margin-box-type>",
+      "syntax": "@top-left-corner | @top-left | @top-center | @top-right | @top-right-corner | @bottom-left-corner | @bottom-left | @bottom-center | @bottom-right | @bottom-right-corner | @left-top | @left-middle | @left-bottom | @right-top | @right-middle | @right-bottom"
+    },
+    {
+      "name": "<page-margin-box>",
+      "syntax": "<page-margin-box-type> '{' <declaration-list> '}'"
+    },
+    {
       "name": "<page-selector-list>",
-      "syntax": "<page-selector>#"
+      "syntax": "[ <page-selector># ]?"
     },
     {
       "name": "<page-selector>",
-      "syntax": "[ <ident-token>? <pseudo-page>* ]!"
+      "syntax": "<pseudo-page>+ | <ident> <pseudo-page>*"
+    },
+    {
+      "name": "<page-size>",
+      "syntax": "A5 | A4 | A3 | B5 | B4 | JIS-B5 | JIS-B4 | letter | legal | ledger"
     },
     {
       "name": "<paint-box>",
@@ -6700,11 +7353,15 @@
     },
     {
       "name": "<paint>",
-      "syntax": "none | <image> | <svg-paint>"
+      "syntax": "none | <color> | <url> [none | <color>]? | context-fill | context-stroke"
     },
     {
-      "name": "<points>",
-      "syntax": "[ <number>+ ]#"
+      "name": "<palette-identifier>",
+      "syntax": "<dashed-ident>"
+    },
+    {
+      "name": "<percentage>",
+      "syntax": ""
     },
     {
       "name": "<polar-color-space>",
@@ -6712,11 +7369,11 @@
     },
     {
       "name": "<position-area>",
-      "syntax": "[ [ left | center | right | span-left | span-right | x-start | x-end | span-x-start | span-x-end | x-self-start | x-self-end | span-x-self-start | span-x-self-end | span-all ] || [ top | center | bottom | span-top | span-bottom | y-start | y-end | span-y-start | span-y-end | y-self-start | y-self-end | span-y-self-start | span-y-self-end | span-all ] | [ block-start | center | block-end | span-block-start | span-block-end | span-all ] || [ inline-start | center | inline-end | span-inline-start | span-inline-end | span-all ] | [ self-block-start | center | self-block-end | span-self-block-start | span-self-block-end | span-all ] || [ self-inline-start | center | self-inline-end | span-self-inline-start | span-self-inline-end | span-all ] | [ start | center | end | span-start | span-end | span-all ]{1,2} | [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2} ]"
+      "syntax": "[ left | center | right | span-left | span-right | x-start | x-end | span-x-start | span-x-end | x-self-start | x-self-end | span-x-self-start | span-x-self-end | span-all ] || [ top | center | bottom | span-top | span-bottom | y-start | y-end | span-y-start | span-y-end | y-self-start | y-self-end | span-y-self-start | span-y-self-end | span-all ] | [ block-start | center | block-end | span-block-start | span-block-end | span-all ] || [ inline-start | center | inline-end | span-inline-start | span-inline-end | span-all ] | [ self-block-start | center | self-block-end | span-self-block-start | span-self-block-end | span-all ] || [ self-inline-start | center | self-inline-end | span-self-inline-start | span-self-inline-end | span-all ] | [ start | center | end | span-start | span-end | span-all ]{1,2} | [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2}"
     },
     {
       "name": "<position>",
-      "syntax": "[ [ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right ] && [ top | center | bottom ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ] ]"
+      "syntax": "[ [ left | center | right ] || [ top | center | bottom ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ]? | [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ] ]"
     },
     {
       "name": "<predefined-rgb-params>",
@@ -6724,27 +7381,23 @@
     },
     {
       "name": "<predefined-rgb>",
-      "syntax": "srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020 | rec2100-pq | rec2100-hlg | rec2100-linear"
+      "syntax": "srgb | srgb-linear | display-p3 | display-p3-linear | a98-rgb | prophoto-rgb | rec2020"
     },
     {
       "name": "<pseudo-class-selector>",
       "syntax": "':' <ident-token> | ':' <function-token> <any-value> ')'"
     },
     {
-      "name": "<pseudo-compound-selector>",
-      "syntax": "<pseudo-element-selector> <pseudo-class-selector>*"
-    },
-    {
       "name": "<pseudo-element-selector>",
-      "syntax": "':' <pseudo-class-selector> | <legacy-pseudo-element-selector>"
+      "syntax": "':' <pseudo-class-selector>"
     },
     {
       "name": "<pseudo-page>",
-      "syntax": "':' [ left | right | first | blank ]"
+      "syntax": ": [ left | right | first | blank ]"
     },
     {
-      "name": "<pt-name-selector>",
-      "syntax": "'*' | <custom-ident>"
+      "name": "<query-in-parens>",
+      "syntax": "( <container-query> ) | ( <size-feature> ) | style( <style-query> ) | scroll-state( <scroll-state-query> ) | <general-enclosed>"
     },
     {
       "name": "<quote>",
@@ -6756,7 +7409,7 @@
     },
     {
       "name": "<radial-gradient-syntax>",
-      "syntax": "[ <radial-shape> || <radial-size> ]? [ at <position> ]? ',' <color-stop-list>"
+      "syntax": "[ [ [ <radial-shape> || <radial-size> ]? [ at <position> ]? ] || <color-interpolation-method> ]? , <color-stop-list>"
     },
     {
       "name": "<radial-shape>",
@@ -6776,15 +7429,7 @@
     },
     {
       "name": "<rectangular-color-space>",
-      "syntax": "srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020 | lab | oklab | xyz | xyz-d50 | xyz-d65"
-    },
-    {
-      "name": "<relative-real-selector-list>",
-      "syntax": "<relative-real-selector>#"
-    },
-    {
-      "name": "<relative-real-selector>",
-      "syntax": "<combinator>? <complex-real-selector>"
+      "syntax": "srgb | srgb-linear | display-p3 | display-p3-linear | a98-rgb | prophoto-rgb | rec2020 | lab | oklab | xyz | xyz-d50 | xyz-d65"
     },
     {
       "name": "<relative-selector-list>",
@@ -6795,20 +7440,16 @@
       "syntax": "<combinator>? <complex-selector>"
     },
     {
-      "name": "<repeat-line-color>",
-      "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <color> ]+ )"
-    },
-    {
-      "name": "<repeat-line-style>",
-      "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-style> ]+ )"
-    },
-    {
-      "name": "<repeat-line-width>",
-      "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-width> ]+ )"
+      "name": "<relative-size>",
+      "syntax": "larger | smaller"
     },
     {
       "name": "<repeat-style>",
-      "syntax": "repeat-x | repeat-y | [repeat | space | round | no-repeat]{1,2}"
+      "syntax": "repeat-x | repeat-y | [ repeat | space | round | no-repeat ]{1,2}"
+    },
+    {
+      "name": "<resolution>",
+      "syntax": ""
     },
     {
       "name": "<reversed-counter-name>",
@@ -6817,6 +7458,26 @@
     {
       "name": "<rounding-strategy>",
       "syntax": "nearest | up | down | to-zero"
+    },
+    {
+      "name": "<scope-end>",
+      "syntax": "<selector-list>"
+    },
+    {
+      "name": "<scope-start>",
+      "syntax": "<selector-list>"
+    },
+    {
+      "name": "<scroll-state-feature>",
+      "syntax": "<media-query-list>"
+    },
+    {
+      "name": "<scroll-state-in-parens>",
+      "syntax": "( <scroll-state-query> ) | ( <scroll-state-feature> ) | <general-enclosed>"
+    },
+    {
+      "name": "<scroll-state-query>",
+      "syntax": "not <scroll-state-in-parens> | <scroll-state-in-parens> [ [ and <scroll-state-in-parens> ]* | [ or <scroll-state-in-parens> ]* ] | <scroll-state-feature>"
     },
     {
       "name": "<scroller>",
@@ -6831,24 +7492,36 @@
       "syntax": "center | start | end | self-start | self-end | flex-start | flex-end"
     },
     {
+      "name": "<shadow-t>",
+      "syntax": "[ <length>{2,3} && <color>? ]"
+    },
+    {
       "name": "<shadow>",
-      "syntax": "<color>? && [<length>{2} <length [0,∞]>? <length>?] && inset?"
+      "syntax": "inset? && <length>{2,4} && <color>?"
     },
     {
       "name": "<shape-box>",
       "syntax": "<visual-box> | margin-box"
     },
     {
+      "name": "<shape>",
+      "syntax": "rect(<top>, <right>, <bottom>, <left>)"
+    },
+    {
       "name": "<side-or-corner>",
-      "syntax": "[left | right] || [top | bottom]"
+      "syntax": "[ left | right ] || [ top | bottom ]"
     },
     {
-      "name": "<simple-selector-list>",
-      "syntax": "<simple-selector>#"
+      "name": "<signed-integer>",
+      "syntax": "<number-token>"
     },
     {
-      "name": "<simple-selector>",
-      "syntax": "<type-selector> | <subclass-selector>"
+      "name": "<signless-integer>",
+      "syntax": "<number-token>"
+    },
+    {
+      "name": "<single-animation-composition>",
+      "syntax": "replace | add | accumulate"
     },
     {
       "name": "<single-animation-direction>",
@@ -6860,15 +7533,19 @@
     },
     {
       "name": "<single-animation-iteration-count>",
-      "syntax": "infinite | <number [0,∞]>"
+      "syntax": "infinite | <number>"
     },
     {
       "name": "<single-animation-play-state>",
       "syntax": "running | paused"
     },
     {
+      "name": "<single-animation-timeline>",
+      "syntax": "auto | none | <dashed-ident> | <scroll()> | <view()>"
+    },
+    {
       "name": "<single-animation>",
-      "syntax": "<time [0s,∞]> || <easing-function> || <time> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ]"
+      "syntax": "<'animation-duration'> || <easing-function> || <'animation-delay'> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ] || <single-animation-timeline>"
     },
     {
       "name": "<single-transition-property>",
@@ -6876,23 +7553,15 @@
     },
     {
       "name": "<single-transition>",
-      "syntax": "[ none | <single-transition-property> ] || <time> || <easing-function> || <time>"
+      "syntax": "[ none | <single-transition-property> ] || <time> || <easing-function> || <time> || <transition-behavior-value>"
     },
     {
-      "name": "<source-size-list>",
-      "syntax": "<source-size>#? ',' <source-size-value>"
+      "name": "<size-feature>",
+      "syntax": "<media-query-list>"
     },
     {
-      "name": "<source-size-value>",
-      "syntax": "<length> | auto"
-    },
-    {
-      "name": "<source-size>",
-      "syntax": "<media-condition> <source-size-value> | auto"
-    },
-    {
-      "name": "<spread-shadow>",
-      "syntax": "<'box-shadow-color'>? && [ <'box-shadow-offset'> [ <'box-shadow-blur'> <'box-shadow-spread'>? ]? ] && <'box-shadow-position'>?"
+      "name": "<size>",
+      "syntax": "closest-side | farthest-side | closest-corner | farthest-corner | <length> | <length-percentage>{2}"
     },
     {
       "name": "<step-easing-function>",
@@ -6901,6 +7570,22 @@
     {
       "name": "<step-position>",
       "syntax": "jump-start | jump-end | jump-none | jump-both | start | end"
+    },
+    {
+      "name": "<string>",
+      "syntax": ""
+    },
+    {
+      "name": "<style-feature>",
+      "syntax": "<declaration>"
+    },
+    {
+      "name": "<style-in-parens>",
+      "syntax": "( <style-query> ) | ( <style-feature> ) | <general-enclosed>"
+    },
+    {
+      "name": "<style-query>",
+      "syntax": "not <style-in-parens> | <style-in-parens> [ [ and <style-in-parens> ]* | [ or <style-in-parens> ]* ] | <style-feature>"
     },
     {
       "name": "<subclass-selector>",
@@ -6912,19 +7597,19 @@
     },
     {
       "name": "<supports-decl>",
-      "syntax": "'(' <declaration> ')'"
+      "syntax": "( <declaration> )"
     },
     {
       "name": "<supports-feature>",
-      "syntax": "<supports-decl>"
+      "syntax": "<supports-decl> | <supports-selector-fn>"
     },
     {
       "name": "<supports-in-parens>",
-      "syntax": "'(' <supports-condition> ')' | <supports-feature> | <general-enclosed>"
+      "syntax": "( <supports-condition> ) | <supports-feature> | <general-enclosed>"
     },
     {
-      "name": "<svg-paint>",
-      "syntax": "child | child( <integer> )"
+      "name": "<supports-selector-fn>",
+      "syntax": "selector( <complex-selector> )"
     },
     {
       "name": "<symbol>",
@@ -6933,6 +7618,10 @@
     {
       "name": "<symbols-type>",
       "syntax": "cyclic | numeric | alphabetic | symbolic | fixed"
+    },
+    {
+      "name": "<system-color>",
+      "syntax": "AccentColor | AccentColorText | ActiveText | ButtonBorder | ButtonFace | ButtonText | Canvas | CanvasText | Field | FieldText | GrayText | Highlight | HighlightText | LinkText | Mark | MarkText | SelectedItem | SelectedItemText | VisitedText"
     },
     {
       "name": "<system-family-name>",
@@ -6944,15 +7633,23 @@
     },
     {
       "name": "<text-edge>",
-      "syntax": "[ text | ideographic | ideographic-ink ] | [ text | ideographic | ideographic-ink | cap | ex ] [ text | ideographic | ideographic-ink | alphabetic ]"
+      "syntax": "[ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]?"
     },
     {
       "name": "<time-percentage>",
-      "syntax": "[ <time> | <percentage> ]"
+      "syntax": "<time> | <percentage>"
+    },
+    {
+      "name": "<time>",
+      "syntax": ""
+    },
+    {
+      "name": "<timeline-range-name>",
+      "syntax": "cover | contain | entry | exit | entry-crossing | exit-crossing"
     },
     {
       "name": "<track-breadth>",
-      "syntax": "<length-percentage [0,∞]> | <flex [0,∞]> | min-content | max-content | auto"
+      "syntax": "<length-percentage> | <flex> | min-content | max-content | auto"
     },
     {
       "name": "<track-list>",
@@ -6960,15 +7657,23 @@
     },
     {
       "name": "<track-repeat>",
-      "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-names>? <track-size> ]+ <line-names>? )"
+      "syntax": "repeat( [ <integer [1,∞]> ] , [ <line-names>? <track-size> ]+ <line-names>? )"
     },
     {
       "name": "<track-size>",
-      "syntax": "<track-breadth> | minmax( <inflexible-breadth> ',' <track-breadth> ) | fit-content( <length-percentage [0,∞]> )"
+      "syntax": "<track-breadth> | minmax( <inflexible-breadth> , <track-breadth> ) | fit-content( <length-percentage> )"
+    },
+    {
+      "name": "<transform-function>",
+      "syntax": "<matrix()> | <translate()> | <translateX()> | <translateY()> | <scale()> | <scaleX()> | <scaleY()> | <rotate()> | <skew()> | <skewX()> | <skewY()> | <matrix3d()> | <translate3d()> | <translateZ()> | <scale3d()> | <scaleZ()> | <rotate3d()> | <rotateX()> | <rotateY()> | <rotateZ()> | <perspective()>"
     },
     {
       "name": "<transform-list>",
       "syntax": "<transform-function>+"
+    },
+    {
+      "name": "<transition-behavior-value>",
+      "syntax": "normal | allow-discrete"
     },
     {
       "name": "<try-size>",
@@ -6979,16 +7684,20 @@
       "syntax": "flip-block || flip-inline || flip-start"
     },
     {
+      "name": "<type-or-unit>",
+      "syntax": "string | color | url | integer | number | length | angle | time | frequency | cap | ch | em | ex | ic | lh | rlh | rem | vb | vi | vw | vh | vmin | vmax | mm | Q | cm | in | pt | pc | px | deg | grad | rad | turn | ms | s | Hz | kHz | %"
+    },
+    {
       "name": "<type-selector>",
       "syntax": "<wq-name> | <ns-prefix>? '*'"
     },
     {
-      "name": "<type>",
-      "syntax": "'<' [ number | string ] '>'"
+      "name": "<url>",
+      "syntax": ""
     },
     {
-      "name": "<url>",
-      "syntax": "<url()> | <src()>"
+      "name": "<viewport-length>",
+      "syntax": "auto | <length-percentage>"
     },
     {
       "name": "<visual-box>",
@@ -7000,10 +7709,10 @@
     },
     {
       "name": "<xyz-params>",
-      "syntax": "<xyz-space> [ <number> | <percentage> | none ]{3}"
+      "syntax": "<xyz> [ <number> | <percentage> | none ]{3}"
     },
     {
-      "name": "<xyz-space>",
+      "name": "<xyz>",
       "syntax": "xyz | xyz-d50 | xyz-d65"
     },
     {
@@ -7020,7 +7729,7 @@
     },
     {
       "name": "anchor-size()",
-      "syntax": "anchor-size( [ <anchor-name> || <anchor-size> ]? ',' <length-percentage>? )"
+      "syntax": "anchor-size( [ <anchor-name> || <anchor-size> ]? , <length-percentage>? )"
     },
     {
       "name": "asin()",
@@ -7035,6 +7744,10 @@
       "syntax": "atan2( <calc-sum>, <calc-sum> )"
     },
     {
+      "name": "attr()",
+      "syntax": "attr( <attr-name> <attr-type>? , <declaration-value>? )"
+    },
+    {
       "name": "blur()",
       "syntax": "blur( <length>? )"
     },
@@ -7047,24 +7760,32 @@
       "syntax": "calc( <calc-sum> )"
     },
     {
+      "name": "calc-size()",
+      "syntax": "calc-size( <calc-size-basis>, <calc-sum> )"
+    },
+    {
       "name": "circle()",
       "syntax": "circle( <radial-size>? [ at <position> ]? )"
     },
     {
       "name": "clamp()",
-      "syntax": "clamp( [ <calc-sum> | none ], <calc-sum>, [ <calc-sum> | none ] )"
+      "syntax": "clamp( <calc-sum>#{3} )"
     },
     {
-      "name": "content()",
-      "syntax": "content( [ text | before | after | first-letter | marker ]? )"
+      "name": "color()",
+      "syntax": "color( [ from <color> ]? <colorspace-params> [ / [ <alpha-value> | none ] ]? )"
+    },
+    {
+      "name": "color-mix()",
+      "syntax": "color-mix( <color-interpolation-method> , [ <color> && <percentage [0,100]>? ]#{2})"
+    },
+    {
+      "name": "conic-gradient()",
+      "syntax": "conic-gradient( [ <conic-gradient-syntax> ] )"
     },
     {
       "name": "contrast()",
       "syntax": "contrast( [ <number> | <percentage> ]? )"
-    },
-    {
-      "name": "control-value()",
-      "syntax": "control-value( <type>? )"
     },
     {
       "name": "cos()",
@@ -7079,6 +7800,10 @@
       "syntax": "counters( <counter-name>, <string>, <counter-style>? )"
     },
     {
+      "name": "cross-fade()",
+      "syntax": "cross-fade( <cf-mixing-image> , <cf-final-image>? )"
+    },
+    {
       "name": "cubic-bezier()",
       "syntax": "cubic-bezier( [ <number [0,1]>, <number> ]#{2} )"
     },
@@ -7091,40 +7816,36 @@
       "syntax": "dynamic-range-limit-mix( [ <'dynamic-range-limit'> && <percentage [0,100]> ]#{2,} )"
     },
     {
+      "name": "element()",
+      "syntax": "element( <id-selector> )"
+    },
+    {
       "name": "ellipse()",
       "syntax": "ellipse( <radial-size>? [ at <position> ]? )"
     },
     {
       "name": "env()",
-      "syntax": "env( <custom-ident> <integer [0,∞]>*, <declaration-value>? )"
+      "syntax": "env( <custom-ident> , <declaration-value>? )"
     },
     {
       "name": "exp()",
       "syntax": "exp( <calc-sum> )"
     },
     {
-      "name": "filter()",
-      "syntax": "filter( [ <image> | <string> ], <filter-value-list> )"
-    },
-    {
       "name": "fit-content()",
-      "syntax": "fit-content( <length-percentage> )"
+      "syntax": "fit-content( <length-percentage [0,∞]> )"
     },
     {
       "name": "grayscale()",
       "syntax": "grayscale( [ <number> | <percentage> ]? )"
     },
     {
-      "name": "hdr-color()",
-      "syntax": "color-hdr([ <color> && <number [0,∞]>? ]#{2})"
-    },
-    {
       "name": "hsl()",
-      "syntax": "[ <legacy-hsl-syntax> | <modern-hsl-syntax> ]"
+      "syntax": "hsl( <hue>, <percentage>, <percentage>, <alpha-value>? ) | hsl( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
     },
     {
       "name": "hsla()",
-      "syntax": "[ <legacy-hsla-syntax> | <modern-hsla-syntax> ]"
+      "syntax": "hsla( <hue>, <percentage>, <percentage>, <alpha-value>? ) | hsla( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
     },
     {
       "name": "hue-rotate()",
@@ -7132,15 +7853,19 @@
     },
     {
       "name": "hwb()",
-      "syntax": "hwb( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+      "syntax": "hwb( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
     },
     {
       "name": "hypot()",
       "syntax": "hypot( <calc-sum># )"
     },
     {
-      "name": "ictcp()",
-      "syntax": "ictcp([from <color>]? [<percentage> | <number> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+      "name": "image()",
+      "syntax": "image( <image-tags>? [ <image-src>? , <color>? ]! )"
+    },
+    {
+      "name": "image-set()",
+      "syntax": "image-set( <image-set-option># )"
     },
     {
       "name": "inset()",
@@ -7151,16 +7876,12 @@
       "syntax": "invert( [ <number> | <percentage> ]? )"
     },
     {
-      "name": "jzazbz()",
-      "syntax": "jzazbz([from <color>]? [<percentage> | <number> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
-    },
-    {
-      "name": "jzczhz()",
-      "syntax": "jzczhz([from <color>]? [<percentage> | <number> | none] [<percentage> | <number> | none] [<hue> | none] [ / [<alpha-value> | none] ]? )"
-    },
-    {
       "name": "lab()",
       "syntax": "lab( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "layer()",
+      "syntax": "layer( <layer-name> )"
     },
     {
       "name": "lch()",
@@ -7169,6 +7890,10 @@
     {
       "name": "leader()",
       "syntax": "leader( <leader-type> )"
+    },
+    {
+      "name": "light-dark()",
+      "syntax": "light-dark( <color>, <color> )"
     },
     {
       "name": "linear()",
@@ -7187,6 +7912,10 @@
       "syntax": "matrix( <number>#{6} )"
     },
     {
+      "name": "matrix3d()",
+      "syntax": "matrix3d( <number>#{16} )"
+    },
+    {
       "name": "max()",
       "syntax": "max( <calc-sum># )"
     },
@@ -7196,7 +7925,7 @@
     },
     {
       "name": "minmax()",
-      "syntax": "minmax(min, max)"
+      "syntax": "minmax( [ <length-percentage> | min-content | max-content | auto ] , [ <length-percentage> | <flex> | min-content | max-content | auto ] )"
     },
     {
       "name": "mod()",
@@ -7220,15 +7949,19 @@
     },
     {
       "name": "palette-mix()",
-      "syntax": "palette-mix(<color-interpolation-method> ',' [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})"
+      "syntax": "palette-mix(<color-interpolation-method> , [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})"
     },
     {
       "name": "path()",
-      "syntax": "path( <'fill-rule'>? ',' <string> )"
+      "syntax": "path( <'fill-rule'>? , <string> )"
+    },
+    {
+      "name": "perspective()",
+      "syntax": "perspective( [ <length [0,∞]> | none ] )"
     },
     {
       "name": "polygon()",
-      "syntax": "polygon( <'fill-rule'>? [ round <length> ]? ',' [<length-percentage> <length-percentage>]# )"
+      "syntax": "polygon( <'fill-rule'>? , [ <length-percentage> <length-percentage> ]# )"
     },
     {
       "name": "pow()",
@@ -7244,11 +7977,15 @@
     },
     {
       "name": "rect()",
-      "syntax": "rect( <top>, <right>, <bottom>, <left> )"
+      "syntax": "rect( [ <length-percentage> | auto ]{4} [ round <'border-radius'> ]? )"
     },
     {
       "name": "rem()",
       "syntax": "rem( <calc-sum>, <calc-sum> )"
+    },
+    {
+      "name": "repeating-conic-gradient()",
+      "syntax": "repeating-conic-gradient( [ <conic-gradient-syntax> ] )"
     },
     {
       "name": "repeating-linear-gradient()",
@@ -7260,23 +7997,35 @@
     },
     {
       "name": "rgb()",
-      "syntax": "[ <legacy-rgb-syntax> | <modern-rgb-syntax> ]"
+      "syntax": "rgb( <percentage>#{3} , <alpha-value>? ) | rgb( <number>#{3} , <alpha-value>? ) | rgb( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )"
     },
     {
       "name": "rgba()",
-      "syntax": "[ <legacy-rgba-syntax> | <modern-rgba-syntax> ]"
+      "syntax": "rgba( <percentage>#{3} , <alpha-value>? ) | rgba( <number>#{3} , <alpha-value>? ) | rgba( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )"
     },
     {
       "name": "rotate()",
       "syntax": "rotate( [ <angle> | <zero> ] )"
     },
     {
-      "name": "round()",
-      "syntax": "round( <rounding-strategy>?, <calc-sum>, <calc-sum>? )"
+      "name": "rotate3d()",
+      "syntax": "rotate3d( <number> , <number> , <number> , [ <angle> | <zero> ] )"
     },
     {
-      "name": "running()",
-      "syntax": "running( <custom-ident> )"
+      "name": "rotateX()",
+      "syntax": "rotateX( [ <angle> | <zero> ] )"
+    },
+    {
+      "name": "rotateY()",
+      "syntax": "rotateY( [ <angle> | <zero> ] )"
+    },
+    {
+      "name": "rotateZ()",
+      "syntax": "rotateZ( [ <angle> | <zero> ] )"
+    },
+    {
+      "name": "round()",
+      "syntax": "round( <rounding-strategy>?, <calc-sum>, <calc-sum> )"
     },
     {
       "name": "saturate()",
@@ -7284,15 +8033,23 @@
     },
     {
       "name": "scale()",
-      "syntax": "scale( <number> ',' <number>? )"
+      "syntax": "scale( [ <number> | <percentage> ]#{1,2} )"
+    },
+    {
+      "name": "scale3d()",
+      "syntax": "scale3d( [ <number> | <percentage> ]#{3} )"
     },
     {
       "name": "scaleX()",
-      "syntax": "scaleX( <number> )"
+      "syntax": "scaleX( [ <number> | <percentage> ] )"
     },
     {
       "name": "scaleY()",
-      "syntax": "scaleY( <number> )"
+      "syntax": "scaleY( [ <number> | <percentage> ] )"
+    },
+    {
+      "name": "scaleZ()",
+      "syntax": "scaleZ( [ <number> | <percentage> ] )"
     },
     {
       "name": "scroll()",
@@ -7312,7 +8069,7 @@
     },
     {
       "name": "skew()",
-      "syntax": "skew( [ <angle> | <zero> ] ',' [ <angle> | <zero> ]? )"
+      "syntax": "skew( [ <angle> | <zero> ] , [ <angle> | <zero> ]? )"
     },
     {
       "name": "skewX()",
@@ -7323,32 +8080,16 @@
       "syntax": "skewY( [ <angle> | <zero> ] )"
     },
     {
-      "name": "snap-block()",
-      "syntax": "snap-block( <length> ',' [ start | end | near ]? )"
-    },
-    {
-      "name": "snap-inline()",
-      "syntax": "snap-inline( <length> ',' [ left | right | near ]? )"
-    },
-    {
       "name": "sqrt()",
       "syntax": "sqrt( <calc-sum> )"
     },
     {
-      "name": "src()",
-      "syntax": "src( <string> <url-modifier>* )"
-    },
-    {
       "name": "steps()",
-      "syntax": "steps( <integer>, <step-position>?)"
-    },
-    {
-      "name": "string()",
-      "syntax": "string( <custom-ident> ',' [ first | start | last | first-except ]? )"
+      "syntax": "steps( <integer>, <step-position>? )"
     },
     {
       "name": "superellipse()",
-      "syntax": "superellipse( <number> | infinity )"
+      "syntax": "superellipse( [ <number> | infinity | -infinity ] )"
     },
     {
       "name": "symbols()",
@@ -7360,19 +8101,23 @@
     },
     {
       "name": "target-counter()",
-      "syntax": "target-counter( [ <string> | <url> ] ',' <custom-ident> ',' <counter-style>? )"
+      "syntax": "target-counter( [ <string> | <url> ] , <custom-ident> , <counter-style>? )"
     },
     {
       "name": "target-counters()",
-      "syntax": "target-counters( [ <string> | <url> ] ',' <custom-ident> ',' <string> ',' <counter-style>? )"
+      "syntax": "target-counters( [ <string> | <url> ] , <custom-ident> , <string> , <counter-style>? )"
     },
     {
       "name": "target-text()",
-      "syntax": "target-text( [ <string> | <url> ] ',' [ content | before | after | first-letter ]? )"
+      "syntax": "target-text( [ <string> | <url> ] , [ content | before | after | first-letter ]? )"
     },
     {
       "name": "translate()",
-      "syntax": "translate( <length-percentage> ',' <length-percentage>? )"
+      "syntax": "translate( <length-percentage> , <length-percentage>? )"
+    },
+    {
+      "name": "translate3d()",
+      "syntax": "translate3d( <length-percentage> , <length-percentage> , <length> )"
     },
     {
       "name": "translateX()",
@@ -7383,16 +8128,16 @@
       "syntax": "translateY( <length-percentage> )"
     },
     {
-      "name": "url()",
-      "syntax": "url( <string> <url-modifier>* ) | <url-token>"
+      "name": "translateZ()",
+      "syntax": "translateZ( <length> )"
     },
     {
       "name": "var()",
-      "syntax": "var( <custom-property-name> ',' <declaration-value>? )"
+      "syntax": "var( <custom-property-name> , <declaration-value>? )"
     },
     {
       "name": "view()",
-      "syntax": "view( [ <axis> || <'view-timeline-inset'> ]? )"
+      "syntax": "view([<axis> || <'view-timeline-inset'>]?)"
     },
     {
       "name": "xywh()",
@@ -7401,37 +8146,12 @@
   ],
   "atrules": [
     {
-      "name": "@-webkit-keyframes",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@bottom-center",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@bottom-left",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@bottom-left-corner",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@bottom-right",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@bottom-right-corner",
-      "descriptors": [],
-      "Values": null
-    },
-    {
       "name": "@charset",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@container",
       "descriptors": [],
       "Values": null
     },
@@ -7439,34 +8159,9 @@
       "name": "@counter-style",
       "descriptors": [
         {
-          "name": "system",
-          "syntax": "cyclic | numeric | alphabetic | symbolic | additive | [fixed <integer>?] | [ extends <counter-style-name> ]",
-          "initial": "symbolic"
-        },
-        {
-          "name": "negative",
-          "syntax": "<symbol> <symbol>?",
-          "initial": "\"-\""
-        },
-        {
-          "name": "prefix",
-          "syntax": "<symbol>",
-          "initial": "\"\""
-        },
-        {
-          "name": "suffix",
-          "syntax": "<symbol>",
-          "initial": "\". \""
-        },
-        {
-          "name": "range",
-          "syntax": "[ [ <integer> | infinite ]{2} ]# | auto",
-          "initial": "auto"
-        },
-        {
-          "name": "pad",
-          "syntax": "<integer [0,∞]> && <symbol>",
-          "initial": "0 \"\""
+          "name": "additive-symbols",
+          "syntax": "[ <integer [0,∞]> && <symbol> ]#",
+          "initial": ""
         },
         {
           "name": "fallback",
@@ -7474,25 +8169,50 @@
           "initial": "decimal"
         },
         {
-          "name": "symbols",
-          "syntax": "<symbol>+",
-          "initial": ""
+          "name": "negative",
+          "syntax": "<symbol> <symbol>?",
+          "initial": "\"-\" hyphen-minus"
         },
         {
-          "name": "additive-symbols",
-          "syntax": "[ <integer [0,∞]> && <symbol> ]#",
-          "initial": ""
+          "name": "pad",
+          "syntax": "<integer [0,∞]> && <symbol>",
+          "initial": "0 \"\""
+        },
+        {
+          "name": "prefix",
+          "syntax": "<symbol>",
+          "initial": "\"\""
+        },
+        {
+          "name": "range",
+          "syntax": "[ [ <integer> | infinite ]{2} ]# | auto",
+          "initial": "auto"
         },
         {
           "name": "speak-as",
           "syntax": "auto | bullets | numbers | words | spell-out | <counter-style-name>",
           "initial": "auto"
+        },
+        {
+          "name": "suffix",
+          "syntax": "<symbol>",
+          "initial": "\". \""
+        },
+        {
+          "name": "symbols",
+          "syntax": "<symbol>+",
+          "initial": ""
+        },
+        {
+          "name": "system",
+          "syntax": "cyclic | numeric | alphabetic | symbolic | additive | [ fixed <integer>? ] | [ extends <counter-style-name> ]",
+          "initial": "symbolic"
         }
       ],
       "Values": null
     },
     {
-      "name": "@custom-selector",
+      "name": "@document",
       "descriptors": [],
       "Values": null
     },
@@ -7500,49 +8220,14 @@
       "name": "@font-face",
       "descriptors": [
         {
-          "name": "font-family",
-          "syntax": "<family-name>",
-          "initial": ""
+          "name": "ascent-override",
+          "syntax": "normal | <percentage>",
+          "initial": "normal"
         },
         {
-          "name": "src",
-          "syntax": "<font-src-list>",
-          "initial": ""
-        },
-        {
-          "name": "font-style",
-          "syntax": "auto | normal | italic | oblique [ <angle [-90deg,90deg]>{1,2} ]?",
-          "initial": "auto"
-        },
-        {
-          "name": "font-weight",
-          "syntax": "auto | <font-weight-absolute>{1,2}",
-          "initial": "auto"
-        },
-        {
-          "name": "font-width",
-          "syntax": "auto | <'font-width'>{1,2}",
-          "initial": "auto"
-        },
-        {
-          "name": "unicode-range",
-          "syntax": "<unicode-range-token>#",
-          "initial": "U+0-10FFFF"
-        },
-        {
-          "name": "font-feature-settings",
-          "syntax": "normal | <feature-tag-value>#",
-          "initial": ""
-        },
-        {
-          "name": "font-variation-settings",
-          "syntax": "normal | [ <string> <number>]#",
-          "initial": ""
-        },
-        {
-          "name": "font-named-instance",
-          "syntax": "auto | <string>",
-          "initial": "auto"
+          "name": "descent-override",
+          "syntax": "normal | <percentage>",
+          "initial": "normal"
         },
         {
           "name": "font-display",
@@ -7550,85 +8235,74 @@
           "initial": "auto"
         },
         {
-          "name": "font-language-override",
-          "syntax": "normal | <string>",
+          "name": "font-family",
+          "syntax": "<family-name>",
           "initial": ""
         },
         {
-          "name": "ascent-override",
-          "syntax": "normal | <percentage [0,∞]>",
-          "initial": ""
+          "name": "font-feature-settings",
+          "syntax": "normal | <feature-tag-value>#",
+          "initial": "normal"
         },
         {
-          "name": "descent-override",
-          "syntax": "normal | <percentage [0,∞]>",
-          "initial": ""
+          "name": "font-stretch",
+          "syntax": "<font-stretch-absolute>{1,2}",
+          "initial": "normal"
+        },
+        {
+          "name": "font-style",
+          "syntax": "normal | italic | oblique <angle>{0,2}",
+          "initial": "normal"
+        },
+        {
+          "name": "font-variation-settings",
+          "syntax": "normal | [ <string> <number> ]#",
+          "initial": "normal"
+        },
+        {
+          "name": "font-weight",
+          "syntax": "<font-weight-absolute>{1,2}",
+          "initial": "normal"
         },
         {
           "name": "line-gap-override",
-          "syntax": "normal | <percentage [0,∞]>",
+          "syntax": "normal | <percentage>",
+          "initial": "normal"
+        },
+        {
+          "name": "size-adjust",
+          "syntax": "<percentage>",
+          "initial": "100%"
+        },
+        {
+          "name": "src",
+          "syntax": "[ <url> [ format( <string># ) ]? | local( <family-name> ) ]#",
           "initial": ""
+        },
+        {
+          "name": "unicode-range",
+          "syntax": "<unicode-range-token>#",
+          "initial": "U+0-10FFFF"
         }
       ],
       "Values": null
     },
     {
       "name": "@font-feature-values",
-      "descriptors": [
-        {
-          "name": "font-display",
-          "syntax": "auto | block | swap | fallback | optional",
-          "initial": "auto"
-        },
-        {
-          "name": "@stylistic",
-          "syntax": "@stylistic { <declaration-list> }",
-          "initial": ""
-        },
-        {
-          "name": "@historical-forms",
-          "syntax": "@historical-forms { <declaration-list> }",
-          "initial": ""
-        },
-        {
-          "name": "@styleset",
-          "syntax": "@styleset { <declaration-list> }",
-          "initial": ""
-        },
-        {
-          "name": "@character-variant",
-          "syntax": "@character-variant { <declaration-list> }",
-          "initial": ""
-        },
-        {
-          "name": "@swash",
-          "syntax": "@swash { <declaration-list> }",
-          "initial": ""
-        },
-        {
-          "name": "@ornaments",
-          "syntax": "@ornaments { <declaration-list> }",
-          "initial": ""
-        },
-        {
-          "name": "@annotation",
-          "syntax": "@annotation { <declaration-list> }",
-          "initial": ""
-        }
-      ],
+      "descriptors": [],
       "Values": null
     },
     {
       "name": "@font-palette-values",
       "descriptors": [
         {
-          "name": "font-family",
-          "syntax": "<family-name>#",
+          "name": "base-palette",
+          "syntax": "light | dark | <integer [0,∞]>",
           "initial": ""
         },
         {
-          "name": "base-palette",
-          "syntax": "light | dark | <integer [0,∞]>",
+          "name": "font-family",
+          "syntax": "<family-name>#",
           "initial": ""
         },
         {
@@ -7638,23 +8312,6 @@
         }
       ],
       "Values": null
-    },
-    {
-      "name": "@function",
-      "descriptors": [
-        {
-          "name": "result",
-          "syntax": "<declaration-value>?",
-          "initial": ""
-        }
-      ],
-      "Values": [
-        {
-          "name": "type()",
-          "value": "type( <syntax> )",
-          "Values": null
-        }
-      ]
     },
     {
       "name": "@import",
@@ -7672,266 +8329,9 @@
       "Values": null
     },
     {
-      "name": "@left-bottom",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@left-middle",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@left-top",
-      "descriptors": [],
-      "Values": null
-    },
-    {
       "name": "@media",
-      "descriptors": [
-        {
-          "name": "-webkit-device-pixel-ratio",
-          "syntax": "<number>",
-          "initial": ""
-        },
-        {
-          "name": "-webkit-transform-3d",
-          "syntax": "<mq-boolean>",
-          "initial": ""
-        },
-        {
-          "name": "width",
-          "syntax": "<length>",
-          "initial": ""
-        },
-        {
-          "name": "height",
-          "syntax": "<length>",
-          "initial": ""
-        },
-        {
-          "name": "aspect-ratio",
-          "syntax": "<ratio>",
-          "initial": ""
-        },
-        {
-          "name": "orientation",
-          "syntax": "portrait | landscape",
-          "initial": ""
-        },
-        {
-          "name": "resolution",
-          "syntax": "<resolution> | infinite",
-          "initial": ""
-        },
-        {
-          "name": "scan",
-          "syntax": "interlace | progressive",
-          "initial": ""
-        },
-        {
-          "name": "grid",
-          "syntax": "<mq-boolean>",
-          "initial": ""
-        },
-        {
-          "name": "update",
-          "syntax": "none | slow | fast",
-          "initial": ""
-        },
-        {
-          "name": "overflow-block",
-          "syntax": "none | scroll | paged",
-          "initial": ""
-        },
-        {
-          "name": "overflow-inline",
-          "syntax": "none | scroll",
-          "initial": ""
-        },
-        {
-          "name": "color",
-          "syntax": "<integer>",
-          "initial": ""
-        },
-        {
-          "name": "color-index",
-          "syntax": "<integer>",
-          "initial": ""
-        },
-        {
-          "name": "monochrome",
-          "syntax": "<integer>",
-          "initial": ""
-        },
-        {
-          "name": "color-gamut",
-          "syntax": "srgb | p3 | rec2020",
-          "initial": ""
-        },
-        {
-          "name": "pointer",
-          "syntax": "none | coarse | fine",
-          "initial": ""
-        },
-        {
-          "name": "hover",
-          "syntax": "none | hover",
-          "initial": ""
-        },
-        {
-          "name": "any-pointer",
-          "syntax": "none | coarse | fine",
-          "initial": ""
-        },
-        {
-          "name": "any-hover",
-          "syntax": "none | hover",
-          "initial": ""
-        },
-        {
-          "name": "device-width",
-          "syntax": "<length>",
-          "initial": ""
-        },
-        {
-          "name": "device-height",
-          "syntax": "<length>",
-          "initial": ""
-        },
-        {
-          "name": "device-aspect-ratio",
-          "syntax": "<ratio>",
-          "initial": ""
-        },
-        {
-          "name": "shape",
-          "syntax": "rect | round",
-          "initial": ""
-        }
-      ],
-      "Values": [
-        {
-          "name": "all",
-          "value": "all",
-          "Values": [
-            {
-              "name": "inherit",
-              "value": "inherit"
-            }
-          ]
-        },
-        {
-          "name": "braille",
-          "value": "braille",
-          "Values": null
-        },
-        {
-          "name": "embossed",
-          "value": "embossed",
-          "Values": null
-        },
-        {
-          "name": "handheld",
-          "value": "handheld",
-          "Values": null
-        },
-        {
-          "name": "print",
-          "value": "print",
-          "Values": null
-        },
-        {
-          "name": "projection",
-          "value": "projection",
-          "Values": null
-        },
-        {
-          "name": "screen",
-          "value": "screen",
-          "Values": null
-        },
-        {
-          "name": "speech",
-          "value": "speech",
-          "Values": null
-        },
-        {
-          "name": "tty",
-          "value": "tty",
-          "Values": null
-        },
-        {
-          "name": "tv",
-          "value": "tv",
-          "Values": null
-        },
-        {
-          "name": "not",
-          "value": "not",
-          "Values": null
-        },
-        {
-          "name": "only",
-          "value": "only",
-          "Values": null
-        },
-        {
-          "name": "all",
-          "value": "all",
-          "Values": null
-        },
-        {
-          "name": "print",
-          "value": "print",
-          "Values": null
-        },
-        {
-          "name": "screen",
-          "value": "screen",
-          "Values": null
-        },
-        {
-          "name": "tty",
-          "value": "tty",
-          "Values": null
-        },
-        {
-          "name": "tv",
-          "value": "tv",
-          "Values": null
-        },
-        {
-          "name": "projection",
-          "value": "projection",
-          "Values": null
-        },
-        {
-          "name": "handheld",
-          "value": "handheld",
-          "Values": null
-        },
-        {
-          "name": "braille",
-          "value": "braille",
-          "Values": null
-        },
-        {
-          "name": "embossed",
-          "value": "embossed",
-          "Values": null
-        },
-        {
-          "name": "aural",
-          "value": "aural",
-          "Values": null
-        },
-        {
-          "name": "speech",
-          "value": "speech",
-          "Values": null
-        }
-      ]
+      "descriptors": [],
+      "Values": null
     },
     {
       "name": "@namespace",
@@ -7942,9 +8342,14 @@
       "name": "@page",
       "descriptors": [
         {
-          "name": "size",
-          "syntax": "<length [0,∞]>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]",
+          "name": "bleed",
+          "syntax": "auto | <length>",
           "initial": "auto"
+        },
+        {
+          "name": "marks",
+          "syntax": "none | [ crop || cross ]",
+          "initial": "none"
         },
         {
           "name": "page-orientation",
@@ -7952,38 +8357,12 @@
           "initial": "upright"
         },
         {
-          "name": "marks",
-          "syntax": "none | [ crop || cross ]",
-          "initial": ""
-        },
-        {
-          "name": "bleed",
-          "syntax": "auto | <length>",
+          "name": "size",
+          "syntax": "<length [0,∞]>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]",
           "initial": "auto"
         }
       ],
-      "Values": [
-        {
-          "name": ":left",
-          "value": ":left",
-          "Values": null
-        },
-        {
-          "name": ":right",
-          "value": ":right",
-          "Values": null
-        },
-        {
-          "name": ":first",
-          "value": ":first",
-          "Values": null
-        },
-        {
-          "name": ":blank",
-          "value": ":blank",
-          "Values": null
-        }
-      ]
+      "Values": null
     },
     {
       "name": "@position-try",
@@ -7994,35 +8373,30 @@
       "name": "@property",
       "descriptors": [
         {
-          "name": "syntax",
-          "syntax": "<string>",
-          "initial": ""
-        },
-        {
           "name": "inherits",
           "syntax": "true | false",
-          "initial": ""
+          "initial": "auto"
         },
         {
           "name": "initial-value",
           "syntax": "<declaration-value>?",
-          "initial": "the guaranteed-invalid value (but see prose)"
+          "initial": ""
+        },
+        {
+          "name": "syntax",
+          "syntax": "<string>",
+          "initial": ""
         }
       ],
       "Values": null
     },
     {
-      "name": "@right-bottom",
+      "name": "@scope",
       "descriptors": [],
       "Values": null
     },
     {
-      "name": "@right-middle",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@right-top",
+      "name": "@starting-style",
       "descriptors": [],
       "Values": null
     },
@@ -8032,55 +8406,103 @@
       "Values": null
     },
     {
-      "name": "@top-center",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@top-left",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@top-left-corner",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@top-right",
-      "descriptors": [],
-      "Values": null
-    },
-    {
-      "name": "@top-right-corner",
-      "descriptors": [],
+      "name": "@view-transition",
+      "descriptors": [
+        {
+          "name": "navigation",
+          "syntax": "auto | none",
+          "initial": "none"
+        },
+        {
+          "name": "types",
+          "syntax": "none | <custom-ident>+",
+          "initial": "none"
+        }
+      ],
       "Values": null
     }
   ],
   "selectors": [
     {
-      "name": "&"
+      "name": "::-moz-progress-bar"
     },
     {
-      "name": "+"
+      "name": "::-moz-range-progress"
+    },
+    {
+      "name": "::-moz-range-thumb"
+    },
+    {
+      "name": "::-moz-range-track"
+    },
+    {
+      "name": "::-ms-browse"
+    },
+    {
+      "name": "::-ms-check"
+    },
+    {
+      "name": "::-ms-clear"
+    },
+    {
+      "name": "::-ms-expand"
+    },
+    {
+      "name": "::-ms-fill"
+    },
+    {
+      "name": "::-ms-fill-lower"
+    },
+    {
+      "name": "::-ms-fill-upper"
+    },
+    {
+      "name": "::-ms-reveal"
+    },
+    {
+      "name": "::-ms-thumb"
+    },
+    {
+      "name": "::-ms-ticks-after"
+    },
+    {
+      "name": "::-ms-ticks-before"
+    },
+    {
+      "name": "::-ms-tooltip"
+    },
+    {
+      "name": "::-ms-track"
+    },
+    {
+      "name": "::-ms-value"
+    },
+    {
+      "name": "::-webkit-progress-bar"
+    },
+    {
+      "name": "::-webkit-progress-inner-value"
+    },
+    {
+      "name": "::-webkit-progress-value"
+    },
+    {
+      "name": "::-webkit-slider-runnable-track"
+    },
+    {
+      "name": "::-webkit-slider-thumb"
     },
     {
       "name": "::after"
+    },
+    {
+      "name": "::backdrop"
     },
     {
       "name": "::before"
     },
     {
       "name": "::checkmark"
-    },
-    {
-      "name": "::clear-icon"
-    },
-    {
-      "name": "::color-swatch"
-    },
-    {
-      "name": "::column"
     },
     {
       "name": "::cue"
@@ -8096,15 +8518,6 @@
     },
     {
       "name": "::details-content"
-    },
-    {
-      "name": "::field-component"
-    },
-    {
-      "name": "::field-separator"
-    },
-    {
-      "name": "::field-text"
     },
     {
       "name": "::file-selector-button"
@@ -8137,34 +8550,19 @@
       "name": "::placeholder"
     },
     {
-      "name": "::search-text"
+      "name": "::scroll-marker"
+    },
+    {
+      "name": "::scroll-marker-group"
     },
     {
       "name": "::selection"
-    },
-    {
-      "name": "::slider-fill"
-    },
-    {
-      "name": "::slider-thumb"
-    },
-    {
-      "name": "::slider-track"
     },
     {
       "name": "::slotted()"
     },
     {
       "name": "::spelling-error"
-    },
-    {
-      "name": "::step-control"
-    },
-    {
-      "name": "::step-down"
-    },
-    {
-      "name": "::step-up"
     },
     {
       "name": "::target-text"
@@ -8188,16 +8586,16 @@
       "name": ":active"
     },
     {
-      "name": ":after"
+      "name": ":active-view-transition"
+    },
+    {
+      "name": ":active-view-transition-type()"
     },
     {
       "name": ":any-link"
     },
     {
       "name": ":autofill"
-    },
-    {
-      "name": ":before"
     },
     {
       "name": ":blank"
@@ -8210,9 +8608,6 @@
     },
     {
       "name": ":current"
-    },
-    {
-      "name": ":current()"
     },
     {
       "name": ":default"
@@ -8239,12 +8634,6 @@
       "name": ":first-child"
     },
     {
-      "name": ":first-letter"
-    },
-    {
-      "name": ":first-line"
-    },
-    {
       "name": ":first-of-type"
     },
     {
@@ -8267,9 +8656,6 @@
     },
     {
       "name": ":has-slotted"
-    },
-    {
-      "name": ":high-value"
     },
     {
       "name": ":host"
@@ -8296,9 +8682,6 @@
       "name": ":is()"
     },
     {
-      "name": ":lang"
-    },
-    {
       "name": ":lang()"
     },
     {
@@ -8317,12 +8700,6 @@
       "name": ":local-link"
     },
     {
-      "name": ":low-value"
-    },
-    {
-      "name": ":matches()"
-    },
-    {
       "name": ":modal"
     },
     {
@@ -8332,19 +8709,10 @@
       "name": ":not()"
     },
     {
-      "name": ":nth()"
-    },
-    {
       "name": ":nth-child()"
     },
     {
-      "name": ":nth-col()"
-    },
-    {
       "name": ":nth-last-child()"
-    },
-    {
-      "name": ":nth-last-col()"
     },
     {
       "name": ":nth-last-of-type()"
@@ -8360,9 +8728,6 @@
     },
     {
       "name": ":open"
-    },
-    {
-      "name": ":optimal-value"
     },
     {
       "name": ":optional"
@@ -8413,7 +8778,13 @@
       "name": ":stalled"
     },
     {
+      "name": ":state()"
+    },
+    {
       "name": ":target"
+    },
+    {
+      "name": ":target-current"
     },
     {
       "name": ":target-within"
@@ -8438,15 +8809,6 @@
     },
     {
       "name": ":xr-overlay"
-    },
-    {
-      "name": ">"
-    },
-    {
-      "name": "||"
-    },
-    {
-      "name": "~"
     }
   ]
 }

--- a/crates/gosub_css3/resources/definitions/definitions_at-rules.json
+++ b/crates/gosub_css3/resources/definitions/definitions_at-rules.json
@@ -1,36 +1,11 @@
 [
   {
-    "name": "@-webkit-keyframes",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@bottom-center",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@bottom-left",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@bottom-left-corner",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@bottom-right",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@bottom-right-corner",
-    "descriptors": [],
-    "Values": null
-  },
-  {
     "name": "@charset",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@container",
     "descriptors": [],
     "Values": null
   },
@@ -38,34 +13,9 @@
     "name": "@counter-style",
     "descriptors": [
       {
-        "name": "system",
-        "syntax": "cyclic | numeric | alphabetic | symbolic | additive | [fixed <integer>?] | [ extends <counter-style-name> ]",
-        "initial": "symbolic"
-      },
-      {
-        "name": "negative",
-        "syntax": "<symbol> <symbol>?",
-        "initial": "\"-\""
-      },
-      {
-        "name": "prefix",
-        "syntax": "<symbol>",
-        "initial": "\"\""
-      },
-      {
-        "name": "suffix",
-        "syntax": "<symbol>",
-        "initial": "\". \""
-      },
-      {
-        "name": "range",
-        "syntax": "[ [ <integer> | infinite ]{2} ]# | auto",
-        "initial": "auto"
-      },
-      {
-        "name": "pad",
-        "syntax": "<integer [0,∞]> && <symbol>",
-        "initial": "0 \"\""
+        "name": "additive-symbols",
+        "syntax": "[ <integer [0,∞]> && <symbol> ]#",
+        "initial": ""
       },
       {
         "name": "fallback",
@@ -73,25 +23,50 @@
         "initial": "decimal"
       },
       {
-        "name": "symbols",
-        "syntax": "<symbol>+",
-        "initial": ""
+        "name": "negative",
+        "syntax": "<symbol> <symbol>?",
+        "initial": "\"-\" hyphen-minus"
       },
       {
-        "name": "additive-symbols",
-        "syntax": "[ <integer [0,∞]> && <symbol> ]#",
-        "initial": ""
+        "name": "pad",
+        "syntax": "<integer [0,∞]> && <symbol>",
+        "initial": "0 \"\""
+      },
+      {
+        "name": "prefix",
+        "syntax": "<symbol>",
+        "initial": "\"\""
+      },
+      {
+        "name": "range",
+        "syntax": "[ [ <integer> | infinite ]{2} ]# | auto",
+        "initial": "auto"
       },
       {
         "name": "speak-as",
         "syntax": "auto | bullets | numbers | words | spell-out | <counter-style-name>",
         "initial": "auto"
+      },
+      {
+        "name": "suffix",
+        "syntax": "<symbol>",
+        "initial": "\". \""
+      },
+      {
+        "name": "symbols",
+        "syntax": "<symbol>+",
+        "initial": ""
+      },
+      {
+        "name": "system",
+        "syntax": "cyclic | numeric | alphabetic | symbolic | additive | [ fixed <integer>? ] | [ extends <counter-style-name> ]",
+        "initial": "symbolic"
       }
     ],
     "Values": null
   },
   {
-    "name": "@custom-selector",
+    "name": "@document",
     "descriptors": [],
     "Values": null
   },
@@ -99,49 +74,14 @@
     "name": "@font-face",
     "descriptors": [
       {
-        "name": "font-family",
-        "syntax": "<family-name>",
-        "initial": ""
+        "name": "ascent-override",
+        "syntax": "normal | <percentage>",
+        "initial": "normal"
       },
       {
-        "name": "src",
-        "syntax": "<font-src-list>",
-        "initial": ""
-      },
-      {
-        "name": "font-style",
-        "syntax": "auto | normal | italic | oblique [ <angle [-90deg,90deg]>{1,2} ]?",
-        "initial": "auto"
-      },
-      {
-        "name": "font-weight",
-        "syntax": "auto | <font-weight-absolute>{1,2}",
-        "initial": "auto"
-      },
-      {
-        "name": "font-width",
-        "syntax": "auto | <'font-width'>{1,2}",
-        "initial": "auto"
-      },
-      {
-        "name": "unicode-range",
-        "syntax": "<unicode-range-token>#",
-        "initial": "U+0-10FFFF"
-      },
-      {
-        "name": "font-feature-settings",
-        "syntax": "normal | <feature-tag-value>#",
-        "initial": ""
-      },
-      {
-        "name": "font-variation-settings",
-        "syntax": "normal | [ <string> <number>]#",
-        "initial": ""
-      },
-      {
-        "name": "font-named-instance",
-        "syntax": "auto | <string>",
-        "initial": "auto"
+        "name": "descent-override",
+        "syntax": "normal | <percentage>",
+        "initial": "normal"
       },
       {
         "name": "font-display",
@@ -149,85 +89,74 @@
         "initial": "auto"
       },
       {
-        "name": "font-language-override",
-        "syntax": "normal | <string>",
+        "name": "font-family",
+        "syntax": "<family-name>",
         "initial": ""
       },
       {
-        "name": "ascent-override",
-        "syntax": "normal | <percentage [0,∞]>",
-        "initial": ""
+        "name": "font-feature-settings",
+        "syntax": "normal | <feature-tag-value>#",
+        "initial": "normal"
       },
       {
-        "name": "descent-override",
-        "syntax": "normal | <percentage [0,∞]>",
-        "initial": ""
+        "name": "font-stretch",
+        "syntax": "<font-stretch-absolute>{1,2}",
+        "initial": "normal"
+      },
+      {
+        "name": "font-style",
+        "syntax": "normal | italic | oblique <angle>{0,2}",
+        "initial": "normal"
+      },
+      {
+        "name": "font-variation-settings",
+        "syntax": "normal | [ <string> <number> ]#",
+        "initial": "normal"
+      },
+      {
+        "name": "font-weight",
+        "syntax": "<font-weight-absolute>{1,2}",
+        "initial": "normal"
       },
       {
         "name": "line-gap-override",
-        "syntax": "normal | <percentage [0,∞]>",
+        "syntax": "normal | <percentage>",
+        "initial": "normal"
+      },
+      {
+        "name": "size-adjust",
+        "syntax": "<percentage>",
+        "initial": "100%"
+      },
+      {
+        "name": "src",
+        "syntax": "[ <url> [ format( <string># ) ]? | local( <family-name> ) ]#",
         "initial": ""
+      },
+      {
+        "name": "unicode-range",
+        "syntax": "<unicode-range-token>#",
+        "initial": "U+0-10FFFF"
       }
     ],
     "Values": null
   },
   {
     "name": "@font-feature-values",
-    "descriptors": [
-      {
-        "name": "font-display",
-        "syntax": "auto | block | swap | fallback | optional",
-        "initial": "auto"
-      },
-      {
-        "name": "@stylistic",
-        "syntax": "@stylistic { <declaration-list> }",
-        "initial": ""
-      },
-      {
-        "name": "@historical-forms",
-        "syntax": "@historical-forms { <declaration-list> }",
-        "initial": ""
-      },
-      {
-        "name": "@styleset",
-        "syntax": "@styleset { <declaration-list> }",
-        "initial": ""
-      },
-      {
-        "name": "@character-variant",
-        "syntax": "@character-variant { <declaration-list> }",
-        "initial": ""
-      },
-      {
-        "name": "@swash",
-        "syntax": "@swash { <declaration-list> }",
-        "initial": ""
-      },
-      {
-        "name": "@ornaments",
-        "syntax": "@ornaments { <declaration-list> }",
-        "initial": ""
-      },
-      {
-        "name": "@annotation",
-        "syntax": "@annotation { <declaration-list> }",
-        "initial": ""
-      }
-    ],
+    "descriptors": [],
     "Values": null
   },
   {
     "name": "@font-palette-values",
     "descriptors": [
       {
-        "name": "font-family",
-        "syntax": "<family-name>#",
+        "name": "base-palette",
+        "syntax": "light | dark | <integer [0,∞]>",
         "initial": ""
       },
       {
-        "name": "base-palette",
-        "syntax": "light | dark | <integer [0,∞]>",
+        "name": "font-family",
+        "syntax": "<family-name>#",
         "initial": ""
       },
       {
@@ -237,23 +166,6 @@
       }
     ],
     "Values": null
-  },
-  {
-    "name": "@function",
-    "descriptors": [
-      {
-        "name": "result",
-        "syntax": "<declaration-value>?",
-        "initial": ""
-      }
-    ],
-    "Values": [
-      {
-        "name": "type()",
-        "value": "type( <syntax> )",
-        "Values": null
-      }
-    ]
   },
   {
     "name": "@import",
@@ -271,266 +183,9 @@
     "Values": null
   },
   {
-    "name": "@left-bottom",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@left-middle",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@left-top",
-    "descriptors": [],
-    "Values": null
-  },
-  {
     "name": "@media",
-    "descriptors": [
-      {
-        "name": "-webkit-device-pixel-ratio",
-        "syntax": "<number>",
-        "initial": ""
-      },
-      {
-        "name": "-webkit-transform-3d",
-        "syntax": "<mq-boolean>",
-        "initial": ""
-      },
-      {
-        "name": "width",
-        "syntax": "<length>",
-        "initial": ""
-      },
-      {
-        "name": "height",
-        "syntax": "<length>",
-        "initial": ""
-      },
-      {
-        "name": "aspect-ratio",
-        "syntax": "<ratio>",
-        "initial": ""
-      },
-      {
-        "name": "orientation",
-        "syntax": "portrait | landscape",
-        "initial": ""
-      },
-      {
-        "name": "resolution",
-        "syntax": "<resolution> | infinite",
-        "initial": ""
-      },
-      {
-        "name": "scan",
-        "syntax": "interlace | progressive",
-        "initial": ""
-      },
-      {
-        "name": "grid",
-        "syntax": "<mq-boolean>",
-        "initial": ""
-      },
-      {
-        "name": "update",
-        "syntax": "none | slow | fast",
-        "initial": ""
-      },
-      {
-        "name": "overflow-block",
-        "syntax": "none | scroll | paged",
-        "initial": ""
-      },
-      {
-        "name": "overflow-inline",
-        "syntax": "none | scroll",
-        "initial": ""
-      },
-      {
-        "name": "color",
-        "syntax": "<integer>",
-        "initial": ""
-      },
-      {
-        "name": "color-index",
-        "syntax": "<integer>",
-        "initial": ""
-      },
-      {
-        "name": "monochrome",
-        "syntax": "<integer>",
-        "initial": ""
-      },
-      {
-        "name": "color-gamut",
-        "syntax": "srgb | p3 | rec2020",
-        "initial": ""
-      },
-      {
-        "name": "pointer",
-        "syntax": "none | coarse | fine",
-        "initial": ""
-      },
-      {
-        "name": "hover",
-        "syntax": "none | hover",
-        "initial": ""
-      },
-      {
-        "name": "any-pointer",
-        "syntax": "none | coarse | fine",
-        "initial": ""
-      },
-      {
-        "name": "any-hover",
-        "syntax": "none | hover",
-        "initial": ""
-      },
-      {
-        "name": "device-width",
-        "syntax": "<length>",
-        "initial": ""
-      },
-      {
-        "name": "device-height",
-        "syntax": "<length>",
-        "initial": ""
-      },
-      {
-        "name": "device-aspect-ratio",
-        "syntax": "<ratio>",
-        "initial": ""
-      },
-      {
-        "name": "shape",
-        "syntax": "rect | round",
-        "initial": ""
-      }
-    ],
-    "Values": [
-      {
-        "name": "all",
-        "value": "all",
-        "Values": [
-          {
-            "name": "inherit",
-            "value": "inherit"
-          }
-        ]
-      },
-      {
-        "name": "braille",
-        "value": "braille",
-        "Values": null
-      },
-      {
-        "name": "embossed",
-        "value": "embossed",
-        "Values": null
-      },
-      {
-        "name": "handheld",
-        "value": "handheld",
-        "Values": null
-      },
-      {
-        "name": "print",
-        "value": "print",
-        "Values": null
-      },
-      {
-        "name": "projection",
-        "value": "projection",
-        "Values": null
-      },
-      {
-        "name": "screen",
-        "value": "screen",
-        "Values": null
-      },
-      {
-        "name": "speech",
-        "value": "speech",
-        "Values": null
-      },
-      {
-        "name": "tty",
-        "value": "tty",
-        "Values": null
-      },
-      {
-        "name": "tv",
-        "value": "tv",
-        "Values": null
-      },
-      {
-        "name": "not",
-        "value": "not",
-        "Values": null
-      },
-      {
-        "name": "only",
-        "value": "only",
-        "Values": null
-      },
-      {
-        "name": "all",
-        "value": "all",
-        "Values": null
-      },
-      {
-        "name": "print",
-        "value": "print",
-        "Values": null
-      },
-      {
-        "name": "screen",
-        "value": "screen",
-        "Values": null
-      },
-      {
-        "name": "tty",
-        "value": "tty",
-        "Values": null
-      },
-      {
-        "name": "tv",
-        "value": "tv",
-        "Values": null
-      },
-      {
-        "name": "projection",
-        "value": "projection",
-        "Values": null
-      },
-      {
-        "name": "handheld",
-        "value": "handheld",
-        "Values": null
-      },
-      {
-        "name": "braille",
-        "value": "braille",
-        "Values": null
-      },
-      {
-        "name": "embossed",
-        "value": "embossed",
-        "Values": null
-      },
-      {
-        "name": "aural",
-        "value": "aural",
-        "Values": null
-      },
-      {
-        "name": "speech",
-        "value": "speech",
-        "Values": null
-      }
-    ]
+    "descriptors": [],
+    "Values": null
   },
   {
     "name": "@namespace",
@@ -541,9 +196,14 @@
     "name": "@page",
     "descriptors": [
       {
-        "name": "size",
-        "syntax": "<length [0,∞]>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]",
+        "name": "bleed",
+        "syntax": "auto | <length>",
         "initial": "auto"
+      },
+      {
+        "name": "marks",
+        "syntax": "none | [ crop || cross ]",
+        "initial": "none"
       },
       {
         "name": "page-orientation",
@@ -551,38 +211,12 @@
         "initial": "upright"
       },
       {
-        "name": "marks",
-        "syntax": "none | [ crop || cross ]",
-        "initial": ""
-      },
-      {
-        "name": "bleed",
-        "syntax": "auto | <length>",
+        "name": "size",
+        "syntax": "<length [0,∞]>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]",
         "initial": "auto"
       }
     ],
-    "Values": [
-      {
-        "name": ":left",
-        "value": ":left",
-        "Values": null
-      },
-      {
-        "name": ":right",
-        "value": ":right",
-        "Values": null
-      },
-      {
-        "name": ":first",
-        "value": ":first",
-        "Values": null
-      },
-      {
-        "name": ":blank",
-        "value": ":blank",
-        "Values": null
-      }
-    ]
+    "Values": null
   },
   {
     "name": "@position-try",
@@ -593,35 +227,30 @@
     "name": "@property",
     "descriptors": [
       {
-        "name": "syntax",
-        "syntax": "<string>",
-        "initial": ""
-      },
-      {
         "name": "inherits",
         "syntax": "true | false",
-        "initial": ""
+        "initial": "auto"
       },
       {
         "name": "initial-value",
         "syntax": "<declaration-value>?",
-        "initial": "the guaranteed-invalid value (but see prose)"
+        "initial": ""
+      },
+      {
+        "name": "syntax",
+        "syntax": "<string>",
+        "initial": ""
       }
     ],
     "Values": null
   },
   {
-    "name": "@right-bottom",
+    "name": "@scope",
     "descriptors": [],
     "Values": null
   },
   {
-    "name": "@right-middle",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@right-top",
+    "name": "@starting-style",
     "descriptors": [],
     "Values": null
   },
@@ -631,28 +260,19 @@
     "Values": null
   },
   {
-    "name": "@top-center",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@top-left",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@top-left-corner",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@top-right",
-    "descriptors": [],
-    "Values": null
-  },
-  {
-    "name": "@top-right-corner",
-    "descriptors": [],
+    "name": "@view-transition",
+    "descriptors": [
+      {
+        "name": "navigation",
+        "syntax": "auto | none",
+        "initial": "none"
+      },
+      {
+        "name": "types",
+        "syntax": "none | <custom-ident>+",
+        "initial": "none"
+      }
+    ],
     "Values": null
   }
 ]

--- a/crates/gosub_css3/resources/definitions/definitions_properties.json
+++ b/crates/gosub_css3/resources/definitions/definitions_properties.json
@@ -1,91 +1,16 @@
 [
   {
-    "name": "-webkit-align-content",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
+    "name": "--*",
+    "syntax": "<declaration-value>",
+    "computed": [
+      "asSpecifiedWithVarsSubstituted"
+    ],
+    "initial": "seeProse",
+    "inherited": true
   },
   {
-    "name": "-webkit-align-items",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-align-self",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-animation",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-animation-delay",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-animation-direction",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-animation-duration",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-animation-fill-mode",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-animation-iteration-count",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-animation-name",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-animation-play-state",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-animation-timing-function",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-appearance",
-    "syntax": "",
+    "name": "-moz-appearance",
+    "syntax": "none | button | button-arrow-down | button-arrow-next | button-arrow-previous | button-arrow-up | button-bevel | button-focus | caret | checkbox | checkbox-container | checkbox-label | checkmenuitem | dualbutton | groupbox | listbox | listitem | menuarrow | menubar | menucheckbox | menuimage | menuitem | menuitemtext | menulist | menulist-button | menulist-text | menulist-textfield | menupopup | menuradio | menuseparator | meterbar | meterchunk | progressbar | progressbar-vertical | progresschunk | progresschunk-vertical | radio | radio-container | radio-label | radiomenuitem | range | range-thumb | resizer | resizerpanel | scale-horizontal | scalethumbend | scalethumb-horizontal | scalethumbstart | scalethumbtick | scalethumb-vertical | scale-vertical | scrollbarbutton-down | scrollbarbutton-left | scrollbarbutton-right | scrollbarbutton-up | scrollbarthumb-horizontal | scrollbarthumb-vertical | scrollbartrack-horizontal | scrollbartrack-vertical | searchfield | separator | sheet | spinner | spinner-downbutton | spinner-textfield | spinner-upbutton | splitter | statusbar | statusbarpanel | tab | tabpanel | tabpanels | tab-scroll-arrow-back | tab-scroll-arrow-forward | textfield | textfield-multiline | toolbar | toolbarbutton | toolbarbutton-dropdown | toolbargripper | toolbox | tooltip | treeheader | treeheadercell | treeheadersortarrow | treeitem | treeline | treetwisty | treetwistyopen | treeview | -moz-mac-unified-toolbar | -moz-win-borderless-glass | -moz-win-browsertabbar-toolbox | -moz-win-communicationstext | -moz-win-communications-toolbox | -moz-win-exclude-glass | -moz-win-glass | -moz-win-mediatext | -moz-win-media-toolbox | -moz-window-button-box | -moz-window-button-box-maximized | -moz-window-button-close | -moz-window-button-maximize | -moz-window-button-minimize | -moz-window-button-restore | -moz-window-frame-bottom | -moz-window-frame-left | -moz-window-frame-right | -moz-window-titlebar | -moz-window-titlebar-maximized",
     "computed": [
       "asSpecified"
     ],
@@ -93,183 +18,856 @@
     "inherited": false
   },
   {
-    "name": "-webkit-backface-visibility",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-moz-binding",
+    "syntax": "<url> | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
     "inherited": false
   },
   {
-    "name": "-webkit-background-clip",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-moz-border-bottom-colors",
+    "syntax": "<color>+ | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
     "inherited": false
   },
   {
-    "name": "-webkit-background-origin",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-moz-border-left-colors",
+    "syntax": "<color>+ | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
     "inherited": false
   },
   {
-    "name": "-webkit-background-size",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-moz-border-right-colors",
+    "syntax": "<color>+ | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
     "inherited": false
   },
   {
-    "name": "-webkit-border-bottom-left-radius",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-moz-border-top-colors",
+    "syntax": "<color>+ | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
     "inherited": false
   },
   {
-    "name": "-webkit-border-bottom-right-radius",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-moz-context-properties",
+    "syntax": "none | [ fill | fill-opacity | stroke | stroke-opacity ]#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "-moz-float-edge",
+    "syntax": "border-box | content-box | margin-box | padding-box",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "content-box",
     "inherited": false
   },
   {
-    "name": "-webkit-border-radius",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-moz-force-broken-image-icon",
+    "syntax": "0 | 1",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
     "inherited": false
   },
   {
-    "name": "-webkit-border-top-left-radius",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-moz-orient",
+    "syntax": "inline | block | horizontal | vertical",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "inline",
     "inherited": false
   },
   {
-    "name": "-webkit-border-top-right-radius",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-moz-outline-radius",
+    "syntax": "<outline-radius>{1,4} [ / <outline-radius>{1,4} ]?",
+    "computed": [
+      "-moz-outline-radius-topleft",
+      "-moz-outline-radius-topright",
+      "-moz-outline-radius-bottomright",
+      "-moz-outline-radius-bottomleft"
+    ],
+    "initial": [
+      "-moz-outline-radius-topleft",
+      "-moz-outline-radius-topright",
+      "-moz-outline-radius-bottomright",
+      "-moz-outline-radius-bottomleft"
+    ],
     "inherited": false
   },
   {
-    "name": "-webkit-box-align",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-moz-outline-radius-bottomleft",
+    "syntax": "<outline-radius>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
     "inherited": false
   },
   {
-    "name": "-webkit-box-flex",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-moz-outline-radius-bottomright",
+    "syntax": "<outline-radius>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
     "inherited": false
   },
   {
-    "name": "-webkit-box-ordinal-group",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-moz-outline-radius-topleft",
+    "syntax": "<outline-radius>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
     "inherited": false
   },
   {
-    "name": "-webkit-box-orient",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-moz-outline-radius-topright",
+    "syntax": "<outline-radius>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
     "inherited": false
   },
   {
-    "name": "-webkit-box-pack",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-moz-stack-sizing",
+    "syntax": "ignore | stretch-to-fit",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "stretch-to-fit",
+    "inherited": true
+  },
+  {
+    "name": "-moz-text-blink",
+    "syntax": "none | blink",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
     "inherited": false
   },
   {
-    "name": "-webkit-box-shadow",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-moz-user-focus",
+    "syntax": "ignore | normal | select-after | select-before | select-menu | select-same | select-all | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
     "inherited": false
   },
   {
-    "name": "-webkit-box-sizing",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-moz-user-input",
+    "syntax": "auto | none | enabled | disabled",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "-moz-user-modify",
+    "syntax": "read-only | read-write | write-only",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "read-only",
+    "inherited": true
+  },
+  {
+    "name": "-moz-window-dragging",
+    "syntax": "drag | no-drag",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "drag",
     "inherited": false
   },
   {
-    "name": "-webkit-filter",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-moz-window-shadow",
+    "syntax": "default | menu | tooltip | sheet | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "default",
     "inherited": false
   },
   {
-    "name": "-webkit-flex",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-ms-accelerator",
+    "syntax": "false | true",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "false",
     "inherited": false
   },
   {
-    "name": "-webkit-flex-basis",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-ms-block-progression",
+    "syntax": "tb | rl | bt | lr",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "tb",
     "inherited": false
   },
   {
-    "name": "-webkit-flex-direction",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-ms-content-zoom-chaining",
+    "syntax": "none | chained",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
     "inherited": false
   },
   {
-    "name": "-webkit-flex-flow",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-ms-content-zoom-limit",
+    "syntax": "<'-ms-content-zoom-limit-min'> <'-ms-content-zoom-limit-max'>",
+    "computed": [
+      "-ms-content-zoom-limit-max",
+      "-ms-content-zoom-limit-min"
+    ],
+    "initial": [
+      "-ms-content-zoom-limit-max",
+      "-ms-content-zoom-limit-min"
+    ],
     "inherited": false
   },
   {
-    "name": "-webkit-flex-grow",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-ms-content-zoom-limit-max",
+    "syntax": "<percentage>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "400%",
     "inherited": false
   },
   {
-    "name": "-webkit-flex-shrink",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-ms-content-zoom-limit-min",
+    "syntax": "<percentage>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "100%",
     "inherited": false
   },
   {
-    "name": "-webkit-flex-wrap",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-ms-content-zoom-snap",
+    "syntax": "<'-ms-content-zoom-snap-type'> || <'-ms-content-zoom-snap-points'>",
+    "computed": [
+      "-ms-content-zoom-snap-type",
+      "-ms-content-zoom-snap-points"
+    ],
+    "initial": [
+      "-ms-content-zoom-snap-type",
+      "-ms-content-zoom-snap-points"
+    ],
     "inherited": false
   },
   {
-    "name": "-webkit-justify-content",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-ms-content-zoom-snap-points",
+    "syntax": "snapInterval( <percentage>, <percentage> ) | snapList( <percentage># )",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "snapInterval(0%, 100%)",
+    "inherited": false
+  },
+  {
+    "name": "-ms-content-zoom-snap-type",
+    "syntax": "none | proximity | mandatory",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "-ms-content-zooming",
+    "syntax": "none | zoom",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "zoomForTheTopLevelNoneForTheRest",
+    "inherited": false
+  },
+  {
+    "name": "-ms-filter",
+    "syntax": "<string>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "\"\"",
+    "inherited": false
+  },
+  {
+    "name": "-ms-flow-from",
+    "syntax": "[ none | <custom-ident> ]#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "-ms-flow-into",
+    "syntax": "[ none | <custom-ident> ]#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "-ms-grid-columns",
+    "syntax": "none | <track-list> | <auto-track-list>",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "-ms-grid-rows",
+    "syntax": "none | <track-list> | <auto-track-list>",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "-ms-high-contrast-adjust",
+    "syntax": "auto | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "-ms-hyphenate-limit-chars",
+    "syntax": "auto | <integer>{1,3}",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "-ms-hyphenate-limit-lines",
+    "syntax": "no-limit | <integer>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "no-limit",
+    "inherited": true
+  },
+  {
+    "name": "-ms-hyphenate-limit-zone",
+    "syntax": "<percentage> | <length>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
+    "inherited": true
+  },
+  {
+    "name": "-ms-ime-align",
+    "syntax": "auto | after",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "-ms-overflow-style",
+    "syntax": "auto | none | scrollbar | -ms-autohiding-scrollbar",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "-ms-scroll-chaining",
+    "syntax": "chained | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "chained",
+    "inherited": false
+  },
+  {
+    "name": "-ms-scroll-limit",
+    "syntax": "<'-ms-scroll-limit-x-min'> <'-ms-scroll-limit-y-min'> <'-ms-scroll-limit-x-max'> <'-ms-scroll-limit-y-max'>",
+    "computed": [
+      "-ms-scroll-limit-x-min",
+      "-ms-scroll-limit-y-min",
+      "-ms-scroll-limit-x-max",
+      "-ms-scroll-limit-y-max"
+    ],
+    "initial": [
+      "-ms-scroll-limit-x-min",
+      "-ms-scroll-limit-y-min",
+      "-ms-scroll-limit-x-max",
+      "-ms-scroll-limit-y-max"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "-ms-scroll-limit-x-max",
+    "syntax": "auto | <length>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "-ms-scroll-limit-x-min",
+    "syntax": "<length>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "-ms-scroll-limit-y-max",
+    "syntax": "auto | <length>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "-ms-scroll-limit-y-min",
+    "syntax": "<length>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "-ms-scroll-rails",
+    "syntax": "none | railed",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "railed",
+    "inherited": false
+  },
+  {
+    "name": "-ms-scroll-snap-points-x",
+    "syntax": "snapInterval( <length-percentage>, <length-percentage> ) | snapList( <length-percentage># )",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "snapInterval(0px, 100%)",
+    "inherited": false
+  },
+  {
+    "name": "-ms-scroll-snap-points-y",
+    "syntax": "snapInterval( <length-percentage>, <length-percentage> ) | snapList( <length-percentage># )",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "snapInterval(0px, 100%)",
+    "inherited": false
+  },
+  {
+    "name": "-ms-scroll-snap-type",
+    "syntax": "none | proximity | mandatory",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "-ms-scroll-snap-x",
+    "syntax": "<'-ms-scroll-snap-type'> <'-ms-scroll-snap-points-x'>",
+    "computed": [
+      "-ms-scroll-snap-type",
+      "-ms-scroll-snap-points-x"
+    ],
+    "initial": [
+      "-ms-scroll-snap-type",
+      "-ms-scroll-snap-points-x"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "-ms-scroll-snap-y",
+    "syntax": "<'-ms-scroll-snap-type'> <'-ms-scroll-snap-points-y'>",
+    "computed": [
+      "-ms-scroll-snap-type",
+      "-ms-scroll-snap-points-y"
+    ],
+    "initial": [
+      "-ms-scroll-snap-type",
+      "-ms-scroll-snap-points-y"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "-ms-scroll-translation",
+    "syntax": "none | vertical-to-horizontal",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": true
+  },
+  {
+    "name": "-ms-scrollbar-3dlight-color",
+    "syntax": "<color>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "dependsOnUserAgent",
+    "inherited": true
+  },
+  {
+    "name": "-ms-scrollbar-arrow-color",
+    "syntax": "<color>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "ButtonText",
+    "inherited": true
+  },
+  {
+    "name": "-ms-scrollbar-base-color",
+    "syntax": "<color>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "dependsOnUserAgent",
+    "inherited": true
+  },
+  {
+    "name": "-ms-scrollbar-darkshadow-color",
+    "syntax": "<color>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "ThreeDDarkShadow",
+    "inherited": true
+  },
+  {
+    "name": "-ms-scrollbar-face-color",
+    "syntax": "<color>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "ThreeDFace",
+    "inherited": true
+  },
+  {
+    "name": "-ms-scrollbar-highlight-color",
+    "syntax": "<color>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "ThreeDHighlight",
+    "inherited": true
+  },
+  {
+    "name": "-ms-scrollbar-shadow-color",
+    "syntax": "<color>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "ThreeDDarkShadow",
+    "inherited": true
+  },
+  {
+    "name": "-ms-scrollbar-track-color",
+    "syntax": "<color>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "Scrollbar",
+    "inherited": true
+  },
+  {
+    "name": "-ms-text-autospace",
+    "syntax": "none | ideograph-alpha | ideograph-numeric | ideograph-parenthesis | ideograph-space",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "-ms-touch-select",
+    "syntax": "grippers | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "grippers",
+    "inherited": true
+  },
+  {
+    "name": "-ms-user-select",
+    "syntax": "none | element | text",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "text",
+    "inherited": false
+  },
+  {
+    "name": "-ms-wrap-flow",
+    "syntax": "auto | both | start | end | maximum | clear",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "-ms-wrap-margin",
+    "syntax": "<length>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "-ms-wrap-through",
+    "syntax": "wrap | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "wrap",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-appearance",
+    "syntax": "none | button | button-bevel | caret | checkbox | default-button | inner-spin-button | listbox | listitem | media-controls-background | media-controls-fullscreen-background | media-current-time-display | media-enter-fullscreen-button | media-exit-fullscreen-button | media-fullscreen-button | media-mute-button | media-overlay-play-button | media-play-button | media-seek-back-button | media-seek-forward-button | media-slider | media-sliderthumb | media-time-remaining-display | media-toggle-closed-captions-button | media-volume-slider | media-volume-slider-container | media-volume-sliderthumb | menulist | menulist-button | menulist-text | menulist-textfield | meter | progress-bar | progress-bar-value | push-button | radio | searchfield | searchfield-cancel-button | searchfield-decoration | searchfield-results-button | searchfield-results-decoration | slider-horizontal | slider-vertical | sliderthumb-horizontal | sliderthumb-vertical | square-button | textarea | textfield | -apple-pay-button",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "noneButOverriddenInUserAgentCSS",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-after",
+    "syntax": "<'border-top'>",
+    "computed": [
+      "border-block-end-width",
+      "border-block-end-style",
+      "border-block-end-color"
+    ],
+    "initial": [
+      "border-block-end-width",
+      "border-block-end-style",
+      "border-block-end-color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-after-color",
+    "syntax": "<'border-top-color'>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-after-style",
+    "syntax": "<'border-top-style'>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-after-width",
+    "syntax": "<'border-top-width'>",
+    "computed": [
+      "absoluteLength"
+    ],
+    "initial": "medium",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-before",
+    "syntax": "<'border-top'>",
+    "computed": [
+      "border-block-start-width",
+      "border-block-start-style",
+      "border-block-start-color"
+    ],
+    "initial": [
+      "border-block-start-width",
+      "border-block-start-style",
+      "border-block-start-color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-before-color",
+    "syntax": "<'border-top-color'>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-before-style",
+    "syntax": "<'border-top-style'>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-before-width",
+    "syntax": "<'border-top-width'>",
+    "computed": [
+      "absoluteLength"
+    ],
+    "initial": "medium",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-end",
+    "syntax": "<'border-top'>",
+    "computed": [
+      "border-inline-end-width",
+      "border-inline-end-style",
+      "border-inline-end-color"
+    ],
+    "initial": [
+      "border-inline-end-width",
+      "border-inline-end-style",
+      "border-inline-end-color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-end-color",
+    "syntax": "<'border-top-color'>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-end-style",
+    "syntax": "<'border-top-style'>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-end-width",
+    "syntax": "<'border-top-width'>",
+    "computed": [
+      "absoluteLength"
+    ],
+    "initial": "medium",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-start",
+    "syntax": "<'border-top'>",
+    "computed": [
+      "border-inline-start-width",
+      "border-inline-start-style",
+      "border-inline-start-color"
+    ],
+    "initial": [
+      "border-inline-start-width",
+      "border-inline-start-style",
+      "border-inline-start-color"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-start-color",
+    "syntax": "<'border-top-color'>",
+    "computed": [
+      "computedColor"
+    ],
+    "initial": "currentcolor",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-start-style",
+    "syntax": "<'border-top-style'>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-border-start-width",
+    "syntax": "<'border-top-width'>",
+    "computed": [
+      "absoluteLength"
+    ],
+    "initial": "medium",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-box-reflect",
+    "syntax": "[ above | below | right | left ]? <length>? <image>?",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-line-clamp",
+    "syntax": "none | <integer>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
     "inherited": false
   },
   {
     "name": "-webkit-mask",
-    "syntax": "",
+    "syntax": "[ <mask-reference> || <position> [ / <bg-size> ]? || <repeat-style> || [ <visual-box> | border | padding | content | text ] || [ <visual-box> | border | padding | content ] ]#",
     "computed": [
       "-webkit-mask-image",
       "-webkit-mask-repeat",
@@ -289,50 +887,17 @@
     "inherited": false
   },
   {
-    "name": "-webkit-mask-box-image",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-mask-box-image-outset",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-mask-box-image-repeat",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-mask-box-image-slice",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-mask-box-image-source",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-mask-box-image-width",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
+    "name": "-webkit-mask-attachment",
+    "syntax": "<attachment>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "scroll",
     "inherited": false
   },
   {
     "name": "-webkit-mask-clip",
-    "syntax": "",
+    "syntax": "[ <coord-box> | no-clip | border | padding | content | text ]#",
     "computed": [
       "asSpecified"
     ],
@@ -341,7 +906,7 @@
   },
   {
     "name": "-webkit-mask-composite",
-    "syntax": "",
+    "syntax": "<composite-style>#",
     "computed": [
       "asSpecified"
     ],
@@ -350,7 +915,7 @@
   },
   {
     "name": "-webkit-mask-image",
-    "syntax": "",
+    "syntax": "<mask-reference>#",
     "computed": [
       "absoluteURIOrNone"
     ],
@@ -359,7 +924,7 @@
   },
   {
     "name": "-webkit-mask-origin",
-    "syntax": "",
+    "syntax": "[ <coord-box> | border | padding | content ]#",
     "computed": [
       "asSpecified"
     ],
@@ -368,7 +933,7 @@
   },
   {
     "name": "-webkit-mask-position",
-    "syntax": "",
+    "syntax": "<position>#",
     "computed": [
       "absoluteLengthOrPercentage"
     ],
@@ -376,8 +941,26 @@
     "inherited": false
   },
   {
+    "name": "-webkit-mask-position-x",
+    "syntax": "[ <length-percentage> | left | center | right ]#",
+    "computed": [
+      "absoluteLengthOrPercentage"
+    ],
+    "initial": "0%",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-mask-position-y",
+    "syntax": "[ <length-percentage> | top | center | bottom ]#",
+    "computed": [
+      "absoluteLengthOrPercentage"
+    ],
+    "initial": "0%",
+    "inherited": false
+  },
+  {
     "name": "-webkit-mask-repeat",
-    "syntax": "",
+    "syntax": "<repeat-style>#",
     "computed": [
       "asSpecified"
     ],
@@ -385,8 +968,26 @@
     "inherited": false
   },
   {
+    "name": "-webkit-mask-repeat-x",
+    "syntax": "repeat | no-repeat | space | round",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "repeat",
+    "inherited": false
+  },
+  {
+    "name": "-webkit-mask-repeat-y",
+    "syntax": "repeat | no-repeat | space | round",
+    "computed": [
+      "absoluteLengthOrPercentage"
+    ],
+    "initial": "repeat",
+    "inherited": false
+  },
+  {
     "name": "-webkit-mask-size",
-    "syntax": "",
+    "syntax": "<bg-size>#",
     "computed": [
       "asSpecified"
     ],
@@ -394,25 +995,22 @@
     "inherited": false
   },
   {
-    "name": "-webkit-order",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
+    "name": "-webkit-overflow-scrolling",
+    "syntax": "auto | touch",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
   },
   {
-    "name": "-webkit-perspective",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-perspective-origin",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
+    "name": "-webkit-tap-highlight-color",
+    "syntax": "<color>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "black",
+    "inherited": true
   },
   {
     "name": "-webkit-text-fill-color",
@@ -424,15 +1022,8 @@
     "inherited": true
   },
   {
-    "name": "-webkit-text-size-adjust",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
     "name": "-webkit-text-stroke",
-    "syntax": "<line-width> || <color>",
+    "syntax": "<length> || <color>",
     "computed": [
       "-webkit-text-stroke-width",
       "-webkit-text-stroke-color"
@@ -454,7 +1045,7 @@
   },
   {
     "name": "-webkit-text-stroke-width",
-    "syntax": "<line-width>",
+    "syntax": "<length>",
     "computed": [
       "absoluteLength"
     ],
@@ -462,64 +1053,26 @@
     "inherited": true
   },
   {
-    "name": "-webkit-transform",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
+    "name": "-webkit-touch-callout",
+    "syntax": "default | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "default",
+    "inherited": true
   },
   {
-    "name": "-webkit-transform-origin",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-transform-style",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-transition",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-transition-delay",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-transition-duration",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-transition-property",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
-  },
-  {
-    "name": "-webkit-transition-timing-function",
-    "syntax": "",
-    "computed": [],
-    "initial": "",
-    "inherited": false
+    "name": "-webkit-user-modify",
+    "syntax": "read-only | read-write | read-write-plaintext-only",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "read-only",
+    "inherited": true
   },
   {
     "name": "-webkit-user-select",
-    "syntax": "",
+    "syntax": "auto | text | none | all",
     "computed": [
       "asSpecified"
     ],
@@ -563,8 +1116,17 @@
     "inherited": false
   },
   {
+    "name": "align-tracks",
+    "syntax": "[ normal | <baseline-position> | <content-distribution> | <overflow-position>? <content-position> ]#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
     "name": "alignment-baseline",
-    "syntax": "baseline | text-bottom | alphabetic | ideographic | middle | central | mathematical | text-top",
+    "syntax": "baseline | alphabetic | ideographic | middle | central | mathematical | text-before-edge | text-after-edge",
     "computed": [
       "theSpecifiedKeyword"
     ],
@@ -626,6 +1188,15 @@
     "inherited": false
   },
   {
+    "name": "animation-composition",
+    "syntax": "<single-animation-composition>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "replace",
+    "inherited": false
+  },
+  {
     "name": "animation-delay",
     "syntax": "<time>#",
     "computed": [
@@ -645,7 +1216,7 @@
   },
   {
     "name": "animation-duration",
-    "syntax": "<time [0s,∞]>#",
+    "syntax": "[ auto | <time [0s,∞]> ]#",
     "computed": [
       "asSpecified"
     ],
@@ -720,6 +1291,15 @@
     "inherited": false
   },
   {
+    "name": "animation-timeline",
+    "syntax": "<single-animation-timeline>#",
+    "computed": [
+      "listEachItemIdentifierOrNoneAuto"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
     "name": "animation-timing-function",
     "syntax": "<easing-function>#",
     "computed": [
@@ -729,12 +1309,48 @@
     "inherited": false
   },
   {
-    "name": "appearance",
-    "syntax": "none | auto | base | <compat-auto> | <compat-special> | base",
+    "name": "animation-trigger",
+    "syntax": "[ none | [ <dashed-ident> <animation-action>+ ]+ ]#",
     "computed": [
       "asSpecified"
     ],
     "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "appearance",
+    "syntax": "none | auto | <compat-auto> | <compat-special>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "aspect-ratio",
+    "syntax": "auto || <ratio>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "backdrop-filter",
+    "syntax": "none | <filter-value-list>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "backface-visibility",
+    "syntax": "visible | hidden",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "visible",
     "inherited": false
   },
   {
@@ -773,7 +1389,7 @@
   },
   {
     "name": "background-blend-mode",
-    "syntax": "<mix-blend-mode>#",
+    "syntax": "<blend-mode>#",
     "computed": [
       "asSpecified"
     ],
@@ -782,7 +1398,7 @@
   },
   {
     "name": "background-clip",
-    "syntax": "<visual-box>#",
+    "syntax": "<bg-clip>#",
     "computed": [
       "asSpecified"
     ],
@@ -827,6 +1443,24 @@
     "inherited": false
   },
   {
+    "name": "background-position-x",
+    "syntax": "[ center | [ [ left | right | x-start | x-end ]? <length-percentage>? ]! ]#",
+    "computed": [
+      "listEachItemConsistingOfAbsoluteLengthPercentageAndOrigin"
+    ],
+    "initial": "0%",
+    "inherited": false
+  },
+  {
+    "name": "background-position-y",
+    "syntax": "[ center | [ [ top | bottom | y-start | y-end ]? <length-percentage>? ]! ]#",
+    "computed": [
+      "listEachItemConsistingOfAbsoluteLengthPercentageAndOrigin"
+    ],
+    "initial": "0%",
+    "inherited": false
+  },
+  {
     "name": "background-repeat",
     "syntax": "<repeat-style>#",
     "computed": [
@@ -846,7 +1480,7 @@
   },
   {
     "name": "baseline-shift",
-    "syntax": "<length-percentage> | sub | super | top | center | bottom",
+    "syntax": "<length-percentage> | sub | super | baseline",
     "computed": [
       "theSpecifiedKeywordOrAComputedLengthPercentageValue"
     ],
@@ -856,7 +1490,9 @@
   {
     "name": "baseline-source",
     "syntax": "auto | first | last",
-    "computed": [],
+    "computed": [
+      "asSpecified"
+    ],
     "initial": "auto",
     "inherited": false
   },
@@ -867,62 +1503,6 @@
       "sameAsWidthAndHeight"
     ],
     "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "block-step",
-    "syntax": "<'block-step-size'> || <'block-step-insert'> || <'block-step-align'> || <'block-step-round'>",
-    "computed": [],
-    "initial": "see individual properties",
-    "inherited": false
-  },
-  {
-    "name": "block-step-align",
-    "syntax": "auto | center | start | end",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "block-step-insert",
-    "syntax": "margin-box | padding-box | content-box",
-    "computed": [],
-    "initial": "margin-box",
-    "inherited": false
-  },
-  {
-    "name": "block-step-round",
-    "syntax": "up | down | nearest",
-    "computed": [],
-    "initial": "up",
-    "inherited": false
-  },
-  {
-    "name": "block-step-size",
-    "syntax": "none | <length [0,∞]>",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "bookmark-label",
-    "syntax": "<content-list>",
-    "computed": [],
-    "initial": "content(text)",
-    "inherited": false
-  },
-  {
-    "name": "bookmark-level",
-    "syntax": "none | <integer [1,∞]>",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "bookmark-state",
-    "syntax": "open | closed",
-    "computed": [],
-    "initial": "open",
     "inherited": false
   },
   {
@@ -942,7 +1522,7 @@
   },
   {
     "name": "border-block",
-    "syntax": "<'border-block-start'>",
+    "syntax": "<'border-top'>",
     "computed": [
       "border-block-width",
       "border-block-style",
@@ -959,29 +1539,33 @@
     "name": "border-block-color",
     "syntax": "<'border-top-color'>{1,2}",
     "computed": [
-      "computedColor"
+      "border-block-start-color",
+      "border-block-end-color"
     ],
-    "initial": "currentcolor",
+    "initial": [
+      "border-block-start-color",
+      "border-block-end-color"
+    ],
     "inherited": false
   },
   {
     "name": "border-block-end",
-    "syntax": "<line-width> || <line-style> || <color>",
+    "syntax": "<'border-top'>",
     "computed": [
-      "border-top-width",
-      "border-top-style",
-      "border-top-color"
+      "border-block-end-width",
+      "border-block-end-style",
+      "border-block-end-color"
     ],
     "initial": [
-      "border-top-width",
-      "border-top-style",
-      "border-top-color"
+      "border-block-end-width",
+      "border-block-end-style",
+      "border-block-end-color"
     ],
     "inherited": false
   },
   {
     "name": "border-block-end-color",
-    "syntax": "<color> | <image-1D>",
+    "syntax": "<'border-top-color'>",
     "computed": [
       "computedColor"
     ],
@@ -989,15 +1573,8 @@
     "inherited": false
   },
   {
-    "name": "border-block-end-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
     "name": "border-block-end-style",
-    "syntax": "<line-style>",
+    "syntax": "<'border-top-style'>",
     "computed": [
       "asSpecified"
     ],
@@ -1006,7 +1583,7 @@
   },
   {
     "name": "border-block-end-width",
-    "syntax": "<line-width>",
+    "syntax": "<'border-top-width'>",
     "computed": [
       "absoluteLengthZeroIfBorderStyleNoneOrHidden"
     ],
@@ -1015,22 +1592,22 @@
   },
   {
     "name": "border-block-start",
-    "syntax": "<line-width> || <line-style> || <color>",
+    "syntax": "<'border-top'>",
     "computed": [
-      "border-width",
-      "border-style",
+      "border-block-start-width",
+      "border-block-start-style",
       "border-block-start-color"
     ],
     "initial": [
-      "border-width",
-      "border-style",
-      "color"
+      "border-block-start-width",
+      "border-block-start-style",
+      "border-block-start-color"
     ],
     "inherited": false
   },
   {
     "name": "border-block-start-color",
-    "syntax": "<color> | <image-1D>",
+    "syntax": "<'border-top-color'>",
     "computed": [
       "computedColor"
     ],
@@ -1038,15 +1615,8 @@
     "inherited": false
   },
   {
-    "name": "border-block-start-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
     "name": "border-block-start-style",
-    "syntax": "<line-style>",
+    "syntax": "<'border-top-style'>",
     "computed": [
       "asSpecified"
     ],
@@ -1055,7 +1625,7 @@
   },
   {
     "name": "border-block-start-width",
-    "syntax": "<line-width>",
+    "syntax": "<'border-top-width'>",
     "computed": [
       "absoluteLengthZeroIfBorderStyleNoneOrHidden"
     ],
@@ -1066,18 +1636,26 @@
     "name": "border-block-style",
     "syntax": "<'border-top-style'>{1,2}",
     "computed": [
-      "asSpecified"
+      "border-block-start-style",
+      "border-block-end-style"
     ],
-    "initial": "none",
+    "initial": [
+      "border-block-start-style",
+      "border-block-end-style"
+    ],
     "inherited": false
   },
   {
     "name": "border-block-width",
     "syntax": "<'border-top-width'>{1,2}",
     "computed": [
-      "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+      "border-block-start-width",
+      "border-block-end-width"
     ],
-    "initial": "medium",
+    "initial": [
+      "border-block-start-width",
+      "border-block-end-width"
+    ],
     "inherited": false
   },
   {
@@ -1097,7 +1675,7 @@
   },
   {
     "name": "border-bottom-color",
-    "syntax": "<color> | <image-1D>",
+    "syntax": "<'border-top-color'>",
     "computed": [
       "computedColor"
     ],
@@ -1110,13 +1688,6 @@
     "computed": [
       "twoAbsoluteLengthOrPercentages"
     ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "border-bottom-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-    "computed": [],
     "initial": "0",
     "inherited": false
   },
@@ -1148,48 +1719,6 @@
     "inherited": false
   },
   {
-    "name": "border-boundary",
-    "syntax": "none | parent | display",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "border-clip",
-    "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
-    "computed": [],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "border-clip-bottom",
-    "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
-    "computed": [],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "border-clip-left",
-    "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
-    "computed": [],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "border-clip-right",
-    "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
-    "computed": [],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "border-clip-top",
-    "syntax": "normal | [ <length-percentage [0,∞]> | <flex> ]+",
-    "computed": [],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
     "name": "border-collapse",
     "syntax": "separate | collapse",
     "computed": [
@@ -1200,12 +1729,12 @@
   },
   {
     "name": "border-color",
-    "syntax": "[ <color> | <image-1D> ]{1,4}",
+    "syntax": "<color>{1,4}",
     "computed": [
-      "border-bottom-color",
-      "border-left-color",
+      "border-top-color",
       "border-right-color",
-      "border-top-color"
+      "border-bottom-color",
+      "border-left-color"
     ],
     "initial": [
       "border-top-color",
@@ -1217,7 +1746,7 @@
   },
   {
     "name": "border-end-end-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "syntax": "<'border-top-left-radius'>",
     "computed": [
       "twoAbsoluteLengthOrPercentages"
     ],
@@ -1226,7 +1755,7 @@
   },
   {
     "name": "border-end-start-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "syntax": "<'border-top-left-radius'>",
     "computed": [
       "twoAbsoluteLengthOrPercentages"
     ],
@@ -1237,11 +1766,11 @@
     "name": "border-image",
     "syntax": "<'border-image-source'> || <'border-image-slice'> [ / <'border-image-width'> | / <'border-image-width'>? / <'border-image-outset'> ]? || <'border-image-repeat'>",
     "computed": [
-      "border-image-outset",
-      "border-image-repeat",
-      "border-image-slice",
       "border-image-source",
-      "border-image-width"
+      "border-image-slice",
+      "border-image-width",
+      "border-image-outset",
+      "border-image-repeat"
     ],
     "initial": [
       "border-image-source",
@@ -1272,7 +1801,7 @@
   },
   {
     "name": "border-image-slice",
-    "syntax": "[<number [0,∞]> | <percentage [0,∞]>]{1,4} && fill?",
+    "syntax": "[ <number [0,∞]> | <percentage [0,∞]> ]{1,4} && fill?",
     "computed": [
       "oneToFourPercentagesOrAbsoluteLengthsPlusFill"
     ],
@@ -1299,7 +1828,7 @@
   },
   {
     "name": "border-inline",
-    "syntax": "<'border-block-start'>",
+    "syntax": "<'border-top'>",
     "computed": [
       "border-inline-width",
       "border-inline-style",
@@ -1316,29 +1845,33 @@
     "name": "border-inline-color",
     "syntax": "<'border-top-color'>{1,2}",
     "computed": [
-      "computedColor"
+      "border-inline-start-color",
+      "border-inline-end-color"
     ],
-    "initial": "currentcolor",
+    "initial": [
+      "border-inline-start-color",
+      "border-inline-end-color"
+    ],
     "inherited": false
   },
   {
     "name": "border-inline-end",
-    "syntax": "<line-width> || <line-style> || <color>",
+    "syntax": "<'border-top'>",
     "computed": [
-      "border-width",
-      "border-style",
+      "border-inline-end-width",
+      "border-inline-end-style",
       "border-inline-end-color"
     ],
     "initial": [
-      "border-width",
-      "border-style",
-      "color"
+      "border-inline-end-width",
+      "border-inline-end-style",
+      "border-inline-end-color"
     ],
     "inherited": false
   },
   {
     "name": "border-inline-end-color",
-    "syntax": "<color> | <image-1D>",
+    "syntax": "<'border-top-color'>",
     "computed": [
       "computedColor"
     ],
@@ -1346,15 +1879,8 @@
     "inherited": false
   },
   {
-    "name": "border-inline-end-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
     "name": "border-inline-end-style",
-    "syntax": "<line-style>",
+    "syntax": "<'border-top-style'>",
     "computed": [
       "asSpecified"
     ],
@@ -1363,7 +1889,7 @@
   },
   {
     "name": "border-inline-end-width",
-    "syntax": "<line-width>",
+    "syntax": "<'border-top-width'>",
     "computed": [
       "absoluteLengthZeroIfBorderStyleNoneOrHidden"
     ],
@@ -1372,22 +1898,22 @@
   },
   {
     "name": "border-inline-start",
-    "syntax": "<line-width> || <line-style> || <color>",
+    "syntax": "<'border-top'>",
     "computed": [
-      "border-width",
-      "border-style",
+      "border-inline-start-width",
+      "border-inline-start-style",
       "border-inline-start-color"
     ],
     "initial": [
-      "border-width",
-      "border-style",
-      "color"
+      "border-inline-start-width",
+      "border-inline-start-style",
+      "border-inline-start-color"
     ],
     "inherited": false
   },
   {
     "name": "border-inline-start-color",
-    "syntax": "<color> | <image-1D>",
+    "syntax": "<'border-top-color'>",
     "computed": [
       "computedColor"
     ],
@@ -1395,15 +1921,8 @@
     "inherited": false
   },
   {
-    "name": "border-inline-start-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
     "name": "border-inline-start-style",
-    "syntax": "<line-style>",
+    "syntax": "<'border-top-style'>",
     "computed": [
       "asSpecified"
     ],
@@ -1412,7 +1931,7 @@
   },
   {
     "name": "border-inline-start-width",
-    "syntax": "<line-width>",
+    "syntax": "<'border-top-width'>",
     "computed": [
       "absoluteLengthZeroIfBorderStyleNoneOrHidden"
     ],
@@ -1423,18 +1942,26 @@
     "name": "border-inline-style",
     "syntax": "<'border-top-style'>{1,2}",
     "computed": [
-      "asSpecified"
+      "border-inline-start-style",
+      "border-inline-end-style"
     ],
-    "initial": "none",
+    "initial": [
+      "border-inline-start-style",
+      "border-inline-end-style"
+    ],
     "inherited": false
   },
   {
     "name": "border-inline-width",
     "syntax": "<'border-top-width'>{1,2}",
     "computed": [
-      "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+      "border-inline-start-width",
+      "border-inline-end-width"
     ],
-    "initial": "medium",
+    "initial": [
+      "border-inline-start-width",
+      "border-inline-end-width"
+    ],
     "inherited": false
   },
   {
@@ -1454,18 +1981,11 @@
   },
   {
     "name": "border-left-color",
-    "syntax": "<color> | <image-1D>",
+    "syntax": "<color>",
     "computed": [
       "computedColor"
     ],
     "initial": "currentcolor",
-    "inherited": false
-  },
-  {
-    "name": "border-left-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-    "computed": [],
-    "initial": "0",
     "inherited": false
   },
   {
@@ -1487,20 +2007,13 @@
     "inherited": false
   },
   {
-    "name": "border-limit",
-    "syntax": "all | [ sides | corners ] <length-percentage [0,∞]>? | [ top | right | bottom | left ] <length-percentage [0,∞]>",
-    "computed": [],
-    "initial": "all",
-    "inherited": false
-  },
-  {
     "name": "border-radius",
     "syntax": "<length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?",
     "computed": [
-      "border-bottom-left-radius",
-      "border-bottom-right-radius",
       "border-top-left-radius",
-      "border-top-right-radius"
+      "border-top-right-radius",
+      "border-bottom-right-radius",
+      "border-bottom-left-radius"
     ],
     "initial": [
       "border-top-left-radius",
@@ -1527,18 +2040,11 @@
   },
   {
     "name": "border-right-color",
-    "syntax": "<color> | <image-1D>",
+    "syntax": "<color>",
     "computed": [
       "computedColor"
     ],
     "initial": "currentcolor",
-    "inherited": false
-  },
-  {
-    "name": "border-right-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-    "computed": [],
-    "initial": "0",
     "inherited": false
   },
   {
@@ -1562,7 +2068,9 @@
   {
     "name": "border-shape",
     "syntax": "none | [ <basic-shape> <geometry-box>?]{1,2}",
-    "computed": [],
+    "computed": [
+      "asSpecified"
+    ],
     "initial": "none",
     "inherited": false
   },
@@ -1577,7 +2085,7 @@
   },
   {
     "name": "border-start-end-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "syntax": "<'border-top-left-radius'>",
     "computed": [
       "twoAbsoluteLengthOrPercentages"
     ],
@@ -1586,7 +2094,7 @@
   },
   {
     "name": "border-start-start-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "syntax": "<'border-top-left-radius'>",
     "computed": [
       "twoAbsoluteLengthOrPercentages"
     ],
@@ -1597,10 +2105,10 @@
     "name": "border-style",
     "syntax": "<line-style>{1,4}",
     "computed": [
-      "border-bottom-style",
-      "border-left-style",
+      "border-top-style",
       "border-right-style",
-      "border-top-style"
+      "border-bottom-style",
+      "border-left-style"
     ],
     "initial": [
       "border-top-style",
@@ -1627,7 +2135,7 @@
   },
   {
     "name": "border-top-color",
-    "syntax": "<color> | <image-1D>",
+    "syntax": "<color>",
     "computed": [
       "computedColor"
     ],
@@ -1640,13 +2148,6 @@
     "computed": [
       "twoAbsoluteLengthOrPercentages"
     ],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "border-top-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?",
-    "computed": [],
     "initial": "0",
     "inherited": false
   },
@@ -1681,10 +2182,10 @@
     "name": "border-width",
     "syntax": "<line-width>{1,4}",
     "computed": [
-      "border-bottom-width",
-      "border-left-width",
+      "border-top-width",
       "border-right-width",
-      "border-top-width"
+      "border-bottom-width",
+      "border-left-width"
     ],
     "initial": [
       "border-top-width",
@@ -1704,6 +2205,15 @@
     "inherited": false
   },
   {
+    "name": "box-align",
+    "syntax": "start | center | end | baseline | stretch",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "stretch",
+    "inherited": false
+  },
+  {
     "name": "box-decoration-break",
     "syntax": "slice | clone",
     "computed": [
@@ -1713,47 +2223,75 @@
     "inherited": false
   },
   {
+    "name": "box-direction",
+    "syntax": "normal | reverse | inherit",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "box-flex",
+    "syntax": "<number>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
+    "name": "box-flex-group",
+    "syntax": "<integer>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "1",
+    "inherited": false
+  },
+  {
+    "name": "box-lines",
+    "syntax": "single | multiple",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "single",
+    "inherited": false
+  },
+  {
+    "name": "box-ordinal-group",
+    "syntax": "<integer>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "1",
+    "inherited": false
+  },
+  {
+    "name": "box-orient",
+    "syntax": "horizontal | vertical | inline-axis | block-axis | inherit",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "inline-axis",
+    "inherited": false
+  },
+  {
+    "name": "box-pack",
+    "syntax": "start | center | end | justify",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "start",
+    "inherited": false
+  },
+  {
     "name": "box-shadow",
-    "syntax": "<spread-shadow>#",
+    "syntax": "none | <shadow>#",
     "computed": [
       "absoluteLengthsSpecifiedColorAsSpecified"
     ],
     "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "box-shadow-blur",
-    "syntax": "<length [0,∞]>#",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "box-shadow-color",
-    "syntax": "<color>#",
-    "computed": [],
-    "initial": "currentcolor",
-    "inherited": false
-  },
-  {
-    "name": "box-shadow-offset",
-    "syntax": "[ none | <length>{2} ]#",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "box-shadow-position",
-    "syntax": "[ outset | inset ]#",
-    "computed": [],
-    "initial": "outset",
-    "inherited": false
-  },
-  {
-    "name": "box-shadow-spread",
-    "syntax": "<length>#",
-    "computed": [],
-    "initial": "0",
     "inherited": false
   },
   {
@@ -1764,13 +2302,6 @@
     ],
     "initial": "content-box",
     "inherited": false
-  },
-  {
-    "name": "box-snap",
-    "syntax": "none | block-start | block-end | center | baseline | last-baseline",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
   },
   {
     "name": "break-after",
@@ -1813,10 +2344,12 @@
     "syntax": "<'caret-color'> || <'caret-animation'> || <'caret-shape'>",
     "computed": [
       "caret-color",
+      "caret-animation",
       "caret-shape"
     ],
     "initial": [
       "caret-color",
+      "caret-animation",
       "caret-shape"
     ],
     "inherited": true
@@ -1824,7 +2357,9 @@
   {
     "name": "caret-animation",
     "syntax": "auto | manual",
-    "computed": [],
+    "computed": [
+      "asSpecified"
+    ],
     "initial": "auto",
     "inherited": true
   },
@@ -1848,7 +2383,7 @@
   },
   {
     "name": "clear",
-    "syntax": "inline-start | inline-end | block-start | block-end | left | right | top | bottom | both-inline | both-block | both | none",
+    "syntax": "none | left | right | both | inline-start | inline-end",
     "computed": [
       "asSpecified"
     ],
@@ -1857,7 +2392,7 @@
   },
   {
     "name": "clip",
-    "syntax": "<rect()> | auto",
+    "syntax": "<shape> | auto",
     "computed": [
       "autoOrRectangle"
     ],
@@ -1892,20 +2427,6 @@
     "inherited": true
   },
   {
-    "name": "color-adjust",
-    "syntax": "<'print-color-adjust'>",
-    "computed": [],
-    "initial": "see individual properties",
-    "inherited": false
-  },
-  {
-    "name": "color-interpolation",
-    "syntax": "auto | sRGB | linearRGB",
-    "computed": [],
-    "initial": "sRGB",
-    "inherited": true
-  },
-  {
     "name": "color-interpolation-filters",
     "syntax": "auto | sRGB | linearRGB",
     "computed": [
@@ -1925,7 +2446,7 @@
   },
   {
     "name": "column-count",
-    "syntax": "auto | <integer [1,∞]>",
+    "syntax": "<integer> | auto",
     "computed": [
       "asSpecified"
     ],
@@ -1934,7 +2455,7 @@
   },
   {
     "name": "column-fill",
-    "syntax": "auto | balance | balance-all",
+    "syntax": "auto | balance",
     "computed": [
       "asSpecified"
     ],
@@ -1943,7 +2464,7 @@
   },
   {
     "name": "column-gap",
-    "syntax": "normal | <length-percentage [0,∞]>",
+    "syntax": "normal | <length-percentage>",
     "computed": [
       "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn"
     ],
@@ -1953,17 +2474,19 @@
   {
     "name": "column-height",
     "syntax": "auto | <length [0,∞]>",
-    "computed": [],
+    "computed": [
+      "autoOrAbsoluteLength"
+    ],
     "initial": "auto",
     "inherited": false
   },
   {
     "name": "column-rule",
-    "syntax": "<gap-rule-list> | <gap-auto-rule-list>",
+    "syntax": "<'column-rule-width'> || <'column-rule-style'> || <'column-rule-color'>",
     "computed": [
-      "column-rule-color",
+      "column-rule-width",
       "column-rule-style",
-      "column-rule-width"
+      "column-rule-color"
     ],
     "initial": [
       "column-rule-width",
@@ -1973,15 +2496,8 @@
     "inherited": false
   },
   {
-    "name": "column-rule-break",
-    "syntax": "none | spanning-item | intersection",
-    "computed": [],
-    "initial": "spanning-item",
-    "inherited": false
-  },
-  {
     "name": "column-rule-color",
-    "syntax": "<line-color-list> | <auto-line-color-list>",
+    "syntax": "<color>",
     "computed": [
       "computedColor"
     ],
@@ -1989,15 +2505,8 @@
     "inherited": false
   },
   {
-    "name": "column-rule-outset",
-    "syntax": "<length-percentage>",
-    "computed": [],
-    "initial": "50%",
-    "inherited": false
-  },
-  {
     "name": "column-rule-style",
-    "syntax": "<line-style-list> | <auto-line-style-list>",
+    "syntax": "<line-style>",
     "computed": [
       "asSpecified"
     ],
@@ -2006,7 +2515,7 @@
   },
   {
     "name": "column-rule-width",
-    "syntax": "<line-width-list> | <auto-line-width-list>",
+    "syntax": "<line-width>",
     "computed": [
       "absoluteLength0IfColumnRuleStyleNoneOrHidden"
     ],
@@ -2015,7 +2524,7 @@
   },
   {
     "name": "column-span",
-    "syntax": "none | <integer [1,∞]> | all | auto",
+    "syntax": "none | all",
     "computed": [
       "asSpecified"
     ],
@@ -2024,9 +2533,9 @@
   },
   {
     "name": "column-width",
-    "syntax": "auto | <length [0,∞]> | min-content | max-content | fit-content(<length-percentage>)",
+    "syntax": "auto | <length [0,∞]>",
     "computed": [
-      "absoluteLengthZeroOrLarger"
+      "autoOrAbsoluteLength"
     ],
     "initial": "auto",
     "inherited": false
@@ -2034,26 +2543,30 @@
   {
     "name": "column-wrap",
     "syntax": "auto | nowrap | wrap",
-    "computed": [],
+    "computed": [
+      "asSpecified"
+    ],
     "initial": "auto",
     "inherited": false
   },
   {
     "name": "columns",
-    "syntax": "<'column-width'> || <'column-count'> [ / <'column-height'> ]?",
+    "syntax": "[ <'column-width'> || <'column-count'> ] [ / <'column-height'> ]?",
     "computed": [
       "column-width",
-      "column-count"
+      "column-count",
+      "column-height"
     ],
     "initial": [
       "column-width",
-      "column-count"
+      "column-count",
+      "column-height"
     ],
     "inherited": false
   },
   {
     "name": "contain",
-    "syntax": "none | strict | content | [ [size | inline-size] || layout || style || paint ]",
+    "syntax": "none | strict | content | [ [ size || inline-size ] || layout || style || paint ]",
     "computed": [
       "asSpecified"
     ],
@@ -2061,8 +2574,88 @@
     "inherited": false
   },
   {
+    "name": "contain-intrinsic-block-size",
+    "syntax": "auto? [ none | <length> ]",
+    "computed": [
+      "asSpecifiedWithLengthValuesComputed"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "contain-intrinsic-height",
+    "syntax": "auto? [ none | <length> ]",
+    "computed": [
+      "asSpecifiedWithLengthValuesComputed"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "contain-intrinsic-inline-size",
+    "syntax": "auto? [ none | <length> ]",
+    "computed": [
+      "asSpecifiedWithLengthValuesComputed"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "contain-intrinsic-size",
+    "syntax": "[ auto? [ none | <length> ] ]{1,2}",
+    "computed": [
+      "contain-intrinsic-width",
+      "contain-intrinsic-height"
+    ],
+    "initial": [
+      "contain-intrinsic-width",
+      "contain-intrinsic-height"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "contain-intrinsic-width",
+    "syntax": "auto? [ none | <length> ]",
+    "computed": [
+      "asSpecifiedWithLengthValuesComputed"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "container",
+    "syntax": "<'container-name'> [ / <'container-type'> ]?",
+    "computed": [
+      "container-name",
+      "container-type"
+    ],
+    "initial": [
+      "container-name",
+      "container-type"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "container-name",
+    "syntax": "none | <custom-ident>+",
+    "computed": [
+      "noneOrOrderedListOfIdentifiers"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "container-type",
+    "syntax": "normal | [ [ size | inline-size ] || scroll-state ]",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
     "name": "content",
-    "syntax": "normal | none | [ <content-replacement> | <content-list> ] [/ [ <string> | <counter> | <attr()> ]+ ]? | <element()>",
+    "syntax": "normal | none | [ <content-replacement> | <content-list> ] [ / [ <string> | <counter> | <attr()> ]+ ]?",
     "computed": [
       "normalOnElementsForPseudosNoneAbsoluteURIStringOrAsSpecified"
     ],
@@ -2080,121 +2673,195 @@
   },
   {
     "name": "corner-block-end-shape",
-    "syntax": "<corner-shape-value>",
-    "computed": [],
-    "initial": "round",
+    "syntax": "<corner-shape-value>{1,2}",
+    "computed": [
+      "corner-end-start-shape",
+      "corner-end-end-shape"
+    ],
+    "initial": [
+      "corner-end-start-shape",
+      "corner-end-end-shape"
+    ],
     "inherited": false
   },
   {
     "name": "corner-block-start-shape",
-    "syntax": "<corner-shape-value>",
-    "computed": [],
-    "initial": "round",
+    "syntax": "<corner-shape-value>{1,2}",
+    "computed": [
+      "corner-start-start-shape",
+      "corner-start-end-shape"
+    ],
+    "initial": [
+      "corner-start-start-shape",
+      "corner-start-end-shape"
+    ],
     "inherited": false
   },
   {
     "name": "corner-bottom-left-shape",
     "syntax": "<corner-shape-value>",
-    "computed": [],
+    "computed": [
+      "correspondingSuperellipse"
+    ],
     "initial": "round",
     "inherited": false
   },
   {
     "name": "corner-bottom-right-shape",
     "syntax": "<corner-shape-value>",
-    "computed": [],
+    "computed": [
+      "correspondingSuperellipse"
+    ],
     "initial": "round",
     "inherited": false
   },
   {
     "name": "corner-bottom-shape",
-    "syntax": "<corner-shape-value>",
-    "computed": [],
-    "initial": "round",
+    "syntax": "<corner-shape-value>{1,2}",
+    "computed": [
+      "corner-bottom-left-shape",
+      "corner-bottom-right-shape"
+    ],
+    "initial": [
+      "corner-bottom-left-shape",
+      "corner-bottom-right-shape"
+    ],
     "inherited": false
   },
   {
     "name": "corner-end-end-shape",
     "syntax": "<corner-shape-value>",
-    "computed": [],
+    "computed": [
+      "correspondingSuperellipse"
+    ],
     "initial": "round",
     "inherited": false
   },
   {
     "name": "corner-end-start-shape",
     "syntax": "<corner-shape-value>",
-    "computed": [],
+    "computed": [
+      "correspondingSuperellipse"
+    ],
     "initial": "round",
     "inherited": false
   },
   {
     "name": "corner-inline-end-shape",
-    "syntax": "<corner-shape-value>",
-    "computed": [],
-    "initial": "round",
+    "syntax": "<corner-shape-value>{1,2}",
+    "computed": [
+      "corner-start-end-shape",
+      "corner-end-end-shape"
+    ],
+    "initial": [
+      "corner-start-end-shape",
+      "corner-end-end-shape"
+    ],
     "inherited": false
   },
   {
     "name": "corner-inline-start-shape",
-    "syntax": "<corner-shape-value>",
-    "computed": [],
-    "initial": "round",
+    "syntax": "<corner-shape-value>{1,2}",
+    "computed": [
+      "corner-start-start-shape",
+      "corner-start-end-shape"
+    ],
+    "initial": [
+      "corner-start-start-shape",
+      "corner-start-end-shape"
+    ],
     "inherited": false
   },
   {
     "name": "corner-left-shape",
-    "syntax": "<corner-shape-value>",
-    "computed": [],
-    "initial": "round",
+    "syntax": "<corner-shape-value>{1,2}",
+    "computed": [
+      "corner-top-left-shape",
+      "corner-bottom-left-shape"
+    ],
+    "initial": [
+      "corner-top-left-shape",
+      "corner-bottom-left-shape"
+    ],
     "inherited": false
   },
   {
     "name": "corner-right-shape",
-    "syntax": "<corner-shape-value>",
-    "computed": [],
-    "initial": "round",
+    "syntax": "<corner-shape-value>{1,2}",
+    "computed": [
+      "corner-top-right-shape",
+      "corner-bottom-right-shape"
+    ],
+    "initial": [
+      "corner-top-right-shape",
+      "corner-bottom-right-shape"
+    ],
     "inherited": false
   },
   {
     "name": "corner-shape",
     "syntax": "<corner-shape-value>{1,4}",
-    "computed": [],
-    "initial": "round",
+    "computed": [
+      "corner-top-left-shape",
+      "corner-top-right-shape",
+      "corner-bottom-left-shape",
+      "corner-bottom-right-shape"
+    ],
+    "initial": [
+      "corner-top-left-shape",
+      "corner-top-right-shape",
+      "corner-bottom-left-shape",
+      "corner-bottom-right-shape"
+    ],
     "inherited": false
   },
   {
     "name": "corner-start-end-shape",
     "syntax": "<corner-shape-value>",
-    "computed": [],
+    "computed": [
+      "correspondingSuperellipse"
+    ],
     "initial": "round",
     "inherited": false
   },
   {
     "name": "corner-start-start-shape",
     "syntax": "<corner-shape-value>",
-    "computed": [],
+    "computed": [
+      "correspondingSuperellipse"
+    ],
     "initial": "round",
     "inherited": false
   },
   {
     "name": "corner-top-left-shape",
     "syntax": "<corner-shape-value>",
-    "computed": [],
+    "computed": [
+      "correspondingSuperellipse"
+    ],
     "initial": "round",
     "inherited": false
   },
   {
     "name": "corner-top-right-shape",
     "syntax": "<corner-shape-value>",
-    "computed": [],
+    "computed": [
+      "correspondingSuperellipse"
+    ],
     "initial": "round",
     "inherited": false
   },
   {
     "name": "corner-top-shape",
-    "syntax": "<corner-shape-value>",
-    "computed": [],
-    "initial": "round",
+    "syntax": "<corner-shape-value>{1,2}",
+    "computed": [
+      "corner-top-left-shape",
+      "corner-top-right-shape"
+    ],
+    "initial": [
+      "corner-top-left-shape",
+      "corner-top-right-shape"
+    ],
     "inherited": false
   },
   {
@@ -2225,29 +2892,8 @@
     "inherited": false
   },
   {
-    "name": "cue",
-    "syntax": "<'cue-before'> <'cue-after'>?",
-    "computed": [],
-    "initial": "see individual properties",
-    "inherited": false
-  },
-  {
-    "name": "cue-after",
-    "syntax": "<uri> <decibel>? | none",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "cue-before",
-    "syntax": "<uri> <decibel>? | none",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
     "name": "cursor",
-    "syntax": "[ [ <url> | <url-set> ] [<x> <y>]? ]#? [ auto | default | none | context-menu | help | pointer | progress | wait | cell | crosshair | text | vertical-text | alias | copy | move | no-drop | not-allowed | grab | grabbing | e-resize | n-resize | ne-resize | nw-resize | s-resize | se-resize | sw-resize | w-resize | ew-resize | ns-resize | nesw-resize | nwse-resize | col-resize | row-resize | all-scroll | zoom-in | zoom-out ]",
+    "syntax": "[ [ <url> [ <x> <y> ]? , ]* <cursor-predefined> ]",
     "computed": [
       "asSpecifiedURLsAbsolute"
     ],
@@ -2256,7 +2902,7 @@
   },
   {
     "name": "cx",
-    "syntax": "<length-percentage>",
+    "syntax": "<length> | <percentage>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -2265,7 +2911,7 @@
   },
   {
     "name": "cy",
-    "syntax": "<length-percentage>",
+    "syntax": "<length> | <percentage>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -2274,7 +2920,7 @@
   },
   {
     "name": "d",
-    "syntax": "none | <string>",
+    "syntax": "none | path(<string>)",
     "computed": [
       "asSpecified"
     ],
@@ -2292,7 +2938,7 @@
   },
   {
     "name": "display",
-    "syntax": "[ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy> | <display-outside> || [ <display-inside> | math ]",
+    "syntax": "[ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy>",
     "computed": [
       "asSpecifiedExceptPositionedFloatingAndRootElementsKeywordMaybeDifferent"
     ],
@@ -2310,8 +2956,10 @@
   },
   {
     "name": "dynamic-range-limit",
-    "syntax": "standard | no-limit | constrained-high | <dynamic-range-limit-mix()>",
-    "computed": [],
+    "syntax": "standard | no-limit | constrained | <dynamic-range-limit-mix()>",
+    "computed": [
+      "computedValueForDynamicRangeLimit"
+    ],
     "initial": "no-limit",
     "inherited": true
   },
@@ -2326,7 +2974,7 @@
   },
   {
     "name": "field-sizing",
-    "syntax": "fixed | content",
+    "syntax": "content | fixed",
     "computed": [
       "asSpecified"
     ],
@@ -2343,27 +2991,6 @@
     "inherited": true
   },
   {
-    "name": "fill-break",
-    "syntax": "bounding-box | slice | clone",
-    "computed": [],
-    "initial": "bounding-box",
-    "inherited": false
-  },
-  {
-    "name": "fill-color",
-    "syntax": "<color>",
-    "computed": [],
-    "initial": "currentcolor",
-    "inherited": true
-  },
-  {
-    "name": "fill-image",
-    "syntax": "<paint>#",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
     "name": "fill-opacity",
     "syntax": "<'opacity'>",
     "computed": [
@@ -2373,40 +3000,12 @@
     "inherited": true
   },
   {
-    "name": "fill-origin",
-    "syntax": "match-parent | fill-box | stroke-box | content-box | padding-box | border-box",
-    "computed": [],
-    "initial": "match-parent",
-    "inherited": false
-  },
-  {
-    "name": "fill-position",
-    "syntax": "<position>#",
-    "computed": [],
-    "initial": "0% 0%",
-    "inherited": true
-  },
-  {
-    "name": "fill-repeat",
-    "syntax": "<repeat-style>#",
-    "computed": [],
-    "initial": "repeat",
-    "inherited": true
-  },
-  {
     "name": "fill-rule",
     "syntax": "nonzero | evenodd",
     "computed": [
       "asSpecified"
     ],
     "initial": "nonzero",
-    "inherited": true
-  },
-  {
-    "name": "fill-size",
-    "syntax": "<bg-size>#",
-    "computed": [],
-    "initial": "auto",
     "inherited": true
   },
   {
@@ -2466,7 +3065,7 @@
   },
   {
     "name": "flex-grow",
-    "syntax": "<number [0,∞]>",
+    "syntax": "<number>",
     "computed": [
       "asSpecified"
     ],
@@ -2475,7 +3074,7 @@
   },
   {
     "name": "flex-shrink",
-    "syntax": "<number [0,∞]>",
+    "syntax": "<number>",
     "computed": [
       "asSpecified"
     ],
@@ -2493,32 +3092,11 @@
   },
   {
     "name": "float",
-    "syntax": "block-start | block-end | inline-start | inline-end | snap-block | <snap-block()> | snap-inline | <snap-inline()> | left | right | top | bottom | none | footnote",
+    "syntax": "left | right | none | inline-start | inline-end",
     "computed": [
       "asSpecified"
     ],
     "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "float-defer",
-    "syntax": "<integer> | last | none",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "float-offset",
-    "syntax": "<length-percentage>",
-    "computed": [],
-    "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "float-reference",
-    "syntax": "inline | column | region | page",
-    "computed": [],
-    "initial": "inline",
     "inherited": false
   },
   {
@@ -2537,20 +3115,6 @@
       "specifiedValueClipped0To1"
     ],
     "initial": "black",
-    "inherited": false
-  },
-  {
-    "name": "flow-from",
-    "syntax": "<ident> | none",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "flow-into",
-    "syntax": "none | <ident> [element | content]?",
-    "computed": [],
-    "initial": "none",
     "inherited": false
   },
   {
@@ -2641,7 +3205,7 @@
   },
   {
     "name": "font-size-adjust",
-    "syntax": "none | <number [0,∞]>",
+    "syntax": "none | [ ex-height | cap-height | ch-width | ic-width | ic-height ]? [ from-font | <number> ]",
     "computed": [
       "asSpecified"
     ],
@@ -2649,17 +3213,26 @@
     "inherited": true
   },
   {
+    "name": "font-smooth",
+    "syntax": "auto | never | always | <absolute-size> | <length>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
     "name": "font-stretch",
-    "syntax": "",
+    "syntax": "<font-stretch-absolute>",
     "computed": [
       "asSpecified"
     ],
     "initial": "normal",
-    "inherited": false
+    "inherited": true
   },
   {
     "name": "font-style",
-    "syntax": "normal | italic | oblique <angle [-90deg,90deg]>?",
+    "syntax": "normal | italic | oblique <angle>?",
     "computed": [
       "asSpecified"
     ],
@@ -2695,7 +3268,7 @@
   },
   {
     "name": "font-synthesis-style",
-    "syntax": "auto | none | oblique-only",
+    "syntax": "auto | none",
     "computed": [
       "asSpecified"
     ],
@@ -2713,7 +3286,7 @@
   },
   {
     "name": "font-variant",
-    "syntax": "normal | none | [ [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ] || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ] || [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ] || [ <east-asian-variant-values> || <east-asian-width-values> || ruby ] || [ sub | super ] || [ text | emoji | unicode ] ]",
+    "syntax": "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> || stylistic( <feature-value-name> ) || historical-forms || styleset( <feature-value-name># ) || character-variant( <feature-value-name># ) || swash( <feature-value-name> ) || ornaments( <feature-value-name> ) || annotation( <feature-value-name> ) || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero || <east-asian-variant-values> || <east-asian-width-values> || ruby ]",
     "computed": [
       "asSpecified"
     ],
@@ -2722,7 +3295,7 @@
   },
   {
     "name": "font-variant-alternates",
-    "syntax": "normal | [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ]",
+    "syntax": "normal | [ stylistic( <feature-value-name> ) || historical-forms || styleset( <feature-value-name># ) || character-variant( <feature-value-name># ) || swash( <feature-value-name> ) || ornaments( <feature-value-name> ) || annotation( <feature-value-name> ) ]",
     "computed": [
       "asSpecified"
     ],
@@ -2785,7 +3358,7 @@
   },
   {
     "name": "font-variation-settings",
-    "syntax": "normal | [ <opentype-tag> <number>]#",
+    "syntax": "normal | [ <string> <number> ]#",
     "computed": [
       "asSpecified"
     ],
@@ -2804,23 +3377,11 @@
   {
     "name": "font-width",
     "syntax": "normal | <percentage [0,∞]> | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded",
-    "computed": [],
+    "computed": [
+      "percentage"
+    ],
     "initial": "normal",
     "inherited": true
-  },
-  {
-    "name": "footnote-display",
-    "syntax": "block | inline | compact",
-    "computed": [],
-    "initial": "block",
-    "inherited": false
-  },
-  {
-    "name": "footnote-policy",
-    "syntax": "auto | line | block",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
   },
   {
     "name": "forced-color-adjust",
@@ -2842,13 +3403,6 @@
       "row-gap",
       "column-gap"
     ],
-    "inherited": false
-  },
-  {
-    "name": "glyph-orientation-vertical",
-    "syntax": "auto | 0deg | 90deg | 0 | 90",
-    "computed": [],
-    "initial": "n/a",
     "inherited": false
   },
   {
@@ -2948,7 +3502,7 @@
   },
   {
     "name": "grid-column-gap",
-    "syntax": "",
+    "syntax": "<length-percentage>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -2966,7 +3520,7 @@
   },
   {
     "name": "grid-gap",
-    "syntax": "",
+    "syntax": "<'grid-row-gap'> <'grid-column-gap'>?",
     "computed": [
       "grid-row-gap",
       "grid-column-gap"
@@ -3001,7 +3555,7 @@
   },
   {
     "name": "grid-row-gap",
-    "syntax": "",
+    "syntax": "<length-percentage>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -3070,12 +3624,30 @@
   },
   {
     "name": "height",
-    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "computed": [
       "percentageAutoOrAbsoluteLength"
     ],
     "initial": "auto",
     "inherited": false
+  },
+  {
+    "name": "hyphenate-character",
+    "syntax": "auto | <string>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "hyphenate-limit-chars",
+    "syntax": "[ auto | <integer> ]{1,3}",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
   },
   {
     "name": "hyphens",
@@ -3088,7 +3660,7 @@
   },
   {
     "name": "image-orientation",
-    "syntax": "from-image | none | [ <angle> || flip ]",
+    "syntax": "from-image | <angle> | [ <angle>? flip ]",
     "computed": [
       "angleRoundedToNextQuarter"
     ],
@@ -3097,7 +3669,7 @@
   },
   {
     "name": "image-rendering",
-    "syntax": "auto | smooth | high-quality | pixelated | crisp-edges",
+    "syntax": "auto | crisp-edges | pixelated | smooth",
     "computed": [
       "asSpecified"
     ],
@@ -3105,8 +3677,26 @@
     "inherited": true
   },
   {
+    "name": "image-resolution",
+    "syntax": "[ from-image || <resolution> ] && snap?",
+    "computed": [
+      "asSpecifiedWithExceptionOfResolution"
+    ],
+    "initial": "1dppx",
+    "inherited": true
+  },
+  {
+    "name": "ime-mode",
+    "syntax": "auto | normal | active | inactive | disabled",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
     "name": "initial-letter",
-    "syntax": "normal | <number [1,∞]> <integer [1,∞]> | <number [1,∞]> && [ drop | raise ]?",
+    "syntax": "normal | [ <number> <integer>? ]",
     "computed": [
       "asSpecified"
     ],
@@ -3115,19 +3705,12 @@
   },
   {
     "name": "initial-letter-align",
-    "syntax": "[ border-box? [ alphabetic | ideographic | hanging | leading ]? ]!",
+    "syntax": "[ auto | alphabetic | hanging | ideographic ]",
     "computed": [
       "asSpecified"
     ],
     "initial": "auto",
-    "inherited": true
-  },
-  {
-    "name": "initial-letter-wrap",
-    "syntax": "none | first | all | grid | <length-percentage>",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
+    "inherited": false
   },
   {
     "name": "inline-size",
@@ -3135,20 +3718,6 @@
     "computed": [
       "sameAsWidthAndHeight"
     ],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "inline-sizing",
-    "syntax": "normal | stretch",
-    "computed": [],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "input-security",
-    "syntax": "auto | none",
-    "computed": [],
     "initial": "auto",
     "inherited": false
   },
@@ -3184,7 +3753,7 @@
   },
   {
     "name": "inset-block-end",
-    "syntax": "auto | <length-percentage>",
+    "syntax": "<'top'>",
     "computed": [
       "sameAsBoxOffsets"
     ],
@@ -3193,7 +3762,7 @@
   },
   {
     "name": "inset-block-start",
-    "syntax": "auto | <length-percentage>",
+    "syntax": "<'top'>",
     "computed": [
       "sameAsBoxOffsets"
     ],
@@ -3215,7 +3784,7 @@
   },
   {
     "name": "inset-inline-end",
-    "syntax": "auto | <length-percentage>",
+    "syntax": "<'top'>",
     "computed": [
       "sameAsBoxOffsets"
     ],
@@ -3224,7 +3793,7 @@
   },
   {
     "name": "inset-inline-start",
-    "syntax": "auto | <length-percentage>",
+    "syntax": "<'top'>",
     "computed": [
       "sameAsBoxOffsets"
     ],
@@ -3234,13 +3803,55 @@
   {
     "name": "interactivity",
     "syntax": "auto | inert",
-    "computed": [],
+    "computed": [
+      "asSpecified"
+    ],
     "initial": "auto",
     "inherited": true
   },
   {
+    "name": "interest-delay",
+    "syntax": "<'interest-delay-start'>{1,2}",
+    "computed": [
+      "interest-delay-start",
+      "interest-delay-end"
+    ],
+    "initial": [
+      "interest-delay-start",
+      "interest-delay-end"
+    ],
+    "inherited": true
+  },
+  {
+    "name": "interest-delay-end",
+    "syntax": "normal | <time>",
+    "computed": [
+      "normalOrComputedTime"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "interest-delay-start",
+    "syntax": "normal | <time>",
+    "computed": [
+      "normalOrComputedTime"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
+    "name": "interpolate-size",
+    "syntax": "numeric-only | allow-keywords",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "numeric-only",
+    "inherited": true
+  },
+  {
     "name": "isolation",
-    "syntax": "<isolation-mode>",
+    "syntax": "auto | isolate",
     "computed": [
       "asSpecified"
     ],
@@ -3272,6 +3883,15 @@
       "asSpecified"
     ],
     "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "justify-tracks",
+    "syntax": "[ normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ] ]#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
     "inherited": false
   },
   {
@@ -3311,22 +3931,17 @@
     "inherited": true
   },
   {
-    "name": "line-fit-edge",
-    "syntax": "leading | <text-edge>",
-    "computed": [],
-    "initial": "leading",
-    "inherited": true
-  },
-  {
-    "name": "line-grid",
-    "syntax": "match-parent | create",
-    "computed": [],
-    "initial": "match-parent",
+    "name": "line-clamp",
+    "syntax": "none | <integer>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
     "inherited": false
   },
   {
     "name": "line-height",
-    "syntax": "normal | <number [0,∞]> | <length-percentage [0,∞]>",
+    "syntax": "normal | <number> | <length> | <percentage>",
     "computed": [
       "absoluteLengthOrAsSpecified"
     ],
@@ -3335,7 +3950,7 @@
   },
   {
     "name": "line-height-step",
-    "syntax": "<length [0,∞]>",
+    "syntax": "<length>",
     "computed": [
       "absoluteLength"
     ],
@@ -3343,22 +3958,8 @@
     "inherited": true
   },
   {
-    "name": "line-snap",
-    "syntax": "none | baseline | contain",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "link-parameters",
-    "syntax": "none | <link-param>+",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
     "name": "list-style",
-    "syntax": "<'list-style-position'> || <'list-style-image'> || <'list-style-type'>",
+    "syntax": "<'list-style-type'> || <'list-style-position'> || <'list-style-image'>",
     "computed": [
       "list-style-image",
       "list-style-position",
@@ -3369,7 +3970,7 @@
       "list-style-position",
       "list-style-image"
     ],
-    "inherited": false
+    "inherited": true
   },
   {
     "name": "list-style-image",
@@ -3456,13 +4057,6 @@
     "inherited": false
   },
   {
-    "name": "margin-break",
-    "syntax": "auto | keep | discard",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
     "name": "margin-inline",
     "syntax": "<'margin-top'>{1,2}",
     "computed": [
@@ -3522,7 +4116,7 @@
   },
   {
     "name": "margin-trim",
-    "syntax": "none | [ block || inline ] | [ block-start || inline-start || block-end || inline-end ]",
+    "syntax": "none | in-flow | all",
     "computed": [
       "asSpecified"
     ],
@@ -3531,7 +4125,7 @@
   },
   {
     "name": "marker",
-    "syntax": "none | <marker-ref>",
+    "syntax": "none | <url>",
     "computed": [
       "asSpecified"
     ],
@@ -3544,7 +4138,7 @@
   },
   {
     "name": "marker-end",
-    "syntax": "none | <marker-ref>",
+    "syntax": "none | <url>",
     "computed": [
       "asSpecifiedURLsAbsolute"
     ],
@@ -3553,7 +4147,7 @@
   },
   {
     "name": "marker-mid",
-    "syntax": "none | <marker-ref>",
+    "syntax": "none | <url>",
     "computed": [
       "asSpecifiedURLsAbsolute"
     ],
@@ -3561,15 +4155,8 @@
     "inherited": true
   },
   {
-    "name": "marker-side",
-    "syntax": "match-self | match-parent",
-    "computed": [],
-    "initial": "match-self",
-    "inherited": true
-  },
-  {
     "name": "marker-start",
-    "syntax": "none | <marker-ref>",
+    "syntax": "none | <url>",
     "computed": [
       "asSpecifiedURLsAbsolute"
     ],
@@ -3651,7 +4238,7 @@
   },
   {
     "name": "mask-border-slice",
-    "syntax": "[ <number> | <percentage> ]{1,4} fill?",
+    "syntax": "<number-percentage>{1,4} fill?",
     "computed": [
       "asSpecified"
     ],
@@ -3758,6 +4345,15 @@
     "inherited": false
   },
   {
+    "name": "masonry-auto-flow",
+    "syntax": "[ pack | next ] || [ definite-first | ordered ]",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "pack",
+    "inherited": false
+  },
+  {
     "name": "math-depth",
     "syntax": "auto-add | add(<integer>) | <integer>",
     "computed": [
@@ -3795,7 +4391,7 @@
   },
   {
     "name": "max-height",
-    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "computed": [
       "percentageAsSpecifiedAbsoluteLengthOrNone"
     ],
@@ -3812,8 +4408,17 @@
     "inherited": false
   },
   {
+    "name": "max-lines",
+    "syntax": "none | <integer>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
     "name": "max-width",
-    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "computed": [
       "percentageAsSpecifiedAbsoluteLengthOrNone"
     ],
@@ -3831,7 +4436,7 @@
   },
   {
     "name": "min-height",
-    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -3849,7 +4454,7 @@
   },
   {
     "name": "min-width",
-    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -3863,34 +4468,6 @@
       "asSpecified"
     ],
     "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "nav-down",
-    "syntax": "auto | <id> [ current | root | <target-name> ]?",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "nav-left",
-    "syntax": "auto | <id> [ current | root | <target-name> ]?",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "nav-right",
-    "syntax": "auto | <id> [ current | root | <target-name> ]?",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "nav-up",
-    "syntax": "auto | <id> [ current | root | <target-name> ]?",
-    "computed": [],
-    "initial": "auto",
     "inherited": false
   },
   {
@@ -3909,6 +4486,15 @@
       "asSpecified"
     ],
     "initial": "50% 50%",
+    "inherited": true
+  },
+  {
+    "name": "object-view-box",
+    "syntax": "none | <basic-shape-rect>",
+    "computed": [
+      "specifiedKeywordOrComputedFunction"
+    ],
+    "initial": "none",
     "inherited": false
   },
   {
@@ -3995,7 +4581,7 @@
   },
   {
     "name": "orphans",
-    "syntax": "<integer [1,∞]>",
+    "syntax": "<integer>",
     "computed": [
       "asSpecified"
     ],
@@ -4019,7 +4605,7 @@
   },
   {
     "name": "outline-color",
-    "syntax": "auto | <color> | <image-1D>",
+    "syntax": "auto | <color>",
     "computed": [
       "autoForTranslucentColorRGBAOtherwiseRGB"
     ],
@@ -4055,7 +4641,7 @@
   },
   {
     "name": "overflow",
-    "syntax": "<'overflow-block'>{1,2}",
+    "syntax": "[ visible | hidden | clip | scroll | auto ]{1,2}",
     "computed": [
       "overflow-x",
       "overflow-y"
@@ -4079,6 +4665,15 @@
       "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
     ],
     "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "overflow-clip-box",
+    "syntax": "padding-box | content-box",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "padding-box",
     "inherited": false
   },
   {
@@ -4124,6 +4719,15 @@
       "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent"
     ],
     "initial": "visible",
+    "inherited": false
+  },
+  {
+    "name": "overlay",
+    "syntax": "none | auto",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
     "inherited": false
   },
   {
@@ -4298,7 +4902,7 @@
   },
   {
     "name": "page-break-after",
-    "syntax": "auto | always | avoid | left | right | inherit",
+    "syntax": "auto | always | avoid | left | right | recto | verso",
     "computed": [
       "asSpecified"
     ],
@@ -4307,7 +4911,7 @@
   },
   {
     "name": "page-break-before",
-    "syntax": "auto | always | avoid | left | right | inherit",
+    "syntax": "auto | always | avoid | left | right | recto | verso",
     "computed": [
       "asSpecified"
     ],
@@ -4316,7 +4920,7 @@
   },
   {
     "name": "page-break-inside",
-    "syntax": "avoid | auto | inherit",
+    "syntax": "auto | avoid",
     "computed": [
       "asSpecified"
     ],
@@ -4333,24 +4937,21 @@
     "inherited": true
   },
   {
-    "name": "pause",
-    "syntax": "<'pause-before'> <'pause-after'>?",
-    "computed": [],
-    "initial": "see individual properties",
-    "inherited": false
-  },
-  {
-    "name": "pause-after",
-    "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
-    "computed": [],
+    "name": "perspective",
+    "syntax": "none | <length>",
+    "computed": [
+      "absoluteLengthOrNone"
+    ],
     "initial": "none",
     "inherited": false
   },
   {
-    "name": "pause-before",
-    "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
-    "computed": [],
-    "initial": "none",
+    "name": "perspective-origin",
+    "syntax": "<position>",
+    "computed": [
+      "forLengthAbsoluteValueOtherwisePercentage"
+    ],
+    "initial": "50% 50%",
     "inherited": false
   },
   {
@@ -4394,7 +4995,7 @@
   },
   {
     "name": "pointer-events",
-    "syntax": "auto | bounding-box | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all | none",
+    "syntax": "auto | none | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all | inherit",
     "computed": [
       "asSpecified"
     ],
@@ -4403,7 +5004,7 @@
   },
   {
     "name": "position",
-    "syntax": "static | relative | absolute | sticky | fixed | <running()>",
+    "syntax": "static | relative | absolute | sticky | fixed",
     "computed": [
       "asSpecified"
     ],
@@ -4412,11 +5013,11 @@
   },
   {
     "name": "position-anchor",
-    "syntax": "auto | <anchor-name>",
+    "syntax": "normal | auto | none | <anchor-name> | match-parent",
     "computed": [
       "asSpecified"
     ],
-    "initial": "auto",
+    "initial": "normal",
     "inherited": false
   },
   {
@@ -4479,7 +5080,7 @@
   },
   {
     "name": "quotes",
-    "syntax": "auto | none | match-parent | [ <string> <string> ]+",
+    "syntax": "none | auto | [ <string> <string> ]+",
     "computed": [
       "asSpecified"
     ],
@@ -4488,7 +5089,7 @@
   },
   {
     "name": "r",
-    "syntax": "<length-percentage>",
+    "syntax": "<length> | <percentage>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -4498,22 +5099,19 @@
   {
     "name": "reading-flow",
     "syntax": "normal | source-order | flex-visual | flex-flow | grid-rows | grid-columns | grid-order",
-    "computed": [],
+    "computed": [
+      "asSpecified"
+    ],
     "initial": "normal",
     "inherited": false
   },
   {
     "name": "reading-order",
     "syntax": "<integer>",
-    "computed": [],
+    "computed": [
+      "specifiedInteger"
+    ],
     "initial": "0",
-    "inherited": false
-  },
-  {
-    "name": "region-fragment",
-    "syntax": "auto | break",
-    "computed": [],
-    "initial": "auto",
     "inherited": false
   },
   {
@@ -4522,27 +5120,6 @@
     "computed": [
       "asSpecified"
     ],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "rest",
-    "syntax": "<'rest-before'> <'rest-after'>?",
-    "computed": [],
-    "initial": "see individual properties",
-    "inherited": false
-  },
-  {
-    "name": "rest-after",
-    "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "rest-before",
-    "syntax": "<time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong",
-    "computed": [],
     "initial": "none",
     "inherited": false
   },
@@ -4556,54 +5133,21 @@
     "inherited": false
   },
   {
-    "name": "row-gap",
-    "syntax": "normal | <length-percentage [0,∞]>",
+    "name": "rotate",
+    "syntax": "none | <angle> | [ x | y | z | <number>{3} ] && <angle>",
     "computed": [
-      "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn"
+      "asSpecified"
     ],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "row-rule",
-    "syntax": "<gap-rule-list> | <gap-auto-rule-list>",
-    "computed": [],
-    "initial": "see individual properties",
-    "inherited": false
-  },
-  {
-    "name": "row-rule-break",
-    "syntax": "none | spanning-item | intersection",
-    "computed": [],
-    "initial": "spanning-item",
-    "inherited": false
-  },
-  {
-    "name": "row-rule-color",
-    "syntax": "<line-color-list> | <auto-line-color-list>",
-    "computed": [],
-    "initial": "currentcolor",
-    "inherited": false
-  },
-  {
-    "name": "row-rule-outset",
-    "syntax": "<length-percentage>",
-    "computed": [],
-    "initial": "50%",
-    "inherited": false
-  },
-  {
-    "name": "row-rule-style",
-    "syntax": "<line-style-list> | <auto-line-style-list>",
-    "computed": [],
     "initial": "none",
     "inherited": false
   },
   {
-    "name": "row-rule-width",
-    "syntax": "<line-width-list> | <auto-line-width-list>",
-    "computed": [],
-    "initial": "medium",
+    "name": "row-gap",
+    "syntax": "normal | <length-percentage>",
+    "computed": [
+      "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn"
+    ],
+    "initial": "normal",
     "inherited": false
   },
   {
@@ -4617,7 +5161,7 @@
   },
   {
     "name": "ruby-merge",
-    "syntax": "separate | merge | auto",
+    "syntax": "separate | collapse | auto",
     "computed": [
       "asSpecified"
     ],
@@ -4627,7 +5171,9 @@
   {
     "name": "ruby-overhang",
     "syntax": "auto | none",
-    "computed": [],
+    "computed": [
+      "theSpecifiedKeyword"
+    ],
     "initial": "auto",
     "inherited": true
   },
@@ -4641,61 +5187,12 @@
     "inherited": true
   },
   {
-    "name": "rule",
-    "syntax": "<'column-rule'>",
-    "computed": [],
-    "initial": "see individual properties",
-    "inherited": false
-  },
-  {
-    "name": "rule-break",
-    "syntax": "<'column-rule-break'>",
-    "computed": [],
-    "initial": "see individual properties",
-    "inherited": false
-  },
-  {
-    "name": "rule-color",
-    "syntax": "<'column-rule-color'>",
-    "computed": [],
-    "initial": "see individual properties",
-    "inherited": false
-  },
-  {
-    "name": "rule-outset",
-    "syntax": "<'column-rule-outset'>",
-    "computed": [],
-    "initial": "see individual properties",
-    "inherited": false
-  },
-  {
-    "name": "rule-paint-order",
-    "syntax": "row-over-column | column-over-row",
-    "computed": [],
-    "initial": "row-over-column",
-    "inherited": false
-  },
-  {
-    "name": "rule-style",
-    "syntax": "<'column-rule-style'>",
-    "computed": [],
-    "initial": "see individual properties",
-    "inherited": false
-  },
-  {
-    "name": "rule-width",
-    "syntax": "<'column-rule-width'>",
-    "computed": [],
-    "initial": "see individual properties",
-    "inherited": false
-  },
-  {
     "name": "rx",
     "syntax": "<length-percentage> | auto",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
-    "initial": "0",
+    "initial": "auto",
     "inherited": false
   },
   {
@@ -4704,7 +5201,16 @@
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
-    "initial": "0",
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "scale",
+    "syntax": "none | [ <number> | <percentage> ]{1,3}",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
     "inherited": false
   },
   {
@@ -4714,6 +5220,15 @@
       "asSpecified"
     ],
     "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "scroll-initial-target",
+    "syntax": "none | nearest",
+    "computed": [
+      "theSpecifiedKeyword"
+    ],
+    "initial": "none",
     "inherited": false
   },
   {
@@ -4832,8 +5347,17 @@
     "inherited": false
   },
   {
+    "name": "scroll-marker-group",
+    "syntax": "none | before | after",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
     "name": "scroll-padding",
-    "syntax": "[ auto | <length-percentage [0,∞]> ]{1,4}",
+    "syntax": "[ auto | <length-percentage> ]{1,4}",
     "computed": [
       "scroll-padding-bottom",
       "scroll-padding-left",
@@ -4850,7 +5374,7 @@
   },
   {
     "name": "scroll-padding-block",
-    "syntax": "[ auto | <length-percentage [0,∞]> ]{1,2}",
+    "syntax": "[ auto | <length-percentage> ]{1,2}",
     "computed": [
       "scroll-padding-block-start",
       "scroll-padding-block-end"
@@ -4863,7 +5387,7 @@
   },
   {
     "name": "scroll-padding-block-end",
-    "syntax": "auto | <length-percentage [0,∞]>",
+    "syntax": "auto | <length-percentage>",
     "computed": [
       "asSpecified"
     ],
@@ -4872,7 +5396,7 @@
   },
   {
     "name": "scroll-padding-block-start",
-    "syntax": "auto | <length-percentage [0,∞]>",
+    "syntax": "auto | <length-percentage>",
     "computed": [
       "asSpecified"
     ],
@@ -4881,7 +5405,7 @@
   },
   {
     "name": "scroll-padding-bottom",
-    "syntax": "auto | <length-percentage [0,∞]>",
+    "syntax": "auto | <length-percentage>",
     "computed": [
       "asSpecified"
     ],
@@ -4890,7 +5414,7 @@
   },
   {
     "name": "scroll-padding-inline",
-    "syntax": "[ auto | <length-percentage [0,∞]> ]{1,2}",
+    "syntax": "[ auto | <length-percentage> ]{1,2}",
     "computed": [
       "scroll-padding-inline-start",
       "scroll-padding-inline-end"
@@ -4903,7 +5427,7 @@
   },
   {
     "name": "scroll-padding-inline-end",
-    "syntax": "auto | <length-percentage [0,∞]>",
+    "syntax": "auto | <length-percentage>",
     "computed": [
       "asSpecified"
     ],
@@ -4912,7 +5436,7 @@
   },
   {
     "name": "scroll-padding-inline-start",
-    "syntax": "auto | <length-percentage [0,∞]>",
+    "syntax": "auto | <length-percentage>",
     "computed": [
       "asSpecified"
     ],
@@ -4921,7 +5445,7 @@
   },
   {
     "name": "scroll-padding-left",
-    "syntax": "auto | <length-percentage [0,∞]>",
+    "syntax": "auto | <length-percentage>",
     "computed": [
       "asSpecified"
     ],
@@ -4930,7 +5454,7 @@
   },
   {
     "name": "scroll-padding-right",
-    "syntax": "auto | <length-percentage [0,∞]>",
+    "syntax": "auto | <length-percentage>",
     "computed": [
       "asSpecified"
     ],
@@ -4939,7 +5463,7 @@
   },
   {
     "name": "scroll-padding-top",
-    "syntax": "auto | <length-percentage [0,∞]>",
+    "syntax": "auto | <length-percentage>",
     "computed": [
       "asSpecified"
     ],
@@ -4956,6 +5480,42 @@
     "inherited": false
   },
   {
+    "name": "scroll-snap-coordinate",
+    "syntax": "none | <position>#",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "scroll-snap-destination",
+    "syntax": "<position>",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "0px 0px",
+    "inherited": false
+  },
+  {
+    "name": "scroll-snap-points-x",
+    "syntax": "none | repeat( <length-percentage> )",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "scroll-snap-points-y",
+    "syntax": "none | repeat( <length-percentage> )",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
     "name": "scroll-snap-stop",
     "syntax": "normal | always",
     "computed": [
@@ -4967,6 +5527,33 @@
   {
     "name": "scroll-snap-type",
     "syntax": "none | [ x | y | block | inline | both ] [ mandatory | proximity ]?",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "scroll-snap-type-x",
+    "syntax": "none | mandatory | proximity",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "scroll-snap-type-y",
+    "syntax": "none | mandatory | proximity",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "scroll-target-group",
+    "syntax": "none | auto",
     "computed": [
       "asSpecified"
     ],
@@ -5042,7 +5629,7 @@
   },
   {
     "name": "shape-margin",
-    "syntax": "<length-percentage [0,∞]>",
+    "syntax": "<length-percentage>",
     "computed": [
       "asSpecifiedRelativeToAbsoluteLengths"
     ],
@@ -5051,7 +5638,7 @@
   },
   {
     "name": "shape-outside",
-    "syntax": "none | [ <basic-shape> || <shape-box> ] | <image>",
+    "syntax": "none | [ <shape-box> || <basic-shape> ] | <image>",
     "computed": [
       "asDefinedForBasicShapeWithAbsoluteURIOtherwiseAsSpecified"
     ],
@@ -5068,48 +5655,6 @@
     "inherited": true
   },
   {
-    "name": "shape-subtract",
-    "syntax": "none | [ <basic-shape>| <uri> ]+",
-    "computed": [],
-    "initial": "none",
-    "inherited": false
-  },
-  {
-    "name": "slider-orientation",
-    "syntax": "auto | left-to-right | right-to-left | top-to-bottom | bottom-to-top",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "spatial-navigation-action",
-    "syntax": "auto | focus | scroll",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "spatial-navigation-contain",
-    "syntax": "auto | contain",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "spatial-navigation-function",
-    "syntax": "normal | grid",
-    "computed": [],
-    "initial": "normal",
-    "inherited": false
-  },
-  {
-    "name": "speak",
-    "syntax": "auto | never | always",
-    "computed": [],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
     "name": "speak-as",
     "syntax": "normal | spell-out || digits || [ literal-punctuation | no-punctuation ]",
     "computed": [
@@ -5120,7 +5665,7 @@
   },
   {
     "name": "stop-color",
-    "syntax": "",
+    "syntax": "<'color'>",
     "computed": [
       "asSpecified"
     ],
@@ -5129,18 +5674,11 @@
   },
   {
     "name": "stop-opacity",
-    "syntax": "",
+    "syntax": "<'opacity'>",
     "computed": [
       "asSpecified"
     ],
     "initial": "black",
-    "inherited": false
-  },
-  {
-    "name": "string-set",
-    "syntax": "none | [ <custom-ident> <string>+ ]#",
-    "computed": [],
-    "initial": "none",
     "inherited": false
   },
   {
@@ -5161,67 +5699,20 @@
     "inherited": true
   },
   {
-    "name": "stroke-align",
-    "syntax": "center | inset | outset",
-    "computed": [],
-    "initial": "center",
-    "inherited": true
-  },
-  {
-    "name": "stroke-alignment",
-    "syntax": "center | inner | outer",
-    "computed": [],
-    "initial": "center",
-    "inherited": true
-  },
-  {
-    "name": "stroke-break",
-    "syntax": "bounding-box | slice | clone",
-    "computed": [],
-    "initial": "bounding-box",
-    "inherited": false
-  },
-  {
     "name": "stroke-color",
-    "syntax": "<color>#",
-    "computed": [],
+    "syntax": "<color>",
+    "computed": [
+      "computedColor"
+    ],
     "initial": "transparent",
     "inherited": true
   },
   {
-    "name": "stroke-dash-corner",
-    "syntax": "none | <length>",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "stroke-dash-justify",
-    "syntax": "none | [ stretch | compress ] || [ dashes || gaps ]",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "stroke-dashadjust",
-    "syntax": "none | [stretch | compress] [dashes | gaps]?",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
     "name": "stroke-dasharray",
-    "syntax": "none | [<length-percentage> | <number>]+#",
+    "syntax": "none | <dasharray>",
     "computed": [
       "listEachItemConsistingOfAbsoluteLengthPercentageOrKeyword"
     ],
-    "initial": "none",
-    "inherited": true
-  },
-  {
-    "name": "stroke-dashcorner",
-    "syntax": "none | <length>",
-    "computed": [],
     "initial": "none",
     "inherited": true
   },
@@ -5235,13 +5726,6 @@
     "inherited": true
   },
   {
-    "name": "stroke-image",
-    "syntax": "<paint>#",
-    "computed": [],
-    "initial": "none",
-    "inherited": true
-  },
-  {
     "name": "stroke-linecap",
     "syntax": "butt | round | square",
     "computed": [
@@ -5252,7 +5736,7 @@
   },
   {
     "name": "stroke-linejoin",
-    "syntax": "[ crop | arcs | miter ] || [ bevel | round | fallback ]",
+    "syntax": "miter | miter-clip | round | bevel | arcs",
     "computed": [
       "asSpecified"
     ],
@@ -5278,36 +5762,8 @@
     "inherited": true
   },
   {
-    "name": "stroke-origin",
-    "syntax": "match-parent | fill-box | stroke-box | content-box | padding-box | border-box",
-    "computed": [],
-    "initial": "match-parent",
-    "inherited": false
-  },
-  {
-    "name": "stroke-position",
-    "syntax": "<position>#",
-    "computed": [],
-    "initial": "0% 0%",
-    "inherited": true
-  },
-  {
-    "name": "stroke-repeat",
-    "syntax": "<repeat-style>#",
-    "computed": [],
-    "initial": "repeat",
-    "inherited": true
-  },
-  {
-    "name": "stroke-size",
-    "syntax": "<bg-size>#",
-    "computed": [],
-    "initial": "auto",
-    "inherited": true
-  },
-  {
     "name": "stroke-width",
-    "syntax": "[<length-percentage> | <number>]#",
+    "syntax": "<length-percentage> | <number>",
     "computed": [
       "absoluteLengthOrPercentageNumbersConverted"
     ],
@@ -5316,7 +5772,7 @@
   },
   {
     "name": "tab-size",
-    "syntax": "<number [0,∞]> | <length [0,∞]>",
+    "syntax": "<integer> | <length>",
     "computed": [
       "specifiedIntegerOrAbsoluteLength"
     ],
@@ -5334,7 +5790,7 @@
   },
   {
     "name": "text-align",
-    "syntax": "start | end | left | right | center | justify | match-parent | justify-all",
+    "syntax": "start | end | left | right | center | justify | match-parent",
     "computed": [
       "asSpecifiedExceptMatchParent"
     ],
@@ -5342,15 +5798,8 @@
     "inherited": true
   },
   {
-    "name": "text-align-all",
-    "syntax": "start | end | left | right | center | justify | match-parent",
-    "computed": [],
-    "initial": "start",
-    "inherited": true
-  },
-  {
     "name": "text-align-last",
-    "syntax": "auto | start | end | left | right | center | justify | match-parent",
+    "syntax": "auto | start | end | left | right | center | justify",
     "computed": [
       "asSpecified"
     ],
@@ -5364,6 +5813,15 @@
       "asSpecified"
     ],
     "initial": "start",
+    "inherited": true
+  },
+  {
+    "name": "text-autospace",
+    "syntax": "normal | <autospace> | auto",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
     "inherited": true
   },
   {
@@ -5382,7 +5840,7 @@
       "theSpecifiedKeyword"
     ],
     "initial": "auto",
-    "inherited": true
+    "inherited": false
   },
   {
     "name": "text-box-trim",
@@ -5395,7 +5853,7 @@
   },
   {
     "name": "text-combine-upright",
-    "syntax": "none | all | [ digits <integer [2,4]>? ]",
+    "syntax": "none | all | [ digits <integer>? ]",
     "computed": [
       "keywordPlusIntegerIfDigits"
     ],
@@ -5404,7 +5862,7 @@
   },
   {
     "name": "text-decoration",
-    "syntax": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'>",
+    "syntax": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'> || <'text-decoration-thickness'>",
     "computed": [
       "text-decoration-line",
       "text-decoration-style",
@@ -5428,13 +5886,40 @@
     "inherited": false
   },
   {
+    "name": "text-decoration-inset",
+    "syntax": "<length>{1,2} | auto",
+    "computed": [
+      "absoluteLengthOrKeyword"
+    ],
+    "initial": "0",
+    "inherited": false
+  },
+  {
     "name": "text-decoration-line",
-    "syntax": "none | [ underline || overline || line-through || blink ]",
+    "syntax": "none | [ underline || overline || line-through || blink ] | spelling-error | grammar-error",
     "computed": [
       "asSpecified"
     ],
     "initial": "none",
     "inherited": false
+  },
+  {
+    "name": "text-decoration-skip",
+    "syntax": "none | [ objects || [ spaces | [ leading-spaces || trailing-spaces ] ] || edges || box-decoration ]",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "objects",
+    "inherited": true
+  },
+  {
+    "name": "text-decoration-skip-ink",
+    "syntax": "auto | all | none",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
   },
   {
     "name": "text-decoration-style",
@@ -5443,6 +5928,15 @@
       "asSpecified"
     ],
     "initial": "solid",
+    "inherited": false
+  },
+  {
+    "name": "text-decoration-thickness",
+    "syntax": "auto | from-font | <length> | <percentage>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
     "inherited": false
   },
   {
@@ -5456,7 +5950,7 @@
       "text-emphasis-style",
       "text-emphasis-color"
     ],
-    "inherited": false
+    "inherited": true
   },
   {
     "name": "text-emphasis-color",
@@ -5469,7 +5963,7 @@
   },
   {
     "name": "text-emphasis-position",
-    "syntax": "[ over | under ] && [ right | left ]?",
+    "syntax": "auto | [ over | under ] && [ right | left ]?",
     "computed": [
       "asSpecified"
     ],
@@ -5487,7 +5981,7 @@
   },
   {
     "name": "text-indent",
-    "syntax": "[ <length-percentage> ] && hanging? && each-line?",
+    "syntax": "<length-percentage> && hanging? && each-line?",
     "computed": [
       "percentageOrAbsoluteLengthPlusKeywords"
     ],
@@ -5496,7 +5990,7 @@
   },
   {
     "name": "text-justify",
-    "syntax": "auto | none | inter-word | inter-character",
+    "syntax": "auto | inter-character | inter-word | none",
     "computed": [
       "asSpecified"
     ],
@@ -5514,7 +6008,7 @@
   },
   {
     "name": "text-overflow",
-    "syntax": "clip | ellipsis",
+    "syntax": "[ clip | ellipsis | <string> ]{1,2}",
     "computed": [
       "asSpecified"
     ],
@@ -5532,7 +6026,7 @@
   },
   {
     "name": "text-shadow",
-    "syntax": "none | [ <color>? && <length>{2,3} ]#",
+    "syntax": "none | <shadow-t>#",
     "computed": [
       "colorPlusThreeAbsoluteLengths"
     ],
@@ -5541,7 +6035,7 @@
   },
   {
     "name": "text-size-adjust",
-    "syntax": "auto | none | <percentage [0,∞]>",
+    "syntax": "none | auto | <percentage>",
     "computed": [
       "asSpecified"
     ],
@@ -5549,8 +6043,17 @@
     "inherited": true
   },
   {
+    "name": "text-spacing-trim",
+    "syntax": "space-all | normal | space-first | trim-start",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": true
+  },
+  {
     "name": "text-transform",
-    "syntax": "none | [capitalize | uppercase | lowercase ] || full-width || full-size-kana",
+    "syntax": "none | [ capitalize | uppercase | lowercase ] || full-width || full-size-kana | math-auto",
     "computed": [
       "asSpecified"
     ],
@@ -5558,8 +6061,45 @@
     "inherited": true
   },
   {
+    "name": "text-underline-offset",
+    "syntax": "auto | <length> | <percentage>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
     "name": "text-underline-position",
-    "syntax": "auto | [ under || [ left | right ] ]",
+    "syntax": "auto | from-font | [ under || [ left | right ] ]",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": true
+  },
+  {
+    "name": "text-wrap",
+    "syntax": "<'text-wrap-mode'> || <'text-wrap-style'>",
+    "computed": [
+      "text-wrap-mode",
+      "text-wrap-style"
+    ],
+    "initial": "wrap",
+    "inherited": true
+  },
+  {
+    "name": "text-wrap-mode",
+    "syntax": "wrap | nowrap",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "wrap",
+    "inherited": true
+  },
+  {
+    "name": "text-wrap-style",
+    "syntax": "auto | balance | stable | pretty",
     "computed": [
       "asSpecified"
     ],
@@ -5568,11 +6108,108 @@
   },
   {
     "name": "timeline-scope",
-    "syntax": "none | all | <dashed-ident>#",
+    "syntax": "none | <dashed-ident>#",
     "computed": [
       "noneOrOrderedListOfIdentifiers"
     ],
     "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "timeline-trigger",
+    "syntax": "none | [ <'timeline-trigger-name'> <'timeline-trigger-source'> <'timeline-trigger-activation-range'> [ '/' <'timeline-trigger-active-range'> ]? ]#",
+    "computed": [
+      "timeline-trigger-name",
+      "timeline-trigger-source",
+      "timeline-trigger-activation-range",
+      "timeline-trigger-active-range"
+    ],
+    "initial": [
+      "timeline-trigger-name",
+      "timeline-trigger-source",
+      "timeline-trigger-activation-range",
+      "timeline-trigger-active-range"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "timeline-trigger-activation-range",
+    "syntax": "[ <'timeline-trigger-activation-range-start'> <'timeline-trigger-activation-range-end'>? ]#",
+    "computed": [
+      "timeline-trigger-activation-range-start",
+      "timeline-trigger-activation-range-end"
+    ],
+    "initial": [
+      "timeline-trigger-activation-range-start",
+      "timeline-trigger-activation-range-end"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "timeline-trigger-activation-range-end",
+    "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+    "computed": [
+      "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "timeline-trigger-activation-range-start",
+    "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+    "computed": [
+      "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
+    "name": "timeline-trigger-active-range",
+    "syntax": "[ <'timeline-trigger-active-range-start'> <'timeline-trigger-active-range-end'>? ]#",
+    "computed": [
+      "timeline-trigger-active-range-start",
+      "timeline-trigger-active-range-end"
+    ],
+    "initial": [
+      "timeline-trigger-active-range-start",
+      "timeline-trigger-active-range-end"
+    ],
+    "inherited": false
+  },
+  {
+    "name": "timeline-trigger-active-range-end",
+    "syntax": "[ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+    "computed": [
+      "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "timeline-trigger-active-range-start",
+    "syntax": "[ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+    "computed": [
+      "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage"
+    ],
+    "initial": "auto",
+    "inherited": false
+  },
+  {
+    "name": "timeline-trigger-name",
+    "syntax": "none | <dashed-ident>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "timeline-trigger-source",
+    "syntax": "<single-animation-timeline>#",
+    "computed": [
+      "listOfNoneAutoIdentScrollOrView"
+    ],
+    "initial": "auto",
     "inherited": false
   },
   {
@@ -5613,11 +6250,20 @@
   },
   {
     "name": "transform-origin",
-    "syntax": "[ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] <length>? | [ [ center | left | right ] && [ center | top | bottom ] ] <length>?",
+    "syntax": "[ <length-percentage> | left | center | right | top | bottom ] | [ [ <length-percentage> | left | center | right ] && [ <length-percentage> | top | center | bottom ] ] <length>?",
     "computed": [
       "forLengthAbsoluteValueOtherwisePercentage"
     ],
     "initial": "50% 50% 0",
+    "inherited": false
+  },
+  {
+    "name": "transform-style",
+    "syntax": "flat | preserve-3d",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "flat",
     "inherited": false
   },
   {
@@ -5640,6 +6286,15 @@
     "inherited": false
   },
   {
+    "name": "transition-behavior",
+    "syntax": "<transition-behavior-value>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "normal",
+    "inherited": false
+  },
+  {
     "name": "transition-delay",
     "syntax": "<time>#",
     "computed": [
@@ -5650,7 +6305,7 @@
   },
   {
     "name": "transition-duration",
-    "syntax": "<time [0s,∞]>#",
+    "syntax": "<time>#",
     "computed": [
       "asSpecified"
     ],
@@ -5676,6 +6331,24 @@
     "inherited": false
   },
   {
+    "name": "translate",
+    "syntax": "none | <length-percentage> [ <length-percentage> <length>? ]?",
+    "computed": [
+      "asSpecifiedRelativeToAbsoluteLengths"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "trigger-scope",
+    "syntax": "none | all | <dashed-ident>#",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
     "name": "unicode-bidi",
     "syntax": "normal | embed | isolate | bidi-override | isolate-override | plaintext",
     "computed": [
@@ -5686,7 +6359,7 @@
   },
   {
     "name": "user-select",
-    "syntax": "auto | text | none | contain | all",
+    "syntax": "auto | text | none | all",
     "computed": [
       "asSpecified"
     ],
@@ -5704,9 +6377,9 @@
   },
   {
     "name": "vertical-align",
-    "syntax": "[ first | last] || <'alignment-baseline'> || <'baseline-shift'>",
+    "syntax": "baseline | sub | super | text-top | text-bottom | middle | top | bottom | <percentage> | <length>",
     "computed": [
-      "absoluteLengthOrKeyword"
+      "asLonghands"
     ],
     "initial": "baseline",
     "inherited": false
@@ -5752,8 +6425,17 @@
     "inherited": false
   },
   {
+    "name": "view-transition-class",
+    "syntax": "none | <custom-ident>+",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
     "name": "view-transition-name",
-    "syntax": "none | <custom-ident>",
+    "syntax": "none | <custom-ident> | match-element",
     "computed": [
       "asSpecified"
     ],
@@ -5770,64 +6452,8 @@
     "inherited": true
   },
   {
-    "name": "voice-balance",
-    "syntax": "<number> | left | center | right | leftwards | rightwards",
-    "computed": [],
-    "initial": "center",
-    "inherited": true
-  },
-  {
-    "name": "voice-duration",
-    "syntax": "auto | <time [0s,∞]>",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "voice-family",
-    "syntax": "[[<family-name> | <generic-voice>],]* [<family-name> | <generic-voice>] | preserve",
-    "computed": [],
-    "initial": "implementation-dependent",
-    "inherited": true
-  },
-  {
-    "name": "voice-pitch",
-    "syntax": "<frequency [0Hz,∞]> && absolute | [[x-low | low | medium | high | x-high] || [<frequency> | <semitones> | <percentage>]]",
-    "computed": [],
-    "initial": "medium",
-    "inherited": true
-  },
-  {
-    "name": "voice-range",
-    "syntax": "<frequency [0Hz,∞]> && absolute | [[x-low | low | medium | high | x-high] || [<frequency> | <semitones> | <percentage>]]",
-    "computed": [],
-    "initial": "medium",
-    "inherited": true
-  },
-  {
-    "name": "voice-rate",
-    "syntax": "[normal | x-slow | slow | medium | fast | x-fast] || <percentage [0,∞]>",
-    "computed": [],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "voice-stress",
-    "syntax": "normal | strong | moderate | none | reduced",
-    "computed": [],
-    "initial": "normal",
-    "inherited": true
-  },
-  {
-    "name": "voice-volume",
-    "syntax": "silent | [[x-soft | soft | medium | loud | x-loud] || <decibel>]",
-    "computed": [],
-    "initial": "medium",
-    "inherited": true
-  },
-  {
     "name": "white-space",
-    "syntax": "normal | pre | nowrap | pre-wrap | break-spaces | pre-line",
+    "syntax": "normal | pre | pre-wrap | pre-line | <'white-space-collapse'> || <'text-wrap-mode'>",
     "computed": [
       "asSpecified"
     ],
@@ -5835,8 +6461,17 @@
     "inherited": true
   },
   {
+    "name": "white-space-collapse",
+    "syntax": "collapse | preserve | preserve-breaks | preserve-spaces | break-spaces",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "collapse",
+    "inherited": true
+  },
+  {
     "name": "widows",
-    "syntax": "<integer [1,∞]>",
+    "syntax": "<integer>",
     "computed": [
       "asSpecified"
     ],
@@ -5845,7 +6480,7 @@
   },
   {
     "name": "width",
-    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "computed": [
       "percentageAutoOrAbsoluteLength"
     ],
@@ -5863,7 +6498,7 @@
   },
   {
     "name": "word-break",
-    "syntax": "normal | keep-all | break-all | break-word",
+    "syntax": "normal | break-all | keep-all | break-word | auto-phrase",
     "computed": [
       "asSpecified"
     ],
@@ -5881,26 +6516,12 @@
   },
   {
     "name": "word-wrap",
-    "syntax": "normal | break-word | anywhere",
+    "syntax": "normal | break-word",
     "computed": [
       "asSpecified"
     ],
     "initial": "normal",
     "inherited": true
-  },
-  {
-    "name": "wrap-flow",
-    "syntax": "auto | both | start | end | minimum | maximum | clear",
-    "computed": [],
-    "initial": "auto",
-    "inherited": false
-  },
-  {
-    "name": "wrap-through",
-    "syntax": "wrap | none",
-    "computed": [],
-    "initial": "wrap",
-    "inherited": false
   },
   {
     "name": "writing-mode",
@@ -5913,7 +6534,7 @@
   },
   {
     "name": "x",
-    "syntax": "<length-percentage>",
+    "syntax": "<length> | <percentage>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -5922,7 +6543,7 @@
   },
   {
     "name": "y",
-    "syntax": "<length-percentage>",
+    "syntax": "<length> | <percentage>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -5931,7 +6552,7 @@
   },
   {
     "name": "z-index",
-    "syntax": "auto | <integer> | inherit",
+    "syntax": "auto | <integer>",
     "computed": [
       "asSpecified"
     ],
@@ -5940,7 +6561,7 @@
   },
   {
     "name": "zoom",
-    "syntax": "<number [0,∞]> || <percentage [0,∞]>",
+    "syntax": "normal | reset | <number [0,∞]> || <percentage [0,∞]>",
     "computed": [
       "asSpecifiedButWithPercentageConvertedToTheEquivalentNumber"
     ],

--- a/crates/gosub_css3/resources/definitions/definitions_selectors.json
+++ b/crates/gosub_css3/resources/definitions/definitions_selectors.json
@@ -1,27 +1,84 @@
 [
   {
-    "name": "&"
+    "name": "::-moz-progress-bar"
   },
   {
-    "name": "+"
+    "name": "::-moz-range-progress"
+  },
+  {
+    "name": "::-moz-range-thumb"
+  },
+  {
+    "name": "::-moz-range-track"
+  },
+  {
+    "name": "::-ms-browse"
+  },
+  {
+    "name": "::-ms-check"
+  },
+  {
+    "name": "::-ms-clear"
+  },
+  {
+    "name": "::-ms-expand"
+  },
+  {
+    "name": "::-ms-fill"
+  },
+  {
+    "name": "::-ms-fill-lower"
+  },
+  {
+    "name": "::-ms-fill-upper"
+  },
+  {
+    "name": "::-ms-reveal"
+  },
+  {
+    "name": "::-ms-thumb"
+  },
+  {
+    "name": "::-ms-ticks-after"
+  },
+  {
+    "name": "::-ms-ticks-before"
+  },
+  {
+    "name": "::-ms-tooltip"
+  },
+  {
+    "name": "::-ms-track"
+  },
+  {
+    "name": "::-ms-value"
+  },
+  {
+    "name": "::-webkit-progress-bar"
+  },
+  {
+    "name": "::-webkit-progress-inner-value"
+  },
+  {
+    "name": "::-webkit-progress-value"
+  },
+  {
+    "name": "::-webkit-slider-runnable-track"
+  },
+  {
+    "name": "::-webkit-slider-thumb"
   },
   {
     "name": "::after"
+  },
+  {
+    "name": "::backdrop"
   },
   {
     "name": "::before"
   },
   {
     "name": "::checkmark"
-  },
-  {
-    "name": "::clear-icon"
-  },
-  {
-    "name": "::color-swatch"
-  },
-  {
-    "name": "::column"
   },
   {
     "name": "::cue"
@@ -37,15 +94,6 @@
   },
   {
     "name": "::details-content"
-  },
-  {
-    "name": "::field-component"
-  },
-  {
-    "name": "::field-separator"
-  },
-  {
-    "name": "::field-text"
   },
   {
     "name": "::file-selector-button"
@@ -78,34 +126,19 @@
     "name": "::placeholder"
   },
   {
-    "name": "::search-text"
+    "name": "::scroll-marker"
+  },
+  {
+    "name": "::scroll-marker-group"
   },
   {
     "name": "::selection"
-  },
-  {
-    "name": "::slider-fill"
-  },
-  {
-    "name": "::slider-thumb"
-  },
-  {
-    "name": "::slider-track"
   },
   {
     "name": "::slotted()"
   },
   {
     "name": "::spelling-error"
-  },
-  {
-    "name": "::step-control"
-  },
-  {
-    "name": "::step-down"
-  },
-  {
-    "name": "::step-up"
   },
   {
     "name": "::target-text"
@@ -129,16 +162,16 @@
     "name": ":active"
   },
   {
-    "name": ":after"
+    "name": ":active-view-transition"
+  },
+  {
+    "name": ":active-view-transition-type()"
   },
   {
     "name": ":any-link"
   },
   {
     "name": ":autofill"
-  },
-  {
-    "name": ":before"
   },
   {
     "name": ":blank"
@@ -151,9 +184,6 @@
   },
   {
     "name": ":current"
-  },
-  {
-    "name": ":current()"
   },
   {
     "name": ":default"
@@ -180,12 +210,6 @@
     "name": ":first-child"
   },
   {
-    "name": ":first-letter"
-  },
-  {
-    "name": ":first-line"
-  },
-  {
     "name": ":first-of-type"
   },
   {
@@ -208,9 +232,6 @@
   },
   {
     "name": ":has-slotted"
-  },
-  {
-    "name": ":high-value"
   },
   {
     "name": ":host"
@@ -237,9 +258,6 @@
     "name": ":is()"
   },
   {
-    "name": ":lang"
-  },
-  {
     "name": ":lang()"
   },
   {
@@ -258,12 +276,6 @@
     "name": ":local-link"
   },
   {
-    "name": ":low-value"
-  },
-  {
-    "name": ":matches()"
-  },
-  {
     "name": ":modal"
   },
   {
@@ -273,19 +285,10 @@
     "name": ":not()"
   },
   {
-    "name": ":nth()"
-  },
-  {
     "name": ":nth-child()"
   },
   {
-    "name": ":nth-col()"
-  },
-  {
     "name": ":nth-last-child()"
-  },
-  {
-    "name": ":nth-last-col()"
   },
   {
     "name": ":nth-last-of-type()"
@@ -301,9 +304,6 @@
   },
   {
     "name": ":open"
-  },
-  {
-    "name": ":optimal-value"
   },
   {
     "name": ":optional"
@@ -354,7 +354,13 @@
     "name": ":stalled"
   },
   {
+    "name": ":state()"
+  },
+  {
     "name": ":target"
+  },
+  {
+    "name": ":target-current"
   },
   {
     "name": ":target-within"
@@ -379,14 +385,5 @@
   },
   {
     "name": ":xr-overlay"
-  },
-  {
-    "name": ">"
-  },
-  {
-    "name": "||"
-  },
-  {
-    "name": "~"
   }
 ]

--- a/crates/gosub_css3/resources/definitions/definitions_values.json
+++ b/crates/gosub_css3/resources/definitions/definitions_values.json
@@ -1,5 +1,9 @@
 [
   {
+    "name": "<absolute-size>",
+    "syntax": "xx-small | x-small | small | medium | large | x-large | xx-large | xxx-large"
+  },
+  {
     "name": "<alpha-value>",
     "syntax": "<number> | <percentage>"
   },
@@ -21,11 +25,31 @@
   },
   {
     "name": "<angle-percentage>",
-    "syntax": "[ <angle> | <percentage> ]"
+    "syntax": "<angle> | <percentage>"
+  },
+  {
+    "name": "<angle>",
+    "syntax": ""
+  },
+  {
+    "name": "<angular-color-hint>",
+    "syntax": "<angle-percentage> | <zero>"
+  },
+  {
+    "name": "<angular-color-stop-list>",
+    "syntax": "<angular-color-stop> , [ <angular-color-hint>? , <angular-color-stop> ]#?"
+  },
+  {
+    "name": "<angular-color-stop>",
+    "syntax": "<color> <color-stop-angle>?"
   },
   {
     "name": "<animateable-feature>",
     "syntax": "scroll-position | contents | <custom-ident>"
+  },
+  {
+    "name": "<animation-action>",
+    "syntax": "none | play | play-once | play-forwards | play-backwards | pause | reset | replay"
   },
   {
     "name": "<attachment>",
@@ -40,40 +64,20 @@
     "syntax": "i | s"
   },
   {
+    "name": "<attr-type>",
+    "syntax": "type( <syntax> ) | raw-string | number | <attr-unit>"
+  },
+  {
     "name": "<attribute-selector>",
     "syntax": "'[' <wq-name> ']' | '[' <wq-name> <attr-matcher> [ <string-token> | <ident-token> ] <attr-modifier>? ']'"
   },
   {
-    "name": "<auto-line-color-list>",
-    "syntax": "[ <line-color-or-repeat> ]* <auto-repeat-line-color> [ <line-color-or-repeat> ]*"
-  },
-  {
-    "name": "<auto-line-style-list>",
-    "syntax": "[ <line-style-or-repeat> ]* <auto-repeat-line-style> [ <line-style-or-repeat> ]*"
-  },
-  {
-    "name": "<auto-line-width-list>",
-    "syntax": "[ <line-width-or-repeat> ]* <auto-repeat-line-width> [ <line-width-or-repeat> ]*"
-  },
-  {
-    "name": "<auto-repeat-line-color>",
-    "syntax": "repeat( auto ',' [ <color> ]+ )"
-  },
-  {
-    "name": "<auto-repeat-line-style>",
-    "syntax": "repeat( auto ',' [ <line-style> ]+ )"
-  },
-  {
-    "name": "<auto-repeat-line-width>",
-    "syntax": "repeat( auto ',' [ <line-width> ]+ )"
-  },
-  {
     "name": "<auto-repeat>",
-    "syntax": "repeat( [ auto-fill | auto-fit ] ',' [ <line-names>? <fixed-size> ]+ <line-names>? )"
+    "syntax": "repeat( [ auto-fill | auto-fit ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
   },
   {
     "name": "<auto-track-list>",
-    "syntax": "[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>? <auto-repeat> [ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>?"
+    "syntax": "[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>? <auto-repeat>\n[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>?"
   },
   {
     "name": "<axis>",
@@ -81,11 +85,19 @@
   },
   {
     "name": "<baseline-position>",
-    "syntax": "[ first | last ]? && baseline"
+    "syntax": "[ first | last ]? baseline"
   },
   {
     "name": "<basic-shape-rect>",
     "syntax": "<inset()> | <rect()> | <xywh()>"
+  },
+  {
+    "name": "<basic-shape>",
+    "syntax": "<inset()> | <xywh()> | <rect()> | <circle()> | <ellipse()> | <polygon()> | <path()> | shape()"
+  },
+  {
+    "name": "<bg-clip>",
+    "syntax": "<visual-box> | border-area | text"
   },
   {
     "name": "<bg-image>",
@@ -105,15 +117,19 @@
   },
   {
     "name": "<blend-mode>",
-    "syntax": "normal | multiply | screen | overlay | darken | lighten | color-dodge |color-burn | hard-light | soft-light | difference | exclusion | hue | saturation | color | luminosity"
+    "syntax": "normal | multiply | screen | overlay | darken | lighten | color-dodge | color-burn | hard-light | soft-light | difference | exclusion | hue | saturation | color | luminosity"
   },
   {
-    "name": "<calc-keyword>",
+    "name": "<calc-constant>",
     "syntax": "e | pi | infinity | -infinity | NaN"
   },
   {
     "name": "<calc-product>",
-    "syntax": "<calc-value> [ [ '*' | / ] <calc-value> ]*"
+    "syntax": "<calc-value> [ '*' <calc-value> | '/' <number> ]*"
+  },
+  {
+    "name": "<calc-size-basis>",
+    "syntax": "<intrinsic-size-keyword> | <calc-size()> | any | <calc-sum>"
   },
   {
     "name": "<calc-sum>",
@@ -121,7 +137,15 @@
   },
   {
     "name": "<calc-value>",
-    "syntax": "<number> | <dimension> | <percentage> | <calc-keyword> | '(' <calc-sum> ')'"
+    "syntax": "<number> | <dimension> | <percentage> | <calc-constant> | ( <calc-sum> )"
+  },
+  {
+    "name": "<cf-final-image>",
+    "syntax": "<image> | <color>"
+  },
+  {
+    "name": "<cf-mixing-image>",
+    "syntax": "<percentage>? && <image>"
   },
   {
     "name": "<class-selector>",
@@ -133,39 +157,43 @@
   },
   {
     "name": "<color-base>",
-    "syntax": "<hex-color> | <color-function> | <named-color> | transparent"
-  },
-  {
-    "name": "<color-font-tech>",
-    "syntax": "[color-COLRv0 | color-COLRv1 | color-SVG | color-sbix | color-CBDT ]"
+    "syntax": "<hex-color> | <color-function> | <named-color> | <color-mix()> | transparent"
   },
   {
     "name": "<color-function>",
-    "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <oklab()> | <oklch()> | <ictcp()> | <jzazbz()> | <jzczhz()> | <color()>"
+    "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <oklab()> | <oklch()> | <color()>"
   },
   {
     "name": "<color-interpolation-method>",
-    "syntax": "in [ <rectangular-color-space> | <polar-color-space> <hue-interpolation-method>? ]"
+    "syntax": "in [ <rectangular-color-space> | <polar-color-space> <hue-interpolation-method>? | <custom-color-space> ]"
   },
   {
-    "name": "<color-space>",
-    "syntax": "<rectangular-color-space> | <polar-color-space>"
+    "name": "<color-stop-angle>",
+    "syntax": "[ <angle-percentage> | <zero> ]{1,2}"
+  },
+  {
+    "name": "<color-stop-length>",
+    "syntax": "<length-percentage>{1,2}"
   },
   {
     "name": "<color-stop-list>",
-    "syntax": "<linear-color-stop> ',' [ <linear-color-hint>? ',' <linear-color-stop> ]#?"
+    "syntax": "<linear-color-stop> , [ <linear-color-hint>? , <linear-color-stop> ]#?"
+  },
+  {
+    "name": "<color-stop>",
+    "syntax": "<color-stop-length> | <color-stop-angle>"
   },
   {
     "name": "<color>",
-    "syntax": "<color-base> | currentColor | <system-color>"
+    "syntax": "<color-base> | currentColor | <system-color> | <light-dark()> | <deprecated-system-color>"
   },
   {
     "name": "<colorspace-params>",
-    "syntax": "[ <predefined-rgb-params> | <xyz-params>]"
+    "syntax": "[<custom-params> | <predefined-rgb-params> | <xyz-params>]"
   },
   {
     "name": "<combinator>",
-    "syntax": "'>' | '+' | '~' | [ '|' '|' ]"
+    "syntax": "'>' | '+' | '~' | [ '||' ]"
   },
   {
     "name": "<common-lig-values>",
@@ -180,28 +208,16 @@
     "syntax": "textfield | menulist-button"
   },
   {
-    "name": "<complex-real-selector-list>",
-    "syntax": "<complex-real-selector>#"
-  },
-  {
-    "name": "<complex-real-selector>",
-    "syntax": "<compound-selector> [ <combinator>? <compound-selector> ]*"
-  },
-  {
     "name": "<complex-selector-list>",
     "syntax": "<complex-selector>#"
   },
   {
-    "name": "<complex-selector-unit>",
-    "syntax": "[ <compound-selector>? <pseudo-compound-selector>* ]!"
-  },
-  {
     "name": "<complex-selector>",
-    "syntax": "<complex-selector-unit> [ <combinator>? <complex-selector-unit> ]*"
+    "syntax": "<compound-selector> [ <combinator>? <compound-selector> ]*"
   },
   {
-    "name": "<composite-mode>",
-    "syntax": "clear | copy | source-over | destination-over | source-in | destination-in | source-out | destination-out | source-atop | destination-atop | xor | lighter | plus-darker | plus-lighter"
+    "name": "<composite-style>",
+    "syntax": "clear | copy | source-over | source-in | source-out | source-atop | destination-over | destination-in | destination-out | destination-atop | xor"
   },
   {
     "name": "<compositing-operator>",
@@ -213,7 +229,23 @@
   },
   {
     "name": "<compound-selector>",
-    "syntax": "[ <type-selector>? <subclass-selector>* ]!"
+    "syntax": "[ <type-selector>? <subclass-selector>* [ <pseudo-element-selector> <pseudo-class-selector>* ]* ]!"
+  },
+  {
+    "name": "<conic-gradient-syntax>",
+    "syntax": "[ [ [ from [ <angle> | <zero> ] ]? [ at <position> ]? ] || <color-interpolation-method> ]? , <angular-color-stop-list>"
+  },
+  {
+    "name": "<container-condition>",
+    "syntax": "[ <container-name>? <container-query>? ]!"
+  },
+  {
+    "name": "<container-name>",
+    "syntax": "<custom-ident>"
+  },
+  {
+    "name": "<container-query>",
+    "syntax": "not <query-in-parens> | <query-in-parens> [ [ and <query-in-parens> ]* | [ or <query-in-parens> ]* ]"
   },
   {
     "name": "<content-distribution>",
@@ -221,7 +253,7 @@
   },
   {
     "name": "<content-list>",
-    "syntax": "[ <string> | <counter()> | <counters()> | <content()> | <attr()> ]+"
+    "syntax": "[ <string> | <image> | <attr()> | <quote> | <counter> ]+"
   },
   {
     "name": "<content-position>",
@@ -241,35 +273,63 @@
   },
   {
     "name": "<corner-shape-value>",
-    "syntax": "round | scoop | bevel | notch | straight | squircle | superellipse(<number [0,∞]> | infinity)"
+    "syntax": "round | scoop | bevel | notch | square | squircle | <superellipse()>"
+  },
+  {
+    "name": "<counter-name>",
+    "syntax": "<custom-ident>"
+  },
+  {
+    "name": "<counter-style-name>",
+    "syntax": "<custom-ident>"
   },
   {
     "name": "<counter-style>",
-    "syntax": "<counter-style-name> | <symbols()>"
+    "syntax": "<counter-style-name> | symbols()"
   },
   {
     "name": "<counter>",
     "syntax": "<counter()> | <counters()>"
   },
   {
-    "name": "<css-type>",
-    "syntax": "<syntax-component> | <type()>"
-  },
-  {
     "name": "<cubic-bezier-easing-function>",
     "syntax": "ease | ease-in | ease-out | ease-in-out | <cubic-bezier()>"
   },
   {
-    "name": "<custom-arg>",
-    "syntax": "'$' <ident-token> ';'"
+    "name": "<cursor-predefined>",
+    "syntax": "auto | default | none | context-menu | help | pointer | progress | wait | cell | crosshair | text | vertical-text | alias | copy | move | no-drop | not-allowed | e-resize | n-resize | ne-resize | nw-resize | s-resize | se-resize | sw-resize | w-resize | ew-resize | ns-resize | nesw-resize | nwse-resize | col-resize | row-resize | all-scroll | zoom-in | zoom-out | grab | grabbing"
   },
   {
-    "name": "<custom-selector>",
-    "syntax": "<custom-arg>? ':' <extension-name> [ '(' <custom-arg>+#? ')' ]? ';'"
+    "name": "<custom-color-space>",
+    "syntax": "<dashed-ident>"
+  },
+  {
+    "name": "<custom-ident>",
+    "syntax": ""
+  },
+  {
+    "name": "<custom-params>",
+    "syntax": "<dashed-ident> [ <number> | <percentage> | none ]+"
   },
   {
     "name": "<dasharray>",
     "syntax": "[ [ <length-percentage> | <number> ]+ ]#"
+  },
+  {
+    "name": "<dashed-ident>",
+    "syntax": ""
+  },
+  {
+    "name": "<dashndashdigit-ident>",
+    "syntax": "<ident-token>"
+  },
+  {
+    "name": "<deprecated-system-color>",
+    "syntax": "ActiveBorder | ActiveCaption | AppWorkspace | Background | ButtonHighlight | ButtonShadow | CaptionText | InactiveBorder | InactiveCaption | InactiveCaptionText | InfoBackground | InfoText | Menu | MenuText | Scrollbar | ThreeDDarkShadow | ThreeDFace | ThreeDHighlight | ThreeDLightShadow | ThreeDShadow | Window | WindowFrame | WindowText"
+  },
+  {
+    "name": "<dimension>",
+    "syntax": ""
   },
   {
     "name": "<discretionary-lig-values>",
@@ -289,7 +349,7 @@
   },
   {
     "name": "<display-legacy>",
-    "syntax": "inline-block | inline-table | inline-flex | inline-grid"
+    "syntax": "inline-block | inline-list-item | inline-table | inline-flex | inline-grid"
   },
   {
     "name": "<display-listitem>",
@@ -320,12 +380,36 @@
     "syntax": "<string> | <custom-ident>+"
   },
   {
+    "name": "<feature-tag-value>",
+    "syntax": "<string> [ <integer> | on | off ]?"
+  },
+  {
+    "name": "<feature-type>",
+    "syntax": "@stylistic | @historical-forms | @styleset | @character-variant | @swash | @ornaments | @annotation"
+  },
+  {
+    "name": "<feature-value-block-list>",
+    "syntax": "<feature-value-block>+"
+  },
+  {
+    "name": "<feature-value-block>",
+    "syntax": "<feature-type> '{' <feature-value-declaration-list> '}'"
+  },
+  {
+    "name": "<feature-value-declaration-list>",
+    "syntax": "<feature-value-declaration>"
+  },
+  {
+    "name": "<feature-value-declaration>",
+    "syntax": "<custom-ident>: <integer>+;"
+  },
+  {
     "name": "<feature-value-name>",
-    "syntax": "<ident>"
+    "syntax": "<custom-ident>"
   },
   {
     "name": "<filter-function>",
-    "syntax": "<blur()> | <brightness()> | <contrast()> | <drop-shadow()> | <grayscale()> | <hue-rotate()> | <invert()> | <opacity()> | <sepia()> | <saturate()>"
+    "syntax": "<blur()> | <brightness()> | <contrast()> | <drop-shadow()> | <grayscale()> | <hue-rotate()> | <invert()> | <opacity()> | <saturate()> | <sepia()>"
   },
   {
     "name": "<filter-value-list>",
@@ -337,31 +421,23 @@
   },
   {
     "name": "<fixed-breadth>",
-    "syntax": "<length-percentage [0,∞]>"
+    "syntax": "<length-percentage>"
   },
   {
     "name": "<fixed-repeat>",
-    "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-names>? <fixed-size> ]+ <line-names>? )"
+    "syntax": "repeat( [ <integer [1,∞]> ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
   },
   {
     "name": "<fixed-size>",
-    "syntax": "<fixed-breadth> | minmax( <fixed-breadth> ',' <track-breadth> ) | minmax( <inflexible-breadth> ',' <fixed-breadth> )"
+    "syntax": "<fixed-breadth> | minmax( <fixed-breadth> , <track-breadth> ) | minmax( <inflexible-breadth> , <fixed-breadth> )"
   },
   {
-    "name": "<font-features-tech>",
-    "syntax": "[features-opentype | features-aat | features-graphite]"
+    "name": "<flex>",
+    "syntax": ""
   },
   {
-    "name": "<font-format>",
-    "syntax": "[<string> | collection | embedded-opentype | opentype | svg | truetype | woff | woff2 ]"
-  },
-  {
-    "name": "<font-src>",
-    "syntax": "<url> [ format(<font-format>)]? [ tech( <font-tech>#)]? | local(<family-name>)"
-  },
-  {
-    "name": "<font-tech>",
-    "syntax": "[<font-features-tech> | <color-font-tech> | variations | palettes | incremental ]"
+    "name": "<font-stretch-absolute>",
+    "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded | <percentage>"
   },
   {
     "name": "<font-variant-css2>",
@@ -369,43 +445,27 @@
   },
   {
     "name": "<font-weight-absolute>",
-    "syntax": "[normal | bold | <number [1,1000]>]"
+    "syntax": "normal | bold | <number [1,1000]>"
   },
   {
     "name": "<font-width-css3>",
     "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
   },
   {
+    "name": "<form-control-identifier>",
+    "syntax": "select"
+  },
+  {
     "name": "<frequency-percentage>",
-    "syntax": "[ <frequency> | <percentage> ]"
+    "syntax": "<frequency> | <percentage>"
   },
   {
-    "name": "<function-parameter>",
-    "syntax": "<custom-property-name> <css-type>? [ ':' <declaration-value> ]?"
+    "name": "<frequency>",
+    "syntax": ""
   },
   {
-    "name": "<gap-auto-repeat-rule>",
-    "syntax": "repeat( auto ',' <gap-rule># )"
-  },
-  {
-    "name": "<gap-auto-rule-list>",
-    "syntax": "<gap-rule-or-repeat>#? ',' <gap-auto-repeat-rule> ',' <gap-rule-or-repeat>#?"
-  },
-  {
-    "name": "<gap-repeat-rule>",
-    "syntax": "repeat( <integer [1,∞]> ',' <gap-rule># )"
-  },
-  {
-    "name": "<gap-rule-list>",
-    "syntax": "<gap-rule-or-repeat>#"
-  },
-  {
-    "name": "<gap-rule-or-repeat>",
-    "syntax": "<gap-rule> | <gap-repeat-rule>"
-  },
-  {
-    "name": "<gap-rule>",
-    "syntax": "<line-width> || <line-style> || <color>"
+    "name": "<general-enclosed>",
+    "syntax": "[ <function-token> <any-value> ) ] | ( <ident> <any-value> )"
   },
   {
     "name": "<generic-complete>",
@@ -413,19 +473,11 @@
   },
   {
     "name": "<generic-family>",
-    "syntax": "<generic-script-specific>| <generic-complete> | <generic-incomplete>"
+    "syntax": "<generic-complete> | <generic-incomplete> | emoji | fangsong"
   },
   {
     "name": "<generic-incomplete>",
     "syntax": "ui-serif | ui-sans-serif | ui-monospace | ui-rounded"
-  },
-  {
-    "name": "<generic-script-specific>",
-    "syntax": "generic(fangsong) | generic(kai) | generic(khmer-mul) | generic(nastaliq)"
-  },
-  {
-    "name": "<generic-voice>",
-    "syntax": "[<age>? <gender> <integer>?]"
   },
   {
     "name": "<geometry-box>",
@@ -433,11 +485,11 @@
   },
   {
     "name": "<gradient>",
-    "syntax": "<linear-gradient()> | <repeating-linear-gradient()> | <radial-gradient()> | <repeating-radial-gradient()>"
+    "syntax": "<linear-gradient()> | <repeating-linear-gradient()> | <radial-gradient()> | <repeating-radial-gradient()> | <conic-gradient()> | <repeating-conic-gradient()>"
   },
   {
     "name": "<grid-line>",
-    "syntax": "auto | <custom-ident> | [ [ <integer [-∞,-1]> | <integer [1,∞]> ] && <custom-ident>? ] | [ span && [ <integer [1,∞]> || <custom-ident> ] ]"
+    "syntax": "auto | <custom-ident> | [ <integer> && <custom-ident>? ] | [ span && [ <integer> || <custom-ident> ] ]"
   },
   {
     "name": "<historical-lig-values>",
@@ -456,28 +508,40 @@
     "syntax": "<hash-token>"
   },
   {
-    "name": "<image>",
-    "syntax": "<url> | <gradient>"
+    "name": "<ident>",
+    "syntax": ""
   },
   {
-    "name": "<import-conditions>",
-    "syntax": "[ supports( [ <supports-condition> | <declaration> ] ) ]? <media-query-list>?"
+    "name": "<image-set-option>",
+    "syntax": "[ <image> | <string> ] [ <resolution> || type(<string>) ]"
+  },
+  {
+    "name": "<image-src>",
+    "syntax": "<url> | <string>"
+  },
+  {
+    "name": "<image-tags>",
+    "syntax": "ltr | rtl"
+  },
+  {
+    "name": "<image>",
+    "syntax": "<url> | <image()> | <image-set()> | <element()> | <paint()> | <cross-fade()> | <gradient>"
   },
   {
     "name": "<inflexible-breadth>",
-    "syntax": "<length-percentage [0,∞]> | min-content | max-content | auto"
+    "syntax": "<length-percentage> | min-content | max-content | auto"
   },
   {
-    "name": "<isolation-mode>",
-    "syntax": "auto | isolate"
+    "name": "<integer>",
+    "syntax": "<number-token>"
   },
   {
     "name": "<keyframe-block>",
-    "syntax": "<keyframe-selector># '{' <declaration-list> '}'"
+    "syntax": "<keyframe-selector># {\n  <declaration-list>\n}"
   },
   {
     "name": "<keyframe-selector>",
-    "syntax": "from | to | <percentage [0,100]>"
+    "syntax": "from | to | <percentage [0,100]> | <timeline-range-name> <percentage>"
   },
   {
     "name": "<keyframes-name>",
@@ -488,44 +552,16 @@
     "syntax": "<ident> [ '.' <ident> ]*"
   },
   {
-    "name": "<layout-box>",
-    "syntax": "<visual-box> | margin-box"
-  },
-  {
     "name": "<leader-type>",
     "syntax": "dotted | solid | space | <string>"
   },
   {
-    "name": "<legacy-hsl-syntax>",
-    "syntax": "hsl( <hue>, <percentage>, <percentage>, <alpha-value>? )"
-  },
-  {
-    "name": "<legacy-hsla-syntax>",
-    "syntax": "hsla( <hue>, <percentage>, <percentage>, <alpha-value>? )"
-  },
-  {
-    "name": "<legacy-pseudo-element-selector>",
-    "syntax": "':' [before | after | first-line | first-letter]"
-  },
-  {
-    "name": "<legacy-rgb-syntax>",
-    "syntax": "rgb( <percentage>#{3} ',' <alpha-value>? ) | rgb( <number>#{3} ',' <alpha-value>? )"
-  },
-  {
-    "name": "<legacy-rgba-syntax>",
-    "syntax": "rgba( <percentage>#{3} ',' <alpha-value>? ) | rgba( <number>#{3} ',' <alpha-value>? )"
-  },
-  {
     "name": "<length-percentage>",
-    "syntax": "[ <length> | <percentage> ]"
+    "syntax": "<length> | <percentage>"
   },
   {
-    "name": "<line-color-list>",
-    "syntax": "[ <line-color-or-repeat> ]+"
-  },
-  {
-    "name": "<line-color-or-repeat>",
-    "syntax": "[ <color> | <repeat-line-color> ]"
+    "name": "<length>",
+    "syntax": ""
   },
   {
     "name": "<line-name-list>",
@@ -536,28 +572,12 @@
     "syntax": "'[' <custom-ident>* ']'"
   },
   {
-    "name": "<line-style-list>",
-    "syntax": "[ <line-style-or-repeat> ]+"
-  },
-  {
-    "name": "<line-style-or-repeat>",
-    "syntax": "[ <line-style> | <repeat-line-style> ]"
-  },
-  {
     "name": "<line-style>",
     "syntax": "none | hidden | dotted | dashed | solid | double | groove | ridge | inset | outset"
   },
   {
-    "name": "<line-width-list>",
-    "syntax": "[ <line-width-or-repeat> ]+"
-  },
-  {
-    "name": "<line-width-or-repeat>",
-    "syntax": "[ <line-width> | <repeat-line-width> ]"
-  },
-  {
     "name": "<line-width>",
-    "syntax": "<length [0,∞]> | thin | medium | thick"
+    "syntax": "<length> | thin | medium | thick"
   },
   {
     "name": "<linear-color-hint>",
@@ -565,7 +585,7 @@
   },
   {
     "name": "<linear-color-stop>",
-    "syntax": "<color> <length-percentage>?"
+    "syntax": "<color> <color-stop-length>?"
   },
   {
     "name": "<linear-easing-function>",
@@ -573,19 +593,15 @@
   },
   {
     "name": "<linear-gradient-syntax>",
-    "syntax": "[ <angle> | <zero> | to <side-or-corner> ]? ',' <color-stop-list>"
-  },
-  {
-    "name": "<link-param>",
-    "syntax": "param( <custom-property-name> <declaration-value>? )"
-  },
-  {
-    "name": "<marker-ref>",
-    "syntax": "<url>"
+    "syntax": "[ [ <angle> | <zero> | to <side-or-corner> ] || <color-interpolation-method> ]? , <color-stop-list>"
   },
   {
     "name": "<mask-layer>",
     "syntax": "<mask-reference> || <position> [ / <bg-size> ]? || <repeat-style> || <geometry-box> || [ <geometry-box> | no-clip ] || <compositing-operator> || <masking-mode>"
+  },
+  {
+    "name": "<mask-position>",
+    "syntax": "[ <length-percentage> | left | center | right ] [ <length-percentage> | top | center | bottom ]?"
   },
   {
     "name": "<mask-reference>",
@@ -601,23 +617,23 @@
   },
   {
     "name": "<media-and>",
-    "syntax": "and <media-in-parens>"
+    "syntax": "<media-in-parens> [ and <media-in-parens> ]+"
   },
   {
     "name": "<media-condition-without-or>",
-    "syntax": "<media-not> | <media-in-parens> <media-and>*"
+    "syntax": "<media-not> | <media-and> | <media-in-parens>"
   },
   {
     "name": "<media-condition>",
-    "syntax": "<media-not> | <media-in-parens> [ <media-and>* | <media-or>* ]"
+    "syntax": "<media-not> | <media-and> | <media-or> | <media-in-parens>"
   },
   {
     "name": "<media-feature>",
-    "syntax": "[ <mf-plain> | <mf-boolean> | <mf-range> ]"
+    "syntax": "( [ <mf-plain> | <mf-boolean> | <mf-range> ] )"
   },
   {
     "name": "<media-in-parens>",
-    "syntax": "'(' <media-condition> ')' | '(' <media-feature> ')' | <general-enclosed>"
+    "syntax": "( <media-condition> ) | <media-feature> | <general-enclosed>"
   },
   {
     "name": "<media-not>",
@@ -625,7 +641,11 @@
   },
   {
     "name": "<media-or>",
-    "syntax": "or <media-in-parens>"
+    "syntax": "<media-in-parens> [ or <media-in-parens> ]+"
+  },
+  {
+    "name": "<media-query-list>",
+    "syntax": "<media-query>#"
   },
   {
     "name": "<media-query>",
@@ -640,72 +660,60 @@
     "syntax": "<mf-name>"
   },
   {
-    "name": "<mf-comparison>",
-    "syntax": "<mf-lt> | <mf-gt> | <mf-eq>"
-  },
-  {
-    "name": "<mf-eq>",
-    "syntax": "'='"
-  },
-  {
-    "name": "<mf-gt>",
-    "syntax": "'>' '='?"
-  },
-  {
-    "name": "<mf-lt>",
-    "syntax": "'<' '='?"
-  },
-  {
     "name": "<mf-name>",
     "syntax": "<ident>"
   },
   {
     "name": "<mf-plain>",
-    "syntax": "<mf-name> ':' <mf-value>"
+    "syntax": "<mf-name> : <mf-value>"
   },
   {
     "name": "<mf-range>",
-    "syntax": "<mf-name> <mf-comparison> <mf-value> | <mf-value> <mf-comparison> <mf-name> | <mf-value> <mf-lt> <mf-name> <mf-lt> <mf-value> | <mf-value> <mf-gt> <mf-name> <mf-gt> <mf-value>"
+    "syntax": "<mf-name> [ '<' | '>' ]? '='? <mf-value>\n| <mf-value> [ '<' | '>' ]? '='? <mf-name>\n| <mf-value> '<' '='? <mf-name> '<' '='? <mf-value>\n| <mf-value> '>' '='? <mf-name> '>' '='? <mf-value>"
   },
   {
     "name": "<mf-value>",
     "syntax": "<number> | <dimension> | <ident> | <ratio>"
   },
   {
-    "name": "<modern-hsl-syntax>",
-    "syntax": "hsl( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
-  },
-  {
-    "name": "<modern-hsla-syntax>",
-    "syntax": "hsla( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
-  },
-  {
-    "name": "<modern-rgb-syntax>",
-    "syntax": "rgb( [ <number> | <percentage> | none]{3} [ / [<alpha-value> | none] ]? )"
-  },
-  {
-    "name": "<modern-rgba-syntax>",
-    "syntax": "rgba( [ <number> | <percentage> | none]{3} [ / [<alpha-value> | none] ]? )"
-  },
-  {
-    "name": "<mq-boolean>",
-    "syntax": "<integer [0,1]>"
+    "name": "<n-dimension>",
+    "syntax": "<dimension-token>"
   },
   {
     "name": "<name-repeat>",
-    "syntax": "repeat( [ <integer [1,∞]> | auto-fill ], <line-names>+)"
+    "syntax": "repeat( [ <integer [1,∞]> | auto-fill ], <line-names>+ )"
+  },
+  {
+    "name": "<named-color>",
+    "syntax": "aliceblue | antiquewhite | aqua | aquamarine | azure | beige | bisque | black | blanchedalmond | blue | blueviolet | brown | burlywood | cadetblue | chartreuse | chocolate | coral | cornflowerblue | cornsilk | crimson | cyan | darkblue | darkcyan | darkgoldenrod | darkgray | darkgreen | darkgrey | darkkhaki | darkmagenta | darkolivegreen | darkorange | darkorchid | darkred | darksalmon | darkseagreen | darkslateblue | darkslategray | darkslategrey | darkturquoise | darkviolet | deeppink | deepskyblue | dimgray | dimgrey | dodgerblue | firebrick | floralwhite | forestgreen | fuchsia | gainsboro | ghostwhite | gold | goldenrod | gray | green | greenyellow | grey | honeydew | hotpink | indianred | indigo | ivory | khaki | lavender | lavenderblush | lawngreen | lemonchiffon | lightblue | lightcoral | lightcyan | lightgoldenrodyellow | lightgray | lightgreen | lightgrey | lightpink | lightsalmon | lightseagreen | lightskyblue | lightslategray | lightslategrey | lightsteelblue | lightyellow | lime | limegreen | linen | magenta | maroon | mediumaquamarine | mediumblue | mediumorchid | mediumpurple | mediumseagreen | mediumslateblue | mediumspringgreen | mediumturquoise | mediumvioletred | midnightblue | mintcream | mistyrose | moccasin | navajowhite | navy | oldlace | olive | olivedrab | orange | orangered | orchid | palegoldenrod | palegreen | paleturquoise | palevioletred | papayawhip | peachpuff | peru | pink | plum | powderblue | purple | rebeccapurple | red | rosybrown | royalblue | saddlebrown | salmon | sandybrown | seagreen | seashell | sienna | silver | skyblue | slateblue | slategray | slategrey | snow | springgreen | steelblue | tan | teal | thistle | tomato | turquoise | violet | wheat | white | whitesmoke | yellow | yellowgreen"
   },
   {
     "name": "<namespace-prefix>",
     "syntax": "<ident>"
   },
   {
+    "name": "<ndash-dimension>",
+    "syntax": "<dimension-token>"
+  },
+  {
+    "name": "<ndashdigit-dimension>",
+    "syntax": "<dimension-token>"
+  },
+  {
+    "name": "<ndashdigit-ident>",
+    "syntax": "<ident-token>"
+  },
+  {
     "name": "<ns-prefix>",
     "syntax": "[ <ident-token> | '*' ]? '|'"
   },
   {
-    "name": "<number-optional-number>",
-    "syntax": "<number> <number>?"
+    "name": "<number-percentage>",
+    "syntax": "<number> | <percentage>"
+  },
+  {
+    "name": "<number>",
+    "syntax": ""
   },
   {
     "name": "<numeric-figure-values>",
@@ -728,20 +736,44 @@
     "syntax": "<number> | <percentage>"
   },
   {
-    "name": "<opentype-tag>",
-    "syntax": "<string>"
+    "name": "<outline-line-style>",
+    "syntax": "none | dotted | dashed | solid | double | groove | ridge | inset | outset"
+  },
+  {
+    "name": "<outline-radius>",
+    "syntax": "<length> | <percentage>"
   },
   {
     "name": "<overflow-position>",
     "syntax": "unsafe | safe"
   },
   {
+    "name": "<overflow>",
+    "syntax": ""
+  },
+  {
+    "name": "<page-body>",
+    "syntax": "<declaration>? [ ; <page-body> ]? | <page-margin-box> <page-body>"
+  },
+  {
+    "name": "<page-margin-box-type>",
+    "syntax": "@top-left-corner | @top-left | @top-center | @top-right | @top-right-corner | @bottom-left-corner | @bottom-left | @bottom-center | @bottom-right | @bottom-right-corner | @left-top | @left-middle | @left-bottom | @right-top | @right-middle | @right-bottom"
+  },
+  {
+    "name": "<page-margin-box>",
+    "syntax": "<page-margin-box-type> '{' <declaration-list> '}'"
+  },
+  {
     "name": "<page-selector-list>",
-    "syntax": "<page-selector>#"
+    "syntax": "[ <page-selector># ]?"
   },
   {
     "name": "<page-selector>",
-    "syntax": "[ <ident-token>? <pseudo-page>* ]!"
+    "syntax": "<pseudo-page>+ | <ident> <pseudo-page>*"
+  },
+  {
+    "name": "<page-size>",
+    "syntax": "A5 | A4 | A3 | B5 | B4 | JIS-B5 | JIS-B4 | letter | legal | ledger"
   },
   {
     "name": "<paint-box>",
@@ -749,11 +781,15 @@
   },
   {
     "name": "<paint>",
-    "syntax": "none | <image> | <svg-paint>"
+    "syntax": "none | <color> | <url> [none | <color>]? | context-fill | context-stroke"
   },
   {
-    "name": "<points>",
-    "syntax": "[ <number>+ ]#"
+    "name": "<palette-identifier>",
+    "syntax": "<dashed-ident>"
+  },
+  {
+    "name": "<percentage>",
+    "syntax": ""
   },
   {
     "name": "<polar-color-space>",
@@ -761,11 +797,11 @@
   },
   {
     "name": "<position-area>",
-    "syntax": "[ [ left | center | right | span-left | span-right | x-start | x-end | span-x-start | span-x-end | x-self-start | x-self-end | span-x-self-start | span-x-self-end | span-all ] || [ top | center | bottom | span-top | span-bottom | y-start | y-end | span-y-start | span-y-end | y-self-start | y-self-end | span-y-self-start | span-y-self-end | span-all ] | [ block-start | center | block-end | span-block-start | span-block-end | span-all ] || [ inline-start | center | inline-end | span-inline-start | span-inline-end | span-all ] | [ self-block-start | center | self-block-end | span-self-block-start | span-self-block-end | span-all ] || [ self-inline-start | center | self-inline-end | span-self-inline-start | span-self-inline-end | span-all ] | [ start | center | end | span-start | span-end | span-all ]{1,2} | [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2} ]"
+    "syntax": "[ left | center | right | span-left | span-right | x-start | x-end | span-x-start | span-x-end | x-self-start | x-self-end | span-x-self-start | span-x-self-end | span-all ] || [ top | center | bottom | span-top | span-bottom | y-start | y-end | span-y-start | span-y-end | y-self-start | y-self-end | span-y-self-start | span-y-self-end | span-all ] | [ block-start | center | block-end | span-block-start | span-block-end | span-all ] || [ inline-start | center | inline-end | span-inline-start | span-inline-end | span-all ] | [ self-block-start | center | self-block-end | span-self-block-start | span-self-block-end | span-all ] || [ self-inline-start | center | self-inline-end | span-self-inline-start | span-self-inline-end | span-all ] | [ start | center | end | span-start | span-end | span-all ]{1,2} | [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2}"
   },
   {
     "name": "<position>",
-    "syntax": "[ [ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right ] && [ top | center | bottom ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ] ]"
+    "syntax": "[ [ left | center | right ] || [ top | center | bottom ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ]? | [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ] ]"
   },
   {
     "name": "<predefined-rgb-params>",
@@ -773,27 +809,23 @@
   },
   {
     "name": "<predefined-rgb>",
-    "syntax": "srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020 | rec2100-pq | rec2100-hlg | rec2100-linear"
+    "syntax": "srgb | srgb-linear | display-p3 | display-p3-linear | a98-rgb | prophoto-rgb | rec2020"
   },
   {
     "name": "<pseudo-class-selector>",
     "syntax": "':' <ident-token> | ':' <function-token> <any-value> ')'"
   },
   {
-    "name": "<pseudo-compound-selector>",
-    "syntax": "<pseudo-element-selector> <pseudo-class-selector>*"
-  },
-  {
     "name": "<pseudo-element-selector>",
-    "syntax": "':' <pseudo-class-selector> | <legacy-pseudo-element-selector>"
+    "syntax": "':' <pseudo-class-selector>"
   },
   {
     "name": "<pseudo-page>",
-    "syntax": "':' [ left | right | first | blank ]"
+    "syntax": ": [ left | right | first | blank ]"
   },
   {
-    "name": "<pt-name-selector>",
-    "syntax": "'*' | <custom-ident>"
+    "name": "<query-in-parens>",
+    "syntax": "( <container-query> ) | ( <size-feature> ) | style( <style-query> ) | scroll-state( <scroll-state-query> ) | <general-enclosed>"
   },
   {
     "name": "<quote>",
@@ -805,7 +837,7 @@
   },
   {
     "name": "<radial-gradient-syntax>",
-    "syntax": "[ <radial-shape> || <radial-size> ]? [ at <position> ]? ',' <color-stop-list>"
+    "syntax": "[ [ [ <radial-shape> || <radial-size> ]? [ at <position> ]? ] || <color-interpolation-method> ]? , <color-stop-list>"
   },
   {
     "name": "<radial-shape>",
@@ -825,15 +857,7 @@
   },
   {
     "name": "<rectangular-color-space>",
-    "syntax": "srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020 | lab | oklab | xyz | xyz-d50 | xyz-d65"
-  },
-  {
-    "name": "<relative-real-selector-list>",
-    "syntax": "<relative-real-selector>#"
-  },
-  {
-    "name": "<relative-real-selector>",
-    "syntax": "<combinator>? <complex-real-selector>"
+    "syntax": "srgb | srgb-linear | display-p3 | display-p3-linear | a98-rgb | prophoto-rgb | rec2020 | lab | oklab | xyz | xyz-d50 | xyz-d65"
   },
   {
     "name": "<relative-selector-list>",
@@ -844,20 +868,16 @@
     "syntax": "<combinator>? <complex-selector>"
   },
   {
-    "name": "<repeat-line-color>",
-    "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <color> ]+ )"
-  },
-  {
-    "name": "<repeat-line-style>",
-    "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-style> ]+ )"
-  },
-  {
-    "name": "<repeat-line-width>",
-    "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-width> ]+ )"
+    "name": "<relative-size>",
+    "syntax": "larger | smaller"
   },
   {
     "name": "<repeat-style>",
-    "syntax": "repeat-x | repeat-y | [repeat | space | round | no-repeat]{1,2}"
+    "syntax": "repeat-x | repeat-y | [ repeat | space | round | no-repeat ]{1,2}"
+  },
+  {
+    "name": "<resolution>",
+    "syntax": ""
   },
   {
     "name": "<reversed-counter-name>",
@@ -866,6 +886,26 @@
   {
     "name": "<rounding-strategy>",
     "syntax": "nearest | up | down | to-zero"
+  },
+  {
+    "name": "<scope-end>",
+    "syntax": "<selector-list>"
+  },
+  {
+    "name": "<scope-start>",
+    "syntax": "<selector-list>"
+  },
+  {
+    "name": "<scroll-state-feature>",
+    "syntax": "<media-query-list>"
+  },
+  {
+    "name": "<scroll-state-in-parens>",
+    "syntax": "( <scroll-state-query> ) | ( <scroll-state-feature> ) | <general-enclosed>"
+  },
+  {
+    "name": "<scroll-state-query>",
+    "syntax": "not <scroll-state-in-parens> | <scroll-state-in-parens> [ [ and <scroll-state-in-parens> ]* | [ or <scroll-state-in-parens> ]* ] | <scroll-state-feature>"
   },
   {
     "name": "<scroller>",
@@ -880,24 +920,36 @@
     "syntax": "center | start | end | self-start | self-end | flex-start | flex-end"
   },
   {
+    "name": "<shadow-t>",
+    "syntax": "[ <length>{2,3} && <color>? ]"
+  },
+  {
     "name": "<shadow>",
-    "syntax": "<color>? && [<length>{2} <length [0,∞]>? <length>?] && inset?"
+    "syntax": "inset? && <length>{2,4} && <color>?"
   },
   {
     "name": "<shape-box>",
     "syntax": "<visual-box> | margin-box"
   },
   {
+    "name": "<shape>",
+    "syntax": "rect(<top>, <right>, <bottom>, <left>)"
+  },
+  {
     "name": "<side-or-corner>",
-    "syntax": "[left | right] || [top | bottom]"
+    "syntax": "[ left | right ] || [ top | bottom ]"
   },
   {
-    "name": "<simple-selector-list>",
-    "syntax": "<simple-selector>#"
+    "name": "<signed-integer>",
+    "syntax": "<number-token>"
   },
   {
-    "name": "<simple-selector>",
-    "syntax": "<type-selector> | <subclass-selector>"
+    "name": "<signless-integer>",
+    "syntax": "<number-token>"
+  },
+  {
+    "name": "<single-animation-composition>",
+    "syntax": "replace | add | accumulate"
   },
   {
     "name": "<single-animation-direction>",
@@ -909,15 +961,19 @@
   },
   {
     "name": "<single-animation-iteration-count>",
-    "syntax": "infinite | <number [0,∞]>"
+    "syntax": "infinite | <number>"
   },
   {
     "name": "<single-animation-play-state>",
     "syntax": "running | paused"
   },
   {
+    "name": "<single-animation-timeline>",
+    "syntax": "auto | none | <dashed-ident> | <scroll()> | <view()>"
+  },
+  {
     "name": "<single-animation>",
-    "syntax": "<time [0s,∞]> || <easing-function> || <time> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ]"
+    "syntax": "<'animation-duration'> || <easing-function> || <'animation-delay'> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ] || <single-animation-timeline>"
   },
   {
     "name": "<single-transition-property>",
@@ -925,23 +981,15 @@
   },
   {
     "name": "<single-transition>",
-    "syntax": "[ none | <single-transition-property> ] || <time> || <easing-function> || <time>"
+    "syntax": "[ none | <single-transition-property> ] || <time> || <easing-function> || <time> || <transition-behavior-value>"
   },
   {
-    "name": "<source-size-list>",
-    "syntax": "<source-size>#? ',' <source-size-value>"
+    "name": "<size-feature>",
+    "syntax": "<media-query-list>"
   },
   {
-    "name": "<source-size-value>",
-    "syntax": "<length> | auto"
-  },
-  {
-    "name": "<source-size>",
-    "syntax": "<media-condition> <source-size-value> | auto"
-  },
-  {
-    "name": "<spread-shadow>",
-    "syntax": "<'box-shadow-color'>? && [ <'box-shadow-offset'> [ <'box-shadow-blur'> <'box-shadow-spread'>? ]? ] && <'box-shadow-position'>?"
+    "name": "<size>",
+    "syntax": "closest-side | farthest-side | closest-corner | farthest-corner | <length> | <length-percentage>{2}"
   },
   {
     "name": "<step-easing-function>",
@@ -950,6 +998,22 @@
   {
     "name": "<step-position>",
     "syntax": "jump-start | jump-end | jump-none | jump-both | start | end"
+  },
+  {
+    "name": "<string>",
+    "syntax": ""
+  },
+  {
+    "name": "<style-feature>",
+    "syntax": "<declaration>"
+  },
+  {
+    "name": "<style-in-parens>",
+    "syntax": "( <style-query> ) | ( <style-feature> ) | <general-enclosed>"
+  },
+  {
+    "name": "<style-query>",
+    "syntax": "not <style-in-parens> | <style-in-parens> [ [ and <style-in-parens> ]* | [ or <style-in-parens> ]* ] | <style-feature>"
   },
   {
     "name": "<subclass-selector>",
@@ -961,19 +1025,19 @@
   },
   {
     "name": "<supports-decl>",
-    "syntax": "'(' <declaration> ')'"
+    "syntax": "( <declaration> )"
   },
   {
     "name": "<supports-feature>",
-    "syntax": "<supports-decl>"
+    "syntax": "<supports-decl> | <supports-selector-fn>"
   },
   {
     "name": "<supports-in-parens>",
-    "syntax": "'(' <supports-condition> ')' | <supports-feature> | <general-enclosed>"
+    "syntax": "( <supports-condition> ) | <supports-feature> | <general-enclosed>"
   },
   {
-    "name": "<svg-paint>",
-    "syntax": "child | child( <integer> )"
+    "name": "<supports-selector-fn>",
+    "syntax": "selector( <complex-selector> )"
   },
   {
     "name": "<symbol>",
@@ -982,6 +1046,10 @@
   {
     "name": "<symbols-type>",
     "syntax": "cyclic | numeric | alphabetic | symbolic | fixed"
+  },
+  {
+    "name": "<system-color>",
+    "syntax": "AccentColor | AccentColorText | ActiveText | ButtonBorder | ButtonFace | ButtonText | Canvas | CanvasText | Field | FieldText | GrayText | Highlight | HighlightText | LinkText | Mark | MarkText | SelectedItem | SelectedItemText | VisitedText"
   },
   {
     "name": "<system-family-name>",
@@ -993,15 +1061,23 @@
   },
   {
     "name": "<text-edge>",
-    "syntax": "[ text | ideographic | ideographic-ink ] | [ text | ideographic | ideographic-ink | cap | ex ] [ text | ideographic | ideographic-ink | alphabetic ]"
+    "syntax": "[ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]?"
   },
   {
     "name": "<time-percentage>",
-    "syntax": "[ <time> | <percentage> ]"
+    "syntax": "<time> | <percentage>"
+  },
+  {
+    "name": "<time>",
+    "syntax": ""
+  },
+  {
+    "name": "<timeline-range-name>",
+    "syntax": "cover | contain | entry | exit | entry-crossing | exit-crossing"
   },
   {
     "name": "<track-breadth>",
-    "syntax": "<length-percentage [0,∞]> | <flex [0,∞]> | min-content | max-content | auto"
+    "syntax": "<length-percentage> | <flex> | min-content | max-content | auto"
   },
   {
     "name": "<track-list>",
@@ -1009,15 +1085,23 @@
   },
   {
     "name": "<track-repeat>",
-    "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-names>? <track-size> ]+ <line-names>? )"
+    "syntax": "repeat( [ <integer [1,∞]> ] , [ <line-names>? <track-size> ]+ <line-names>? )"
   },
   {
     "name": "<track-size>",
-    "syntax": "<track-breadth> | minmax( <inflexible-breadth> ',' <track-breadth> ) | fit-content( <length-percentage [0,∞]> )"
+    "syntax": "<track-breadth> | minmax( <inflexible-breadth> , <track-breadth> ) | fit-content( <length-percentage> )"
+  },
+  {
+    "name": "<transform-function>",
+    "syntax": "<matrix()> | <translate()> | <translateX()> | <translateY()> | <scale()> | <scaleX()> | <scaleY()> | <rotate()> | <skew()> | <skewX()> | <skewY()> | <matrix3d()> | <translate3d()> | <translateZ()> | <scale3d()> | <scaleZ()> | <rotate3d()> | <rotateX()> | <rotateY()> | <rotateZ()> | <perspective()>"
   },
   {
     "name": "<transform-list>",
     "syntax": "<transform-function>+"
+  },
+  {
+    "name": "<transition-behavior-value>",
+    "syntax": "normal | allow-discrete"
   },
   {
     "name": "<try-size>",
@@ -1028,16 +1112,20 @@
     "syntax": "flip-block || flip-inline || flip-start"
   },
   {
+    "name": "<type-or-unit>",
+    "syntax": "string | color | url | integer | number | length | angle | time | frequency | cap | ch | em | ex | ic | lh | rlh | rem | vb | vi | vw | vh | vmin | vmax | mm | Q | cm | in | pt | pc | px | deg | grad | rad | turn | ms | s | Hz | kHz | %"
+  },
+  {
     "name": "<type-selector>",
     "syntax": "<wq-name> | <ns-prefix>? '*'"
   },
   {
-    "name": "<type>",
-    "syntax": "'<' [ number | string ] '>'"
+    "name": "<url>",
+    "syntax": ""
   },
   {
-    "name": "<url>",
-    "syntax": "<url()> | <src()>"
+    "name": "<viewport-length>",
+    "syntax": "auto | <length-percentage>"
   },
   {
     "name": "<visual-box>",
@@ -1049,10 +1137,10 @@
   },
   {
     "name": "<xyz-params>",
-    "syntax": "<xyz-space> [ <number> | <percentage> | none ]{3}"
+    "syntax": "<xyz> [ <number> | <percentage> | none ]{3}"
   },
   {
-    "name": "<xyz-space>",
+    "name": "<xyz>",
     "syntax": "xyz | xyz-d50 | xyz-d65"
   },
   {
@@ -1069,7 +1157,7 @@
   },
   {
     "name": "anchor-size()",
-    "syntax": "anchor-size( [ <anchor-name> || <anchor-size> ]? ',' <length-percentage>? )"
+    "syntax": "anchor-size( [ <anchor-name> || <anchor-size> ]? , <length-percentage>? )"
   },
   {
     "name": "asin()",
@@ -1084,6 +1172,10 @@
     "syntax": "atan2( <calc-sum>, <calc-sum> )"
   },
   {
+    "name": "attr()",
+    "syntax": "attr( <attr-name> <attr-type>? , <declaration-value>? )"
+  },
+  {
     "name": "blur()",
     "syntax": "blur( <length>? )"
   },
@@ -1096,24 +1188,32 @@
     "syntax": "calc( <calc-sum> )"
   },
   {
+    "name": "calc-size()",
+    "syntax": "calc-size( <calc-size-basis>, <calc-sum> )"
+  },
+  {
     "name": "circle()",
     "syntax": "circle( <radial-size>? [ at <position> ]? )"
   },
   {
     "name": "clamp()",
-    "syntax": "clamp( [ <calc-sum> | none ], <calc-sum>, [ <calc-sum> | none ] )"
+    "syntax": "clamp( <calc-sum>#{3} )"
   },
   {
-    "name": "content()",
-    "syntax": "content( [ text | before | after | first-letter | marker ]? )"
+    "name": "color()",
+    "syntax": "color( [ from <color> ]? <colorspace-params> [ / [ <alpha-value> | none ] ]? )"
+  },
+  {
+    "name": "color-mix()",
+    "syntax": "color-mix( <color-interpolation-method> , [ <color> && <percentage [0,100]>? ]#{2})"
+  },
+  {
+    "name": "conic-gradient()",
+    "syntax": "conic-gradient( [ <conic-gradient-syntax> ] )"
   },
   {
     "name": "contrast()",
     "syntax": "contrast( [ <number> | <percentage> ]? )"
-  },
-  {
-    "name": "control-value()",
-    "syntax": "control-value( <type>? )"
   },
   {
     "name": "cos()",
@@ -1128,6 +1228,10 @@
     "syntax": "counters( <counter-name>, <string>, <counter-style>? )"
   },
   {
+    "name": "cross-fade()",
+    "syntax": "cross-fade( <cf-mixing-image> , <cf-final-image>? )"
+  },
+  {
     "name": "cubic-bezier()",
     "syntax": "cubic-bezier( [ <number [0,1]>, <number> ]#{2} )"
   },
@@ -1140,40 +1244,36 @@
     "syntax": "dynamic-range-limit-mix( [ <'dynamic-range-limit'> && <percentage [0,100]> ]#{2,} )"
   },
   {
+    "name": "element()",
+    "syntax": "element( <id-selector> )"
+  },
+  {
     "name": "ellipse()",
     "syntax": "ellipse( <radial-size>? [ at <position> ]? )"
   },
   {
     "name": "env()",
-    "syntax": "env( <custom-ident> <integer [0,∞]>*, <declaration-value>? )"
+    "syntax": "env( <custom-ident> , <declaration-value>? )"
   },
   {
     "name": "exp()",
     "syntax": "exp( <calc-sum> )"
   },
   {
-    "name": "filter()",
-    "syntax": "filter( [ <image> | <string> ], <filter-value-list> )"
-  },
-  {
     "name": "fit-content()",
-    "syntax": "fit-content( <length-percentage> )"
+    "syntax": "fit-content( <length-percentage [0,∞]> )"
   },
   {
     "name": "grayscale()",
     "syntax": "grayscale( [ <number> | <percentage> ]? )"
   },
   {
-    "name": "hdr-color()",
-    "syntax": "color-hdr([ <color> && <number [0,∞]>? ]#{2})"
-  },
-  {
     "name": "hsl()",
-    "syntax": "[ <legacy-hsl-syntax> | <modern-hsl-syntax> ]"
+    "syntax": "hsl( <hue>, <percentage>, <percentage>, <alpha-value>? ) | hsl( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
   },
   {
     "name": "hsla()",
-    "syntax": "[ <legacy-hsla-syntax> | <modern-hsla-syntax> ]"
+    "syntax": "hsla( <hue>, <percentage>, <percentage>, <alpha-value>? ) | hsla( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
   },
   {
     "name": "hue-rotate()",
@@ -1181,15 +1281,19 @@
   },
   {
     "name": "hwb()",
-    "syntax": "hwb( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+    "syntax": "hwb( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
   },
   {
     "name": "hypot()",
     "syntax": "hypot( <calc-sum># )"
   },
   {
-    "name": "ictcp()",
-    "syntax": "ictcp([from <color>]? [<percentage> | <number> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+    "name": "image()",
+    "syntax": "image( <image-tags>? [ <image-src>? , <color>? ]! )"
+  },
+  {
+    "name": "image-set()",
+    "syntax": "image-set( <image-set-option># )"
   },
   {
     "name": "inset()",
@@ -1200,16 +1304,12 @@
     "syntax": "invert( [ <number> | <percentage> ]? )"
   },
   {
-    "name": "jzazbz()",
-    "syntax": "jzazbz([from <color>]? [<percentage> | <number> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
-  },
-  {
-    "name": "jzczhz()",
-    "syntax": "jzczhz([from <color>]? [<percentage> | <number> | none] [<percentage> | <number> | none] [<hue> | none] [ / [<alpha-value> | none] ]? )"
-  },
-  {
     "name": "lab()",
     "syntax": "lab( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "layer()",
+    "syntax": "layer( <layer-name> )"
   },
   {
     "name": "lch()",
@@ -1218,6 +1318,10 @@
   {
     "name": "leader()",
     "syntax": "leader( <leader-type> )"
+  },
+  {
+    "name": "light-dark()",
+    "syntax": "light-dark( <color>, <color> )"
   },
   {
     "name": "linear()",
@@ -1236,6 +1340,10 @@
     "syntax": "matrix( <number>#{6} )"
   },
   {
+    "name": "matrix3d()",
+    "syntax": "matrix3d( <number>#{16} )"
+  },
+  {
     "name": "max()",
     "syntax": "max( <calc-sum># )"
   },
@@ -1245,7 +1353,7 @@
   },
   {
     "name": "minmax()",
-    "syntax": "minmax(min, max)"
+    "syntax": "minmax( [ <length-percentage> | min-content | max-content | auto ] , [ <length-percentage> | <flex> | min-content | max-content | auto ] )"
   },
   {
     "name": "mod()",
@@ -1269,15 +1377,19 @@
   },
   {
     "name": "palette-mix()",
-    "syntax": "palette-mix(<color-interpolation-method> ',' [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})"
+    "syntax": "palette-mix(<color-interpolation-method> , [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})"
   },
   {
     "name": "path()",
-    "syntax": "path( <'fill-rule'>? ',' <string> )"
+    "syntax": "path( <'fill-rule'>? , <string> )"
+  },
+  {
+    "name": "perspective()",
+    "syntax": "perspective( [ <length [0,∞]> | none ] )"
   },
   {
     "name": "polygon()",
-    "syntax": "polygon( <'fill-rule'>? [ round <length> ]? ',' [<length-percentage> <length-percentage>]# )"
+    "syntax": "polygon( <'fill-rule'>? , [ <length-percentage> <length-percentage> ]# )"
   },
   {
     "name": "pow()",
@@ -1293,11 +1405,15 @@
   },
   {
     "name": "rect()",
-    "syntax": "rect( <top>, <right>, <bottom>, <left> )"
+    "syntax": "rect( [ <length-percentage> | auto ]{4} [ round <'border-radius'> ]? )"
   },
   {
     "name": "rem()",
     "syntax": "rem( <calc-sum>, <calc-sum> )"
+  },
+  {
+    "name": "repeating-conic-gradient()",
+    "syntax": "repeating-conic-gradient( [ <conic-gradient-syntax> ] )"
   },
   {
     "name": "repeating-linear-gradient()",
@@ -1309,23 +1425,35 @@
   },
   {
     "name": "rgb()",
-    "syntax": "[ <legacy-rgb-syntax> | <modern-rgb-syntax> ]"
+    "syntax": "rgb( <percentage>#{3} , <alpha-value>? ) | rgb( <number>#{3} , <alpha-value>? ) | rgb( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )"
   },
   {
     "name": "rgba()",
-    "syntax": "[ <legacy-rgba-syntax> | <modern-rgba-syntax> ]"
+    "syntax": "rgba( <percentage>#{3} , <alpha-value>? ) | rgba( <number>#{3} , <alpha-value>? ) | rgba( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )"
   },
   {
     "name": "rotate()",
     "syntax": "rotate( [ <angle> | <zero> ] )"
   },
   {
-    "name": "round()",
-    "syntax": "round( <rounding-strategy>?, <calc-sum>, <calc-sum>? )"
+    "name": "rotate3d()",
+    "syntax": "rotate3d( <number> , <number> , <number> , [ <angle> | <zero> ] )"
   },
   {
-    "name": "running()",
-    "syntax": "running( <custom-ident> )"
+    "name": "rotateX()",
+    "syntax": "rotateX( [ <angle> | <zero> ] )"
+  },
+  {
+    "name": "rotateY()",
+    "syntax": "rotateY( [ <angle> | <zero> ] )"
+  },
+  {
+    "name": "rotateZ()",
+    "syntax": "rotateZ( [ <angle> | <zero> ] )"
+  },
+  {
+    "name": "round()",
+    "syntax": "round( <rounding-strategy>?, <calc-sum>, <calc-sum> )"
   },
   {
     "name": "saturate()",
@@ -1333,15 +1461,23 @@
   },
   {
     "name": "scale()",
-    "syntax": "scale( <number> ',' <number>? )"
+    "syntax": "scale( [ <number> | <percentage> ]#{1,2} )"
+  },
+  {
+    "name": "scale3d()",
+    "syntax": "scale3d( [ <number> | <percentage> ]#{3} )"
   },
   {
     "name": "scaleX()",
-    "syntax": "scaleX( <number> )"
+    "syntax": "scaleX( [ <number> | <percentage> ] )"
   },
   {
     "name": "scaleY()",
-    "syntax": "scaleY( <number> )"
+    "syntax": "scaleY( [ <number> | <percentage> ] )"
+  },
+  {
+    "name": "scaleZ()",
+    "syntax": "scaleZ( [ <number> | <percentage> ] )"
   },
   {
     "name": "scroll()",
@@ -1361,7 +1497,7 @@
   },
   {
     "name": "skew()",
-    "syntax": "skew( [ <angle> | <zero> ] ',' [ <angle> | <zero> ]? )"
+    "syntax": "skew( [ <angle> | <zero> ] , [ <angle> | <zero> ]? )"
   },
   {
     "name": "skewX()",
@@ -1372,32 +1508,16 @@
     "syntax": "skewY( [ <angle> | <zero> ] )"
   },
   {
-    "name": "snap-block()",
-    "syntax": "snap-block( <length> ',' [ start | end | near ]? )"
-  },
-  {
-    "name": "snap-inline()",
-    "syntax": "snap-inline( <length> ',' [ left | right | near ]? )"
-  },
-  {
     "name": "sqrt()",
     "syntax": "sqrt( <calc-sum> )"
   },
   {
-    "name": "src()",
-    "syntax": "src( <string> <url-modifier>* )"
-  },
-  {
     "name": "steps()",
-    "syntax": "steps( <integer>, <step-position>?)"
-  },
-  {
-    "name": "string()",
-    "syntax": "string( <custom-ident> ',' [ first | start | last | first-except ]? )"
+    "syntax": "steps( <integer>, <step-position>? )"
   },
   {
     "name": "superellipse()",
-    "syntax": "superellipse( <number> | infinity )"
+    "syntax": "superellipse( [ <number> | infinity | -infinity ] )"
   },
   {
     "name": "symbols()",
@@ -1409,19 +1529,23 @@
   },
   {
     "name": "target-counter()",
-    "syntax": "target-counter( [ <string> | <url> ] ',' <custom-ident> ',' <counter-style>? )"
+    "syntax": "target-counter( [ <string> | <url> ] , <custom-ident> , <counter-style>? )"
   },
   {
     "name": "target-counters()",
-    "syntax": "target-counters( [ <string> | <url> ] ',' <custom-ident> ',' <string> ',' <counter-style>? )"
+    "syntax": "target-counters( [ <string> | <url> ] , <custom-ident> , <string> , <counter-style>? )"
   },
   {
     "name": "target-text()",
-    "syntax": "target-text( [ <string> | <url> ] ',' [ content | before | after | first-letter ]? )"
+    "syntax": "target-text( [ <string> | <url> ] , [ content | before | after | first-letter ]? )"
   },
   {
     "name": "translate()",
-    "syntax": "translate( <length-percentage> ',' <length-percentage>? )"
+    "syntax": "translate( <length-percentage> , <length-percentage>? )"
+  },
+  {
+    "name": "translate3d()",
+    "syntax": "translate3d( <length-percentage> , <length-percentage> , <length> )"
   },
   {
     "name": "translateX()",
@@ -1432,16 +1556,16 @@
     "syntax": "translateY( <length-percentage> )"
   },
   {
-    "name": "url()",
-    "syntax": "url( <string> <url-modifier>* ) | <url-token>"
+    "name": "translateZ()",
+    "syntax": "translateZ( <length> )"
   },
   {
     "name": "var()",
-    "syntax": "var( <custom-property-name> ',' <declaration-value>? )"
+    "syntax": "var( <custom-property-name> , <declaration-value>? )"
   },
   {
     "name": "view()",
-    "syntax": "view( [ <axis> || <'view-timeline-inset'> ]? )"
+    "syntax": "view([<axis> || <'view-timeline-inset'>]?)"
   },
   {
     "name": "xywh()",

--- a/crates/gosub_css3/src/matcher/property_definitions.rs
+++ b/crates/gosub_css3/src/matcher/property_definitions.rs
@@ -12,7 +12,7 @@ use crate::stylesheet::CssValue;
 
 /// List of elements that are built-in data types in the CSS specification. These will be handled
 /// by the syntax matcher as built-in types.
-const BUILTIN_DATA_TYPES: [&str; 43] = [
+const BUILTIN_DATA_TYPES: [&str; 49] = [
     "absolute-size",
     "age",
     "angle",
@@ -56,6 +56,12 @@ const BUILTIN_DATA_TYPES: [&str; 43] = [
     "element()", //TODO: this is not a builtin!
     "dynamic-range-limit-mix()",
     "palette-mix()",
+    "declaration-value",
+    "number-token",
+    "autospace",
+    "dimension",
+    "resolution",
+    "url",
 ];
 
 /// A CSS property definition including its type and initial value and optional expanded values if it's a shorthand property
@@ -454,7 +460,11 @@ fn parse_syntax_file<M: Map<String, SyntaxDefinition>>(json: serde_json::Value) 
 
     let entries = json.as_array().unwrap();
     for entry in entries {
-        match CssSyntax::new(entry.get("syntax").unwrap().as_str().unwrap()).compile() {
+        let syntax_str = entry.get("syntax").unwrap().as_str().unwrap();
+        if syntax_str.is_empty() {
+            continue;
+        }
+        match CssSyntax::new(syntax_str).compile() {
             Ok(ast) => {
                 let mut name = entry.get("name").unwrap().to_string();
                 let mut ty = SyntaxType::None;
@@ -605,7 +615,7 @@ mod tests {
             .with_level(log::LevelFilter::Warn)
             .init()
             .unwrap();
-        assert_eq!(CSS_DEFINITIONS.len(), 656);
+        assert_eq!(CSS_DEFINITIONS.len(), 664);
     }
 
     #[test]

--- a/crates/gosub_css3/src/matcher/styling.rs
+++ b/crates/gosub_css3/src/matcher/styling.rs
@@ -766,10 +766,10 @@ mod tests {
         assert_eq!(
             prop.get_props_from_shorthand(),
             vec![
+                "border-top-color",
+                "border-right-color",
                 "border-bottom-color",
                 "border-left-color",
-                "border-right-color",
-                "border-top-color",
             ]
         );
 


### PR DESCRIPTION
This now updates the CSS definition files. The reason is to use the css-typegen again and generate the full current types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated and expanded CSS support: refreshed at‑rule, selector, and value grammars with many modern rules, pseudo-classes/elements, and browser-specific entries.
  * Added support for new view/transition and scope-related at-rules and selector states.

* **Bug Fixes / Compatibility**
  * Improved parsing and datatype recognition for a wider range of CSS primitives and functions.
  * Fixed shorthand expansion ordering for border-color.

* **Tests**
  * Adjusted tests to reflect the expanded definitions and counts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gosub-io/gosub-engine/pull/984?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->