### PR TITLE
README: add animated hero

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ DynamiteC <shethshails@gmail.com>
 Emre AYDIN <aeaydin1@gmail.com>
 heygsc <1596920983@qq.com>
 Joshua Thijssen <jthijssen@noxlogic.nl>
+livlign <linhtt90@gmail.com>
 Nicholas Nguyen <nicholas.nguyen@chargeitspot.com>
 Niklas Scheerhoorn <sinner1991@gmail.com>
 Shark <sharktheone@proton.me>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="resources/images/hero.gif" alt="Gosub — an embeddable, async browser engine in Rust. Parses HTML5/CSS3, lays out with Taffy, renders to Cairo, Vello, or your own backend. 21 crates, one engine.">
+</p>
+
 # Gosub Browser Engine
 
 An embeddable, async browser engine written in Rust.


### PR DESCRIPTION
Hi! I took a shot at a README hero for gosub-engine — a 20s loop walking through the four stages the README highlights (parse → layout → render → compose) plus the 21-crate workspace. Aimed for the submarine/cyan brand the logo establishes.

If it's not the vibe, no hard feelings — close at will. Happy to iterate on copy, pacing, or the crate roster if you'd like a v2.

- 1200×675, ~20s loop, 9.9 MB
- Embeds at the top of the README via relative path

Generated with [repo-visuals](https://github.com/livlign/claude-skills) — a Claude Code plugin for designing README heroes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a centered hero image at the top of the README for improved visual presentation.

* **Chores**
  * Updated AUTHORS to add a new contributor entry (livlign).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gosub-io/gosub-engine/pull/996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->