### PR TITLE
Extract backend-specific code into gosub_renderer_cairo, gosub_renderer_vello, gosub_renderer_skia

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3351,6 +3351,7 @@ dependencies = [
  "gosub_interface",
  "gosub_net",
  "gosub_pipeline",
+ "gosub_renderer_cairo",
  "gosub_shared",
  "gtk4",
  "hashbrown 0.17.1",
@@ -3523,14 +3524,10 @@ dependencies = [
  "gosub_interface",
  "gosub_net",
  "gosub_shared",
- "gtk4",
  "hex",
  "image",
  "log",
- "pangocairo",
  "parking_lot",
- "parley 0.3.0",
- "pollster",
  "rand 0.10.1",
  "regex",
  "resvg",
@@ -3538,11 +3535,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "skia-safe",
  "taffy",
  "url",
- "vello 0.4.1",
- "winit",
 ]
 
 [[package]]
@@ -3561,6 +3555,50 @@ dependencies = [
  "url",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "gosub_renderer_cairo"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cow-utils",
+ "gosub_pipeline",
+ "gosub_shared",
+ "gtk4",
+ "log",
+ "pangocairo",
+ "parking_lot",
+ "resvg",
+]
+
+[[package]]
+name = "gosub_renderer_skia"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "gosub_pipeline",
+ "gosub_shared",
+ "log",
+ "parking_lot",
+ "skia-safe",
+]
+
+[[package]]
+name = "gosub_renderer_vello"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "gosub_pipeline",
+ "gosub_shared",
+ "log",
+ "parking_lot",
+ "parley 0.3.0",
+ "pollster",
+ "resvg",
+ "skia-safe",
+ "vello 0.4.1",
+ "winit",
 ]
 
 [[package]]

--- a/crates/gosub_engine/Cargo.toml
+++ b/crates/gosub_engine/Cargo.toml
@@ -14,6 +14,7 @@ gosub_html5 = { version = "0.1.1", path = "../gosub_html5" }
 gosub_css3 = { version = "0.1.2", path = "../gosub_css3" }
 gosub_interface = { version = "0.1.2", path = "../gosub_interface" }
 gosub_pipeline = { version = "0.1.0", path = "../gosub_pipeline", optional = true }
