### PR TITLE
[render-pipeline-docs]

### DIFF
--- a/docs/render-pipeline/README.md
+++ b/docs/render-pipeline/README.md
@@ -1,0 +1,116 @@
+# Render Pipeline
+
+The Gosub render pipeline transforms a parsed HTML document into pixel data displayed in a window. It is a **staged, tile-based pipeline** that runs entirely on the CPU by default, with optional GPU acceleration via the Vello backend.
+
+The pipeline lives behind the `pipeline` Cargo feature. When that feature is disabled, the engine falls back to a placeholder gray clear (only when no document is loaded) — no layout or painting occurs.
+
+## Quick navigation
+
+| Document | Contents |
+|----------|----------|
+| [Stages](stages.md) | Deep dive into each of the 7 pipeline stages |
+| [Data structures](data-structures.md) | Key types and how they flow between stages |
+| [Backends](backends.md) | How render backends consume the display list |
+
+## Architecture overview
+
+```
+  EngineDocument (DOM + stylesheets)
+         │
+         ▼
+  ┌──────────────────────────────────┐
+  │  Stage 1 – Render Tree Builder   │  crates/gosub_pipeline/src/rendertree_builder/
+  │  Filter invisible nodes          │
+  └──────────────┬───────────────────┘
+                 │  RenderTree
+                 ▼
+  ┌──────────────────────────────────┐
+  │  Stage 2 – Layout (Taffy)        │  crates/gosub_pipeline/src/layouter/
+  │  Compute box models              │
+  └──────────────┬───────────────────┘
+                 │  LayoutTree
+                 ▼
+  ┌──────────────────────────────────┐
+  │  Stage 3 – Layering              │  crates/gosub_pipeline/src/layering/
+  │  Assign elements to layers       │
+  └──────────────┬───────────────────┘
+                 │  LayerList
+                 ▼
+  ┌──────────────────────────────────┐
+  │  Stage 4 – Tiling                │  crates/gosub_pipeline/src/tiler.rs
+  │  Subdivide viewport into tiles   │
+  └──────────────┬───────────────────┘
+                 │  TileList
+                 ▼
+  ┌──────────────────────────────────┐
+  │  Stage 5 – Painting              │  crates/gosub_pipeline/src/painter/
+  │  Generate paint commands         │
+  └──────────────┬───────────────────┘
+                 │  TileList (with PaintCommands)
+                 ▼
+  ┌──────────────────────────────────┐
+  │  Stage 6 – Rasterization         │  crates/gosub_pipeline/src/rasterizer/
+  │  Execute commands → pixel data   │
+  └──────────────┬───────────────────┘
+                 │  TextureStore
+                 ▼
+  ┌──────────────────────────────────┐
+  │  Stage 7 – Compositing           │  context.rs (pipeline_render)
+  │  Assemble tiles → display list   │
+  └──────────────┬───────────────────┘
+                 │  RenderList (DisplayItem::Blit …)
+                 ▼
+  ┌──────────────────────────────────┐
+  │  Render Backend                  │  crates/gosub_cairo / gosub_vello
+  │  Draw display list to window     │
+  └──────────────────────────────────┘
+```
+
+## Entry points
+
+### Triggering a rebuild
+
+`BrowsingContext` (in `crates/gosub_engine/src/engine/context.rs`) owns the dirty flags and the cached `RenderList`. Three methods mark the pipeline as needing a rebuild:
+
+```rust
+context.set_document(doc);     // new HTML loaded
+context.set_viewport(vp);      // window resized
+context.invalidate_render();   // DOM/CSS changed
+```
+
+### Running the pipeline
+
+```rust
+// Called each draw tick; no-ops when clean
+context.rebuild_render_list_if_needed();
+```
+
+Internally this calls the free function `pipeline_render(doc, viewport, &mut render_list)` which runs all seven stages and populates the `RenderList`.
+
+## Feature flags
+
+| Flag | Enables | Requires |
+|------|---------|----------|
+| `pipeline` | The pipeline crate and all 7 stages | — |
+| `backend_cairo` | Cairo rasterizer + GTK4 window | `pipeline`, `text_pango`, GTK4 |
+| `backend_vello` | Vello GPU rasterizer | `pipeline`, `wgpu`, `winit` |
+| `text_pango` | Pangocairo text layout | GTK4 |
+| `text_parley` | Pure-Rust Parley text layout | — |
+| `text_skia` | Skia text layout | skia-safe |
+
+A typical development build with Cairo:
+
+```
+cargo build --features backend_cairo
+```
+
+When neither `backend_cairo` nor `backend_vello` is enabled, `DisplayItem::Blit` commands are emitted into the render list but no backend is wired to consume them, so nothing is visible. This is intentional — new backends can be developed against the same display list.
+
+## Key constants
+
+| Name | Value | Where | Purpose |
+|------|-------|-------|---------|
+| Tile size | 256 × 256 px | `context.rs` | Default tile dimensions |
+| `DEFAULT_FONT_SIZE` | 16.0 px | `layouter/taffy.rs` | Fallback font size |
+| `DEFAULT_FONT_FAMILY` | `"Sans"` | `layouter/taffy.rs` | Fallback font family |
+| Invisible tags | `head style script meta link title` | `rendertree_builder/tree.rs` | Nodes pruned from render tree |

