### PR TITLE
[pipeline-screenshot]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,10 @@ name = "egui-vello"
 path = "examples/egui-vello/main.rs"
 
 [[example]]
+name = "pipeline-screenshot"
+path = "examples/pipeline-screenshot/main.rs"
+
+[[example]]
 name = "metrics-cli"
 path = "examples/metrics_cli.rs"
 

--- a/crates/gosub_pipeline/tools/compare_css.py
+++ b/crates/gosub_pipeline/tools/compare_css.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Compare computed CSS properties between gosub and Firefox.
+
+Usage:
+    python3 compare_css.py <gosub.json> <firefox.json>
+
+gosub.json  — produced by running with GOSUB_DUMP_CSS=/tmp/gosub.json
+firefox.json — produced in the browser console:
+    copy(JSON.stringify([...document.querySelectorAll('*')].map(el => ({
+        tag: el.tagName.toLowerCase(), id: el.id, class: el.className,
+        styles: Object.fromEntries([...getComputedStyle(el)].map(p => [p, getComputedStyle(el)[p]]))
+    })), null, 2))
+"""
+
+import json
+import re
+import sys
+from collections import defaultdict
+
+# Elements the gosub render tree skips entirely
+INVISIBLE_TAGS = {"head", "script", "style", "meta", "link", "title", "svg", "noscript"}
+
+# Default root font size used for em→px conversion
+BASE_FONT_PX = 16.0
+
+
+def parse_color(s: str):
+    """Return (r, g, b, a) floats 0-255 / 1.0, or None."""
+    s = s.strip()
+    m = re.match(r"rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)", s)
+    if m:
+        r, g, b = float(m.group(1)), float(m.group(2)), float(m.group(3))
+        a = float(m.group(4)) if m.group(4) is not None else 1.0
+        return (r, g, b, a)
+    return None
+
+
+def normalize_value(prop: str, val: str, base_font_px: float = BASE_FONT_PX) -> str:
+    """Normalize a CSS value to a canonical form for comparison."""
+    val = val.strip()
+
+    # em / rem → px
+    m = re.fullmatch(r"([-+]?[\d.]+)em", val)
+    if m:
+        return f"{float(m.group(1)) * base_font_px:.4g}px"
+    m = re.fullmatch(r"([-+]?[\d.]+)rem", val)
+    if m:
+        return f"{float(m.group(1)) * base_font_px:.4g}px"
+
+    # Colors: canonicalize to rgba(r, g, b, a) with rounded integers
+    c = parse_color(val)
+    if c is not None:
+        r, g, b, a = c
+        if a == 1.0:
+            return f"rgb({int(round(r))}, {int(round(g))}, {int(round(b))})"
+        else:
+            return f"rgba({int(round(r))}, {int(round(g))}, {int(round(b))}, {a:.4g})"
+
+    # Strip trailing .0 from pixel values like "8.0px" → "8px"
+    m = re.fullmatch(r"([-+]?[\d]+)\.0+px", val)
+    if m:
+        return f"{m.group(1)}px"
+
+    return val
+
+
+def match_key(el: dict) -> tuple:
+    return (el["tag"], el.get("id", ""), el.get("class", ""))
+
+
+def filter_firefox(elements: list) -> list:
+    return [e for e in elements if e["tag"] not in INVISIBLE_TAGS]
+
+
+def build_index(elements: list) -> dict:
+    """Group elements by (tag, id, class), preserving order within each group."""
+    idx = defaultdict(list)
+    for el in elements:
+        idx[match_key(el)].append(el)
+    return idx
+
+
+def compare(gosub_path: str, firefox_path: str):
+    gosub_elements = json.load(open(gosub_path))
+    firefox_elements = filter_firefox(json.load(open(firefox_path)))
+
+    firefox_idx = build_index(firefox_elements)
+    # Track how many times each key has been consumed
+    firefox_consumed = defaultdict(int)
+
+    total_props = 0
+    mismatches = []
+    unmatched_gosub = []
+
+    for gsub in gosub_elements:
+        key = match_key(gsub)
+        ff_group = firefox_idx.get(key, [])
+        pos = firefox_consumed[key]
+        firefox_consumed[key] += 1
+
+        if pos >= len(ff_group):
+            unmatched_gosub.append(gsub)
+            continue
+
+        ff = ff_group[pos]
+
+        for css_prop, gsub_val in gsub["styles"].items():
+            ff_val = ff["styles"].get(css_prop)
+            if ff_val is None:
+                continue  # Firefox doesn't have this property (shouldn't happen for standard props)
+
+            norm_gsub = normalize_value(css_prop, gsub_val)
+            norm_ff   = normalize_value(css_prop, ff_val)
+            total_props += 1
+
+            if norm_gsub != norm_ff:
+                mismatches.append({
+                    "element": f"<{gsub['tag']}> id={gsub.get('id','')!r} class={gsub.get('class','')!r} pos={pos}",
+                    "property": css_prop,
+                    "gosub":   gsub_val,
+                    "firefox": ff_val,
+                    "gosub_norm":   norm_gsub,
+                    "firefox_norm": norm_ff,
+                })
+
+    # ── Report ──────────────────────────────────────────────────────────────
+    print(f"Compared {len(gosub_elements)} gosub elements against {len(firefox_elements)} Firefox elements")
+    print(f"Checked {total_props} property values\n")
+
+    if unmatched_gosub:
+        print(f"WARNING: {len(unmatched_gosub)} gosub element(s) had no Firefox counterpart:")
+        for el in unmatched_gosub:
+            print(f"  <{el['tag']}> id={el.get('id','')!r} class={el.get('class','')!r}")
+        print()
+
+    if not mismatches:
+        print("All checked properties match!")
+        return
+
+    # Group mismatches by element
+    by_element = defaultdict(list)
+    for m in mismatches:
+        by_element[m["element"]].append(m)
+
+    print(f"MISMATCHES ({len(mismatches)} total across {len(by_element)} element(s)):\n")
+    for elem, ms in by_element.items():
+        print(f"  {elem}")
+        for m in ms:
+            print(f"    {m['property']:35s}  gosub={m['gosub_norm']!r:20s}  firefox={m['firefox_norm']!r}")
+        print()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(__doc__)
+        sys.exit(1)
+    compare(sys.argv[1], sys.argv[2])

--- a/crates/gosub_renderer_cairo/src/bin/pipeline-cairo.rs
+++ b/crates/gosub_renderer_cairo/src/bin/pipeline-cairo.rs
@@ -28,7 +28,9 @@ const WINDOW_HEIGHT: f64 = 768.0;
 fn main() {
     let doc = common::document::parser::document_from_json("file://.", "cm.json");
     let mut output = String::new();
-    let _ = doc.print_tree(&mut output);
+    if let Err(e) = doc.print_tree(&mut output) {
+        log::warn!("Failed to print tree: {:?}", e);
+    }
     println!("{}", output);
 
     let doc = Arc::new(doc);
@@ -108,11 +110,12 @@ fn build_ui(
 
     let dim = {
         let state = browser_state.read();
-        let Some(tile_list) = state.tile_list.as_ref() else {
+        let Some(ref tile_list) = state.tile_list else {
+            log::error!("No tile list");
             return;
         };
-        let guard = tile_list.read();
-        guard.layer_list.layout_tree.root_dimension
+        let d = tile_list.read().layer_list.layout_tree.root_dimension;
+        d
     };
 
     let area = DrawingArea::new();
@@ -148,47 +151,39 @@ fn build_ui(
         motion_controller.connect_motion(move |_, x, y| {
             let el_id = {
                 let state = bs.read();
-                let Some(tile_list) = state.tile_list.as_ref() else {
+                let Some(ref tile_list) = state.tile_list else {
                     return;
                 };
-                let guard = tile_list.read();
-                guard.layer_list.find_element_at(x, y)
+                let id = tile_list.read().layer_list.find_element_at(x, y);
+                id
             };
             let che = bs.read().current_hovered_element;
 
             let mut tile_ids = vec![];
             {
                 let state = bs.read();
-                if let Some(tile_list) = state.tile_list.as_ref() {
-                    let tl = tile_list.read();
-                    match (che, el_id) {
-                        (Some(current_id), Some(new_id)) if current_id != new_id => {
-                            tl.get_tiles_for_element(current_id)
-                                .iter()
-                                .for_each(|tid| tile_ids.push(*tid));
-                            tl.get_tiles_for_element(new_id)
-                                .iter()
-                                .for_each(|tid| tile_ids.push(*tid));
-                        }
-                        (None, Some(new_id)) => {
-                            tl.get_tiles_for_element(new_id)
-                                .iter()
-                                .for_each(|tid| tile_ids.push(*tid));
-                        }
-                        (Some(current_id), None) => {
-                            tl.get_tiles_for_element(current_id)
-                                .iter()
-                                .for_each(|tid| tile_ids.push(*tid));
-                        }
-                        _ => {}
+                let Some(ref tile_list) = state.tile_list else {
+                    return;
+                };
+                match (che, el_id) {
+                    (Some(current_id), Some(new_id)) if current_id != new_id => {
+                        tile_list.read().get_tiles_for_element(current_id).iter().for_each(|tid| tile_ids.push(*tid));
+                        tile_list.read().get_tiles_for_element(new_id).iter().for_each(|tid| tile_ids.push(*tid));
                     }
+                    (None, Some(new_id)) => {
+                        tile_list.read().get_tiles_for_element(new_id).iter().for_each(|tid| tile_ids.push(*tid));
+                    }
+                    (Some(current_id), None) => {
+                        tile_list.read().get_tiles_for_element(current_id).iter().for_each(|tid| tile_ids.push(*tid));
+                    }
+                    _ => {}
                 }
             }
 
             let mut state = bs.write();
             if state.current_hovered_element != el_id {
                 if let Some(id) = el_id {
-                    if let Some(tile_list) = state.tile_list.as_ref() {
+                    if let Some(ref tile_list) = state.tile_list {
                         let binding = tile_list.read();
                         if let Some(layout_element) = binding.layer_list.layout_tree.get_node_by_id(id) {
                             println!("Hovered element id:");
@@ -199,7 +194,7 @@ fn build_ui(
                 }
 
                 for tile_id in &tile_ids {
-                    if let Some(tile_list) = state.tile_list.as_ref() {
+                    if let Some(ref tile_list) = state.tile_list {
                         tile_list.write().invalidate_tile(*tile_id);
                     }
                 }
@@ -293,15 +288,15 @@ fn build_ui(
                         WireframeState::Only => state.wireframed = WireframeState::Both,
                         WireframeState::Both => state.wireframed = WireframeState::None,
                     }
-                    if let Some(tl) = state.tile_list.as_ref() {
-                        tl.write().invalidate_all();
+                    if let Some(ref tile_list) = state.tile_list {
+                        tile_list.write().invalidate_all();
                     }
                     area.queue_draw();
                 }
                 key if key == gtk4::gdk::Key::d => {
                     state.debug_hover = !state.debug_hover;
-                    if let Some(tl) = state.tile_list.as_ref() {
-                        tl.write().invalidate_all();
+                    if let Some(ref tile_list) = state.tile_list {
+                        tile_list.write().invalidate_all();
                     }
                     area.queue_draw();
                 }
@@ -323,7 +318,8 @@ fn build_ui(
 
 fn do_paint(layer_id: LayerId, browser_state: &Arc<RwLock<BrowserState>>) {
     let state = browser_state.read();
-    let Some(tile_list) = state.tile_list.as_ref() else {
+    let Some(ref tile_list) = state.tile_list else {
+        log::error!("No tile list found");
         return;
     };
     let painter = Painter::new(tile_list.read().layer_list.clone());
@@ -356,7 +352,8 @@ fn do_rasterize(
     let mut ts = texture_store.write();
     let ms = media_store.read();
 
-    let Some(tile_list) = state.tile_list.as_ref() else {
+    let Some(ref tile_list) = state.tile_list else {
+        log::error!("No tile list found");
         return;
     };
 
@@ -437,8 +434,8 @@ fn on_viewport_changed(
     let mut state = browser_state.write();
 
     if width != state.viewport.width || height != state.viewport.height {
-        if let Some(tl) = state.tile_list.as_ref() {
-            tl.write().invalidate_all();
+        if let Some(ref tile_list) = state.tile_list {
+            tile_list.write().invalidate_all();
         }
     }
 

--- a/crates/gosub_renderer_cairo/src/bin/pipeline-cairo.rs
+++ b/crates/gosub_renderer_cairo/src/bin/pipeline-cairo.rs
@@ -167,14 +167,30 @@ fn build_ui(
                 };
                 match (che, el_id) {
                     (Some(current_id), Some(new_id)) if current_id != new_id => {
-                        tile_list.read().get_tiles_for_element(current_id).iter().for_each(|tid| tile_ids.push(*tid));
-                        tile_list.read().get_tiles_for_element(new_id).iter().for_each(|tid| tile_ids.push(*tid));
+                        tile_list
+                            .read()
+                            .get_tiles_for_element(current_id)
+                            .iter()
+                            .for_each(|tid| tile_ids.push(*tid));
+                        tile_list
+                            .read()
+                            .get_tiles_for_element(new_id)
+                            .iter()
+                            .for_each(|tid| tile_ids.push(*tid));
                     }
                     (None, Some(new_id)) => {
-                        tile_list.read().get_tiles_for_element(new_id).iter().for_each(|tid| tile_ids.push(*tid));
+                        tile_list
+                            .read()
+                            .get_tiles_for_element(new_id)
+                            .iter()
+                            .for_each(|tid| tile_ids.push(*tid));
                     }
                     (Some(current_id), None) => {
-                        tile_list.read().get_tiles_for_element(current_id).iter().for_each(|tid| tile_ids.push(*tid));
+                        tile_list
+                            .read()
+                            .get_tiles_for_element(current_id)
+                            .iter()
+                            .for_each(|tid| tile_ids.push(*tid));
                     }
                     _ => {}
                 }

--- a/crates/gosub_renderer_cairo/src/rasterizer.rs
+++ b/crates/gosub_renderer_cairo/src/rasterizer.rs
@@ -33,13 +33,13 @@ impl Rasterable for CairoRasterizer {
         let tile_h = tile.rect.height as i32 * dpr;
 
         let Ok(mut surface) = cairo::ImageSurface::create(cairo::Format::ARgb32, tile_w, tile_h) else {
-            log::error!("Failed to create Cairo image surface for tile rasterization");
+            log::error!("Failed to create Cairo image surface");
             return None;
         };
 
         {
             let Ok(cr) = cairo::Context::new(&surface) else {
-                log::error!("Failed to create Cairo context for tile rasterization");
+                log::error!("Failed to create Cairo context");
                 return None;
             };
             // Scale the context so all CSS-pixel coordinates map to physical pixels.

--- a/crates/gosub_renderer_vello/src/bin/pipeline-vello.rs
+++ b/crates/gosub_renderer_vello/src/bin/pipeline-vello.rs
@@ -33,7 +33,7 @@ use winit::window::{Window, WindowId};
 
 const TILE_DIMENSION: f64 = 256.0;
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let doc = common::document::parser::document_from_json("https://brettgfitzgerald.com", "brett.json");
 
     let window_dimension = Dimension::new(800.0, 600.0);
@@ -55,10 +55,7 @@ fn main() {
     let media_store = Arc::new(RwLock::new(MediaStore::new()));
     let doc: Arc<dyn PipelineDocument> = Arc::new(doc);
 
-    let Ok(event_loop) = EventLoop::new() else {
-        log::error!("Failed to create event loop");
-        return;
-    };
+    let event_loop = EventLoop::new()?;
     event_loop.set_control_flow(ControlFlow::Poll);
 
     let mut app = App::new(
@@ -70,6 +67,7 @@ fn main() {
         media_store,
     );
     let _ = event_loop.run_app(&mut app);
+    Ok(())
 }
 
 fn reflow(doc: &Arc<dyn PipelineDocument>, browser_state: &Arc<RwLock<BrowserState>>) {
@@ -160,7 +158,14 @@ impl ApplicationHandler for App<'_> {
 
         self.pfs = Instant::now();
         self.frame = 0;
-        self.env = create_window_env(event_loop, self.window_title.as_str(), self.window_size);
+        self.env = match create_window_env(event_loop, self.window_title.as_str(), self.window_size) {
+            Ok(env) => Some(env),
+            Err(e) => {
+                log::error!("Failed to create window: {:?}", e);
+                event_loop.exit();
+                None
+            }
+        };
 
         reflow(&self.doc, &self.browser_state);
     }
@@ -177,7 +182,9 @@ impl ApplicationHandler for App<'_> {
 
                 let (width, height): (u32, u32) = physical_size.into();
 
-                let Some(surface) = env.surface.as_mut() else { return };
+                let Some(surface) = env.surface.as_mut() else {
+                    return;
+                };
                 env.render_ctx.resize_surface(surface, width, height);
 
                 self.browser_state.write().viewport = Rect::new(0.0, 0.0, width as f64, height as f64);
@@ -189,27 +196,30 @@ impl ApplicationHandler for App<'_> {
                 self.pfs = Instant::now();
                 println!("Redraw requested: framecount: {}", self.frame);
 
-                let Some(surface) = env.surface.as_ref() else { return };
+                let Some(surface) = env.surface.as_ref() else {
+                    return;
+                };
                 let dev_id = surface.dev_id;
                 let DeviceHandle { device, queue, .. } = &env.render_ctx.devices[dev_id];
 
                 let vis_layers = self.browser_state.read().visible_layer_list.clone();
 
-                {
-                    let Some(renderer) = env.renderer.as_mut() else { return };
-                    for (i, &visible) in vis_layers.iter().enumerate() {
-                        if visible {
-                            do_paint(LayerId::new(i as u64), &self.browser_state);
-                            do_rasterize(
-                                device,
-                                queue,
-                                renderer.clone(),
-                                LayerId::new(i as u64),
-                                &self.browser_state,
-                                &self.texture_store,
-                                &self.media_store,
-                            );
-                        }
+                let Some(renderer) = env.renderer.as_mut() else {
+                    return;
+                };
+
+                for (i, &visible) in vis_layers.iter().enumerate() {
+                    if visible {
+                        do_paint(LayerId::new(i as u64), &self.browser_state);
+                        do_rasterize(
+                            device,
+                            queue,
+                            renderer.clone(),
+                            LayerId::new(i as u64),
+                            &self.browser_state,
+                            &self.texture_store,
+                            &self.media_store,
+                        );
                     }
                 }
 
@@ -230,7 +240,9 @@ impl ApplicationHandler for App<'_> {
                     texture_store: self.texture_store.clone(),
                 });
 
-                let Some(binding) = env.renderer.clone() else { return };
+                let Some(binding) = env.renderer.clone() else {
+                    return;
+                };
                 let mut renderer = binding.borrow_mut();
                 let _ = renderer.render_to_surface(device, queue, &scene, &surface_texture, &render_params);
 
@@ -319,7 +331,7 @@ impl ApplicationHandler for App<'_> {
     }
 }
 
-fn create_window_env<'s>(el: &ActiveEventLoop, title: &str, size: Dimension) -> Option<Env<'s>> {
+fn create_window_env<'s>(el: &ActiveEventLoop, title: &str, size: Dimension) -> anyhow::Result<Env<'s>> {
     log::info!(
         "Creating ({}x{}) window with title: {} ",
         size.width,
@@ -332,23 +344,16 @@ fn create_window_env<'s>(el: &ActiveEventLoop, title: &str, size: Dimension) -> 
     let mut attribs = Window::default_attributes();
     attribs.title = title.to_string();
     attribs.inner_size = Some(Size::Physical(PhysicalSize::new(size.width as u32, size.height as u32)));
-    let Ok(window) = el.create_window(attribs) else {
-        log::error!("Failed to create window");
-        return None;
-    };
-    let window = Arc::new(window);
+    let window = Arc::new(el.create_window(attribs)?);
 
     let size = window.inner_size();
     let surface_future =
         render_ctx.create_surface(window.clone(), size.width, size.height, wgpu::PresentMode::AutoVsync);
-    let Ok(surface) = pollster::block_on(surface_future) else {
-        log::error!("Failed to create render surface");
-        return None;
-    };
+    let surface = pollster::block_on(surface_future)?;
 
     let dev_handle = &render_ctx.devices[surface.dev_id];
 
-    let Ok(renderer) = Renderer::new(
+    let renderer = Renderer::new(
         &dev_handle.device,
         RendererOptions {
             surface_format: Some(surface.format),
@@ -356,10 +361,8 @@ fn create_window_env<'s>(el: &ActiveEventLoop, title: &str, size: Dimension) -> 
             antialiasing_support: AaSupport::all(),
             num_init_threads: None,
         },
-    ) else {
-        log::error!("Failed to create Vello renderer");
-        return None;
-    };
+    )
+    .map_err(|e| anyhow::anyhow!("Failed to create Vello renderer: {:?}", e))?;
 
     #[allow(clippy::arc_with_non_send_sync)]
     let env = Env {
@@ -371,7 +374,7 @@ fn create_window_env<'s>(el: &ActiveEventLoop, title: &str, size: Dimension) -> 
 
     log::info!("vello window created");
 
-    Some(env)
+    Ok(env)
 }
 
 fn do_paint(layer_id: LayerId, browser_state: &Arc<RwLock<BrowserState>>) {

--- a/crates/gosub_renderer_vello/src/rasterizer.rs
+++ b/crates/gosub_renderer_vello/src/rasterizer.rs
@@ -93,7 +93,7 @@ impl Rasterable for VelloRasterizer<'_> {
             tile_size.width as u32,
             tile_size.height as u32,
             tile.id,
-        );
+        )?;
 
         let texture_id = texture_store.add(tile_size.width as usize, tile_size.height as usize, texture_data);
 
@@ -125,7 +125,7 @@ fn read_texture_to_image(
     width: u32,
     height: u32,
     _id: TileId,
-) -> Vec<u8> {
+) -> Option<Vec<u8>> {
     let unpadded_bytes_per_row = width * 4;
     let padded_bytes_per_row = (unpadded_bytes_per_row + 255) & !255;
 
@@ -164,10 +164,10 @@ fn read_texture_to_image(
         let _ = sender.send(result);
     });
     device.poll(vello::wgpu::Maintain::Wait);
-    if receiver.recv().ok().and_then(|r| r.ok()).is_none() {
-        log::error!("Failed to map vello output buffer for reading");
-        return Vec::new();
-    }
+    let Ok(Ok(())) = receiver.recv() else {
+        log::error!("Failed to map texture buffer for reading");
+        return None;
+    };
 
     let padded = buffer_slice.get_mapped_range();
     let mut result = Vec::with_capacity((unpadded_bytes_per_row * height) as usize);
@@ -179,5 +179,5 @@ fn read_texture_to_image(
     drop(padded);
     buffer.unmap();
 
-    result
+    Some(result)
 }

--- a/examples/pipeline-screenshot/main.rs
+++ b/examples/pipeline-screenshot/main.rs
@@ -1,0 +1,305 @@
+//! Headless screenshot tool: loads a URL through the full gosub_pipeline render system and
+//! saves the result as a PNG without opening a window.
+//!
+//! Usage:
+//!   cargo run --example pipeline-screenshot -- <url> [output.png] [width]
+//!
+//! width defaults to 1280. Height is determined automatically from the full page content.
+//! Maximum captured page height is 16384 px (safety cap).
+//!
+//! If no display is available (e.g. CI), set GDK_BACKEND=offscreen before running.
+
+use gosub_engine::events::{EngineEvent, NavigationEvent, TabCommand};
+use gosub_engine::render::backend::ExternalHandle;
+use gosub_engine::render::backends::cairo::CairoBackend;
+use gosub_engine::render::DefaultCompositor;
+use gosub_engine::storage::{InMemorySessionStore, PartitionPolicy, SqliteLocalStore, StorageService};
+use gosub_engine::tab::{TabDefaults, TabId};
+use gosub_engine::zone::{ZoneConfig, ZoneId, ZoneServices};
+use gosub_engine::GosubEngine;
+use gtk4::cairo::{Context, Format, ImageSurface};
+use image::ColorType;
+use once_cell::sync::Lazy;
+use parking_lot::RwLock;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::runtime::{Builder, Runtime};
+use url::Url;
+use uuid::uuid;
+
+const DEFAULT_ZONE: uuid::Uuid = uuid!("f1234567-abcd-4000-8000-000000000003");
+/// Maximum page height to capture, in CSS pixels. Prevents out-of-memory on huge pages.
+const MAX_PAGE_HEIGHT: u32 = 16384;
+
+static TOKIO_RT: Lazy<Runtime> = Lazy::new(|| {
+    Builder::new_multi_thread()
+        .enable_io()
+        .enable_time()
+        .thread_name("gosub-screenshot-rt")
+        .build()
+        .expect("tokio runtime")
+});
+
+fn main() {
+    simple_logger::init_with_env().unwrap_or_default();
+
+    let args: Vec<String> = std::env::args().collect();
+    let url_str = args.get(1).map(|s| s.as_str()).unwrap_or("https://example.com").to_string();
+    let output = args.get(2).map(|s| s.as_str()).unwrap_or("screenshot.png").to_string();
+    let viewport_w: u32 = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(1280);
+
+    let url_str = if url_str.contains("://") {
+        url_str
+    } else {
+        format!("https://{url_str}")
+    };
+    let url = Url::parse(&url_str).expect("invalid URL");
+
+    // GTK must be initialised before pango can measure fonts. No window is created.
+    // On headless systems set GDK_BACKEND=offscreen.
+    gtk4::init().expect("GTK init failed — try setting GDK_BACKEND=offscreen");
+    gosub_engine::init_gtk_resources();
+
+    let _rt_guard = TOKIO_RT.enter();
+
+    // Redraw notifications: engine → main thread.
+    let (tx_redraw, rx_redraw) = std::sync::mpsc::channel::<()>();
+
+    let compositor = Arc::new(RwLock::new(DefaultCompositor::new(move || {
+        let _ = tx_redraw.send(());
+    })));
+
+    let backend = CairoBackend::new();
+    let mut engine = GosubEngine::new(None, Arc::new(backend), compositor.clone());
+    let _join = engine.start().expect("engine start");
+    let mut event_rx = engine.subscribe_events();
+
+    let zone_cfg = ZoneConfig::builder().build().expect("ZoneConfig");
+    let zone_services = ZoneServices {
+        storage: Arc::new(StorageService::new(
+            Arc::new(SqliteLocalStore::new(":memory:").expect("local store")),
+            Arc::new(InMemorySessionStore::new()),
+        )),
+        cookie_store: None,
+        cookie_jar: None,
+        partition_policy: PartitionPolicy::None,
+    };
+
+    let mut zone = engine
+        .create_zone(zone_cfg, zone_services, Some(ZoneId::from(DEFAULT_ZONE)))
+        .expect("create_zone");
+
+    let tab = TOKIO_RT
+        .block_on(zone.create_tab(
+            TabDefaults {
+                url: None,
+                title: Some("screenshot".to_string()),
+                viewport: None,
+            },
+            None,
+        ))
+        .expect("create_tab");
+
+    let tab_id: TabId = tab.tab_id;
+
+    // Use a tall initial viewport so the full page is laid out and rasterized.
+    // After the first render we trigger a 1-pixel scroll to get a TileCache handle
+    // which carries page_height — then we composite only the real content rows.
+    let tab_nav = tab.clone();
+    TOKIO_RT.spawn(async move {
+        let _ = tab_nav.send(TabCommand::SetViewport {
+            x: 0,
+            y: 0,
+            width: viewport_w,
+            height: MAX_PAGE_HEIGHT,
+        }).await;
+        let _ = tab_nav.send(TabCommand::Navigate { url: url.to_string() }).await;
+        let _ = tab_nav.send(TabCommand::ResumeDrawing { fps: 30 }).await;
+    });
+
+    let timeout = Duration::from_secs(30);
+    let deadline = Instant::now() + timeout;
+
+    eprintln!("Loading {url_str} (viewport width={viewport_w})…");
+
+    // ── Phase 1: wait for navigation to complete + first full render ──────────────
+    let mut nav_done = false;
+    let mut first_render_done = false;
+
+    while Instant::now() < deadline {
+        while rx_redraw.try_recv().is_ok() {
+            if nav_done {
+                first_render_done = true;
+            }
+        }
+
+        loop {
+            match event_rx.try_recv() {
+                Ok(EngineEvent::Navigation { tab_id: tid, event }) if tid == tab_id => {
+                    match event {
+                        NavigationEvent::Finished { .. } => {
+                            eprintln!("Navigation finished.");
+                            nav_done = true;
+                        }
+                        NavigationEvent::Failed { error, .. } => {
+                            eprintln!("Navigation failed: {error}");
+                            std::process::exit(1);
+                        }
+                        NavigationEvent::FailedUrl { error, .. } => {
+                            eprintln!("Invalid URL: {error}");
+                            std::process::exit(1);
+                        }
+                        _ => {}
+                    }
+                }
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+
+        if nav_done && first_render_done {
+            break;
+        }
+
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    if !nav_done || !first_render_done {
+        eprintln!("Timeout waiting for first render ({timeout:?})");
+        std::process::exit(1);
+    }
+
+    // ── Phase 2: trigger a 1px scroll to get TileCache which carries page_height ──
+    // The pipeline already has cached tiles; the scroll just swaps the handle type.
+    let tab_scroll = tab.clone();
+    TOKIO_RT.spawn(async move {
+        let _ = tab_scroll.send(TabCommand::MouseScroll { delta_x: 0.0, delta_y: 1.0 }).await;
+    });
+
+    let mut tile_cache_handle: Option<ExternalHandle> = None;
+    let deadline2 = Instant::now() + Duration::from_secs(5);
+
+    while Instant::now() < deadline2 {
+        while rx_redraw.try_recv().is_ok() {
+            if let Some(handle) = compositor.read().frame_for(tab_id) {
+                if matches!(handle, ExternalHandle::TileCache { .. }) {
+                    tile_cache_handle = Some(handle);
+                }
+            }
+        }
+        if tile_cache_handle.is_some() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    // ── Phase 3: composite tiles into a full-page PNG ────────────────────────────
+    let (tiles, dpr, page_height_f) = match tile_cache_handle {
+        Some(ExternalHandle::TileCache { tiles, dpr, page_height, .. }) => (tiles, dpr, page_height),
+        _ => {
+            // TileCache unavailable (e.g. the page is too short to scroll).
+            // Fall back: grab whatever the compositor has and crop at the content rows.
+            eprintln!("TileCache not available; falling back to composited frame.");
+            let handle = compositor.read().frame_for(tab_id).unwrap_or_else(|| {
+                eprintln!("No rendered frame available.");
+                std::process::exit(1);
+            });
+            match handle {
+                ExternalHandle::CpuPixelsOwned { width, height, stride, pixels, .. } => {
+                    let actual_h = crop_height(&pixels, width, height, stride as usize);
+                    eprintln!("Saving {}x{} (cropped from {})", width, actual_h, height);
+                    save_argb32_as_png(&pixels, width, actual_h, stride as usize, &output);
+                    return;
+                }
+                _ => {
+                    eprintln!("Unexpected handle type");
+                    std::process::exit(1);
+                }
+            }
+        }
+    };
+
+    let page_h = (page_height_f.ceil() as u32).min(MAX_PAGE_HEIGHT).max(1);
+    let dpr_f = dpr as f64;
+
+    eprintln!("Page size: {}×{} CSS px (DPR {}). Compositing {} tile(s)…",
+        viewport_w, page_h, dpr, tiles.len());
+
+    // Composite all tiles at their page-coordinate positions onto a surface covering
+    // the full page (scroll offset = 0).
+    let surface = ImageSurface::create(Format::ARgb32, viewport_w as i32, page_h as i32)
+        .expect("ImageSurface create");
+    let cr = Context::new(&surface).expect("Cairo context");
+
+    cr.set_source_rgb(1.0, 1.0, 1.0);
+    cr.rectangle(0.0, 0.0, viewport_w as f64, page_h as f64);
+    cr.fill().unwrap_or_default();
+
+    for tile in tiles.iter() {
+        // SAFETY: tile.data is Arc-owned and lives for this compositing call.
+        let tile_surface = unsafe {
+            gtk4::cairo::ImageSurface::create_for_data_unsafe(
+                tile.data.as_ptr() as *mut u8,
+                Format::ARgb32,
+                tile.width as i32,
+                tile.height as i32,
+                (tile.width * 4) as i32,
+            )
+        };
+        if let Ok(ts) = tile_surface {
+            ts.set_device_scale(dpr_f, dpr_f);
+            cr.set_source_surface(&ts, tile.page_x as f64, tile.page_y as f64).unwrap_or_default();
+            cr.paint().unwrap_or_default();
+        }
+    }
+    drop(cr);
+    surface.flush();
+
+    let mut surface = surface;
+    let stride = surface.stride() as usize;
+    let raw = surface.data().expect("surface data");
+    save_argb32_as_png(&raw, viewport_w, page_h, stride, &output);
+}
+
+/// Detect the last row that contains non-white pixels (for fallback cropping).
+fn crop_height(pixels: &[u8], width: u32, height: u32, stride: usize) -> u32 {
+    for row in (0..height as usize).rev() {
+        for col in 0..width as usize {
+            let off = row * stride + col * 4;
+            let b = pixels[off];
+            let g = pixels[off + 1];
+            let r = pixels[off + 2];
+            if r != 255 || g != 255 || b != 255 {
+                return (row + 1) as u32;
+            }
+        }
+    }
+    height
+}
+
+/// Convert ARgb32 (premultiplied, LE: B G R A bytes) → RGBA8 straight-alpha and save as PNG.
+fn save_argb32_as_png(pixels: &[u8], width: u32, height: u32, stride: usize, path: &str) {
+    let mut rgba: Vec<u8> = Vec::with_capacity((width * height * 4) as usize);
+    for row in 0..height as usize {
+        for col in 0..width as usize {
+            let off = row * stride + col * 4;
+            let b = pixels[off];
+            let g = pixels[off + 1];
+            let r = pixels[off + 2];
+            let a = pixels[off + 3];
+            if a == 0 {
+                rgba.extend_from_slice(&[0, 0, 0, 0]);
+            } else if a == 255 {
+                rgba.extend_from_slice(&[r, g, b, 255]);
+            } else {
+                let af = a as f32 / 255.0;
+                rgba.push((r as f32 / af).min(255.0).round() as u8);
+                rgba.push((g as f32 / af).min(255.0).round() as u8);
+                rgba.push((b as f32 / af).min(255.0).round() as u8);
+                rgba.push(a);
+            }
+        }
+    }
+    image::save_buffer(path, &rgba, width, height, ColorType::Rgba8).expect("save PNG");
+    eprintln!("Saved {path} ({}×{})", width, height);
+}

--- a/examples/pipeline-screenshot/main.rs
+++ b/examples/pipeline-screenshot/main.rs
@@ -44,7 +44,11 @@ fn main() {
     simple_logger::init_with_env().unwrap_or_default();
 
     let args: Vec<String> = std::env::args().collect();
-    let url_str = args.get(1).map(|s| s.as_str()).unwrap_or("https://example.com").to_string();
+    let url_str = args
+        .get(1)
+        .map(|s| s.as_str())
+        .unwrap_or("https://example.com")
+        .to_string();
     let output = args.get(2).map(|s| s.as_str()).unwrap_or("screenshot.png").to_string();
     let viewport_w: u32 = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(1280);
 
@@ -107,12 +111,14 @@ fn main() {
     // which carries page_height — then we composite only the real content rows.
     let tab_nav = tab.clone();
     TOKIO_RT.spawn(async move {
-        let _ = tab_nav.send(TabCommand::SetViewport {
-            x: 0,
-            y: 0,
-            width: viewport_w,
-            height: MAX_PAGE_HEIGHT,
-        }).await;
+        let _ = tab_nav
+            .send(TabCommand::SetViewport {
+                x: 0,
+                y: 0,
+                width: viewport_w,
+                height: MAX_PAGE_HEIGHT,
+            })
+            .await;
         let _ = tab_nav.send(TabCommand::Navigate { url: url.to_string() }).await;
         let _ = tab_nav.send(TabCommand::ResumeDrawing { fps: 30 }).await;
     });
@@ -135,23 +141,21 @@ fn main() {
 
         loop {
             match event_rx.try_recv() {
-                Ok(EngineEvent::Navigation { tab_id: tid, event }) if tid == tab_id => {
-                    match event {
-                        NavigationEvent::Finished { .. } => {
-                            eprintln!("Navigation finished.");
-                            nav_done = true;
-                        }
-                        NavigationEvent::Failed { error, .. } => {
-                            eprintln!("Navigation failed: {error}");
-                            std::process::exit(1);
-                        }
-                        NavigationEvent::FailedUrl { error, .. } => {
-                            eprintln!("Invalid URL: {error}");
-                            std::process::exit(1);
-                        }
-                        _ => {}
+                Ok(EngineEvent::Navigation { tab_id: tid, event }) if tid == tab_id => match event {
+                    NavigationEvent::Finished { .. } => {
+                        eprintln!("Navigation finished.");
+                        nav_done = true;
                     }
-                }
+                    NavigationEvent::Failed { error, .. } => {
+                        eprintln!("Navigation failed: {error}");
+                        std::process::exit(1);
+                    }
+                    NavigationEvent::FailedUrl { error, .. } => {
+                        eprintln!("Invalid URL: {error}");
+                        std::process::exit(1);
+                    }
+                    _ => {}
+                },
                 Ok(_) => {}
                 Err(_) => break,
             }
@@ -173,7 +177,12 @@ fn main() {
     // The pipeline already has cached tiles; the scroll just swaps the handle type.
     let tab_scroll = tab.clone();
     TOKIO_RT.spawn(async move {
-        let _ = tab_scroll.send(TabCommand::MouseScroll { delta_x: 0.0, delta_y: 1.0 }).await;
+        let _ = tab_scroll
+            .send(TabCommand::MouseScroll {
+                delta_x: 0.0,
+                delta_y: 1.0,
+            })
+            .await;
     });
 
     let mut tile_cache_handle: Option<ExternalHandle> = None;
@@ -195,7 +204,12 @@ fn main() {
 
     // ── Phase 3: composite tiles into a full-page PNG ────────────────────────────
     let (tiles, dpr, page_height_f) = match tile_cache_handle {
-        Some(ExternalHandle::TileCache { tiles, dpr, page_height, .. }) => (tiles, dpr, page_height),
+        Some(ExternalHandle::TileCache {
+            tiles,
+            dpr,
+            page_height,
+            ..
+        }) => (tiles, dpr, page_height),
         _ => {
             // TileCache unavailable (e.g. the page is too short to scroll).
             // Fall back: grab whatever the compositor has and crop at the content rows.
@@ -205,7 +219,13 @@ fn main() {
                 std::process::exit(1);
             });
             match handle {
-                ExternalHandle::CpuPixelsOwned { width, height, stride, pixels, .. } => {
+                ExternalHandle::CpuPixelsOwned {
+                    width,
+                    height,
+                    stride,
+                    pixels,
+                    ..
+                } => {
                     let actual_h = crop_height(&pixels, width, height, stride as usize);
                     eprintln!("Saving {}x{} (cropped from {})", width, actual_h, height);
                     save_argb32_as_png(&pixels, width, actual_h, stride as usize, &output);
@@ -219,16 +239,20 @@ fn main() {
         }
     };
 
-    let page_h = (page_height_f.ceil() as u32).min(MAX_PAGE_HEIGHT).max(1);
+    let page_h = (page_height_f.ceil() as u32).clamp(1, MAX_PAGE_HEIGHT);
     let dpr_f = dpr as f64;
 
-    eprintln!("Page size: {}×{} CSS px (DPR {}). Compositing {} tile(s)…",
-        viewport_w, page_h, dpr, tiles.len());
+    eprintln!(
+        "Page size: {}×{} CSS px (DPR {}). Compositing {} tile(s)…",
+        viewport_w,
+        page_h,
+        dpr,
+        tiles.len()
+    );
 
     // Composite all tiles at their page-coordinate positions onto a surface covering
     // the full page (scroll offset = 0).
-    let surface = ImageSurface::create(Format::ARgb32, viewport_w as i32, page_h as i32)
-        .expect("ImageSurface create");
+    let surface = ImageSurface::create(Format::ARgb32, viewport_w as i32, page_h as i32).expect("ImageSurface create");
     let cr = Context::new(&surface).expect("Cairo context");
 
     cr.set_source_rgb(1.0, 1.0, 1.0);
@@ -248,7 +272,8 @@ fn main() {
         };
         if let Ok(ts) = tile_surface {
             ts.set_device_scale(dpr_f, dpr_f);
-            cr.set_source_surface(&ts, tile.page_x as f64, tile.page_y as f64).unwrap_or_default();
+            cr.set_source_surface(&ts, tile.page_x as f64, tile.page_y as f64)
+                .unwrap_or_default();
             cr.paint().unwrap_or_default();
         }
     }


### PR DESCRIPTION
Added a screenshot tool that will render a complete full website to a PNG file. You can define the width of the viewport, but the height depends on the actual size of the page. (later on we need to see how this would work with things like doomscrolling)


Part of a stacked diff series.

*Created by pancake.* 🥞

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a headless screenshot tool for rendering websites to PNG images without a graphical interface

* **Developer Tools**
  * Added a CSS property comparison utility for validating rendered styles against reference browsers

* **Improvements**
  * Enhanced error handling and diagnostic logging in Cairo and Vello renderers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gosub-io/gosub-engine/pull/1006?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->