+gosub_renderer_cairo = { version = "0.1.0", path = "../gosub_renderer_cairo", optional = true }
 uuid = { version = "1.17.0", features = ["v4", "serde"] }
 reqwest = { version = "0.13.3", features = ["json", "gzip", "brotli", "deflate", "cookies", "rustls", "stream"] }
 tokio = { version = "1.52", features = [
@@ -100,8 +101,8 @@ winit = ["dep:winit", "dep:wgpu"]
 gtk4 = ["dep:gtk4", "dep:cairo-rs"]
 sqlite_cookie_store = ["r2d2", "r2d2_sqlite"]
 pipeline = ["dep:gosub_pipeline"]
-backend_cairo = ["dep:gtk4", "dep:cairo-rs", "pipeline", "gosub_pipeline/backend_cairo"]
-backend_vello = ["dep:vello", "dep:wgpu", "pipeline", "gosub_pipeline/backend_vello"]
+backend_cairo = ["dep:gtk4", "dep:cairo-rs", "pipeline", "dep:gosub_renderer_cairo"]
+backend_vello = ["dep:vello", "dep:wgpu", "pipeline"]
 backend_skia = ["dep:skia-safe"]
 parley_layout = []
 metrics = []

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -336,8 +336,8 @@ fn pipeline_render(doc: Arc<EngineDocument>, viewport: &Viewport, rl: &mut Rende
     let texture_store = {
         use gosub_pipeline::common::media::MediaStore;
         use gosub_pipeline::common::texture_store::TextureStore;
-        use gosub_pipeline::rasterizer::cairo::CairoRasterizer;
         use gosub_pipeline::rasterizer::Rasterable;
+        use gosub_renderer_cairo::CairoRasterizer;
 
         let t = Instant::now();
         let ts6 = timing_start!("pipeline.rasterize");

--- a/crates/gosub_pipeline/Cargo.toml
+++ b/crates/gosub_pipeline/Cargo.toml
@@ -2,17 +2,7 @@
 name = "gosub_pipeline"
 version = "0.1.0"
 edition = "2021"
-
-[[bin]]
-name = "pipeline-cairo"
-path = "src/bin/pipeline-cairo.rs"
-required-features = ["text_pango", "backend_cairo"]
-
-[[bin]]
-name = "pipeline-vello"
-path = "src/bin/pipeline-vello.rs"
-required-features = ["backend_vello", "text_parley"]
-
+autobins = false
 
 [dependencies]
 taffy = { version = "0.9", default-features = false, features = ["std", "taffy_tree", "flexbox", "grid", "block_layout", "content_size", "calc"] }
@@ -39,24 +29,8 @@ parking_lot = "0.12"
 gosub_shared = { version = "0.1.1", path = "../gosub_shared", registry = "gosub" }
 gosub_interface = { version = "0.1.2", path = "../gosub_interface", registry = "gosub" }
 
-parley = { version = "0.3.0", optional = true }
-pangocairo = { version = "0.22", optional = true }
-gtk4 = { version = "0.11.1", optional = true }
-vello = { version = "0.4.1", optional = true }
-winit = { version = "0.30.12", optional = true }
-pollster = { version = "0.4.0", optional = true }
-skia-safe = { version = "0.87.0", features = ["textlayout"], optional = true }
-
 [dev-dependencies]
 gosub_html5 = { path = "../gosub_html5", registry = "gosub" }
 gosub_css3 = { path = "../gosub_css3", registry = "gosub" }
 url = "2"
 
-[features]
-default = ["text_parley"]
-text_pango = ["dep:pangocairo", "dep:gtk4"]
-text_parley = ["dep:parley"]
-text_skia = ["dep:skia-safe"]
-backend_cairo = ["dep:gtk4", "text_pango"]
-backend_vello = ["dep:vello", "dep:winit", "dep:pollster"]
-backend_skia = ["dep:skia-safe"]

--- a/crates/gosub_pipeline/src/common/font.rs
+++ b/crates/gosub_pipeline/src/common/font.rs
@@ -1,10 +1,3 @@
-#[cfg(feature = "text_pango")]
-pub mod pango;
-#[cfg(feature = "text_parley")]
-pub mod parley;
-#[cfg(feature = "text_skia")]
-pub mod skia;
-
 #[derive(Debug, Clone)]
 pub enum FontAlignment {
     /// Start of the line (left for LTR, right for RTL)

--- a/crates/gosub_pipeline/src/compositor.rs
+++ b/crates/gosub_pipeline/src/compositor.rs
@@ -1,10 +1,3 @@
-#[cfg(feature = "backend_cairo")]
-pub mod cairo;
-#[cfg(feature = "backend_skia")]
-pub mod skia;
-#[cfg(feature = "backend_vello")]
-pub mod vello;
-
 pub trait Composable {
     type Config;
     type Return;

--- a/crates/gosub_pipeline/src/painter/commands/rectangle.rs
+++ b/crates/gosub_pipeline/src/painter/commands/rectangle.rs
@@ -63,7 +63,7 @@ impl Rectangle {
         }
     }
 
-    pub(crate) fn is_rounded(&self) -> bool {
+    pub fn is_rounded(&self) -> bool {
         self.radius_top.x > 0.0
             || self.radius_top.y > 0.0
             || self.radius_right.x > 0.0

--- a/crates/gosub_pipeline/src/rasterizer.rs
+++ b/crates/gosub_pipeline/src/rasterizer.rs
@@ -3,16 +3,6 @@ use crate::common::texture::TextureId;
 use crate::common::texture_store::TextureStore;
 use crate::tiler::Tile;
 
-// Rasterizing can be pretty simple by itself, since it only needs to execute the paint commands for
-// the specific 2D library we are using. All calculations should have been done in the layouter.
-
-#[cfg(feature = "backend_cairo")]
-pub mod cairo;
-#[cfg(feature = "backend_skia")]
-pub mod skia;
-#[cfg(feature = "backend_vello")]
-pub mod vello;
-
 pub trait Rasterable {
     fn rasterize(&self, tile: &Tile, texture_store: &mut TextureStore, media_store: &MediaStore) -> Option<TextureId>;
 }

--- a/crates/gosub_renderer_cairo/Cargo.toml
+++ b/crates/gosub_renderer_cairo/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "gosub_renderer_cairo"
+version = "0.1.0"
+edition = "2021"
+description = "Cairo rasterizer and compositor backend for the Gosub render pipeline"
+license = "MIT"
+
+[[bin]]
+name = "pipeline-cairo"
+path = "src/bin/pipeline-cairo.rs"
+required-features = ["text_pango"]
+
+[dependencies]
+gosub_pipeline = { version = "0.1.0", path = "../gosub_pipeline" }
+gosub_shared = { version = "0.1.1", path = "../gosub_shared", registry = "gosub" }
+resvg = "0.47.0"
+log = "0.4.29"
+anyhow = "1.0"
+cow-utils = "0.1"
+parking_lot = "0.12"
+
+gtk4 = { version = "0.11.1" }
+pangocairo = { version = "0.22", optional = true }
+
+[features]
+default = ["text_pango"]
+text_pango = ["dep:pangocairo"]
+text_parley = []
+text_skia = []
+
+[lints]
+workspace = true

--- a/crates/gosub_renderer_cairo/src/bin/pipeline-cairo.rs
+++ b/crates/gosub_renderer_cairo/src/bin/pipeline-cairo.rs
@@ -1,0 +1,463 @@
+use gosub_pipeline::common;
+use gosub_pipeline::common::browser_state::{BrowserState, WireframeState};
+use gosub_pipeline::common::geo::{Dimension, Rect};
+use gosub_pipeline::common::media::MediaStore;
+use gosub_pipeline::common::TextureStore;
+use gosub_pipeline::compositor::Composable;
+use gosub_pipeline::layering::layer::{LayerId, LayerList};
+use gosub_pipeline::layouter::taffy::TaffyLayouter;
+use gosub_pipeline::layouter::CanLayout;
+use gosub_pipeline::painter::Painter;
+use gosub_pipeline::rasterizer::Rasterable;
+use gosub_pipeline::rendertree_builder::RenderTree;
+use gosub_pipeline::tiler::{TileList, TileState};
+use gosub_renderer_cairo::compositor::{CairoCompositor, CairoCompositorConfig};
+use gosub_renderer_cairo::CairoRasterizer;
+use gtk4::prelude::{
+    AdjustmentExt, ApplicationExt, ApplicationExtManual, DrawingAreaExt, DrawingAreaExtManual, GtkWindowExt, WidgetExt,
+};
+use gtk4::{glib, Adjustment, Application, ApplicationWindow, DrawingArea, EventControllerMotion, ScrolledWindow};
+use parking_lot::RwLock;
+use std::sync::Arc;
+
+const TILE_DIMENSION: f64 = 256.0;
+
+const WINDOW_WIDTH: f64 = 1024.0;
+const WINDOW_HEIGHT: f64 = 768.0;
+
+fn main() {
+    let doc = common::document::parser::document_from_json("file://.", "cm.json");
+    let mut output = String::new();
+    doc.print_tree(&mut output).expect("");
+    println!("{}", output);
+
+    let doc = Arc::new(doc);
+
+    let mut render_tree = RenderTree::new(doc.clone());
+    render_tree.parse();
+
+    let mut layouter = TaffyLayouter::new();
+    let layout_tree = layouter.layout(render_tree, None, 1.0);
+    layouter.print_tree();
+    println!(
+        "Layout width: {}, height: {}",
+        layout_tree.root_dimension.width, layout_tree.root_dimension.height
+    );
+
+    let layer_list = LayerList::new(layout_tree);
+
+    let mut tile_list = TileList::new(layer_list, Dimension::new(TILE_DIMENSION, TILE_DIMENSION));
+    tile_list.generate();
+
+    let app = Application::builder().application_id("io.gosub.renderer").build();
+
+    let layer_count = tile_list.layer_list.layer_ids.read().len();
+    let browser_state = BrowserState {
+        visible_layer_list: vec![true; layer_count],
+        wireframed: WireframeState::None,
+        debug_hover: false,
+        current_hovered_element: None,
+        tile_list: Some(RwLock::new(tile_list)),
+        show_tilegrid: true,
+        viewport: Rect::ZERO,
+        dpi_scale_factor: 1.0,
+    };
+
+    let browser_state = Arc::new(RwLock::new(browser_state));
+    let texture_store = Arc::new(RwLock::new(TextureStore::new()));
+    let media_store = Arc::new(RwLock::new(MediaStore::new()));
+
+    let bs_clone = browser_state.clone();
+    let ts_clone = texture_store.clone();
+    let ms_clone = media_store.clone();
+
+    app.connect_activate(move |app| {
+        build_ui(app, bs_clone.clone(), ts_clone.clone(), ms_clone.clone());
+    });
+
+    println!(
+        r"
+---------------------------------------
+    Gosub Rendering Pipeline Concept
+---------------------------------------
+
+Available key commands:
+  0-9   Toggle layer [0-9]
+  w     Toggle wireframe
+  d     Toggle debug hover
+  t     Toggle tile grid
+
+"
+    );
+
+    app.run();
+}
+
+fn build_ui(
+    app: &Application,
+    browser_state: Arc<RwLock<BrowserState>>,
+    texture_store: Arc<RwLock<TextureStore>>,
+    media_store: Arc<RwLock<MediaStore>>,
+) {
+    let window = ApplicationWindow::builder()
+        .application(app)
+        .title("Renderer")
+        .default_width(WINDOW_WIDTH as i32)
+        .default_height(WINDOW_HEIGHT as i32)
+        .build();
+
+    let dim = {
+        let state = browser_state.read();
+        let d = state
+            .tile_list
+            .as_ref()
+            .unwrap()
+            .read()
+            .layer_list
+            .layout_tree
+            .root_dimension;
+        d
+    };
+
+    let area = DrawingArea::new();
+    area.set_content_width(dim.width as i32);
+    area.set_content_height(dim.height as i32);
+
+    {
+        let bs = browser_state.clone();
+        let ts = texture_store.clone();
+        let ms = media_store.clone();
+        area.set_draw_func(move |_area, cr, _width, _height| {
+            let vis_layers = bs.read().visible_layer_list.clone();
+
+            for (i, &visible) in vis_layers.iter().enumerate() {
+                if visible {
+                    do_paint(LayerId::new(i as u64), &bs);
+                    do_rasterize(LayerId::new(i as u64), &bs, &ts, &ms);
+                }
+            }
+
+            CairoCompositor::compose(CairoCompositorConfig {
+                cr: cr.clone(),
+                browser_state: bs.clone(),
+                texture_store: ts.clone(),
+            });
+        });
+    }
+
+    let motion_controller = EventControllerMotion::new();
+    let area_clone = area.clone();
+    {
+        let bs = browser_state.clone();
+        motion_controller.connect_motion(move |_, x, y| {
+            let el_id = {
+                let state = bs.read();
+                let id = state
+                    .tile_list
+                    .as_ref()
+                    .unwrap()
+                    .read()
+                    .layer_list
+                    .find_element_at(x, y);
+                id
+            };
+            let che = bs.read().current_hovered_element;
+
+            let mut tile_ids = vec![];
+            {
+                let state = bs.read();
+                match (che, el_id) {
+                    (Some(current_id), Some(new_id)) if current_id != new_id => {
+                        state
+                            .tile_list
+                            .as_ref()
+                            .unwrap()
+                            .read()
+                            .get_tiles_for_element(current_id)
+                            .iter()
+                            .for_each(|tid| tile_ids.push(*tid));
+                        state
+                            .tile_list
+                            .as_ref()
+                            .unwrap()
+                            .read()
+                            .get_tiles_for_element(new_id)
+                            .iter()
+                            .for_each(|tid| tile_ids.push(*tid));
+                    }
+                    (None, Some(new_id)) => {
+                        state
+                            .tile_list
+                            .as_ref()
+                            .unwrap()
+                            .read()
+                            .get_tiles_for_element(new_id)
+                            .iter()
+                            .for_each(|tid| tile_ids.push(*tid));
+                    }
+                    (Some(current_id), None) => {
+                        state
+                            .tile_list
+                            .as_ref()
+                            .unwrap()
+                            .read()
+                            .get_tiles_for_element(current_id)
+                            .iter()
+                            .for_each(|tid| tile_ids.push(*tid));
+                    }
+                    _ => {}
+                }
+            }
+
+            let mut state = bs.write();
+            if state.current_hovered_element != el_id {
+                if let Some(id) = el_id {
+                    let binding = state.tile_list.as_ref().unwrap().read();
+                    let layout_element = binding.layer_list.layout_tree.get_node_by_id(id).unwrap();
+                    println!("Hovered element id:");
+                    println!("   Layout ID : {:?}", el_id);
+                    println!("   DOM ID    : {:?}", layout_element.dom_node_id);
+                }
+
+                for tile_id in &tile_ids {
+                    state.tile_list.as_ref().unwrap().write().invalidate_tile(*tile_id);
+                }
+
+                state.current_hovered_element = el_id;
+                area_clone.queue_draw();
+            }
+        });
+    }
+    area.add_controller(motion_controller);
+
+    let scroll = ScrolledWindow::builder()
+        .hscrollbar_policy(gtk4::PolicyType::Always)
+        .vscrollbar_policy(gtk4::PolicyType::Always)
+        .child(&area)
+        .build();
+    window.set_child(Some(&scroll));
+
+    connect_viewport_signals(&scroll, &area, browser_state.clone());
+
+    let controller = gtk4::EventControllerKey::new();
+    {
+        let bs = browser_state.clone();
+        controller.connect_key_pressed(move |_controller, keyval, _keycode, _state| {
+            let mut state = bs.write();
+
+            match keyval {
+                key if key == gtk4::gdk::Key::_1 => {
+                    if let Some(v) = state.visible_layer_list.get_mut(0) {
+                        *v = !*v;
+                        area.queue_draw();
+                    }
+                }
+                key if key == gtk4::gdk::Key::_2 => {
+                    if let Some(v) = state.visible_layer_list.get_mut(1) {
+                        *v = !*v;
+                        area.queue_draw();
+                    }
+                }
+                key if key == gtk4::gdk::Key::_3 => {
+                    if let Some(v) = state.visible_layer_list.get_mut(2) {
+                        *v = !*v;
+                        area.queue_draw();
+                    }
+                }
+                key if key == gtk4::gdk::Key::_4 => {
+                    if let Some(v) = state.visible_layer_list.get_mut(3) {
+                        *v = !*v;
+                        area.queue_draw();
+                    }
+                }
+                key if key == gtk4::gdk::Key::_5 => {
+                    if let Some(v) = state.visible_layer_list.get_mut(4) {
+                        *v = !*v;
+                        area.queue_draw();
+                    }
+                }
+                key if key == gtk4::gdk::Key::_6 => {
+                    if let Some(v) = state.visible_layer_list.get_mut(5) {
+                        *v = !*v;
+                        area.queue_draw();
+                    }
+                }
+                key if key == gtk4::gdk::Key::_7 => {
+                    if let Some(v) = state.visible_layer_list.get_mut(6) {
+                        *v = !*v;
+                        area.queue_draw();
+                    }
+                }
+                key if key == gtk4::gdk::Key::_8 => {
+                    if let Some(v) = state.visible_layer_list.get_mut(7) {
+                        *v = !*v;
+                        area.queue_draw();
+                    }
+                }
+                key if key == gtk4::gdk::Key::_9 => {
+                    if let Some(v) = state.visible_layer_list.get_mut(8) {
+                        *v = !*v;
+                        area.queue_draw();
+                    }
+                }
+                key if key == gtk4::gdk::Key::_0 => {
+                    if let Some(v) = state.visible_layer_list.get_mut(9) {
+                        *v = !*v;
+                        area.queue_draw();
+                    }
+                }
+                key if key == gtk4::gdk::Key::w => {
+                    match state.wireframed {
+                        WireframeState::None => state.wireframed = WireframeState::Only,
+                        WireframeState::Only => state.wireframed = WireframeState::Both,
+                        WireframeState::Both => state.wireframed = WireframeState::None,
+                    }
+                    state.tile_list.as_ref().unwrap().write().invalidate_all();
+                    area.queue_draw();
+                }
+                key if key == gtk4::gdk::Key::d => {
+                    state.debug_hover = !state.debug_hover;
+                    state.tile_list.as_ref().unwrap().write().invalidate_all();
+                    area.queue_draw();
+                }
+                key if key == gtk4::gdk::Key::t => {
+                    state.show_tilegrid = !state.show_tilegrid;
+                    area.queue_draw();
+                }
+                _ => (),
+            }
+
+            glib::Propagation::Proceed
+        });
+    }
+    window.add_controller(controller);
+
+    window.set_default_size(WINDOW_WIDTH as i32, WINDOW_HEIGHT as i32);
+    window.show();
+}
+
+fn do_paint(layer_id: LayerId, browser_state: &Arc<RwLock<BrowserState>>) {
+    let state = browser_state.read();
+    let painter = Painter::new(state.tile_list.as_ref().unwrap().read().layer_list.clone());
+
+    let tile_ids = state
+        .tile_list
+        .as_ref()
+        .unwrap()
+        .read()
+        .get_intersecting_tiles(layer_id, state.viewport);
+    for tile_id in tile_ids {
+        let mut binding = state.tile_list.as_ref().unwrap().write();
+        let Some(tile) = binding.get_tile_mut(tile_id) else {
+            log::warn!("Tile not found: {:?}", tile_id);
+            continue;
+        };
+
+        if tile.state == TileState::Clean || tile.state == TileState::Empty {
+            continue;
+        }
+
+        for tiled_layout_element in &mut tile.elements {
+            tiled_layout_element.paint_commands = painter.paint(tiled_layout_element, &state);
+        }
+    }
+}
+
+fn do_rasterize(
+    layer_id: LayerId,
+    browser_state: &Arc<RwLock<BrowserState>>,
+    texture_store: &Arc<RwLock<TextureStore>>,
+    media_store: &Arc<RwLock<MediaStore>>,
+) {
+    let state = browser_state.read();
+    let mut ts = texture_store.write();
+    let ms = media_store.read();
+
+    let tile_ids = state
+        .tile_list
+        .as_ref()
+        .unwrap()
+        .read()
+        .get_intersecting_tiles(layer_id, state.viewport);
+    for tile_id in tile_ids {
+        let mut binding = state.tile_list.as_ref().unwrap().write();
+        let Some(tile) = binding.get_tile(tile_id) else {
+            log::warn!("Tile not found: {:?}", tile_id);
+            continue;
+        };
+
+        if tile.state == TileState::Clean || tile.state == TileState::Empty {
+            continue;
+        }
+
+        let Some(tile) = binding.get_tile_mut(tile_id) else {
+            log::warn!("Tile not found: {:?}", tile_id);
+            continue;
+        };
+
+        let rasterizer = CairoRasterizer::new();
+        match rasterizer.rasterize(tile, &mut ts, &ms) {
+            Some(texture_id) => {
+                tile.texture_id = Some(texture_id);
+                tile.state = TileState::Clean;
+            }
+            None => {
+                tile.state = TileState::Empty;
+            }
+        }
+    }
+}
+
+fn connect_viewport_signals(scroll: &ScrolledWindow, area: &DrawingArea, browser_state: Arc<RwLock<BrowserState>>) {
+    let hadjustment = scroll.hadjustment();
+    let vadjustment = scroll.vadjustment();
+
+    {
+        let area = area.clone();
+        let vadj = vadjustment.clone();
+        let bs = browser_state.clone();
+        hadjustment.connect_value_changed(move |adj| {
+            on_viewport_changed(&area, adj, &vadj, &bs);
+        });
+    }
+
+    {
+        let area = area.clone();
+        let hadj = hadjustment.clone();
+        let bs = browser_state.clone();
+        vadjustment.connect_value_changed(move |adj| {
+            on_viewport_changed(&area, &hadj, adj, &bs);
+        });
+    }
+
+    {
+        let area_clone = area.clone();
+        let hadj = hadjustment.clone();
+        let vadj = vadjustment.clone();
+        let bs = browser_state.clone();
+        area.connect_resize(move |_, _, _| {
+            on_viewport_changed(&area_clone, &hadj, &vadj, &bs);
+        });
+    }
+}
+
+fn on_viewport_changed(
+    area: &DrawingArea,
+    hadj: &Adjustment,
+    vadj: &Adjustment,
+    browser_state: &Arc<RwLock<BrowserState>>,
+) {
+    let x = hadj.value();
+    let y = vadj.value();
+    let width = hadj.page_size();
+    let height = vadj.page_size();
+
+    let mut state = browser_state.write();
+
+    if width != state.viewport.width || height != state.viewport.height {
+        state.tile_list.as_ref().unwrap().write().invalidate_all();
+    }
+
+    state.viewport = Rect::new(x, y, width, height);
+    area.queue_draw();
+}

--- a/crates/gosub_renderer_cairo/src/compositor.rs
+++ b/crates/gosub_renderer_cairo/src/compositor.rs
@@ -1,0 +1,37 @@
+use crate::compositor::compositor::cairo_compositor;
+use gosub_pipeline::common::browser_state::BrowserState;
+use gosub_pipeline::common::TextureStore;
+use gosub_pipeline::compositor::Composable;
+use gosub_pipeline::layering::layer::LayerId;
+use gtk4::cairo;
+use parking_lot::RwLock;
+use std::sync::Arc;
+
+pub struct CairoCompositorConfig {
+    pub cr: cairo::Context,
+    pub browser_state: Arc<RwLock<BrowserState>>,
+    pub texture_store: Arc<RwLock<TextureStore>>,
+}
+
+mod compositor;
+
+pub struct CairoCompositor {}
+
+impl Composable for CairoCompositor {
+    type Config = CairoCompositorConfig;
+    type Return = ();
+
+    fn compose(config: Self::Config) {
+        let state = config.browser_state.read();
+
+        let layers: Vec<LayerId> = state
+            .visible_layer_list
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &visible)| if visible { Some(LayerId::new(i as u64)) } else { None })
+            .collect();
+
+        let texture_store = config.texture_store.read();
+        cairo_compositor(&config.cr, layers, &state, &texture_store);
+    }
+}

--- a/crates/gosub_renderer_cairo/src/compositor/compositor.rs
+++ b/crates/gosub_renderer_cairo/src/compositor/compositor.rs
@@ -1,0 +1,66 @@
+use gosub_pipeline::common::browser_state::BrowserState;
+use gosub_pipeline::common::TextureStore;
+use gosub_pipeline::layering::layer::LayerId;
+use gtk4::cairo;
+use gtk4::cairo::ImageSurface;
+
+pub fn cairo_compositor(
+    cr: &cairo::Context,
+    layer_ids: Vec<LayerId>,
+    state: &BrowserState,
+    texture_store: &TextureStore,
+) {
+    for layer_id in layer_ids {
+        compose_layer(cr, layer_id, state, texture_store);
+    }
+}
+
+pub fn compose_layer(cr: &cairo::Context, layer_id: LayerId, state: &BrowserState, texture_store: &TextureStore) {
+    let Some(ref tile_list) = state.tile_list else {
+        log::error!("No tile list found");
+        return;
+    };
+
+    let tile_list_guard = tile_list.read();
+    let tile_ids = tile_list_guard.get_intersecting_tiles(layer_id, state.viewport);
+
+    for tile_id in tile_ids {
+        let Some(tile) = tile_list_guard.get_tile(tile_id) else {
+            log::warn!("Tile not found: {:?}", tile_id);
+            continue;
+        };
+
+        let Some(texture_id) = tile.texture_id else {
+            log::error!("No texture found for tile: {:?}", tile_id);
+            continue;
+        };
+
+        let Some(texture) = texture_store.get(texture_id) else {
+            log::error!("No texture found for tile: {:?}", tile_id);
+            continue;
+        };
+
+        let surface = match ImageSurface::create_for_data(
+            texture.data.clone(),
+            cairo::Format::ARgb32,
+            texture.width as i32,
+            texture.height as i32,
+            texture.width as i32 * 4,
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                log::error!("Failed to create image surface for tile {:?}: {:?}", tile_id, e);
+                continue;
+            }
+        };
+
+        cr.rectangle(tile.rect.x, tile.rect.y, tile.rect.width, tile.rect.height);
+        if let Err(e) = cr.set_source_surface(surface, tile.rect.x, tile.rect.y) {
+            log::warn!("Failed to set source surface for tile {:?}: {:?}", tile_id, e);
+            continue;
+        }
+        if let Err(e) = cr.fill() {
+            log::warn!("Failed to fill tile {:?}: {:?}", tile_id, e);
+        }
+    }
+}

--- a/crates/gosub_renderer_cairo/src/font/mod.rs
+++ b/crates/gosub_renderer_cairo/src/font/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "text_pango")]
+pub mod pango;

--- a/crates/gosub_renderer_cairo/src/font/pango.rs
+++ b/crates/gosub_renderer_cairo/src/font/pango.rs
@@ -1,0 +1,62 @@
+use cow_utils::CowUtils;
+use gtk4::gio::{Settings, SettingsSchemaSource};
+use gtk4::pango;
+use gtk4::pango::Weight;
+use gtk4::prelude::{FontFamilyExt, SettingsExt};
+
+const DEFAULT_FONT_FAMILY: &str = "sans";
+
+pub fn find_available_font(families: &str, ctx: &pango::Context) -> String {
+    let available_fonts: Vec<String> = ctx
+        .list_families()
+        .iter()
+        .map(|f| f.name().cow_to_ascii_lowercase().into_owned())
+        .collect();
+
+    for font in families.split(',') {
+        let font_name = font.trim().trim_matches(|c| c == '"' || c == '\'').to_string();
+
+        if font_name.eq_ignore_ascii_case("system-ui") {
+            if let Some(system_font) = get_system_ui_font() {
+                return system_font;
+            }
+            continue;
+        }
+
+        let normalized = font_name.cow_to_ascii_lowercase();
+        if available_fonts.contains(&normalized.into_owned()) {
+            return font_name;
+        }
+    }
+
+    DEFAULT_FONT_FAMILY.to_string()
+}
+
+fn get_system_ui_font() -> Option<String> {
+    let schema_source = SettingsSchemaSource::default()?;
+    let schema = schema_source.lookup("org.gnome.desktop.interface", true)?;
+
+    if schema.has_key("font-name") {
+        let settings = Settings::new("org.gnome.desktop.interface");
+        let font_name: String = settings.string("font-name").into();
+
+        return Some(font_name.split_whitespace().next().unwrap_or(DEFAULT_FONT_FAMILY).to_string());
+    }
+
+    None
+}
+
+pub fn to_pango_weight(weight: usize) -> Weight {
+    match weight {
+        0..=149 => Weight::Thin,
+        150..=249 => Weight::Ultralight,
+        250..=349 => Weight::Light,
+        350..=449 => Weight::Semilight,
+        450..=549 => Weight::Normal,
+        550..=649 => Weight::Medium,
+        650..=749 => Weight::Semibold,
+        750..=849 => Weight::Bold,
+        850..=949 => Weight::Ultrabold,
+        _ => Weight::Heavy,
+    }
+}

--- a/crates/gosub_renderer_cairo/src/lib.rs
+++ b/crates/gosub_renderer_cairo/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod compositor;
+pub mod rasterizer;
+pub(crate) mod font;
+
+pub use compositor::{CairoCompositor, CairoCompositorConfig};
+pub use rasterizer::CairoRasterizer;

--- a/crates/gosub_renderer_cairo/src/rasterizer.rs
+++ b/crates/gosub_renderer_cairo/src/rasterizer.rs
@@ -1,0 +1,81 @@
+use gosub_pipeline::common::media::MediaStore;
+use gosub_pipeline::common::texture::TextureId;
+use gosub_pipeline::common::TextureStore;
+use gosub_pipeline::painter::commands::PaintCommand;
+use gosub_pipeline::rasterizer::Rasterable;
+use gosub_pipeline::tiler::Tile;
+use gtk4::cairo;
+
+mod brush;
+mod rectangle;
+mod svg;
+mod text;
+
+#[derive(Default)]
+pub struct CairoRasterizer {}
+
+impl CairoRasterizer {
+    pub fn new() -> CairoRasterizer {
+        CairoRasterizer {}
+    }
+}
+
+impl Rasterable for CairoRasterizer {
+    fn rasterize(&self, tile: &Tile, texture_store: &mut TextureStore, media_store: &MediaStore) -> Option<TextureId> {
+        let mut surface =
+            cairo::ImageSurface::create(cairo::Format::ARgb32, tile.rect.width as i32, tile.rect.height as i32)
+                .expect("Failed to create image surface");
+
+        {
+            let cr = cairo::Context::new(&surface).expect("Failed to create cairo context");
+
+            for element in &tile.elements {
+                for command in &element.paint_commands {
+                    match command {
+                        PaintCommand::Svg(command) => {
+                            svg::do_paint_svg(&cr.clone(), tile, &command.rect, command.media_id, media_store);
+                        }
+                        PaintCommand::Rectangle(command) => {
+                            rectangle::do_paint_rectangle(&cr.clone(), tile, command, media_store);
+                        }
+                        PaintCommand::Text(command) => {
+                            #[cfg(feature = "text_pango")]
+                            match text::pango::do_paint_text(&cr.clone(), tile, command, media_store) {
+                                Ok(_) => {}
+                                Err(e) => {
+                                    log::warn!("Failed to paint text: {:?}", e);
+                                }
+                            }
+                            #[cfg(all(not(feature = "text_pango"), feature = "text_parley"))]
+                            match text::parley::do_paint_text(&cr.clone(), tile, command, media_store) {
+                                Ok(_) => {}
+                                Err(e) => {
+                                    log::warn!("Failed to paint text: {:?}", e);
+                                }
+                            }
+                            #[cfg(not(any(feature = "text_pango", feature = "text_parley")))]
+                            {
+                                let _ = command;
+                                log::warn!("No text backend enabled; text will not be rendered");
+                            }
+                        }
+                    }
+                }
+            }
+
+            surface.flush();
+        }
+
+        let w = surface.width() as usize;
+        let h = surface.height() as usize;
+
+        let Ok(data) = surface.data() else {
+            log::error!("Failed to get Cairo surface data");
+            return None;
+        };
+
+        let texture_id = texture_store.add(w, h, data.to_vec());
+
+        Some(texture_id)
+    }
+}

--- a/crates/gosub_renderer_cairo/src/rasterizer/brush.rs
+++ b/crates/gosub_renderer_cairo/src/rasterizer/brush.rs
@@ -1,0 +1,67 @@
+use gosub_pipeline::common::geo::Rect;
+use gosub_pipeline::common::media::MediaStore;
+use gosub_pipeline::painter::commands::brush::Brush;
+use gtk4::cairo::Context;
+use gtk4::gdk_pixbuf::{Colorspace, Pixbuf};
+use gtk4::glib::Bytes;
+use gtk4::prelude::GdkCairoContextExt;
+
+pub fn set_brush(cr: &Context, brush: &Brush, rect: Rect, media_store: &MediaStore) {
+    match brush {
+        Brush::Solid(color) => {
+            cr.set_source_rgba(color.r() as f64, color.g() as f64, color.b() as f64, color.a() as f64);
+        }
+        Brush::Image(media_id) => {
+            if rect.width == 0.0 || rect.height == 0.0 {
+                return;
+            }
+
+            let media = media_store.get_image(*media_id);
+            let img = &media.image;
+
+            if img.width() == 0 || img.height() == 0 {
+                log::warn!("Image has zero dimensions, skipping image brush");
+                return;
+            }
+
+            let bytes = Bytes::from(img.as_raw().as_slice());
+            let pixbuf = Pixbuf::from_bytes(
+                &bytes,
+                Colorspace::Rgb,
+                true,
+                8,
+                img.width() as i32,
+                img.height() as i32,
+                img.width() as i32 * 4,
+            );
+
+            let scale_x = rect.width / img.width() as f64;
+            let scale_y = rect.height / img.height() as f64;
+
+            let Some(scaled_pixbuf) =
+                Pixbuf::new(Colorspace::Rgb, true, 8, rect.width as i32, rect.height as i32)
+            else {
+                log::warn!(
+                    "Failed to create scaled pixbuf for dimensions {}x{}",
+                    rect.width,
+                    rect.height
+                );
+                return;
+            };
+            pixbuf.scale(
+                &scaled_pixbuf,
+                0,
+                0,
+                rect.width as i32,
+                rect.height as i32,
+                0.0,
+                0.0,
+                scale_x,
+                scale_y,
+                gtk4::gdk_pixbuf::InterpType::Bilinear,
+            );
+
+            cr.set_source_pixbuf(&scaled_pixbuf, rect.x, rect.y);
+        }
+    }
+}

--- a/crates/gosub_renderer_cairo/src/rasterizer/rectangle.rs
+++ b/crates/gosub_renderer_cairo/src/rasterizer/rectangle.rs
@@ -1,0 +1,117 @@
+use crate::rasterizer::brush::set_brush;
+use gosub_pipeline::common::media::MediaStore;
+use gosub_pipeline::painter::commands::border::BorderStyle;
+use gosub_pipeline::painter::commands::rectangle::Rectangle;
+use gosub_pipeline::tiler::Tile;
+use gtk4::cairo::Context;
+
+pub(crate) fn do_paint_rectangle(cr: &Context, tile: &Tile, rectangle: &Rectangle, media_store: &MediaStore) {
+    _ = cr.save();
+
+    cr.translate(-tile.rect.x, -tile.rect.y);
+    cr.rectangle(tile.rect.x, tile.rect.y, tile.rect.width, tile.rect.height);
+    cr.clip();
+
+    if let Some(brush) = rectangle.background() {
+        setup_rectangle_path(cr, rectangle);
+        set_brush(cr, brush, rectangle.rect(), media_store);
+        _ = cr.fill();
+    }
+
+    setup_rectangle_path(cr, rectangle);
+
+    cr.set_line_width(rectangle.border().width() as f64);
+    set_brush(cr, &rectangle.border().brush(), rectangle.rect(), media_store);
+    match rectangle.border().style() {
+        BorderStyle::None => {}
+        BorderStyle::Solid => {
+            _ = cr.stroke();
+        }
+        BorderStyle::Dashed => {
+            cr.set_dash(&[50.0, 10.0, 10.0, 10.0], 0.0);
+            _ = cr.stroke();
+        }
+        BorderStyle::Dotted => {
+            cr.set_dash(&[10.0, 10.0], 0.0);
+            _ = cr.stroke();
+        }
+        BorderStyle::Double => {
+            if rectangle.border().width() >= 3.0 {
+                let width = (rectangle.border().width() / 2.0).floor();
+                cr.set_line_width(width as f64);
+                _ = cr.stroke();
+
+                let gap_size = 1.0;
+
+                cr.rectangle(
+                    rectangle.rect().x + width as f64 + gap_size,
+                    rectangle.rect().y + width as f64 + gap_size,
+                    rectangle.rect().width - 2.0 * (width as f64 + gap_size),
+                    rectangle.rect().height - 2.0 * (width as f64 + gap_size),
+                );
+                _ = cr.stroke();
+            } else {
+                _ = cr.stroke();
+            }
+        }
+        BorderStyle::Groove => {}
+        BorderStyle::Ridge => {}
+        BorderStyle::Inset => {}
+        BorderStyle::Outset => {}
+        BorderStyle::Hidden => {}
+    }
+
+    _ = cr.restore();
+}
+
+fn setup_rectangle_path(cr: &Context, rect: &Rectangle) {
+    let (r_tl, r_tr, r_br, r_bl) = rect.radius_x();
+
+    if r_tl == 0.0 && r_tr == 0.0 && r_br == 0.0 && r_bl == 0.0 {
+        cr.rectangle(rect.rect().x, rect.rect().y, rect.rect().width, rect.rect().height);
+        return;
+    }
+
+    cr.move_to(rect.rect().x + r_tl, rect.rect().y);
+
+    cr.line_to(rect.rect().x + rect.rect().width - r_tr, rect.rect().y);
+    cr.arc(
+        rect.rect().x + rect.rect().width - r_tr,
+        rect.rect().y + r_tr,
+        r_tr,
+        -0.5 * std::f64::consts::PI,
+        0.0,
+    );
+
+    cr.line_to(
+        rect.rect().x + rect.rect().width,
+        rect.rect().y + rect.rect().height - r_br,
+    );
+    cr.arc(
+        rect.rect().x + rect.rect().width - r_br,
+        rect.rect().y + rect.rect().height - r_br,
+        r_br,
+        0.0,
+        0.5 * std::f64::consts::PI,
+    );
+
+    cr.line_to(rect.rect().x + r_bl, rect.rect().y + rect.rect().height);
+    cr.arc(
+        rect.rect().x + r_bl,
+        rect.rect().y + rect.rect().height - r_bl,
+        r_bl,
+        0.5 * std::f64::consts::PI,
+        std::f64::consts::PI,
+    );
+
+    cr.line_to(rect.rect().x, rect.rect().y + r_tl);
+    cr.arc(
+        rect.rect().x + r_tl,
+        rect.rect().y + r_tl,
+        r_tl,
+        std::f64::consts::PI,
+        1.5 * std::f64::consts::PI,
+    );
+
+    cr.close_path();
+}

--- a/crates/gosub_renderer_cairo/src/rasterizer/svg.rs
+++ b/crates/gosub_renderer_cairo/src/rasterizer/svg.rs
@@ -1,0 +1,77 @@
+use gosub_pipeline::common::media::{MediaId, MediaStore};
+use gosub_pipeline::painter::commands::rectangle::Rectangle;
+use gosub_pipeline::tiler::Tile;
+use gtk4::cairo::Context;
+use resvg::usvg::Transform;
+
+pub(crate) fn do_paint_svg(cr: &Context, tile: &Tile, rect: &Rectangle, media_id: MediaId, media_store: &MediaStore) {
+    log::debug!("Painting SVG: {:?}", media_id);
+    let media = media_store.get_svg(media_id);
+
+    let target_dim = rect.rect().dimension();
+    let dest_x = rect.rect().x - tile.rect.x;
+    let dest_y = rect.rect().y - tile.rect.y;
+
+    {
+        let cached = media.svg.rendered.read();
+        if cached.dimension == target_dim && !cached.data.is_empty() {
+            let surface = match gtk4::cairo::ImageSurface::create_for_data(
+                cached.data.clone(),
+                gtk4::cairo::Format::ARgb32,
+                cached.dimension.width as i32,
+                cached.dimension.height as i32,
+                cached.dimension.width as i32 * 4,
+            ) {
+                Ok(s) => s,
+                Err(e) => {
+                    log::warn!("Failed to create image surface for cached SVG {:?}: {:?}", media_id, e);
+                    return;
+                }
+            };
+            _ = cr.set_source_surface(&surface, dest_x, dest_y);
+            _ = cr.paint();
+            return;
+        }
+    }
+
+    let target_w = (target_dim.width as u32).max(1);
+    let target_h = (target_dim.height as u32).max(1);
+
+    let pixmap_size = media.svg.tree.size().to_int_size();
+    let intrinsic_w = pixmap_size.width().max(1) as f32;
+    let intrinsic_h = pixmap_size.height().max(1) as f32;
+    let sx = target_w as f32 / intrinsic_w;
+    let sy = target_h as f32 / intrinsic_h;
+
+    let Some(mut pixmap) = resvg::tiny_skia::Pixmap::new(target_w, target_h) else {
+        log::warn!("SVG has zero or invalid dimensions, skipping render");
+        return;
+    };
+    resvg::render(&media.svg.tree, Transform::from_scale(sx, sy), &mut pixmap.as_mut());
+
+    let mut new_data = pixmap.data().to_vec();
+    for chunk in new_data.chunks_exact_mut(4) {
+        chunk.swap(0, 2);
+    }
+
+    let mut cached = media.svg.rendered.write();
+    cached.data = new_data;
+    cached.dimension = target_dim;
+
+    let surface = match gtk4::cairo::ImageSurface::create_for_data(
+        cached.data.clone(),
+        gtk4::cairo::Format::ARgb32,
+        cached.dimension.width as i32,
+        cached.dimension.height as i32,
+        cached.dimension.width as i32 * 4,
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("Failed to create image surface for SVG {:?}: {:?}", media_id, e);
+            return;
+        }
+    };
+
+    _ = cr.set_source_surface(&surface, dest_x, dest_y);
+    _ = cr.paint();
+}

--- a/crates/gosub_renderer_cairo/src/rasterizer/text.rs
+++ b/crates/gosub_renderer_cairo/src/rasterizer/text.rs
@@ -1,0 +1,9 @@
+#[cfg(not(any(feature = "text_parley", feature = "text_pango", feature = "text_skia")))]
+compile_error!("Either the 'text_parley', 'text_skia', or 'text_pango' feature must be enabled");
+
+#[cfg(feature = "text_pango")]
+pub mod pango;
+#[cfg(feature = "text_parley")]
+pub mod parley;
+#[cfg(feature = "text_skia")]
+pub mod skia;

--- a/crates/gosub_renderer_cairo/src/rasterizer/text/pango.rs
+++ b/crates/gosub_renderer_cairo/src/rasterizer/text/pango.rs
@@ -1,0 +1,54 @@
+use crate::font::pango::{find_available_font, to_pango_weight};
+use crate::rasterizer::brush::set_brush;
+use gosub_pipeline::common::media::MediaStore;
+use gosub_pipeline::painter::commands::text::Text;
+use gosub_pipeline::tiler::Tile;
+use gtk4::cairo::{Context, Error, Format, ImageSurface};
+use gtk4::pango::SCALE;
+use pangocairo::functions::{context_set_resolution, create_layout};
+use pangocairo::pango::{FontDescription, WrapMode};
+
+pub(crate) fn do_paint_text(cr: &Context, tile: &Tile, cmd: &Text, media_store: &MediaStore) -> Result<(), Error> {
+    let surface = create_text_layout(cmd, media_store)?;
+
+    cr.save()?;
+
+    cr.translate(-tile.rect.x, -tile.rect.y);
+    cr.rectangle(tile.rect.x, tile.rect.y, tile.rect.width, tile.rect.height);
+    cr.clip();
+
+    cr.move_to(cmd.rect.x, cmd.rect.y);
+    cr.set_source_surface(&surface, cmd.rect.x, cmd.rect.y)?;
+    cr.paint()?;
+    cr.restore()?;
+
+    Ok(())
+}
+
+fn create_text_layout(cmd: &Text, media_store: &MediaStore) -> Result<ImageSurface, Error> {
+    let width = (cmd.rect.width.ceil() as i32).max(1);
+    let height = (cmd.rect.height.ceil() as i32).max(1);
+    let surface = ImageSurface::create(Format::ARgb32, width, height)?;
+    let cr = Context::new(&surface)?;
+    let layout = create_layout(&cr);
+
+    context_set_resolution(&layout.context(), 72.0);
+
+    let selected_family = find_available_font(cmd.font_info.family.as_str(), &layout.context());
+    let mut font_desc = FontDescription::new();
+    font_desc.set_family(&selected_family);
+    font_desc.set_size((cmd.font_info.size * SCALE as f64) as i32);
+    font_desc.set_weight(to_pango_weight(cmd.font_info.weight as usize));
+    layout.set_font_description(Some(&font_desc));
+
+    layout.set_text(cmd.text.as_str());
+    layout.set_width((cmd.rect.width * SCALE as f64) as i32);
+    layout.set_wrap(WrapMode::Word);
+    layout.set_spacing(0);
+
+    set_brush(&cr, &cmd.brush, cmd.rect, media_store);
+    cr.move_to(0.0, 0.0);
+    pangocairo::functions::show_layout(&cr, &layout);
+
+    Ok(surface)
+}

--- a/crates/gosub_renderer_cairo/src/rasterizer/text/parley.rs
+++ b/crates/gosub_renderer_cairo/src/rasterizer/text/parley.rs
@@ -1,0 +1,9 @@
+use gosub_pipeline::common::media::MediaStore;
+use gosub_pipeline::painter::commands::text::Text;
+use gosub_pipeline::tiler::Tile;
+use gtk4::cairo::{Context, Error};
+
+#[allow(dead_code)]
+pub(crate) fn do_paint_text(_cr: &Context, _tile: &Tile, _cmd: &Text, _media_store: &MediaStore) -> Result<(), Error> {
+    Err(Error::UserFontNotImplemented)
+}

--- a/crates/gosub_renderer_cairo/src/rasterizer/text/skia.rs
+++ b/crates/gosub_renderer_cairo/src/rasterizer/text/skia.rs
@@ -1,0 +1,10 @@
+use gosub_pipeline::common::media::MediaStore;
+use gosub_pipeline::painter::commands::text::Text;
+use gosub_pipeline::tiler::Tile;
+use gtk4::cairo::{Context, Error};
+
+#[allow(dead_code)]
+pub(crate) fn do_paint_text(_cr: &Context, _tile: &Tile, _cmd: &Text, _media_store: &MediaStore) -> Result<(), Error> {
+    log::warn!("Skia text rendering is not implemented for the Cairo backend");
+    Ok(())
+}

--- a/crates/gosub_renderer_skia/Cargo.toml
+++ b/crates/gosub_renderer_skia/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "gosub_renderer_skia"
+version = "0.1.0"
+edition = "2021"
+description = "Skia rasterizer and compositor backend for the Gosub render pipeline"
+license = "MIT"
+
+[dependencies]
+gosub_pipeline = { version = "0.1.0", path = "../gosub_pipeline" }
+gosub_shared = { version = "0.1.1", path = "../gosub_shared", registry = "gosub" }
+log = "0.4.29"
+anyhow = "1.0"
+parking_lot = "0.12"
+
+skia-safe = { version = "0.87.0", features = ["textlayout"] }
+
+[lints]
+workspace = true

--- a/crates/gosub_renderer_skia/src/compositor.rs
+++ b/crates/gosub_renderer_skia/src/compositor.rs
@@ -1,0 +1,28 @@
+use crate::compositor::compositor::skia_compositor;
+use gosub_pipeline::common::browser_state::BrowserState;
+use gosub_pipeline::common::TextureStore;
+use gosub_pipeline::layering::layer::LayerId;
+use parking_lot::RwLock;
+use std::sync::Arc;
+
+mod compositor;
+
+pub struct SkiaCompositor {}
+
+pub fn skia_compose(
+    canvas: &skia_safe::Canvas,
+    browser_state: &Arc<RwLock<BrowserState>>,
+    texture_store: &Arc<RwLock<TextureStore>>,
+) {
+    let state = browser_state.read();
+
+    let layers: Vec<LayerId> = state
+        .visible_layer_list
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &visible)| visible.then_some(LayerId::new(i as u64)))
+        .collect();
+
+    let ts = texture_store.read();
+    skia_compositor(canvas, layers, &state, &ts);
+}