--- a/docs/render-pipeline/backends.md
+++ b/docs/render-pipeline/backends.md
@@ -1,0 +1,135 @@
+# Render Backends
+
+A render backend is responsible for consuming the `RenderList` produced by
+Stage 7 and drawing it to a visible surface (a window, an off-screen buffer, or
+a PNG file).
+
+Backends are **decoupled from the pipeline**: they see only `DisplayItem` enums
+and have no knowledge of tiles, textures, or paint commands.
+
+---
+
+## The `RenderBackend` trait
+
+**File:** `crates/gosub_engine/src/render/backend.rs`
+
+```rust
+pub trait RenderBackend {
+    fn name(&self) -> &'static str;
+    fn create_surface(&self, size: SurfaceSize, present: PresentMode)
+        -> Result<Box<dyn ErasedSurface + Send>>;
+    fn render(&self, ctx: &mut BrowsingContext, surface: &mut dyn ErasedSurface)
+        -> Result<()>;
+    fn snapshot(&self, surface: &mut dyn ErasedSurface, max_dim: u32)
+        -> Result<RgbaImage>;
+    fn external_handle(&self, surface: &mut dyn ErasedSurface)
+        -> Result<ExternalHandle>;
+}
+```
+
+`render()` reads `ctx.render_list()` and draws each `DisplayItem` onto the
+`ErasedSurface`. After drawing, the surface can be presented to a window or
+read back via `snapshot()`.
+
+---
+
+## Cairo backend
+
+**Crate:** `crates/gosub_cairo/`  
+**Feature:** `backend_cairo`  
+**Surface type:** `OffscreenCairoSurface` (CPU, ARgb32 pixel buffer)
+
+### How it draws each `DisplayItem`
+
+| Variant | Cairo operation |
+|---------|----------------|
+| `Clear { color }` | `set_operator(Source)` + `paint()` — replaces entire surface |
+| `Rect { … }` | `rectangle()` + `fill()` |
+| `TextRun { … }` | `select_font_face()` + `show_text()` (basic fallback, no Pango) |
+| `Blit { x, y, w, h, data }` | `create_for_data_unsafe()` → `SurfacePattern` → `fill()` |
+
+The `Blit` path is the primary path when the pipeline is active. It:
+
+1. Validates `data.len() >= h * w * 4` before touching the pointer.
+2. Creates a read-only `cairo::ImageSurface` over the existing buffer (zero
+   copy — Cairo never writes to source data).
+3. Builds a `SurfacePattern` with a translation matrix that maps from page
+   space into surface space.
+4. Fills the tile rectangle with the pattern.
+
+### Thread safety
+
+`OffscreenCairoSurface` is `Send`. The `CairoBackend` struct is stateless and
+can be shared across threads.
+
+### GTK integration
+
+The `gosub_cairo` crate also provides a GTK4 drawing area integration (in
+`src/lib.rs`) that calls `render()` on the `draw` signal and uses
+`ExternalHandle` to hand the pixel buffer to GDK.
+
+---
+
+## Vello backend
+
+**Crate:** `crates/gosub_vello/`  
+**Feature:** `backend_vello`  
+**Surface type:** GPU texture via wgpu
+
+### How it draws each `DisplayItem`
+
+| Variant | Vello operation |
+|---------|----------------|
+| `Clear { color }` | Clears the wgpu render pass |
+| `Rect { … }` | `scene.fill()` with a solid brush |
+| `TextRun { … }` | Logs a warning; not yet implemented |
+| `Blit { … }` | Logs a warning; not yet implemented |
+
+The Vello backend currently has its own internal rasterization path (separate
+from the `TextureStore` blit approach used by Stage 7). Full integration with
+the compositing stage is pending.
+
+### wgpu surface lifecycle
+
+`VelloSurface` wraps a `wgpu::Surface` and a `wgpu::Texture`. `create_surface`
+creates the wgpu resources; `present()` submits the render pass and presents
+the swap chain.
+
+---
+
+## Null backend
+
+**File:** `crates/gosub_engine/src/render/backends/null.rs`  
+**Always available** (no feature flag required)
+
+The null backend does nothing. It is used in headless tests and CI where no
+display server is available. `render()` is a no-op; `snapshot()` returns a
+1×1 transparent image.
+
+---
+
+## Adding a new backend
+
+1. Implement `RenderBackend` for your type.
+2. Implement `ErasedSurface` for your surface type.
+3. Handle at minimum `DisplayItem::Clear` and `DisplayItem::Blit`.
+4. Wire it up in `BrowsingContext::new()` behind a feature flag.
+
+The pipeline's output is a flat `Vec<DisplayItem>` — no Rust generics or
+associated types leak into the backend interface. Any backend that can blit
+an ARgb32 buffer can be integrated without touching the pipeline crates.
+
+---
+
+## Pixel format
+
+All `Blit` payloads and `OffscreenCairoSurface` pixel buffers use the same
+format:
+
+- **Format:** `cairo::Format::ARgb32` (also known as `BGRA8888` on
+  little-endian, with premultiplied alpha)
+- **Stride:** `width * 4` bytes
+- **Total size:** `height * width * 4` bytes
+
+When blitting to a different format (e.g. wgpu `Bgra8UnormSrgb`), the backend
+is responsible for any format conversion.

