### PR TITLE
[timings]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,8 @@ console-subscriber = "0.5"
 # Enables extended debugging information during parsing.
 debug_parser = []
 debug_parser_verbose = []
+# Enables the HTTP metrics server (http://127.0.0.1:9090/metrics) in examples.
+metrics = ["gosub_engine/metrics"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.91"

--- a/crates/gosub_engine/Cargo.toml
+++ b/crates/gosub_engine/Cargo.toml
@@ -104,6 +104,7 @@ backend_cairo = ["dep:gtk4", "dep:cairo-rs", "pipeline", "gosub_pipeline/backend
 backend_vello = ["dep:vello", "dep:wgpu", "pipeline", "gosub_pipeline/backend_vello"]
 backend_skia = ["dep:skia-safe"]
 parley_layout = []
+metrics = []
 
 wayland = ["gdk4-wayland"]
 x11 = ["gdk4-x11"]

--- a/crates/gosub_engine/examples/metrics_cli.rs
+++ b/crates/gosub_engine/examples/metrics_cli.rs
@@ -13,34 +13,32 @@ use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let args: Vec<String> = std::env::args().collect();
-
     let mut host = "127.0.0.1".to_string();
     let mut port: u16 = 9090;
     let mut reset = false;
     let mut json_output = false;
     let mut watch_interval: Option<u64> = None;
 
-    let mut i = 1;
-    while i < args.len() {
-        match args[i].as_str() {
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
             "--host" => {
-                i += 1;
-                host = args.get(i).cloned().unwrap_or(host);
+                if let Some(v) = args.next() {
+                    host = v;
+                }
             }
             "--port" => {
-                i += 1;
-                port = args.get(i).and_then(|p| p.parse().ok()).unwrap_or(port);
+                if let Some(v) = args.next() {
+                    port = v.parse().unwrap_or(port);
+                }
             }
             "--reset" => reset = true,
             "--json" => json_output = true,
             "--watch" => {
-                i += 1;
-                watch_interval = args.get(i).and_then(|s| s.parse().ok()).or(Some(1));
+                watch_interval = args.next().and_then(|s| s.parse().ok()).or(Some(1));
             }
             _ => {}
         }
-        i += 1;
     }
 
     let base = format!("http://{host}:{port}");

--- a/crates/gosub_engine/examples/metrics_cli.rs
+++ b/crates/gosub_engine/examples/metrics_cli.rs
@@ -1,0 +1,145 @@
+//! Gosub metrics CLI — fetches and displays timing stats from a running engine.
+//!
+//! Usage:
+//!   cargo run --example metrics_cli                   # defaults: 127.0.0.1:9090
+//!   cargo run --example metrics_cli -- --port 9091
+//!   cargo run --example metrics_cli -- --reset        # clear counters
+//!   cargo run --example metrics_cli -- --json         # raw JSON output
+//!   cargo run --example metrics_cli -- --host 0.0.0.0 --port 9090
+//!   cargo run --example metrics_cli -- --watch 2      # poll every 2 seconds
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+
+    let mut host = "127.0.0.1".to_string();
+    let mut port: u16 = 9090;
+    let mut reset = false;
+    let mut json_output = false;
+    let mut watch_interval: Option<u64> = None;
+
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--host" => {
+                i += 1;
+                host = args.get(i).cloned().unwrap_or(host);
+            }
+            "--port" => {
+                i += 1;
+                port = args.get(i).and_then(|p| p.parse().ok()).unwrap_or(port);
+            }
+            "--reset" => reset = true,
+            "--json" => json_output = true,
+            "--watch" => {
+                i += 1;
+                watch_interval = args.get(i).and_then(|s| s.parse().ok()).or(Some(1));
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    let base = format!("http://{host}:{port}");
+
+    loop {
+        let path = if reset { "/metrics/reset" } else { "/metrics" };
+        let url = format!("{base}{path}");
+
+        match fetch(&url).await {
+            Ok(body) => {
+                if json_output || reset {
+                    println!("{body}");
+                } else {
+                    print_table(&body);
+                }
+            }
+            Err(e) => {
+                eprintln!("error: could not reach {url}: {e}");
+                eprintln!("  Is the engine running with metrics::start({port}) called?");
+            }
+        }
+
+        if reset {
+            break;
+        }
+
+        match watch_interval {
+            Some(secs) => {
+                tokio::time::sleep(Duration::from_secs(secs)).await;
+                // Clear screen for watch mode
+                print!("\x1B[2J\x1B[1;1H");
+            }
+            None => break,
+        }
+    }
+
+    Ok(())
+}
+
+async fn fetch(url: &str) -> anyhow::Result<String> {
+    let resp = reqwest::get(url).await?.text().await?;
+    Ok(resp)
+}
+
+fn print_table(json: &str) {
+    let v: serde_json::Value = match serde_json::from_str(json) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("failed to parse response: {e}");
+            eprintln!("{json}");
+            return;
+        }
+    };
+
+    let Some(namespaces) = v["namespaces"].as_object() else {
+        println!("(no metrics recorded yet)");
+        return;
+    };
+
+    if namespaces.is_empty() {
+        println!("(no metrics recorded yet)");
+        return;
+    }
+
+    // Sort alphabetically for stable output
+    let sorted: BTreeMap<_, _> = namespaces.iter().collect();
+
+    let hdr = format!(
+        "{:<30} {:>8} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10}",
+        "Namespace", "Count", "Total", "Min", "Max", "Avg", "p50", "p75", "p95", "p99"
+    );
+    let sep = "-".repeat(hdr.len());
+    println!("{hdr}");
+    println!("{sep}");
+
+    for (ns, stats) in &sorted {
+        let count = stats["count"].as_u64().unwrap_or(0);
+        let total = fmt_us(stats["total_us"].as_u64().unwrap_or(0));
+        let min = fmt_us(stats["min_us"].as_u64().unwrap_or(0));
+        let max = fmt_us(stats["max_us"].as_u64().unwrap_or(0));
+        let avg = fmt_us(stats["avg_us"].as_u64().unwrap_or(0));
+        let p50 = fmt_us(stats["p50_us"].as_u64().unwrap_or(0));
+        let p75 = fmt_us(stats["p75_us"].as_u64().unwrap_or(0));
+        let p95 = fmt_us(stats["p95_us"].as_u64().unwrap_or(0));
+        let p99 = fmt_us(stats["p99_us"].as_u64().unwrap_or(0));
+
+        println!(
+            "{:<30} {:>8} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10}",
+            ns, count, total, min, max, avg, p50, p75, p95, p99
+        );
+    }
+}
+
+fn fmt_us(us: u64) -> String {
+    if us < 1_000 {
+        format!("{us}µs")
+    } else if us < 1_000_000 {
+        format!("{:.1}ms", us as f64 / 1_000.0)
+    } else {
+        format!("{:.2}s", us as f64 / 1_000_000.0)
+    }
+}

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -208,6 +208,7 @@ fn pipeline_render(doc: Arc<EngineDocument>, viewport: &Viewport, rl: &mut Rende
     use gosub_pipeline::painter::Painter;
     use gosub_pipeline::rendertree_builder::RenderTree;
     use gosub_pipeline::tiler::{TileList, TileState};
+    use gosub_shared::{timing_start, timing_stop};
     use std::time::Instant;
 
     log::info!(
@@ -216,6 +217,7 @@ fn pipeline_render(doc: Arc<EngineDocument>, viewport: &Viewport, rl: &mut Rende
         viewport.height
     );
     let t_total = Instant::now();
+    let ts_total = timing_start!("pipeline.total");
 
     rl.items.push(DisplayItem::Clear {
         color: Color::new(1.0, 1.0, 1.0, 1.0),
@@ -223,9 +225,11 @@ fn pipeline_render(doc: Arc<EngineDocument>, viewport: &Viewport, rl: &mut Rende
 
     // Stage 1: render tree
     let t = Instant::now();
+    let ts1 = timing_start!("pipeline.render_tree");
     let adapter = GosubDocumentAdapter::<HtmlEngineConfig>::new(doc);
     let mut render_tree = RenderTree::new(Arc::new(adapter));
     render_tree.parse();
+    timing_stop!(ts1);
     log::info!(
         "[pipeline] stage 1 render-tree:  {:>6.1}ms  ({} nodes)",
         t.elapsed().as_secs_f64() * 1000.0,
@@ -240,8 +244,10 @@ fn pipeline_render(doc: Arc<EngineDocument>, viewport: &Viewport, rl: &mut Rende
 
     // Stage 2: layout
     let t = Instant::now();
+    let ts2 = timing_start!("pipeline.layout");
     let mut layouter = TaffyLayouter::new();
     let layout_tree = layouter.layout(render_tree, vp_dim, 1.0);
+    timing_stop!(ts2);
     log::info!(
         "[pipeline] stage 2 layout:        {:>6.1}ms  (root {}x{:.0})",
         t.elapsed().as_secs_f64() * 1000.0,
@@ -251,8 +257,10 @@ fn pipeline_render(doc: Arc<EngineDocument>, viewport: &Viewport, rl: &mut Rende
 
     // Stage 3: layering
     let t = Instant::now();
+    let ts3 = timing_start!("pipeline.layering");
     let layer_list = LayerList::new(layout_tree);
     let layer_count = layer_list.layer_ids.read().len();
+    timing_stop!(ts3);
     log::info!(
         "[pipeline] stage 3 layering:      {:>6.1}ms  ({} layers)",
         t.elapsed().as_secs_f64() * 1000.0,
@@ -261,9 +269,11 @@ fn pipeline_render(doc: Arc<EngineDocument>, viewport: &Viewport, rl: &mut Rende
 
     // Stage 4: tiling
     let t = Instant::now();
+    let ts4 = timing_start!("pipeline.tiling");
     let mut tile_list = TileList::new(layer_list, PipelineDimension::new(256.0, 256.0));
     tile_list.generate();
     let total_tiles = tile_list.arena.len();
+    timing_stop!(ts4);
     log::info!(
         "[pipeline] stage 4 tiling:        {:>6.1}ms  ({} tiles total)",
         t.elapsed().as_secs_f64() * 1000.0,
@@ -272,6 +282,7 @@ fn pipeline_render(doc: Arc<EngineDocument>, viewport: &Viewport, rl: &mut Rende
 
     // Stage 5: painting
     let t = Instant::now();
+    let ts5 = timing_start!("pipeline.painting");
     let vp_rect = PipelineRect::new(0.0, 0.0, viewport.width as f64, viewport.height as f64);
     let layer_ids = tile_list.layer_list.layer_ids.read().clone();
     let paint_state = BrowserState {
@@ -312,6 +323,7 @@ fn pipeline_render(doc: Arc<EngineDocument>, viewport: &Viewport, rl: &mut Rende
             }
         }
     }
+    timing_stop!(ts5);
     log::info!(
         "[pipeline] stage 5 painting:      {:>6.1}ms  ({} tiles painted, {} commands total)",
         t.elapsed().as_secs_f64() * 1000.0,
@@ -328,6 +340,7 @@ fn pipeline_render(doc: Arc<EngineDocument>, viewport: &Viewport, rl: &mut Rende
         use gosub_pipeline::rasterizer::Rasterable;
 
         let t = Instant::now();
+        let ts6 = timing_start!("pipeline.rasterize");
         let media_store = MediaStore::new();
         let mut texture_store = TextureStore::new();
         let rasterizer = CairoRasterizer::new();
@@ -366,6 +379,7 @@ fn pipeline_render(doc: Arc<EngineDocument>, viewport: &Viewport, rl: &mut Rende
                 }
             }
         }
+        timing_stop!(ts6);
         log::info!(
             "[pipeline] stage 6 rasterize:     {:>6.1}ms  ({} clean, {} empty)",
             t.elapsed().as_secs_f64() * 1000.0,
@@ -379,6 +393,7 @@ fn pipeline_render(doc: Arc<EngineDocument>, viewport: &Viewport, rl: &mut Rende
     #[cfg(feature = "backend_cairo")]
     {
         let t = Instant::now();
+        let ts7 = timing_start!("pipeline.composite");
         let mut blits = 0usize;
         for tile in tile_list.arena.values() {
             if let (Some(texture_id), true) = (tile.texture_id, tile.state == TileState::Clean) {
@@ -401,6 +416,7 @@ fn pipeline_render(doc: Arc<EngineDocument>, viewport: &Viewport, rl: &mut Rende
                 }
             }
         }
+        timing_stop!(ts7);
         log::info!(
             "[pipeline] stage 7 composite:     {:>6.1}ms  ({} blit items emitted)",
             t.elapsed().as_secs_f64() * 1000.0,
@@ -408,5 +424,6 @@ fn pipeline_render(doc: Arc<EngineDocument>, viewport: &Viewport, rl: &mut Rende
         );
     }
 
+    timing_stop!(ts_total);
     log::info!("[pipeline] total: {:.1}ms", t_total.elapsed().as_secs_f64() * 1000.0);
 }

--- a/crates/gosub_engine/src/engine/pipeline/html.rs
+++ b/crates/gosub_engine/src/engine/pipeline/html.rs
@@ -7,6 +7,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::stream;
+use gosub_shared::timing_guard;
 use http::Method;
 use parking_lot::Mutex;
 use std::sync::Arc;
@@ -113,6 +114,7 @@ impl HtmlPipelineImpl {
 
         let was_cancelled = handle.cancel.is_cancelled();
 
+        let _doc_timer = timing_guard!("html.document", meta.final_url.as_str());
         let res = parse_main_document_stream(
             meta.final_url, // This is the base URL
             reader,

--- a/crates/gosub_engine/src/lib.rs
+++ b/crates/gosub_engine/src/lib.rs
@@ -112,6 +112,9 @@ pub mod util;
 
 pub mod html;
 
+#[cfg(feature = "metrics")]
+pub mod metrics;
+
 pub use engine::{BrowsingContext, EngineError, GosubEngine};
 
 pub use engine::types::Action;

--- a/crates/gosub_engine/src/metrics.rs
+++ b/crates/gosub_engine/src/metrics.rs
@@ -1,0 +1,84 @@
+//! Lightweight HTTP metrics server.
+//!
+//! Call [`start`] once at engine startup to expose timing data over HTTP.
+//!
+//! # Endpoints
+//!
+//! | Method | Path              | Description                            |
+//! |--------|-------------------|----------------------------------------|
+//! | GET    | `/metrics`        | JSON snapshot of all timing namespaces |
+//! | GET    | `/metrics/reset`  | Clear all timing counters              |
+//! | GET    | `/health`         | Liveness probe (`{"status":"ok"}`)     |
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Spawn the metrics HTTP server on `127.0.0.1:{port}` in a background Tokio task.
+///
+/// The function returns immediately; the server runs until the process exits.
+pub fn start(port: u16) {
+    tokio::spawn(async move {
+        if let Err(e) = serve(port).await {
+            log::error!("[metrics] server stopped: {e}");
+        }
+    });
+    log::info!("[metrics] server starting on http://127.0.0.1:{port}/metrics");
+}
+
+async fn serve(port: u16) -> std::io::Result<()> {
+    let listener = TcpListener::bind(format!("127.0.0.1:{port}")).await?;
+    log::info!("[metrics] listening on http://127.0.0.1:{port}");
+    loop {
+        let (stream, _addr) = listener.accept().await?;
+        tokio::spawn(handle(stream));
+    }
+}
+
+async fn handle(mut stream: TcpStream) {
+    let mut buf = vec![0u8; 2048];
+    let n = stream.read(&mut buf).await.unwrap_or(0);
+    let req = std::str::from_utf8(&buf[..n]).unwrap_or("");
+    let first_line = req.lines().next().unwrap_or("");
+
+    let (code, phrase, body) = if first_line.starts_with("GET /metrics/reset") {
+        gosub_shared::timing::reset_stats();
+        (200u16, "OK", r#"{"status":"reset"}"#.to_string())
+    } else if first_line.starts_with("GET /metrics") || first_line.starts_with("HEAD /metrics") {
+        (200, "OK", build_metrics_json())
+    } else if first_line.starts_with("GET /health") {
+        (200, "OK", r#"{"status":"ok"}"#.to_string())
+    } else {
+        (404, "Not Found", r#"{"error":"not found"}"#.to_string())
+    };
+
+    let response = format!(
+        "HTTP/1.1 {code} {phrase}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes()).await;
+}
+
+fn build_metrics_json() -> String {
+    use gosub_shared::timing::snapshot_stats;
+    use serde_json::{json, Map, Value};
+
+    let mut map = Map::new();
+    for s in snapshot_stats() {
+        map.insert(
+            s.namespace.clone(),
+            json!({
+                "count":    s.count,
+                "total_us": s.total_us,
+                "min_us":   s.min_us,
+                "max_us":   s.max_us,
+                "avg_us":   s.avg_us,
+                "p50_us":   s.p50_us,
+                "p75_us":   s.p75_us,
+                "p95_us":   s.p95_us,
+                "p99_us":   s.p99_us,
+            }),
+        );
+    }
+
+    serde_json::to_string_pretty(&json!({ "namespaces": Value::Object(map) })).unwrap_or_else(|_| "{}".to_string())
+}

--- a/crates/gosub_net/src/net/fetch.rs
+++ b/crates/gosub_net/src/net/fetch.rs
@@ -5,6 +5,7 @@ use crate::types::PeekBuf;
 use anyhow::{anyhow, Context};
 use bytes::Bytes;
 use futures_util::{stream, StreamExt, TryStreamExt};
+use gosub_shared::timing_guard;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -44,6 +45,7 @@ pub async fn fetch_response_top(
     observer: Arc<dyn NetObserver + Send + Sync>,
 ) -> Result<ResponseTop, NetError> {
     // Emit we are starting
+    let _timer = timing_guard!("net.fetch", url.as_str());
     let started = Instant::now();
     observer.on_event(NetEvent::Started { url: url.clone() });
 
@@ -282,6 +284,7 @@ pub async fn fetch_response_complete(
     // Total time of read allowed (if any)
     total_body_timeout: Option<Duration>,
 ) -> Result<(FetchResultMeta, Vec<u8>), NetError> {
+    let _timer = timing_guard!("net.fetch_complete", url.as_str());
     let started = Instant::now();
 
     let ResponseTop {

--- a/crates/gosub_pipeline/src/rasterizer/skia.rs
+++ b/crates/gosub_pipeline/src/rasterizer/skia.rs
@@ -61,13 +61,13 @@ impl Rasterable for SkiaRasterizer {
             for command in &element.paint_commands {
                 match command {
                     PaintCommand::Rectangle(command) => {
-                        rectangle::do_paint_rectangle(canvas, &tile, &command);
+                        rectangle::do_paint_rectangle(canvas, tile, command);
                     }
                     PaintCommand::Text(command) => {
-                        let _ = text::do_paint_text(canvas, &tile, &command, self.dpi_scale_factor);
+                        let _ = text::do_paint_text(canvas, tile, command, self.dpi_scale_factor);
                     }
                     PaintCommand::Svg(command) => {
-                        svg::do_paint_svg(canvas, &tile, command.media_id, &command.rect);
+                        svg::do_paint_svg(canvas, tile, command.media_id, &command.rect);
                     }
                 }
             }

--- a/crates/gosub_pipeline/src/rasterizer/vello/text/skia.rs
+++ b/crates/gosub_pipeline/src/rasterizer/vello/text/skia.rs
@@ -11,7 +11,7 @@ pub fn do_paint_text(scene: &mut Scene, cmd: &Text, tile_size: Dimension, affine
 
     let mut surface = skia_safe::surfaces::raster_n32_premul((tile_size.width as i32, tile_size.height as i32))
         .ok_or_else(|| anyhow::anyhow!("Failed to create Skia surface for text rendering"))?;
-    let mut canvas = surface.canvas();
+    let canvas = surface.canvas();
 
     canvas.clip_rect(
         skia_safe::Rect::new(0.0, 0.0, tile_size.width as f32, tile_size.height as f32),
@@ -34,7 +34,7 @@ pub fn do_paint_text(scene: &mut Scene, cmd: &Text, tile_size: Dimension, affine
     );
     canvas.clear(skia_safe::Color::TRANSPARENT);
     canvas.concat(&matrix);
-    paragraph.paint(&mut canvas, (cmd.rect.x as f32, cmd.rect.y as f32));
+    paragraph.paint(canvas, (cmd.rect.x as f32, cmd.rect.y as f32));
 
     let Some(peek) = canvas.peek_pixels() else {
         return Err(anyhow::anyhow!("Failed to peek pixels from Skia canvas"));

--- a/crates/gosub_shared/src/timing.rs
+++ b/crates/gosub_shared/src/timing.rs
@@ -53,8 +53,23 @@ pub struct Stats {
     p99: u64,
 }
 
+/// Aggregated timing statistics for a single namespace, suitable for external consumption.
+#[derive(Debug, Clone)]
+pub struct NamespaceStats {
+    pub namespace: String,
+    pub count: u64,
+    pub total_us: u64,
+    pub min_us: u64,
+    pub max_us: u64,
+    pub avg_us: u64,
+    pub p50_us: u64,
+    pub p75_us: u64,
+    pub p95_us: u64,
+    pub p99_us: u64,
+}
+
 fn percentage_to_index(count: u64, percentage: f64) -> usize {
-    (count as f64 * percentage) as usize
+    ((count as f64 * percentage) as usize).min(count.saturating_sub(1) as usize)
 }
 
 impl TimingTable {
@@ -95,14 +110,14 @@ impl TimingTable {
 
         durations.sort_unstable();
         let count = durations.len() as u64;
-        let total = durations.iter().sum();
+        let total: u64 = durations.iter().sum();
         let min = *durations.first().unwrap_or(&0);
         let max = *durations.last().unwrap_or(&0);
-        let avg = total / count;
-        let p50 = durations[percentage_to_index(count, 0.50)];
-        let p75 = durations[percentage_to_index(count, 0.75)];
-        let p95 = durations[percentage_to_index(count, 0.95)];
-        let p99 = durations[percentage_to_index(count, 0.99)];
+        let avg = total.checked_div(count).unwrap_or(0);
+        let p50 = durations.get(percentage_to_index(count, 0.50)).copied().unwrap_or(0);
+        let p75 = durations.get(percentage_to_index(count, 0.75)).copied().unwrap_or(0);
+        let p95 = durations.get(percentage_to_index(count, 0.95)).copied().unwrap_or(0);
+        let p99 = durations.get(percentage_to_index(count, 0.99)).copied().unwrap_or(0);
 
         Stats {
             count,
@@ -115,6 +130,35 @@ impl TimingTable {
             p95,
             p99,
         }
+    }
+
+    /// Returns aggregated stats for every registered namespace.
+    #[must_use]
+    pub fn namespace_stats(&self) -> Vec<NamespaceStats> {
+        self.namespaces
+            .iter()
+            .map(|(ns, timer_ids)| {
+                let s = self.get_stats(timer_ids);
+                NamespaceStats {
+                    namespace: ns.clone(),
+                    count: s.count,
+                    total_us: s.total,
+                    min_us: s.min,
+                    max_us: s.max,
+                    avg_us: s.avg,
+                    p50_us: s.p50,
+                    p75_us: s.p75,
+                    p95_us: s.p95,
+                    p99_us: s.p99,
+                }
+            })
+            .collect()
+    }
+
+    /// Clears all recorded timings.
+    pub fn clear(&mut self) {
+        self.timers.clear();
+        self.namespaces.clear();
     }
 
     fn scale(&self, value: u64, scale: Scale) -> String {
@@ -184,6 +228,42 @@ lazy_static! {
     pub static ref TIMING_TABLE: Mutex<TimingTable> = Mutex::new(TimingTable::default());
 }
 
+/// Returns a snapshot of all namespace statistics from the global timing table.
+pub fn snapshot_stats() -> Vec<NamespaceStats> {
+    TIMING_TABLE.lock().namespace_stats()
+}
+
+/// Clears all recorded timings from the global timing table.
+pub fn reset_stats() {
+    TIMING_TABLE.lock().clear();
+}
+
+/// RAII timer guard — stops the timer when dropped, regardless of how the
+/// enclosing scope exits (normal return, early return, `?`, panic).
+///
+/// Obtain one via [`timing_guard!`] or [`TimerGuard::start`].
+pub struct TimerGuard {
+    id: TimerId,
+}
+
+impl TimerGuard {
+    pub fn start(namespace: &str, context: &str) -> Self {
+        let id = TIMING_TABLE.lock().start_timer(namespace, Some(context.to_string()));
+        Self { id }
+    }
+
+    pub fn start_anon(namespace: &str) -> Self {
+        let id = TIMING_TABLE.lock().start_timer(namespace, None);
+        Self { id }
+    }
+}
+
+impl Drop for TimerGuard {
+    fn drop(&mut self) {
+        TIMING_TABLE.lock().stop_timer(self.id);
+    }
+}
+
 #[allow(clippy::crate_in_macro_def)]
 #[macro_export]
 macro_rules! timing_start {
@@ -204,6 +284,26 @@ macro_rules! timing_stop {
     ($timer_id:expr) => {{
         $crate::timing::TIMING_TABLE.lock().stop_timer($timer_id);
     }};
+}
+
+/// Start a scoped timer that stops automatically when the returned guard drops.
+///
+/// Use this instead of `timing_start!/timing_stop!` whenever the measured
+/// block has multiple exit paths (early returns, `?`, etc.).
+///
+/// ```rust,ignore
+/// let _t = timing_guard!("net.fetch", url.as_str());
+/// // timer stops when `_t` goes out of scope, on any path
+/// ```
+#[allow(clippy::crate_in_macro_def)]
+#[macro_export]
+macro_rules! timing_guard {
+    ($namespace:expr, $context:expr) => {
+        $crate::timing::TimerGuard::start($namespace, $context)
+    };
+    ($namespace:expr) => {
+        $crate::timing::TimerGuard::start_anon($namespace)
+    };
 }
 
 #[allow(clippy::crate_in_macro_def)]

--- a/crates/gosub_vello/src/vello_svg.rs
+++ b/crates/gosub_vello/src/vello_svg.rs
@@ -28,7 +28,7 @@ impl SvgRenderer<VelloBackend> for VelloSVG {
 
     fn render(&mut self, _doc: &SVGDocument) -> Result<ImageBuffer<VelloBackend>> {
         // vello_svg::render_tree(scene.inner(), &doc.tree); //TODO: too old versions that vello_svg uses
-        Err(anyhow::anyhow!("SVG rendering not yet implemented for Vello backend").into())
+        Err(anyhow::anyhow!("SVG rendering not yet implemented for Vello backend"))
     }
 
     fn render_with_size(
@@ -36,6 +36,6 @@ impl SvgRenderer<VelloBackend> for VelloSVG {
         _doc: &Self::SvgDocument,
         _size: Size<u32>,
     ) -> gosub_shared::types::Result<ImageBuffer<VelloBackend>> {
-        Err(anyhow::anyhow!("SVG rendering not yet implemented for Vello backend").into())
+        Err(anyhow::anyhow!("SVG rendering not yet implemented for Vello backend"))
     }
 }

--- a/examples/gtk-cairo/main.rs
+++ b/examples/gtk-cairo/main.rs
@@ -75,6 +75,8 @@ fn main() {
         let backend = gosub_engine::render::backends::cairo::CairoBackend::new();
         let mut engine = GosubEngine::new(None, Arc::new(backend), compositor.clone());
         let _engine_join_handle = engine.start().expect("engine start failed");
+        #[cfg(feature = "metrics")]
+        gosub_engine::metrics::start(9090);
         // Subscribe to engine events
         let event_rx = engine.subscribe_events();
 


### PR DESCRIPTION
Part of a stacked diff series.

*Created by pancake.*

Added timings to the different parts of the render engine and other parts. This allows us to easily see the timings and find bottlenecks quickly. It uses a separate http server at port 9090, which is behind a compile feature flag (`metrics`). 

<img width="1701" height="1143" alt="image" src="https://github.com/user-attachments/assets/61ca5e17-ae76-47f4-8531-61cbd497fd91" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional metrics feature enabling HTTP metrics server at `127.0.0.1:9090/metrics` to expose engine performance statistics.
  * Introduced metrics CLI tool with support for querying metrics, resetting counters, JSON output, and watch mode.
  * Enhanced timing instrumentation across rendering pipeline and network operations for detailed performance analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gosub-io/gosub-engine/pull/992?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->