--- a/crates/gosub_renderer_skia/src/compositor/compositor.rs
+++ b/crates/gosub_renderer_skia/src/compositor/compositor.rs
@@ -1,0 +1,77 @@
+use gosub_pipeline::common::browser_state::BrowserState;
+use gosub_pipeline::common::TextureStore;
+use gosub_pipeline::layering::layer::LayerId;
+use skia_safe::{AlphaType, ColorType, Data, ISize, ImageInfo};
+
+pub fn skia_compositor(
+    canvas: &skia_safe::Canvas,
+    layer_ids: Vec<LayerId>,
+    state: &BrowserState,
+    texture_store: &TextureStore,
+) {
+    for layer_id in layer_ids {
+        compose_layer(canvas, layer_id, state, texture_store);
+    }
+}
+
+pub fn compose_layer(
+    canvas: &skia_safe::Canvas,
+    layer_id: LayerId,
+    state: &BrowserState,
+    texture_store: &TextureStore,
+) {
+    let Some(ref tile_list) = state.tile_list else {
+        log::error!("No tile list found");
+        return;
+    };
+
+    let tile_list_guard = tile_list.read();
+    let tile_ids = tile_list_guard.get_intersecting_tiles(layer_id, state.viewport);
+    let show_tilegrid = state.show_tilegrid;
+
+    for tile_id in tile_ids {
+        let Some(tile) = tile_list_guard.get_tile(tile_id) else {
+            log::warn!("Tile not found: {:?}", tile_id);
+            continue;
+        };
+
+        let Some(texture_id) = tile.texture_id else {
+            log::error!("No texture found for tile: {:?}", tile_id);
+            continue;
+        };
+
+        let Some(texture) = texture_store.get(texture_id) else {
+            log::error!("No texture found for tile: {:?}", tile_id);
+            continue;
+        };
+
+        let image_info = ImageInfo::new(
+            ISize::new(texture.width as i32, texture.height as i32),
+            ColorType::RGBA8888,
+            AlphaType::Premul,
+            None,
+        );
+
+        let data = Data::new_copy(texture.data.as_slice());
+
+        let Some(img) = skia_safe::images::raster_from_data(&image_info, &data, texture.width * 4) else {
+            log::error!("Failed to create Skia image for tile {:?}", tile_id);
+            continue;
+        };
+
+        canvas.draw_image(&img, (tile.rect.x.round() as f32, tile.rect.y.round() as f32), None);
+
+        if show_tilegrid {
+            let mut paint = skia_safe::Paint::new(skia_safe::Color4f::new(1.0, 0.0, 0.0, 0.25), None);
+            paint.set_stroke(true);
+
+            let rect = skia_safe::Rect::from_xywh(
+                tile.rect.x as f32,
+                tile.rect.y as f32,
+                tile.rect.width as f32,
+                tile.rect.height as f32,
+            );
+            canvas.draw_rect(rect, &paint);
+        }
+    }
+}