--- a/docs/render-pipeline/data-structures.md
+++ b/docs/render-pipeline/data-structures.md
@@ -1,0 +1,323 @@
+# Data Structures
+
+This document describes the key types that flow through the render pipeline.
+Types are listed in pipeline order.
+
+---
+
+## ID types
+
+All pipeline IDs are newtypes over `u64` and compare equal when the underlying
+value matches. Conversions between related ID types (e.g. `RenderNodeId` ↔
+`NodeId`) are provided by `From`/`Into` impls.
+
+| Type | Crate | Meaning |
+|------|-------|---------|
+| `NodeId` | `gosub_shared` | DOM node in the parsed document |
+| `RenderNodeId` | `gosub_pipeline` | Node in the render tree (filtered DOM) |
+| `LayoutElementId` | `gosub_pipeline` | Node in the layout tree |
+| `LayerId` | `gosub_pipeline` | Rendering layer |
+| `TileId` | `gosub_pipeline` | Individual tile |
+| `TextureId` | `gosub_pipeline` | Rasterized pixel buffer |
+| `MediaId` | `gosub_pipeline` | Image or SVG resource |
+
+---
+
+## Document adapter — `PipelineDocument`
+
+**File:** `crates/gosub_pipeline/src/common/document/pipeline_doc.rs`
+
+```rust
+pub trait PipelineDocument: Send + Sync {
+    fn root(&self) -> Option<NodeId>;
+    fn children(&self, id: NodeId) -> Vec<NodeId>;
+    fn node_kind(&self, id: NodeId) -> PipelineNodeKind;
+    fn tag_name(&self, id: NodeId) -> Option<String>;
+    fn is_display_none(&self, id: NodeId) -> bool;
+    fn parent(&self, id: NodeId) -> Option<NodeId>;
+    fn get_style(&self, id: NodeId, prop: StyleProperty) -> Option<StyleValue>;
+    fn get_style_f32(&self, id: NodeId, prop: StyleProperty) -> f32;
+    fn html_node_id(&self) -> Option<NodeId>;
+    fn body_node_id(&self) -> Option<NodeId>;
+    fn base_url(&self) -> String;
+    fn get_node_by_id(&self, id: NodeId) -> Option<Node>;
+    fn inner_html(&self, id: NodeId) -> String;
+}
+```
+
+The concrete implementation for the Gosub DOM is `GosubDocumentAdapter<C>`,
+which wraps `Arc<C::Document>` and lazily computes CSS properties via
+`C::CssSystem::properties_from_node()`. Styles are never cached inside the
+adapter — each call recomputes from the stylesheet list.
+
+The `root()` implementation returns the `<html>` element (not the synthetic
+`Document` node at index 0) because the render pipeline expects a real element
+as its root. When the document root is already an element (fragment documents),
+it falls back to `doc.root()` directly.
+
+---
+
+## Stage 1 output — `RenderTree`
+
+**File:** `crates/gosub_pipeline/src/rendertree_builder/tree.rs`
+
+```rust
+pub struct RenderTree {
+    pub doc: Arc<dyn PipelineDocument>,
+    pub arena: HashMap<RenderNodeId, RenderNode>,
+    pub root_id: Option<RenderNodeId>,
+}
+
+pub struct RenderNode {
+    pub node_id: RenderNodeId,
+    pub children: Vec<RenderNodeId>,
+}
+```
+
+The render tree is a lightweight mirror of the visible DOM. It holds no style
+data itself — style queries go through `doc.get_style()` on demand.
+
+---
+
+## Stage 2 output — `LayoutTree`
+
+**File:** `crates/gosub_pipeline/src/layouter/mod.rs`
+
+```rust
+pub struct LayoutTree {
+    pub render_tree: RenderTree,
+    pub arena: HashMap<LayoutElementId, LayoutElementNode>,
+    pub root_id: LayoutElementId,
+    pub root_dimension: Dimension,
+}
+
+pub struct LayoutElementNode {
+    pub id: LayoutElementId,
+    pub dom_node_id: DomNodeId,
+    pub render_node_id: RenderNodeId,
+    pub children: Vec<LayoutElementId>,
+    pub box_model: BoxModel,
+    pub context: ElementContext,
+}
+```
+
+### `BoxModel`
+
+```rust
+pub struct BoxModel {
+    pub margin_box:  Rect,   // outer edge
+    pub border_box:  Rect,   // inside margin
+    pub padding_box: Rect,   // inside border
+    pub content_box: Rect,   // inside padding
+}
+```
+
+All four boxes share the same origin offset. `content_box` is used for text
+and image intrinsic sizing.
+
+### `ElementContext`
+
+Carries metadata that is only meaningful for specific element kinds:
+
+```rust
+pub enum ElementContext {
+    None,
+    Text(ElementContextText),
+    Image(ElementContextImage),
+    Svg(ElementContextSvg),
+}
+```
+
+`ElementContextText` holds the string value, `FontInfo`, and a `text_offset`
+(where the baseline sits relative to the content box). `ElementContextImage`
+and `ElementContextSvg` hold the `MediaId` and the intrinsic `Dimension`.
+
+---
+
+## Stage 3 output — `LayerList`
+
+**File:** `crates/gosub_pipeline/src/layering/layer.rs`
+
+```rust
+pub struct LayerList {
+    pub layout_tree: Arc<LayoutTree>,
+    layer_ids: RwLock<Vec<LayerId>>,
+    layers: RwLock<HashMap<LayerId, Layer>>,
+}
+
+pub struct Layer {
+    pub layer_id: LayerId,
+    pub order: isize,        // compositing z-order; higher = on top
+    pub elements: Vec<LayoutElementId>,
+}
+```
+
+Iteration order for compositing: layers sorted ascending by `order`.
+
+---
+
+## Stage 4 output — `TileList`
+
+**File:** `crates/gosub_pipeline/src/tiler.rs`
+
+```rust
+pub struct TileList {
+    pub layer_list: Arc<LayerList>,
+    pub tiles: HashMap<LayerId, TileLayer>,
+    pub arena: HashMap<TileId, Tile>,
+    pub default_tile_dimension: Dimension,
+}
+
+pub struct Tile {
+    pub id: TileId,
+    pub layer_id: LayerId,
+    pub elements: Vec<TiledLayoutElement>,
+    pub texture_id: Option<TextureId>,
+    pub state: TileState,
+    pub rect: Rect,           // position in page space
+    pub bgcolor: Option<(f32,f32,f32,f32)>,
+}
+
+pub struct TiledLayoutElement {
+    pub id: LayoutElementId,
+    pub rect: Rect,           // element rect clipped to tile boundary
+    pub position: Coordinate, // element origin within tile-local space
+    pub paint_commands: Vec<PaintCommand>,
+}
+
+pub enum TileState {
+    Dirty,           // needs rasterization
+    Clean,           // has valid texture
+    Empty,           // no visible content
+    Unrenderable,    // backend cannot handle
+}
+```
+
+`TileLayer` wraps an `rstar::RTree<TileRect>` for spatial queries. Each tile
+in the tree stores its bounding rect and `TileId`.
+
+---
+
+## Stage 5 output — `PaintCommand`
+
+**File:** `crates/gosub_pipeline/src/painter/commands.rs`
+
+```rust
+pub enum PaintCommand {
+    Text(Text),
+    Rectangle(Rectangle),
+    Svg(PaintSvg),
+}
+```
+
+### `Rectangle`
+
+```rust
+pub struct Rectangle {
+    pub rect:   Rect,
+    pub brush:  Brush,
+    pub border: Option<Border>,
+    pub radius: Option<Radius>,
+}
+```
+
+`Border` has per-side `width: f32`, `style: BorderStyle`, and `color: Color`.
+`Radius` has four per-corner values (top-left, top-right, bottom-right,
+bottom-left).
+
+### `Brush`
+
+```rust
+pub enum Brush {
+    Solid(Color),
+    Image(MediaId),
+    // gradient planned
+}
+```
+
+### `Text`
+
+```rust
+pub struct Text {
+    pub text:      String,
+    pub rect:      Rect,
+    pub font_info: FontInfo,
+    pub brush:     Brush,
+}
+```
+
+`FontInfo` carries `family: String`, `size: f64`, and `weight: u32`.
+
+---
+
+## Stage 6 output — `TextureStore`
+
+**File:** `crates/gosub_pipeline/src/common/texture_store.rs`
+
+```rust
+pub struct TextureStore {
+    textures: HashMap<TextureId, Texture>,
+}
+
+pub struct Texture {
+    pub width:  u32,
+    pub height: u32,
+    pub data:   Arc<Vec<u8>>,   // premultiplied ARgb32, stride = width * 4
+}
+```
+
+Textures are reference-counted (`Arc`) so the compositing stage can hand the
+data directly into `DisplayItem::Blit` without a copy when possible.
+
+---
+
+## Stage 7 output — `RenderList`
+
+**File:** `crates/gosub_engine/src/render/render_list.rs`
+
+```rust
+pub struct RenderList {
+    pub items: Vec<DisplayItem>,
+}
+
+pub enum DisplayItem {
+    Clear  { color: Color },
+    Rect   { x: f32, y: f32, w: f32, h: f32, color: Color },
+    TextRun { x: f32, y: f32, text: String, size: f32, color: Color, max_width: Option<f32> },
+    Blit   { x: f32, y: f32, w: u32, h: u32, data: Arc<Vec<u8>> },
+}
+```
+
+Only `Clear` and `Blit` are used by the current pipeline:
+
+- `Clear` — written by the pipeline as the first item to fill the background
+  white before any tiles are blitted.
+- `Blit` — one per clean tile; coordinates are in **page space** (the backend
+  applies a viewport-offset transform before drawing).
+
+`Rect` and `TextRun` are fallback variants used by the non-pipeline rendering
+path and available to backends that bypass the tile compositor.
+
+---
+
+## Supporting stores
+
+### `MediaStore`
+
+**File:** `crates/gosub_pipeline/src/common/media.rs`
+
+Holds decoded images and parsed SVG documents keyed by `MediaId`. Loaded on
+demand during layout (for intrinsic sizing) and rasterization. A single
+`MediaStore` instance is created per pipeline run and passed through Stages 6
+and 7.
+
+> **Note:** `TaffyLayouter` currently creates its own `MediaStore` internally.
+> This means images loaded during layout are not shared with the rasterizer's
+> store. This is a known limitation.
+
+### `BrowserState`
+
+**File:** `crates/gosub_pipeline/src/common/browser_state.rs`
+
+Carries the current viewport rect and DPI scale factor. Passed to the painter
+so that viewport-relative units (e.g. `vw`, `vh`) can be resolved.