--- a/crates/gosub_renderer_skia/src/font/mod.rs
+++ b/crates/gosub_renderer_skia/src/font/mod.rs
@@ -1,0 +1,1 @@
+pub mod skia;

--- a/crates/gosub_renderer_skia/src/font/skia.rs
+++ b/crates/gosub_renderer_skia/src/font/skia.rs
@@ -1,0 +1,66 @@
+use gosub_pipeline::common::font::{FontAlignment, FontInfo};
+use skia_safe::textlayout::{Paragraph, ParagraphBuilder, ParagraphStyle, TextStyle};
+use skia_safe::{FontStyle, Paint};
+
+thread_local! {
+    static FC: skia_safe::textlayout::FontCollection = {
+        let mut fc = skia_safe::textlayout::FontCollection::new();
+        fc.set_default_font_manager(skia_safe::FontMgr::new(), None);
+        fc
+    };
+}
+
+pub fn get_skia_paragraph(
+    text: &str,
+    font_info: &FontInfo,
+    max_width: f64,
+    paint: Option<&Paint>,
+    _dpi_scale_factor: f32,
+) -> Paragraph {
+    let mut paragraph_style = ParagraphStyle::new();
+    paragraph_style.set_text_align(match font_info.alignment {
+        FontAlignment::Start => skia_safe::textlayout::TextAlign::Start,
+        FontAlignment::Center => skia_safe::textlayout::TextAlign::Center,
+        FontAlignment::End => skia_safe::textlayout::TextAlign::End,
+        FontAlignment::Justify => skia_safe::textlayout::TextAlign::Justify,
+    });
+    paragraph_style.set_text_direction(skia_safe::textlayout::TextDirection::LTR);
+
+    let mut paragraph_builder = ParagraphBuilder::new(&paragraph_style, FC.with(|fc| fc.clone()));
+
+    let paint = match paint {
+        Some(p) => p.clone(),
+        None => Paint::default(),
+    };
+
+    let font_size_px = font_info.size;
+    let line_height_px = 1.2 * font_size_px;
+
+    let mut ts = TextStyle::new();
+    ts.set_foreground_paint(&paint);
+    ts.set_font_size(font_size_px as f32);
+    ts.set_height(line_height_px as f32);
+    ts.set_font_families(&[font_info.family.clone()]);
+    ts.set_font_style(FontStyle::new(
+        font_info.weight.into(),
+        font_info.width.into(),
+        to_slant(font_info.slant),
+    ));
+    paragraph_builder.push_style(&ts);
+
+    paragraph_builder.add_text(text);
+
+    let mut paragraph = paragraph_builder.build();
+    paragraph.layout(max_width as f32);
+
+    paragraph
+}
+
+fn to_slant(slant: i32) -> skia_safe::font_style::Slant {
+    match slant {
+        0 => skia_safe::font_style::Slant::Upright,
+        1 => skia_safe::font_style::Slant::Italic,
+        2 => skia_safe::font_style::Slant::Oblique,
+        _ => skia_safe::font_style::Slant::Upright,
+    }
+}

--- a/crates/gosub_renderer_skia/src/lib.rs
+++ b/crates/gosub_renderer_skia/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod compositor;
+pub mod rasterizer;
+pub(crate) mod font;
+
+pub use compositor::{SkiaCompositor, skia_compose};
+pub use rasterizer::SkiaRasterizer;

--- a/crates/gosub_renderer_skia/src/rasterizer.rs
+++ b/crates/gosub_renderer_skia/src/rasterizer.rs
@@ -1,0 +1,120 @@
+use gosub_pipeline::common::media::MediaStore;
+use gosub_pipeline::common::texture::TextureId;
+use gosub_pipeline::common::TextureStore;
+use gosub_pipeline::layering::layer::LayerId;
+use gosub_pipeline::painter::commands::PaintCommand;
+use gosub_pipeline::rasterizer::Rasterable;
+use gosub_pipeline::tiler::Tile;
+use skia_safe::{Bitmap, Canvas, Matrix, Paint, Rect, SamplingOptions, TileMode};
+
+mod paint;
+mod rectangle;
+mod svg;
+mod text;
+
+pub struct SkiaRasterizer {
+    dpi_scale_factor: f32,
+}
+
+impl SkiaRasterizer {
+    pub fn new(dpi_scale_factor: f32) -> Self {
+        Self { dpi_scale_factor }
+    }
+}
+
+impl Rasterable for SkiaRasterizer {
+    fn rasterize(&self, tile: &Tile, texture_store: &mut TextureStore, _media_store: &MediaStore) -> Option<TextureId> {
+        let width = tile.rect.width as u32;
+        let height = tile.rect.height as u32;
+
+        if tile.layer_id != LayerId::new(0) && tile.elements.is_empty() {
+            return None;
+        }
+
+        let Some(mut surface) =
+            skia_safe::surfaces::raster_n32_premul(skia_safe::ISize::new(width as i32, height as i32))
+        else {
+            log::error!("Failed to create Skia surface for tile rasterization");
+            return None;
+        };
+
+        let canvas = surface.canvas();
+
+        if tile.layer_id == LayerId::new(0) {
+            if tile.bgcolor.is_some() {
+                let bgcolor = tile.bgcolor.expect("bgcolor checked above");
+                canvas.clear(skia_safe::Color4f::new(bgcolor.0, bgcolor.1, bgcolor.2, bgcolor.3));
+            } else {
+                canvas.clear(skia_safe::Color4f::new(1.0, 1.0, 1.0, 1.0));
+            }
+        }
+
+        canvas.clip_rect(Rect::new(0.0, 0.0, width as f32, height as f32), None, None);
+        canvas.translate((-tile.rect.x as f32, -tile.rect.y as f32));
+
+        for element in &tile.elements {
+            for command in &element.paint_commands {
+                match command {
+                    PaintCommand::Rectangle(command) => {
+                        rectangle::do_paint_rectangle(canvas, tile, command);
+                    }
+                    PaintCommand::Text(command) => {
+                        let _ = text::do_paint_text(canvas, tile, command, self.dpi_scale_factor);
+                    }
+                    PaintCommand::Svg(command) => {
+                        svg::do_paint_svg(canvas, tile, command.media_id, &command.rect);
+                    }
+                }
+            }
+        }
+
+        let Some(peek) = canvas.peek_pixels() else {
+            log::error!("Failed to peek pixels from Skia canvas");
+            return None;
+        };
+        let Some(bytes) = peek.bytes() else {
+            log::error!("Failed to get bytes from Skia pixel info");
+            return None;
+        };
+        let pixels = bytes.to_vec();
+
+        let texture_id = texture_store.add(width as usize, height as usize, pixels);
+
+        Some(texture_id)
+    }
+}
+
+#[allow(unused)]
+const CHECKERED_COLOR_1: skia_safe::Color4f = skia_safe::Color4f::new(1.0, 1.0, 1.0, 1.0);
+#[allow(unused)]
+const CHECKERED_COLOR_2: skia_safe::Color4f = skia_safe::Color4f::new(1.0, 0.7, 0.7, 1.0);
+
+#[allow(unused)]
+fn clear_canvas(canvas: &Canvas, size: (i32, i32)) {
+    let tile_size = 8.0;
+
+    let mut bitmap = Bitmap::new();
+    bitmap.alloc_n32_pixels((2 * tile_size as i32, 2 * tile_size as i32), true);
+    {
+        let Some(tmp_canvas) = Canvas::from_bitmap(&bitmap, None) else {
+            return;
+        };
+        tmp_canvas.clear(CHECKERED_COLOR_1);
+
+        let paint = Paint::new(CHECKERED_COLOR_2, None);
+        tmp_canvas.draw_rect(Rect::new(tile_size, 0.0, tile_size * 2.0, tile_size), &paint);
+        tmp_canvas.draw_rect(Rect::new(0.0, tile_size, tile_size, tile_size * 2.0), &paint);
+    }
+
+    let Some(shader) = bitmap.as_image().to_shader(
+        (TileMode::Repeat, TileMode::Repeat),
+        SamplingOptions::default(),
+        Matrix::i(),
+    ) else {
+        return;
+    };
+
+    let mut paint = Paint::default();
+    paint.set_shader(shader);
+    canvas.draw_rect(Rect::new(0.0, 0.0, size.1 as f32, size.1 as f32), &paint);
+}

--- a/crates/gosub_renderer_skia/src/rasterizer/paint.rs
+++ b/crates/gosub_renderer_skia/src/rasterizer/paint.rs
@@ -1,0 +1,8 @@
+use gosub_pipeline::painter::commands::PaintCommand;
+use gosub_pipeline::tiler::Tile;
+use skia_safe::Canvas;
+
+#[allow(dead_code)]
+pub fn do_paint(_canvas: &Canvas, _tile: &Tile, _cmd: &PaintCommand) {
+    unimplemented!("Skia paint rasterization is not yet implemented")
+}

--- a/crates/gosub_renderer_skia/src/rasterizer/rectangle.rs
+++ b/crates/gosub_renderer_skia/src/rasterizer/rectangle.rs
@@ -1,0 +1,7 @@
+use gosub_pipeline::painter::commands::rectangle::Rectangle;
+use gosub_pipeline::tiler::Tile;
+use skia_safe::Canvas;
+
+pub fn do_paint_rectangle(_canvas: &Canvas, _tile: &Tile, _cmd: &Rectangle) {
+    unimplemented!("Skia rectangle rasterization is not yet implemented")
+}

--- a/crates/gosub_renderer_skia/src/rasterizer/svg.rs
+++ b/crates/gosub_renderer_skia/src/rasterizer/svg.rs
@@ -1,0 +1,8 @@
+use gosub_pipeline::common::media::MediaId;
+use gosub_pipeline::painter::commands::rectangle::Rectangle;
+use gosub_pipeline::tiler::Tile;
+use skia_safe::Canvas;
+
+pub fn do_paint_svg(_canvas: &Canvas, _tile: &Tile, _media_id: MediaId, _rect: &Rectangle) {
+    unimplemented!("Skia SVG rasterization is not yet implemented")
+}

--- a/crates/gosub_renderer_skia/src/rasterizer/text.rs
+++ b/crates/gosub_renderer_skia/src/rasterizer/text.rs
@@ -1,0 +1,7 @@
+use gosub_pipeline::painter::commands::text::Text;
+use gosub_pipeline::tiler::Tile;
+use skia_safe::Canvas;
+
+pub fn do_paint_text(_canvas: &Canvas, _tile: &Tile, _cmd: &Text, _dpi_scale_factor: f32) -> Result<(), anyhow::Error> {
+    anyhow::bail!("Skia text rasterization is not yet implemented")
+}

--- a/crates/gosub_renderer_vello/Cargo.toml
+++ b/crates/gosub_renderer_vello/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "gosub_renderer_vello"
+version = "0.1.0"
+edition = "2021"
+description = "Vello rasterizer and compositor backend for the Gosub render pipeline"
+license = "MIT"
+
+[[bin]]
+name = "pipeline-vello"
+path = "src/bin/pipeline-vello.rs"
+required-features = ["text_parley"]
+
+[dependencies]
+gosub_pipeline = { version = "0.1.0", path = "../gosub_pipeline" }
+gosub_shared = { version = "0.1.1", path = "../gosub_shared", registry = "gosub" }
+resvg = "0.47.0"
+log = "0.4.29"
+anyhow = "1.0"
+parking_lot = "0.12"
+
+vello = "0.4.1"
+pollster = "0.4.0"
+winit = "0.30.12"
+
+parley = { version = "0.3.0", optional = true }
+skia-safe = { version = "0.87.0", features = ["textlayout"], optional = true }
+
+[features]
+default = ["text_parley"]
+text_parley = ["dep:parley"]
+text_skia = ["dep:skia-safe"]
+text_pango = []
+
+[lints]
+workspace = true