--- a/docs/render-pipeline/stages.md
+++ b/docs/render-pipeline/stages.md
@@ -1,0 +1,275 @@
+# Pipeline Stages
+
+All seven stages run inside `pipeline_render()` in
+`crates/gosub_engine/src/engine/context.rs`. Each stage is timed and its
+duration is logged at `INFO` level with the `[pipeline]` prefix.
+
+---
+
+## Stage 1 — Render Tree Builder
+
+**Crate/module:** `crates/gosub_pipeline/src/rendertree_builder/`  
+**Input:** `Arc<dyn PipelineDocument>`  
+**Output:** `RenderTree`
+
+The render tree is a pruned, flat-indexed copy of the DOM that contains only
+nodes relevant to rendering. Anything the CSS engine would also skip is dropped
+here before layout gets involved.
+
+### What gets filtered out
+
+- Elements whose tag name is in the *invisible set*:
+  `head`, `style`, `script`, `meta`, `link`, `title`
+- Comment nodes
+- Elements with `display: none`
+
+### Algorithm
+
+`build_rendertree()` does an iterative post-order traversal using an explicit
+`Frame` stack (avoids stack overflow on deep documents). For each element node
+it pushes a `RenderNode` into the arena; for text nodes it preserves them as
+children of their parent element.
+
+The result is a `HashMap<RenderNodeId, RenderNode>` with a single `root_id`.
+`RenderNodeId` is a newtype over `u64` and is convertible to/from the
+interface-level `NodeId`.
+
+---
+
+## Stage 2 — Layout
+
+**Crate/module:** `crates/gosub_pipeline/src/layouter/taffy.rs`  
+**Input:** `RenderTree`, viewport `Dimension`  
+**Output:** `LayoutTree`
+
+Layout computes the final position and size of every render node using the
+[Taffy](https://github.com/DioxusLabs/taffy) CSS layout engine.
+
+### Steps
+
+1. **Tree conversion** — `generate_tree()` walks the `RenderTree` and creates
+   a parallel `TaffyTree<TaffyContext>`. Each node carries a `TaffyContext`
+   that tells the measure callback what kind of content it holds.
+
+2. **CSS → Taffy** — `CssTaffyConverter` maps pipeline `StylePropertyList`
+   values to Taffy's `Style` struct. Supported CSS properties include flex,
+   grid, box model, sizing, positioning, overflow, and typography basics.
+
+3. **Measurement callbacks** — Taffy calls back into Gosub for intrinsic sizes:
+   - *Text nodes* call `get_text_layout()` with the font descriptor and
+     available width, returning a pixel `Size`.
+   - *Image/SVG nodes* return the intrinsic `Dimension` stored in
+     `ElementContextImage` / `ElementContextSvg`.
+
+4. **`populate_boxmodel()`** — After Taffy finishes, results are read back and
+   stored in `LayoutElementNode.box_model` as a `BoxModel` with four `Edges`
+   (margin, border, padding, content).
+
+### `LayoutTree` structure
+
+```
+LayoutTree
+├── render_tree: RenderTree         (source)
+├── arena: HashMap<LayoutElementId, LayoutElementNode>
+│   └── LayoutElementNode
+│       ├── box_model: BoxModel     (margin/border/padding/content)
+│       ├── context: ElementContext (None | Text | Image | Svg)
+│       └── children: Vec<LayoutElementId>
+└── root_dimension: Dimension       (viewport extent after layout)
+```
+
+---
+
+## Stage 3 — Layering
+
+**Crate/module:** `crates/gosub_pipeline/src/layering/`  
+**Input:** `Arc<LayoutTree>`  
+**Output:** `Arc<LayerList>`
+
+Layering assigns layout elements to ordered *layers* for correct z-order
+compositing. The current implementation is intentionally minimal.
+
+### Current behaviour
+
+- All elements go into a **default layer** at `order = 0`.
+- Any element corresponding to an `<img>` tag gets its own dedicated layer at
+  `order = 1`, ensuring images render on top of normal content.
+
+### Future work
+
+Full CSS stacking context support (z-index, `position: fixed`, opacity layers,
+mix-blend-mode) is not yet implemented. The architecture has a clean
+`LayerList` / `Layer` abstraction ready for it.
+
+---
+
+## Stage 4 — Tiling
+
+**Crate/module:** `crates/gosub_pipeline/src/tiler.rs`  
+**Input:** `Arc<LayerList>`, viewport rect  
+**Output:** `TileList`
+
+The viewport is divided into a uniform grid of tiles. Each tile represents a
+fixed-size region (default: **256 × 256 pixels**) of page space. Elements are
+clipped and distributed to whichever tiles they intersect.
+
+### Tile grid construction
+
+```
+cols = ceil(viewport_width  / tile_width)
+rows = ceil(viewport_height / tile_height)
+```
+
+One grid is created per layer. Tiles are inserted into an **R* tree**
+(`rstar::RTree`) for fast spatial queries.
+
+### Element distribution
+
+For each layout element, `get_intersecting_tiles()` queries the R* tree and
+returns all tiles the element's bounding rect overlaps. For each intersecting
+tile, a `TiledLayoutElement` is created:
+
+- `rect` — the element's bounding box clipped to the tile boundary
+- `position` — where the element origin falls inside the tile
+- `paint_commands` — filled in Stage 5
+
+### `TileState`
+
+Each tile starts with `state = Dirty`. After rasterization it becomes `Clean`
+(has a texture) or `Empty` (no visible content, skip compositing).
+
+---
+
+## Stage 5 — Painting
+
+**Crate/module:** `crates/gosub_pipeline/src/painter/`  
+**Input:** `TileList` (elements without paint commands)  
+**Output:** `TileList` (elements with `Vec<PaintCommand>`)
+
+The painter converts each `TiledLayoutElement` into a sequence of backend-
+independent draw commands. At this stage no pixels are produced — painting
+is purely a data transformation.
+
+### Command generation
+
+`Painter::paint(element, browser_state)` is called for each element in each
+tile. It inspects the element's `ElementContext` and `BoxModel` to decide which
+commands to emit:
+
+| Element kind | Command emitted |
+|---|---|
+| Text node | `PaintCommand::Text { text, font_info, brush, rect }` |
+| `<img>` | `PaintCommand::Rectangle` with `Brush::Image(media_id)` |
+| `<svg>` | `PaintCommand::Svg { media_id, rect }` |
+| Everything else | `PaintCommand::Rectangle` with background color, border, radius |
+
+### Paint command types
+
+```rust
+pub enum PaintCommand {
+    Text(Text),
+    Rectangle(Rectangle),
+    Svg(PaintSvg),
+}
+```
+
+A `Rectangle` carries:
+- `rect: Rect` — position and size
+- `brush: Brush` — fill (`Solid(Color)` or `Image(MediaId)`)
+- `border: Option<Border>` — per-side width, style, color
+- `radius: Option<Radius>` — per-corner border radius
+
+A `Text` carries the string, `FontInfo` (family, size, weight), colour brush,
+and the bounding rect.
+
+---
+
+## Stage 6 — Rasterization
+
+**Crate/module:** `crates/gosub_pipeline/src/rasterizer/`  
+**Input:** `TileList`, `&MediaStore`  
+**Output:** `TextureStore` (pixel buffers keyed by `TextureId`)
+
+Rasterization executes the paint commands and produces raw ARGB32 pixel buffers.
+The rasterizer backend is selected at compile time via feature flags.
+
+### Cairo rasterizer (`rasterizer/cairo.rs`)
+
+1. Create a `cairo::ImageSurface` (ARgb32 format) sized to the tile dimensions.
+2. Create a `cairo::Context` from the surface.
+3. For each paint command in the tile:
+   - `Rectangle` → `rectangle::do_paint_rectangle()` — sets source colour or
+     image brush, draws path, fills; handles borders and rounded corners.
+   - `Text` → `text::pango::do_paint_text()` (or Parley/Skia stub) — renders
+     text via Pangocairo into an off-screen surface, then blits.
+   - `Svg` → `svg::do_paint_svg()` — loads SVG from `MediaStore`, renders via
+     librsvg.
+4. Flush the surface, copy pixel data to a `Vec<u8>`, store in `TextureStore`.
+
+All coordinates inside the rasterizer are in **tile-local space** (origin at
+tile top-left). The tiler's `position` field provides the tile-relative offset
+for each element.
+
+### Vello rasterizer (`rasterizer/vello.rs`)
+
+GPU-accelerated path using wgpu. Paint commands are translated to Vello scene
+graph nodes and submitted to the GPU. Texture readback populates the same
+`TextureStore` interface so Stage 7 is backend-agnostic.
+
+### Text backends
+
+| Feature flag | Library | Notes |
+|---|---|---|
+| `text_pango` | Pangocairo | Requires GTK4; production quality |
+| `text_parley` | Parley | Pure Rust; default |
+| `text_skia` | Skia | Stub, not yet implemented |
+
+When multiple text features are enabled, `text_pango` takes precedence.
+
+---
+
+## Stage 7 — Compositing
+
+**Location:** `pipeline_render()` in `crates/gosub_engine/src/engine/context.rs`  
+**Input:** `TileList` + `TextureStore`  
+**Output:** `RenderList` populated with `DisplayItem::Blit`
+
+The final stage assembles rasterized tiles into the display list that backends
+consume. Only `Clean` tiles (those that were successfully rasterized) are
+included.
+
+### Algorithm
+
+```
+for tile in tile_list.all_tiles():
+    if tile.state == Clean and tile.texture_id is Some:
+        texture = texture_store.get(texture_id)
+        render_list.push(DisplayItem::Blit {
+            x: tile.rect.x,
+            y: tile.rect.y,
+            w: texture.width,
+            h: texture.height,
+            data: texture.data.clone(),   // ARgb32, stride = w * 4
+        })
+```
+
+`Empty` tiles are skipped (transparent region, no need to blit).
+
+### Current limitation
+
+Stages 6 and 7 are currently gated on `#[cfg(feature = "backend_cairo")]`.
+The Vello backend has its own rasterization path and does not use the
+`TextureStore` blit approach. Supporting multiple compositing strategies is
+future work.
+
+---
+
+## Dirty flags and caching
+
+The pipeline short-circuits at `rebuild_render_list_if_needed()` when
+`render_dirty` is false. Within the pipeline itself there is currently no
+incremental caching — all seven stages run from scratch on every dirty frame.
+
+Tile `TileState` is reset to `Dirty` at the start of each pipeline run.
+Future optimisations could preserve `Clean` tiles whose source elements have
+not changed.


### PR DESCRIPTION
Part of a stacked diff series.

*Created by pancake.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the render pipeline, covering the seven-stage architecture (render tree building through compositing), multiple backend implementations (Cairo, Vello, Null), core data structures used across stages, and algorithms for layout, layering, tiling, painting, and rasterization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gosub-io/gosub-engine/pull/991?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->