--- a/crates/gosub_renderer_vello/src/bin/pipeline-vello.rs
+++ b/crates/gosub_renderer_vello/src/bin/pipeline-vello.rs
@@ -1,0 +1,441 @@
+use gosub_pipeline::common;
+use gosub_pipeline::common::browser_state::{BrowserState, WireframeState};
+use gosub_pipeline::common::document::pipeline_doc::PipelineDocument;
+use gosub_pipeline::common::geo::{Dimension, Rect};
+use gosub_pipeline::common::media::MediaStore;
+use gosub_pipeline::common::TextureStore;
+use gosub_pipeline::compositor::Composable;
+use gosub_pipeline::layering::layer::{LayerId, LayerList};
+use gosub_pipeline::layouter::taffy::TaffyLayouter;
+use gosub_pipeline::layouter::CanLayout;
+use gosub_pipeline::painter::Painter;
+use gosub_pipeline::rasterizer::Rasterable;
+use gosub_pipeline::rendertree_builder::RenderTree;
+use gosub_pipeline::tiler::{TileList, TileState};
+use gosub_renderer_vello::compositor::{VelloCompositor, VelloCompositorConfig};
+use gosub_renderer_vello::VelloRasterizer;
+use parking_lot::RwLock;
+use std::cell::RefCell;
+use std::fmt::Formatter;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::Instant;
+use vello::peniko::color;
+use vello::util::{DeviceHandle, RenderContext, RenderSurface};
+use vello::{wgpu, AaConfig, AaSupport, RenderParams, Renderer, RendererOptions};
+use winit::application::ApplicationHandler;
+use winit::dpi::{PhysicalSize, Size};
+use winit::event::{KeyEvent, WindowEvent};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+use winit::keyboard::KeyCode;
+use winit::keyboard::PhysicalKey::Code;
+use winit::window::{Window, WindowId};
+
+const TILE_DIMENSION: f64 = 256.0;
+
+fn main() {
+    let doc = common::document::parser::document_from_json("https://brettgfitzgerald.com", "brett.json");
+
+    let window_dimension = Dimension::new(800.0, 600.0);
+    let viewport_dimension = Dimension::new(1024.0, 768.0);
+
+    let browser_state = BrowserState {
+        visible_layer_list: vec![],
+        wireframed: WireframeState::None,
+        debug_hover: false,
+        current_hovered_element: None,
+        show_tilegrid: true,
+        viewport: Rect::new(0.0, 0.0, viewport_dimension.width, viewport_dimension.height),
+        tile_list: None,
+        dpi_scale_factor: 1.0,
+    };
+
+    let browser_state = Arc::new(RwLock::new(browser_state));
+    let texture_store = Arc::new(RwLock::new(TextureStore::new()));
+    let media_store = Arc::new(RwLock::new(MediaStore::new()));
+    let doc: Arc<dyn PipelineDocument> = Arc::new(doc);
+
+    let event_loop = EventLoop::new().unwrap();
+    event_loop.set_control_flow(ControlFlow::Poll);
+
+    let mut app = App::new(
+        "Pipeline Vello",
+        window_dimension,
+        doc,
+        browser_state,
+        texture_store,
+        media_store,
+    );
+    let _ = event_loop.run_app(&mut app);
+}
+
+fn reflow(doc: &Arc<dyn PipelineDocument>, browser_state: &Arc<RwLock<BrowserState>>) {
+    let (viewport, dpi_scale_factor) = {
+        let state = browser_state.read();
+        (state.viewport, state.dpi_scale_factor)
+    };
+
+    println!("reflowing to dimension: {:?}", viewport);
+
+    let mut render_tree = RenderTree::new(doc.clone());
+    render_tree.parse();
+
+    let mut layouter = TaffyLayouter::new();
+    let layout_tree = layouter.layout(
+        render_tree,
+        Some(Dimension::new(viewport.width, viewport.height)),
+        dpi_scale_factor,
+    );
+
+    let layer_list = LayerList::new(layout_tree);
+    let mut tile_list = TileList::new(layer_list, Dimension::new(TILE_DIMENSION, TILE_DIMENSION));
+    tile_list.generate();
+
+    let layer_count = tile_list.layer_list.layer_ids.read().len();
+    let mut state = browser_state.write();
+    state.visible_layer_list.resize(layer_count, true);
+    state.tile_list = Some(RwLock::new(tile_list));
+}
+
+#[allow(clippy::arc_with_non_send_sync)]
+struct Env<'s> {
+    pub render_ctx: RenderContext,
+    pub renderer: Option<Rc<RefCell<Renderer>>>,
+    pub surface: Option<RenderSurface<'s>>,
+    pub window: Option<Arc<Window>>,
+}
+
+impl std::fmt::Debug for Env<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Env").finish()
+    }
+}
+
+struct App<'s> {
+    env: Option<Env<'s>>,
+    frame: usize,
+    pfs: Instant,
+    #[allow(unused)]
+    fps: f32,
+    window_size: Dimension,
+    window_title: String,
+    doc: Arc<dyn PipelineDocument>,
+    browser_state: Arc<RwLock<BrowserState>>,
+    texture_store: Arc<RwLock<TextureStore>>,
+    media_store: Arc<RwLock<MediaStore>>,
+}
+
+impl App<'_> {
+    fn new(
+        window_title: &str,
+        window_size: Dimension,
+        doc: Arc<dyn PipelineDocument>,
+        browser_state: Arc<RwLock<BrowserState>>,
+        texture_store: Arc<RwLock<TextureStore>>,
+        media_store: Arc<RwLock<MediaStore>>,
+    ) -> Self {
+        App {
+            env: None,
+            frame: 0,
+            pfs: Instant::now(),
+            fps: 0.0,
+            window_size,
+            window_title: window_title.to_string(),
+            doc,
+            browser_state,
+            texture_store,
+            media_store,
+        }
+    }
+}
+
+impl ApplicationHandler for App<'_> {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self.env.is_some() {
+            return;
+        }
+
+        self.pfs = Instant::now();
+        self.frame = 0;
+        self.env = Some(create_window_env(
+            event_loop,
+            self.window_title.as_str(),
+            self.window_size,
+        ));
+
+        reflow(&self.doc, &self.browser_state);
+    }
+
+    fn window_event(&mut self, event_loop: &ActiveEventLoop, _id: WindowId, event: WindowEvent) {
+        let Some(env) = &mut self.env else { return };
+
+        match event {
+            WindowEvent::CloseRequested => {
+                event_loop.exit();
+            }
+            WindowEvent::Resized(physical_size) => {
+                println!("Resized to {:?}", physical_size);
+
+                let (width, height): (u32, u32) = physical_size.into();
+
+                env.render_ctx
+                    .resize_surface(env.surface.as_mut().unwrap(), width, height);
+
+                self.browser_state.write().viewport = Rect::new(0.0, 0.0, width as f64, height as f64);
+
+                reflow(&self.doc, &self.browser_state);
+            }
+            WindowEvent::RedrawRequested => {
+                self.frame += 1;
+                self.pfs = Instant::now();
+                println!("Redraw requested: framecount: {}", self.frame);
+
+                let surface = env.surface.as_ref().unwrap();
+                let dev_id = surface.dev_id;
+                let DeviceHandle { device, queue, .. } = &env.render_ctx.devices[dev_id];
+
+                let vis_layers = self.browser_state.read().visible_layer_list.clone();
+
+                let renderer = &mut env.renderer.as_mut().unwrap();
+
+                for (i, &visible) in vis_layers.iter().enumerate() {
+                    if visible {
+                        do_paint(LayerId::new(i as u64), &self.browser_state);
+                        do_rasterize(
+                            device,
+                            queue,
+                            renderer.clone(),
+                            LayerId::new(i as u64),
+                            &self.browser_state,
+                            &self.texture_store,
+                            &self.media_store,
+                        );
+                    }
+                }
+
+                let surface_texture = surface
+                    .surface
+                    .get_current_texture()
+                    .expect("Failed to get current texture");
+
+                let render_params = RenderParams {
+                    base_color: color::palette::css::DARK_MAGENTA,
+                    width: self.browser_state.read().viewport.width as u32,
+                    height: self.browser_state.read().viewport.height as u32,
+                    antialiasing_method: AaConfig::Msaa16,
+                };
+
+                let scene = VelloCompositor::compose(VelloCompositorConfig {
+                    browser_state: self.browser_state.clone(),
+                    texture_store: self.texture_store.clone(),
+                });
+
+                let binding = env.renderer.clone().unwrap();
+                let mut renderer = binding.borrow_mut();
+                let _ = renderer.render_to_surface(device, queue, &scene, &surface_texture, &render_params);
+
+                surface_texture.present();
+            }
+            WindowEvent::KeyboardInput {
+                event:
+                    KeyEvent {
+                        physical_key,
+                        logical_key,
+                        state,
+                        repeat,
+                        ..
+                    },
+                ..
+            } => {
+                if !state.is_pressed() || repeat {
+                    return;
+                }
+
+                let Some(window) = env.window.as_ref() else {
+                    return;
+                };
+
+                if logical_key == "q" {
+                    event_loop.exit();
+                }
+
+                if physical_key >= Code(KeyCode::Digit0) && physical_key <= Code(KeyCode::Digit9) {
+                    let mut state = self.browser_state.write();
+
+                    let layer_id = match physical_key {
+                        Code(KeyCode::Digit1) => 0,
+                        Code(KeyCode::Digit2) => 1,
+                        Code(KeyCode::Digit3) => 2,
+                        Code(KeyCode::Digit4) => 3,
+                        Code(KeyCode::Digit5) => 4,
+                        Code(KeyCode::Digit6) => 5,
+                        Code(KeyCode::Digit7) => 6,
+                        Code(KeyCode::Digit8) => 7,
+                        Code(KeyCode::Digit9) => 8,
+                        Code(KeyCode::Digit0) => 9,
+                        _ => unreachable!(),
+                    };
+                    if let Some(v) = state.visible_layer_list.get_mut(layer_id) {
+                        *v = !*v;
+                    }
+                    window.request_redraw();
+                }
+
+                if logical_key == "w" {
+                    let mut state = self.browser_state.write();
+
+                    match state.wireframed {
+                        WireframeState::None => state.wireframed = WireframeState::Only,
+                        WireframeState::Only => state.wireframed = WireframeState::Both,
+                        WireframeState::Both => state.wireframed = WireframeState::None,
+                    }
+
+                    if let Some(ref tile_list) = state.tile_list {
+                        tile_list.write().invalidate_all();
+                    }
+                    window.request_redraw();
+                }
+
+                if logical_key == "d" {
+                    let mut state = self.browser_state.write();
+
+                    state.debug_hover = !state.debug_hover;
+
+                    if let Some(ref tile_list) = state.tile_list {
+                        tile_list.write().invalidate_all();
+                    }
+                    window.request_redraw();
+                }
+
+                if logical_key == "t" {
+                    let mut state = self.browser_state.write();
+                    state.show_tilegrid = !state.show_tilegrid;
+                    drop(state);
+                    window.request_redraw();
+                }
+            }
+            _ => (),
+        }
+    }
+}
+
+fn create_window_env<'s>(el: &ActiveEventLoop, title: &str, size: Dimension) -> Env<'s> {
+    log::info!(
+        "Creating ({}x{}) window with title: {} ",
+        size.width,
+        size.height,
+        title
+    );
+
+    let mut render_ctx = RenderContext::new();
+
+    let mut attribs = Window::default_attributes();
+    attribs.title = title.to_string();
+    attribs.inner_size = Some(Size::Physical(PhysicalSize::new(size.width as u32, size.height as u32)));
+    let window = Arc::new(el.create_window(attribs).unwrap());
+
+    let size = window.inner_size();
+    let surface_future =
+        render_ctx.create_surface(window.clone(), size.width, size.height, wgpu::PresentMode::AutoVsync);
+    let surface = pollster::block_on(surface_future).expect("Failed to create surface");
+
+    let dev_handle = &render_ctx.devices[surface.dev_id];
+
+    let renderer = Renderer::new(
+        &dev_handle.device,
+        RendererOptions {
+            surface_format: Some(surface.format),
+            use_cpu: false,
+            antialiasing_support: AaSupport::all(),
+            num_init_threads: None,
+        },
+    );
+
+    #[allow(clippy::arc_with_non_send_sync)]
+    let env = Env {
+        render_ctx,
+        window: Some(window),
+        surface: Some(surface),
+        renderer: Some(Rc::new(RefCell::new(renderer.unwrap()))),
+    };
+
+    log::info!("vello window created");
+
+    env
+}
+
+fn do_paint(layer_id: LayerId, browser_state: &Arc<RwLock<BrowserState>>) {
+    let state = browser_state.read();
+
+    let Some(ref tile_list) = state.tile_list else {
+        log::error!("No tile list found");
+        return;
+    };
+
+    let painter = Painter::new(tile_list.read().layer_list.clone());
+
+    let tile_ids = tile_list.read().get_intersecting_tiles(layer_id, state.viewport);
+    for tile_id in tile_ids {
+        let mut binding = tile_list.write();
+        let Some(tile) = binding.get_tile_mut(tile_id) else {
+            log::warn!("Tile not found: {:?}", tile_id);
+            continue;
+        };
+
+        if tile.state == TileState::Clean || tile.state == TileState::Empty {
+            continue;
+        }
+
+        for tiled_layout_element in &mut tile.elements {
+            tiled_layout_element.paint_commands = painter.paint(tiled_layout_element, &state);
+        }
+    }
+}
+
+fn do_rasterize(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    renderer: Rc<RefCell<Renderer>>,
+    layer_id: LayerId,
+    browser_state: &Arc<RwLock<BrowserState>>,
+    texture_store: &Arc<RwLock<TextureStore>>,
+    media_store: &Arc<RwLock<MediaStore>>,
+) {
+    let state = browser_state.read();
+    let mut ts = texture_store.write();
+    let ms = media_store.read();
+
+    let Some(ref tile_list) = state.tile_list else {
+        log::error!("No tile list found");
+        return;
+    };
+
+    let tile_ids = tile_list.read().get_intersecting_tiles(layer_id, state.viewport);
+    for tile_id in tile_ids {
+        let mut binding = tile_list.write();
+        let Some(tile) = binding.get_tile(tile_id) else {
+            log::warn!("Tile not found: {:?}", tile_id);
+            continue;
+        };
+
+        if tile.state == TileState::Clean || tile.state == TileState::Empty {
+            continue;
+        }
+
+        let Some(tile) = binding.get_tile_mut(tile_id) else {
+            log::warn!("Tile not found: {:?}", tile_id);
+            continue;
+        };
+
+        let rasterizer = VelloRasterizer::new(device, queue, &renderer);
+        match rasterizer.rasterize(tile, &mut ts, &ms) {
+            Some(texture_id) => {
+                tile.texture_id = Some(texture_id);
+                tile.state = TileState::Clean;
+            }
+            None => {
+                tile.state = TileState::Empty;
+            }
+        }
+    }
+}

--- a/crates/gosub_renderer_vello/src/compositor.rs
+++ b/crates/gosub_renderer_vello/src/compositor.rs
@@ -1,0 +1,35 @@
+use crate::compositor::compositor::vello_compositor;
+use gosub_pipeline::common::browser_state::BrowserState;
+use gosub_pipeline::common::TextureStore;
+use gosub_pipeline::compositor::Composable;
+use gosub_pipeline::layering::layer::LayerId;
+use parking_lot::RwLock;
+use std::sync::Arc;
+
+pub struct VelloCompositorConfig {
+    pub browser_state: Arc<RwLock<BrowserState>>,
+    pub texture_store: Arc<RwLock<TextureStore>>,
+}
+
+mod compositor;
+
+pub struct VelloCompositor {}
+
+impl Composable for VelloCompositor {
+    type Config = VelloCompositorConfig;
+    type Return = vello::Scene;
+
+    fn compose(config: Self::Config) -> Self::Return {
+        let state = config.browser_state.read();
+
+        let layers: Vec<LayerId> = state
+            .visible_layer_list
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &visible)| if visible { Some(LayerId::new(i as u64)) } else { None })
+            .collect();
+
+        let texture_store = config.texture_store.read();
+        vello_compositor(layers, &state, &texture_store)
+    }
+}

--- a/crates/gosub_renderer_vello/src/compositor/compositor.rs
+++ b/crates/gosub_renderer_vello/src/compositor/compositor.rs
@@ -1,0 +1,59 @@
+use gosub_pipeline::common::browser_state::BrowserState;
+use gosub_pipeline::common::TextureStore;
+use gosub_pipeline::layering::layer::LayerId;
+use vello::kurbo::Affine;
+use vello::peniko::{Blob, Image, ImageFormat};
+
+pub fn vello_compositor(layer_ids: Vec<LayerId>, state: &BrowserState, texture_store: &TextureStore) -> vello::Scene {
+    let mut scene = vello::Scene::new();
+
+    for layer_id in layer_ids {
+        compose_layer(&mut scene, layer_id, state, texture_store);
+    }
+
+    scene
+}
+
+pub fn compose_layer(scene: &mut vello::Scene, layer_id: LayerId, state: &BrowserState, texture_store: &TextureStore) {
+    let Some(ref tile_list) = state.tile_list else {
+        log::error!("No tile list found");
+        return;
+    };
+
+    let tile_ids = tile_list.read().get_intersecting_tiles(layer_id, state.viewport);
+    for tile_id in tile_ids {
+        let tile_data = {
+            let binding = tile_list.read();
+            match binding.get_tile(tile_id) {
+                None => {
+                    log::warn!("Tile not found: {:?}", tile_id);
+                    None
+                }
+                Some(tile) => match tile.texture_id {
+                    None => {
+                        log::error!("No texture found for tile: {:?}", tile_id);
+                        None
+                    }
+                    Some(tid) => Some((tid, tile.rect)),
+                },
+            }
+        };
+        let Some((texture_id, tile_rect)) = tile_data else {
+            continue;
+        };
+
+        let Some(texture) = texture_store.get(texture_id) else {
+            log::error!("No texture found for tile: {:?}", tile_id);
+            continue;
+        };
+
+        let surface = Image::new(
+            Blob::from(texture.data.clone()),
+            ImageFormat::Rgba8,
+            texture.width as u32,
+            texture.height as u32,
+        );
+
+        scene.draw_image(&surface, Affine::translate((tile_rect.x.round(), tile_rect.y.round())));
+    }
+}

--- a/crates/gosub_renderer_vello/src/font/mod.rs
+++ b/crates/gosub_renderer_vello/src/font/mod.rs
@@ -1,0 +1,5 @@
+#[cfg(feature = "text_parley")]
+pub mod parley;
+
+#[cfg(feature = "text_skia")]
+pub mod skia;

--- a/crates/gosub_renderer_vello/src/font/parley.rs
+++ b/crates/gosub_renderer_vello/src/font/parley.rs
@@ -1,0 +1,56 @@
+use gosub_pipeline::common::font::FontAlignment;
+use parking_lot::Mutex;
+use parley::{AlignmentOptions, Layout};
+use std::sync::OnceLock;
+
+static FONT_CTX: OnceLock<Mutex<parley::FontContext>> = OnceLock::new();
+static LAYOUT_CTX: OnceLock<Mutex<parley::LayoutContext>> = OnceLock::new();
+
+pub fn get_font_context() -> parking_lot::MutexGuard<'static, parley::FontContext> {
+    FONT_CTX.get_or_init(|| Mutex::new(parley::FontContext::new())).lock()
+}
+
+fn get_layout_context() -> parking_lot::MutexGuard<'static, parley::LayoutContext> {
+    LAYOUT_CTX
+        .get_or_init(|| Mutex::new(parley::LayoutContext::new()))
+        .lock()
+}
+
+pub fn get_parley_layout(
+    text: &str,
+    font_family: &str,
+    font_size: f64,
+    line_height: f64,
+    font_weight: i32,
+    max_width: f64,
+    alignment: FontAlignment,
+) -> Layout<[u8; 4]> {
+    let font_stack = parley::FontStack::from(font_family);
+
+    let display_scale = 1.0;
+    let max_advance = (max_width * display_scale) as f32;
+
+    let mut font_ctx = get_font_context();
+    let mut layout_ctx = get_layout_context();
+
+    let mut builder = layout_ctx.ranged_builder(&mut font_ctx, text, display_scale as f32);
+    builder.push_default(font_stack);
+    builder.push_default(parley::StyleProperty::LineHeight(line_height as f32 / font_size as f32));
+    builder.push_default(parley::StyleProperty::FontSize(font_size as f32));
+    builder.push_default(parley::StyleProperty::FontWeight(parley::FontWeight::new(
+        font_weight as f32,
+    )));
+
+    let align = match alignment {
+        FontAlignment::Start => parley::layout::Alignment::Start,
+        FontAlignment::Center => parley::layout::Alignment::Middle,
+        FontAlignment::End => parley::layout::Alignment::End,
+        FontAlignment::Justify => parley::layout::Alignment::Justified,
+    };
+
+    let mut layout: Layout<[u8; 4]> = builder.build(text);
+    layout.break_all_lines(Some(max_advance * 1.01));
+    layout.align(Some(max_advance), align, AlignmentOptions::default());
+
+    layout
+}

--- a/crates/gosub_renderer_vello/src/font/skia.rs
+++ b/crates/gosub_renderer_vello/src/font/skia.rs
@@ -1,0 +1,66 @@
+use gosub_pipeline::common::font::{FontAlignment, FontInfo};
+use skia_safe::textlayout::{Paragraph, ParagraphBuilder, ParagraphStyle, TextStyle};
+use skia_safe::{FontStyle, Paint};
+
+thread_local! {
+    static FC: skia_safe::textlayout::FontCollection = {
+        let mut fc = skia_safe::textlayout::FontCollection::new();
+        fc.set_default_font_manager(skia_safe::FontMgr::new(), None);
+        fc
+    };
+}
+
+pub fn get_skia_paragraph(
+    text: &str,
+    font_info: &FontInfo,
+    max_width: f64,
+    paint: Option<&Paint>,
+    _dpi_scale_factor: f32,
+) -> Paragraph {
+    let mut paragraph_style = ParagraphStyle::new();
+    paragraph_style.set_text_align(match font_info.alignment {
+        FontAlignment::Start => skia_safe::textlayout::TextAlign::Start,
+        FontAlignment::Center => skia_safe::textlayout::TextAlign::Center,
+        FontAlignment::End => skia_safe::textlayout::TextAlign::End,
+        FontAlignment::Justify => skia_safe::textlayout::TextAlign::Justify,
+    });
+    paragraph_style.set_text_direction(skia_safe::textlayout::TextDirection::LTR);
+
+    let mut paragraph_builder = ParagraphBuilder::new(&paragraph_style, FC.with(|fc| fc.clone()));
+
+    let paint = match paint {
+        Some(p) => p.clone(),
+        None => Paint::default(),
+    };
+
+    let font_size_px = font_info.size;
+    let line_height_px = 1.2 * font_size_px;
+
+    let mut ts = TextStyle::new();
+    ts.set_foreground_paint(&paint);
+    ts.set_font_size(font_size_px as f32);
+    ts.set_height(line_height_px as f32);
+    ts.set_font_families(&[font_info.family.clone()]);
+    ts.set_font_style(FontStyle::new(
+        font_info.weight.into(),
+        font_info.width.into(),
+        to_slant(font_info.slant),
+    ));
+    paragraph_builder.push_style(&ts);
+
+    paragraph_builder.add_text(text);
+
+    let mut paragraph = paragraph_builder.build();
+    paragraph.layout(max_width as f32);
+
+    paragraph
+}
+
+fn to_slant(slant: i32) -> skia_safe::font_style::Slant {
+    match slant {
+        0 => skia_safe::font_style::Slant::Upright,
+        1 => skia_safe::font_style::Slant::Italic,
+        2 => skia_safe::font_style::Slant::Oblique,
+        _ => skia_safe::font_style::Slant::Upright,
+    }
+}

--- a/crates/gosub_renderer_vello/src/lib.rs
+++ b/crates/gosub_renderer_vello/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod compositor;
+pub mod rasterizer;
+pub(crate) mod font;
+
+pub use compositor::{VelloCompositor, VelloCompositorConfig};
+pub use rasterizer::VelloRasterizer;

--- a/crates/gosub_renderer_vello/src/rasterizer.rs
+++ b/crates/gosub_renderer_vello/src/rasterizer.rs
@@ -1,0 +1,180 @@
+use gosub_pipeline::common::geo::Dimension;
+use gosub_pipeline::common::media::MediaStore;
+use gosub_pipeline::common::texture::TextureId;
+use gosub_pipeline::common::TextureStore;
+use gosub_pipeline::painter::commands::PaintCommand;
+use gosub_pipeline::rasterizer::Rasterable;
+use gosub_pipeline::tiler::{Tile, TileId};
+use std::cell::RefCell;
+use vello::kurbo::{Affine, Rect, Vec2};
+use vello::peniko::{Color, Mix};
+use vello::wgpu::{Device, Queue, Texture, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages};
+use vello::{AaConfig, Renderer, Scene};
+
+mod brush;
+mod rectangle;
+mod svg;
+mod text;
+
+pub struct VelloRasterizer<'a> {
+    device: &'a Device,
+    queue: &'a Queue,
+    renderer: &'a RefCell<Renderer>,
+}
+
+impl<'a> VelloRasterizer<'a> {
+    pub fn new(device: &'a Device, queue: &'a Queue, renderer: &'a RefCell<Renderer>) -> Self {
+        Self {
+            device,
+            queue,
+            renderer,
+        }
+    }
+}
+
+impl Rasterable for VelloRasterizer<'_> {
+    fn rasterize(&self, tile: &Tile, texture_store: &mut TextureStore, media_store: &MediaStore) -> Option<TextureId> {
+        let mut scene = Scene::new();
+
+        let tile_size = Dimension::new(tile.rect.width, tile.rect.height);
+
+        let clip = Rect::new(0.0, 0.0, tile_size.width, tile_size.height);
+        scene.push_layer(Mix::Clip, 1.0, Affine::IDENTITY, &clip);
+
+        let affine = Affine::translate(Vec2::new(-tile.rect.x, -tile.rect.y));
+
+        for element in &tile.elements {
+            for command in &element.paint_commands {
+                match command {
+                    PaintCommand::Svg(command) => {
+                        svg::do_paint_svg(&mut scene, command.media_id, &command.rect, affine, media_store);
+                    }
+                    PaintCommand::Rectangle(command) => {
+                        rectangle::do_paint_rectangle(&mut scene, command, affine, media_store);
+                    }
+                    PaintCommand::Text(command) => {
+                        match text::do_paint_text(&mut scene, command, tile_size, affine, media_store) {
+                            Ok(_) => {}
+                            Err(e) => {
+                                log::warn!("Failed to paint text: {:?}", e);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        scene.pop_layer();
+
+        let texture = create_offscreen_texture(self.device, tile_size.width as u32, tile_size.height as u32);
+
+        let render_params = vello::RenderParams {
+            base_color: Color::new([0.0, 0.0, 0.0, 0.0]),
+            width: tile.rect.width as u32,
+            height: tile.rect.height as u32,
+            antialiasing_method: AaConfig::Msaa16,
+        };
+
+        if let Err(e) = self.renderer.borrow_mut().render_to_texture(
+            self.device,
+            self.queue,
+            &scene,
+            &texture.create_view(&Default::default()),
+            &render_params,
+        ) {
+            log::error!("Vello render_to_texture failed: {:?}", e);
+            return None;
+        }
+
+        let texture_data = read_texture_to_image(
+            self.device,
+            self.queue,
+            &texture,
+            tile_size.width as u32,
+            tile_size.height as u32,
+            tile.id,
+        );
+
+        let texture_id = texture_store.add(tile_size.width as usize, tile_size.height as usize, texture_data);
+
+        Some(texture_id)
+    }
+}
+
+fn create_offscreen_texture(device: &Device, width: u32, height: u32) -> Texture {
+    device.create_texture(&TextureDescriptor {
+        label: Some("Tile texture"),
+        size: vello::wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: TextureDimension::D2,
+        format: TextureFormat::Rgba8Unorm,
+        usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::COPY_SRC | TextureUsages::STORAGE_BINDING,
+        view_formats: &[],
+    })
+}
+
+fn read_texture_to_image(
+    device: &Device,
+    queue: &Queue,
+    texture: &Texture,
+    width: u32,
+    height: u32,
+    _id: TileId,
+) -> Vec<u8> {
+    let unpadded_bytes_per_row = width * 4;
+    let padded_bytes_per_row = (unpadded_bytes_per_row + 255) & !255;
+
+    let buffer_size = (padded_bytes_per_row * height) as vello::wgpu::BufferAddress;
+    let buffer = device.create_buffer(&vello::wgpu::BufferDescriptor {
+        label: Some("Texture Read Buffer"),
+        size: buffer_size,
+        usage: vello::wgpu::BufferUsages::COPY_DST | vello::wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    let mut encoder = device.create_command_encoder(&vello::wgpu::CommandEncoderDescriptor {
+        label: Some("Texture Copy Encoder"),
+    });
+    encoder.copy_texture_to_buffer(
+        texture.as_image_copy(),
+        vello::wgpu::ImageCopyBuffer {
+            buffer: &buffer,
+            layout: vello::wgpu::ImageDataLayout {
+                offset: 0,
+                bytes_per_row: Some(padded_bytes_per_row),
+                rows_per_image: Some(height),
+            },
+        },
+        vello::wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+    );
+    queue.submit(std::iter::once(encoder.finish()));
+
+    let buffer_slice = buffer.slice(..);
+    let (sender, receiver) = std::sync::mpsc::channel();
+    buffer_slice.map_async(vello::wgpu::MapMode::Read, move |result| {
+        sender.send(result).unwrap();
+    });
+    device.poll(vello::wgpu::Maintain::Wait);
+    receiver.recv().unwrap().unwrap();
+
+    let padded = buffer_slice.get_mapped_range();
+    let mut result = Vec::with_capacity((unpadded_bytes_per_row * height) as usize);
+    for row in 0..height {
+        let start = (row * padded_bytes_per_row) as usize;
+        let end = start + unpadded_bytes_per_row as usize;
+        result.extend_from_slice(&padded[start..end]);
+    }
+    drop(padded);
+    buffer.unmap();
+
+    result
+}

--- a/crates/gosub_renderer_vello/src/rasterizer/brush.rs
+++ b/crates/gosub_renderer_vello/src/rasterizer/brush.rs
@@ -1,0 +1,25 @@
+use gosub_pipeline::common::geo::Rect;
+use gosub_pipeline::common::media::MediaStore;
+use gosub_pipeline::painter::commands::brush::Brush;
+use vello::peniko::color::{AlphaColor, Rgba8};
+use vello::peniko::Image as PenikoImage;
+use vello::peniko::{Blob, Brush as VelloBrush};
+
+pub fn set_brush(brush: &Brush, _rect: Rect, media_store: &MediaStore) -> VelloBrush {
+    match brush {
+        Brush::Solid(color) => {
+            let c = Rgba8::from_u8_array([color.r8(), color.g8(), color.b8(), color.a8()]);
+            VelloBrush::Solid(AlphaColor::from(c))
+        }
+        Brush::Image(media_id) => {
+            let media = media_store.get_image(*media_id);
+
+            VelloBrush::Image(PenikoImage::new(
+                Blob::<u8>::from(media.image.as_raw().clone()),
+                vello::peniko::ImageFormat::Rgba8,
+                media.image.width(),
+                media.image.height(),
+            ))
+        }
+    }
+}

--- a/crates/gosub_renderer_vello/src/rasterizer/rectangle.rs
+++ b/crates/gosub_renderer_vello/src/rasterizer/rectangle.rs
@@ -1,0 +1,174 @@
+use crate::rasterizer::brush::set_brush;
+use gosub_pipeline::common::media::MediaStore;
+use gosub_pipeline::painter::commands::border::BorderStyle;
+use gosub_pipeline::painter::commands::rectangle::Rectangle;
+use vello::kurbo;
+use vello::kurbo::{Affine, PathEl, Point, Rect, RoundedRect, Shape};
+use vello::peniko::Fill;
+
+pub(crate) fn do_paint_rectangle(scene: &mut vello::Scene, rect: &Rectangle, affine: Affine, media_store: &MediaStore) {
+    if let Some(brush) = rect.background() {
+        let vello_rect = setup_rectangle_path(rect);
+        let vello_brush = set_brush(brush, rect.rect(), media_store);
+        scene.fill(Fill::NonZero, affine, &vello_brush, None, &vello_rect);
+    }
+
+    match rect.border().style() {
+        BorderStyle::None => {}
+        BorderStyle::Solid => draw_single_border(scene, rect, affine, vec![], media_store),
+        BorderStyle::Dashed => draw_single_border(scene, rect, affine, vec![50.0, 10.0, 10.0, 10.0], media_store),
+        BorderStyle::Dotted => draw_single_border(scene, rect, affine, vec![10.0, 10.0], media_store),
+        BorderStyle::Double => draw_double_border(scene, rect, affine, media_store),
+        BorderStyle::Groove | BorderStyle::Ridge | BorderStyle::Inset | BorderStyle::Outset => {
+            log::warn!(
+                "Border style {:?} not yet implemented, falling back to solid",
+                rect.border().style()
+            );
+            draw_single_border(scene, rect, affine, vec![], media_store)
+        }
+        BorderStyle::Hidden => {}
+    }
+}
+
+fn draw_single_border(
+    scene: &mut vello::Scene,
+    rect: &Rectangle,
+    affine: Affine,
+    dashes: Vec<f64>,
+    media_store: &MediaStore,
+) {
+    let binding = rect.border().brushes();
+    let Some(brush) = binding.first() else {
+        return;
+    };
+    let vello_shape = setup_rectangle_path(rect);
+    let vello_brush = set_brush(brush, rect.rect(), media_store);
+    let vello_stroke = kurbo::Stroke::new(rect.border().width() as f64).with_dashes(0.0, dashes);
+    scene.stroke(&vello_stroke, affine, &vello_brush, None, &vello_shape);
+}
+
+fn draw_double_border(scene: &mut vello::Scene, rect: &Rectangle, affine: Affine, media_store: &MediaStore) {
+    let binding = rect.border().brushes();
+    let Some(brush) = binding.first() else {
+        return;
+    };
+    let vello_shape = setup_rectangle_path(rect);
+    let vello_brush = set_brush(brush, rect.rect(), media_store);
+
+    if rect.border().width() < 3.0 {
+        scene.stroke(
+            &kurbo::Stroke::new(rect.border().width() as f64),
+            affine,
+            &vello_brush,
+            None,
+            &vello_shape,
+        );
+        return;
+    }
+
+    let width = (rect.border().width() / 2.0).floor();
+    scene.stroke(
+        &kurbo::Stroke::new(width as f64),
+        affine,
+        &vello_brush,
+        None,
+        &vello_shape,
+    );
+
+    let gap_size = 1.0;
+    let inset = width as f64 + gap_size;
+
+    let inner_border_shape = if rect.is_rounded() {
+        let (r_tl, r_tr, r_br, r_bl) = rect.radius_x();
+        ShapeEnum::RoundedRect(RoundedRect::new(
+            rect.rect().x + inset,
+            rect.rect().y + inset,
+            rect.rect().x + rect.rect().width - inset,
+            rect.rect().y + rect.rect().height - inset,
+            (
+                (r_tl - inset).max(0.0),
+                (r_tr - inset).max(0.0),
+                (r_br - inset).max(0.0),
+                (r_bl - inset).max(0.0),
+            ),
+        ))
+    } else {
+        ShapeEnum::Rect(Rect::new(
+            rect.rect().x + inset,
+            rect.rect().y + inset,
+            rect.rect().x + rect.rect().width - inset,
+            rect.rect().y + rect.rect().height - inset,
+        ))
+    };
+    scene.stroke(
+        &kurbo::Stroke::new(width as f64),
+        affine,
+        &vello_brush,
+        None,
+        &inner_border_shape,
+    );
+}
+
+enum ShapeEnum {
+    Rect(Rect),
+    RoundedRect(RoundedRect),
+}
+
+impl Shape for ShapeEnum {
+    type PathElementsIter<'iter> = Box<dyn Iterator<Item = PathEl> + 'iter>;
+
+    fn path_elements(&self, tolerance: f64) -> Self::PathElementsIter<'_> {
+        match self {
+            ShapeEnum::Rect(rect) => Box::new(rect.path_elements(tolerance)),
+            ShapeEnum::RoundedRect(rounded_rect) => Box::new(rounded_rect.path_elements(tolerance)),
+        }
+    }
+
+    fn area(&self) -> f64 {
+        match self {
+            ShapeEnum::Rect(rect) => rect.area(),
+            ShapeEnum::RoundedRect(rounded_rect) => rounded_rect.area(),
+        }
+    }
+
+    fn perimeter(&self, accuracy: f64) -> f64 {
+        match self {
+            ShapeEnum::Rect(rect) => rect.perimeter(accuracy),
+            ShapeEnum::RoundedRect(rounded_rect) => rounded_rect.perimeter(accuracy),
+        }
+    }
+
+    fn winding(&self, pt: Point) -> i32 {
+        match self {
+            ShapeEnum::Rect(rect) => rect.winding(pt),
+            ShapeEnum::RoundedRect(rounded_rect) => rounded_rect.winding(pt),
+        }
+    }
+
+    fn bounding_box(&self) -> Rect {
+        match self {
+            ShapeEnum::Rect(rect) => rect.bounding_box(),
+            ShapeEnum::RoundedRect(rounded_rect) => rounded_rect.bounding_box(),
+        }
+    }
+}
+
+fn setup_rectangle_path(rect: &Rectangle) -> ShapeEnum {
+    if rect.is_rounded() {
+        let (r_tl, r_tr, r_br, r_bl) = rect.radius_x();
+        return ShapeEnum::RoundedRect(RoundedRect::new(
+            rect.rect().x,
+            rect.rect().y,
+            rect.rect().x + rect.rect().width,
+            rect.rect().y + rect.rect().height,
+            (r_tl, r_tr, r_br, r_bl),
+        ));
+    }
+
+    ShapeEnum::Rect(Rect::new(
+        rect.rect().x,
+        rect.rect().y,
+        rect.rect().x + rect.rect().width,
+        rect.rect().y + rect.rect().height,
+    ))
+}

--- a/crates/gosub_renderer_vello/src/rasterizer/svg.rs
+++ b/crates/gosub_renderer_vello/src/rasterizer/svg.rs
@@ -1,0 +1,68 @@
+use gosub_pipeline::common::media::{MediaId, MediaStore};
+use gosub_pipeline::painter::commands::rectangle::Rectangle;
+use resvg::usvg::Transform;
+use vello::kurbo::Affine;
+use vello::peniko::{Blob, ImageFormat};
+
+pub(crate) fn do_paint_svg(
+    scene: &mut vello::Scene,
+    media_id: MediaId,
+    rect: &Rectangle,
+    affine: Affine,
+    media_store: &MediaStore,
+) {
+    log::debug!("Painting SVG: {:?}", media_id);
+
+    let media = media_store.get_svg(media_id);
+    let target_dim = rect.rect().dimension();
+
+    {
+        let cached = media.svg.rendered.read();
+        if cached.dimension == target_dim && !cached.data.is_empty() {
+            let data = Blob::from(cached.data.clone());
+            let vello_img = vello::peniko::Image::new(
+                data,
+                ImageFormat::Rgba8,
+                cached.dimension.width as u32,
+                cached.dimension.height as u32,
+            );
+            scene.draw_image(&vello_img, affine);
+            return;
+        }
+    }
+
+    let intrinsic = media.svg.tree.size().to_int_size();
+    let target_w = (target_dim.width as u32).max(1);
+    let target_h = (target_dim.height as u32).max(1);
+    let scale_x = target_w as f32 / intrinsic.width().max(1) as f32;
+    let scale_y = target_h as f32 / intrinsic.height().max(1) as f32;
+    let Some(mut pixmap) = resvg::tiny_skia::Pixmap::new(target_w, target_h) else {
+        log::error!(
+            "Failed to allocate pixmap for SVG {:?} ({}x{})",
+            media_id,
+            target_w,
+            target_h
+        );
+        return;
+    };
+    resvg::render(
+        &media.svg.tree,
+        Transform::from_scale(scale_x, scale_y),
+        &mut pixmap.as_mut(),
+    );
+    let new_data = pixmap.data().to_vec();
+
+    let mut cached = media.svg.rendered.write();
+    cached.data = new_data;
+    cached.dimension = target_dim;
+
+    let data = Blob::from(cached.data.clone());
+    let vello_img = vello::peniko::Image::new(
+        data,
+        ImageFormat::Rgba8,
+        cached.dimension.width as u32,
+        cached.dimension.height as u32,
+    );
+
+    scene.draw_image(&vello_img, affine);
+}

--- a/crates/gosub_renderer_vello/src/rasterizer/text.rs
+++ b/crates/gosub_renderer_vello/src/rasterizer/text.rs
@@ -1,0 +1,17 @@
+#[cfg(not(any(feature = "text_parley", feature = "text_pango", feature = "text_skia")))]
+compile_error!("Either the 'text_parley', 'text_skia', or 'text_pango' feature must be enabled");
+
+#[cfg(feature = "text_parley")]
+pub mod parley;
+#[cfg(feature = "text_parley")]
+pub use crate::rasterizer::text::parley::do_paint_text;
+
+#[cfg(feature = "text_skia")]
+pub mod skia;
+#[cfg(all(feature = "text_skia", not(feature = "text_parley")))]
+pub use crate::rasterizer::text::skia::do_paint_text;
+
+#[cfg(feature = "text_pango")]
+pub mod pango;
+#[cfg(all(feature = "text_pango", not(feature = "text_parley"), not(feature = "text_skia")))]
+pub use crate::rasterizer::text::pango::do_paint_text;

--- a/crates/gosub_renderer_vello/src/rasterizer/text/pango.rs
+++ b/crates/gosub_renderer_vello/src/rasterizer/text/pango.rs
@@ -1,0 +1,14 @@
+use gosub_pipeline::common::geo::Dimension;
+use gosub_pipeline::painter::commands::text::Text;
+use vello::kurbo::Affine;
+use vello::Scene;
+
+#[allow(dead_code)]
+pub fn do_paint_text(
+    _scene: &mut Scene,
+    _cmd: &Text,
+    _tile_size: Dimension,
+    _affine: Affine,
+) -> Result<(), anyhow::Error> {
+    anyhow::bail!("Pango text rendering is not implemented for the Vello backend")
+}

--- a/crates/gosub_renderer_vello/src/rasterizer/text/parley.rs
+++ b/crates/gosub_renderer_vello/src/rasterizer/text/parley.rs
@@ -1,0 +1,88 @@
+use crate::font::parley::get_parley_layout;
+use crate::rasterizer::brush::set_brush;
+use gosub_pipeline::common::geo::{Dimension, Rect};
+use gosub_pipeline::common::media::MediaStore;
+use gosub_pipeline::painter::commands::brush::Brush;
+use gosub_pipeline::painter::commands::text::Text;
+use parley::layout::{GlyphRun, PositionedLayoutItem};
+use vello::kurbo::Affine;
+use vello::peniko::Fill;
+use vello::Scene;
+
+pub fn do_paint_text(
+    scene: &mut Scene,
+    cmd: &Text,
+    _tile_size: Dimension,
+    affine: Affine,
+    media_store: &MediaStore,
+) -> Result<(), anyhow::Error> {
+    let layout = get_parley_layout(
+        cmd.text.as_str(),
+        cmd.font_info.family.as_str(),
+        cmd.font_info.size,
+        cmd.font_info.line_height,
+        cmd.font_info.weight,
+        cmd.rect.width,
+        cmd.font_info.alignment.clone(),
+    );
+
+    for line in layout.lines() {
+        for item in line.items() {
+            match item {
+                PositionedLayoutItem::GlyphRun(glyph_run) => {
+                    render_glyph_run(scene, glyph_run, &cmd.brush, &cmd.rect, affine, media_store);
+                }
+                PositionedLayoutItem::InlineBox(_inline_box) => {
+                    continue;
+                }
+            };
+        }
+    }
+
+    Ok(())
+}
+
+fn render_glyph_run(
+    scene: &mut Scene,
+    glyph_run: GlyphRun<[u8; 4]>,
+    brush: &Brush,
+    rect: &Rect,
+    affine: Affine,
+    media_store: &MediaStore,
+) {
+    let vello_brush = set_brush(brush, *rect, media_store);
+
+    let mut x = glyph_run.offset() + rect.x as f32;
+    let y = glyph_run.baseline() + rect.y as f32;
+    let run = glyph_run.run();
+    let font = run.font();
+    let font_size = run.font_size();
+    let synthesis = run.synthesis();
+    let glyph_xform = synthesis
+        .skew()
+        .map(|angle| Affine::skew(angle.to_radians().tan() as f64, 0.0));
+    let coords = run.normalized_coords();
+
+    scene
+        .draw_glyphs(font)
+        .brush(&vello_brush)
+        .glyph_transform(glyph_xform)
+        .font_size(font_size)
+        .hint(true)
+        .transform(affine)
+        .normalized_coords(coords)
+        .draw(
+            Fill::NonZero,
+            glyph_run.glyphs().map(|glyph| {
+                let gx = x + glyph.x;
+                let gy = y + glyph.y;
+                x += glyph.advance;
+
+                vello::Glyph {
+                    id: glyph.id as _,
+                    x: gx.round(),
+                    y: gy.round(),
+                }
+            }),
+        );
+}

--- a/crates/gosub_renderer_vello/src/rasterizer/text/skia.rs
+++ b/crates/gosub_renderer_vello/src/rasterizer/text/skia.rs
@@ -1,0 +1,56 @@
+use crate::font::skia::get_skia_paragraph;
+use gosub_pipeline::common::geo::Dimension;
+use gosub_pipeline::painter::commands::text::Text;
+use vello::kurbo::Affine;
+use vello::peniko::Blob;
+use vello::Scene;
+
+#[allow(dead_code)]
+pub fn do_paint_text(scene: &mut Scene, cmd: &Text, tile_size: Dimension, affine: Affine) -> Result<(), anyhow::Error> {
+    let paragraph = get_skia_paragraph(cmd.text.as_str(), &cmd.font_info, cmd.rect.width, None, 1.00);
+
+    let mut surface = skia_safe::surfaces::raster_n32_premul((tile_size.width as i32, tile_size.height as i32))
+        .ok_or_else(|| anyhow::anyhow!("Failed to create Skia surface for text rendering"))?;
+    let canvas = surface.canvas();
+
+    canvas.clip_rect(
+        skia_safe::Rect::new(0.0, 0.0, tile_size.width as f32, tile_size.height as f32),
+        None,
+        None,
+    );
+    let c = affine.as_coeffs();
+    let matrix = skia_safe::Matrix::new_all(
+        c[0] as f32,
+        c[2] as f32,
+        c[4] as f32,
+        c[1] as f32,
+        c[3] as f32,
+        c[5] as f32,
+        0.0,
+        0.0,
+        1.0,
+    );
+    canvas.clear(skia_safe::Color::TRANSPARENT);
+    canvas.concat(&matrix);
+    paragraph.paint(canvas, (cmd.rect.x as f32, cmd.rect.y as f32));
+
+    let Some(peek) = canvas.peek_pixels() else {
+        return Err(anyhow::anyhow!("Failed to peek pixels from Skia canvas"));
+    };
+    let Some(bytes) = peek.bytes() else {
+        return Err(anyhow::anyhow!("Failed to get bytes from Skia pixel info"));
+    };
+    let pixels = bytes.to_vec();
+
+    let blob = Blob::from(pixels);
+    let mut img = vello::peniko::Image::new(
+        blob,
+        vello::peniko::ImageFormat::Rgba8,
+        tile_size.width as u32,
+        tile_size.height as u32,
+    );
+    img.quality = vello::peniko::ImageQuality::High;
+    scene.draw_image(&img, Affine::IDENTITY);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Moves Cairo rasterizer, compositor, fonts, and pipeline binary into `gosub_renderer_cairo`
- Moves Vello rasterizer, compositor, fonts, and pipeline binary into `gosub_renderer_vello`
- Moves Skia rasterizer and compositor into `gosub_renderer_skia`
- Strips all backend-specific code from `gosub_pipeline`, leaving only the `Rasterable` and `Composable` traits
- Updates `gosub_engine` to import `CairoRasterizer` from `gosub_renderer_cairo`

## Test plan
- [ ] `cargo build --workspace` passes with zero errors
- [ ] `cargo build --bin pipeline-cairo -p gosub_renderer_cairo` builds correctly
- [ ] `cargo build --bin pipeline-vello -p gosub_renderer_vello` builds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)