### PR TITLE
Pipeline performance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3315,6 +3315,7 @@ dependencies = [
  "r2d2",
  "r2d2_sqlite",
  "rand 0.10.1",
+ "rayon",
  "regex",
  "reqwest",
  "serde",

--- a/crates/gosub_engine/Cargo.toml
+++ b/crates/gosub_engine/Cargo.toml
@@ -57,6 +57,7 @@ winit = { version = "0.30.12", optional = true }
 eframe = { version = "0.34.3", optional = true, features = ["wgpu"] }
 egui = { version = "0.31.0", optional = true }
 num_cpus = "1.17.0"
+rayon = "1"
 time = "0.3.41"
 tokio-util = { version = "0.7.16", features = ["io"] }
 tempfile = "3.21.0"

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -844,7 +844,7 @@ fn pipeline_composite(cache: &PipelineCache, scroll_x: f64, scroll_y: f64, vp_w:
             y: (tile.page_y - scroll_y) as f32,
             w: tile.width,
             h: tile.height,
-            data: (*tile.data).clone(),
+            data: Arc::clone(&tile.data),
         });
         blits += 1;
     }

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -593,123 +593,99 @@ fn pipeline_build_cache(
     );
 
     // Stage 6: rasterize ALL tiles → collect into BakedTile vec.
-    #[cfg(feature = "backend_cairo")]
-    let baked_tiles = {
-        use gosub_render_pipeline::common::media::MediaStore;
-        use gosub_render_pipeline::common::texture_store::TextureStore;
-        use gosub_render_pipeline::rasterizer::Rasterable;
-        use gosub_renderer_cairo::CairoRasterizer;
+    //
+    // Cairo and Skia rasterize tiles independently (no shared GPU state), so we use
+    // rayon to spread the work across all available CPU cores.  Each worker gets its
+    // own temporary TextureStore so there is zero shared mutable state in the hot loop.
+    //
+    // Three phases:
+    //   1. Collect IDs of dirty tiles (sequential — cheap iteration).
+    //   2. Rasterize each tile in parallel → Option<BakedTile>.
+    //   3. Update tile states and gather results (sequential — trivial).
+    //
+    // Vello stays sequential because all tiles share a Mutex<Renderer>; batching
+    // (not parallelism) is the fix there.
+    #[cfg(any(feature = "backend_cairo", feature = "backend_skia"))]
+    macro_rules! rasterize_parallel {
+        ($rasterizer:expr, $label:literal) => {{
+            use gosub_render_pipeline::common::media::MediaStore;
+            use gosub_render_pipeline::common::texture_store::TextureStore;
+            use gosub_render_pipeline::rasterizer::Rasterable;
+            use rayon::prelude::*;
 
-        let t = Instant::now();
-        let ts6 = timing_start!("pipeline.rasterize");
-        let media_store = MediaStore::new();
-        let mut texture_store = TextureStore::new();
-        let rasterizer = CairoRasterizer::new();
-        let mut rasterized = 0usize;
-        let mut empty = 0usize;
-        for &layer_id in &layer_ids {
-            let tile_ids = tile_list.get_intersecting_tiles(layer_id, full_page_rect);
-            for tile_id in tile_ids {
-                if let Some(tile) = tile_list.get_tile_mut(tile_id) {
-                    if tile.state == TileState::Dirty {
-                        match rasterizer.rasterize(tile, &mut texture_store, &media_store) {
-                            Some(texture_id) => {
-                                tile.texture_id = Some(texture_id);
-                                tile.state = TileState::Clean;
-                                rasterized += 1;
-                            }
-                            None => {
-                                tile.state = TileState::Empty;
-                                empty += 1;
-                            }
+            let t = Instant::now();
+            let ts6 = timing_start!("pipeline.rasterize");
+            let media_store = MediaStore::new();
+            let rasterizer = $rasterizer;
+
+            // Phase 1: collect IDs of dirty tiles across all layers.
+            let dirty_ids: Vec<TileId> = layer_ids
+                .iter()
+                .flat_map(|&layer_id| tile_list.get_intersecting_tiles(layer_id, full_page_rect))
+                .filter(|&id| tile_list.arena.get(&id).map_or(false, |t| t.state == TileState::Dirty))
+                .collect();
+
+            // Phase 2: parallel rasterization — no shared mutable state.
+            let results: Vec<(TileId, Option<BakedTile>)> = dirty_ids
+                .par_iter()
+                .map(|&tile_id| {
+                    let baked = tile_list.arena.get(&tile_id).and_then(|tile| {
+                        let mut local_store = TextureStore::new();
+                        let tex_id = rasterizer.rasterize(tile, &mut local_store, &media_store)?;
+                        let tex = local_store.get(tex_id)?;
+                        Some(BakedTile {
+                            page_x: tile.rect.x,
+                            page_y: tile.rect.y,
+                            width: tex.width as u32,
+                            height: tex.height as u32,
+                            data: Arc::clone(&tex.data),
+                        })
+                    });
+                    (tile_id, baked)
+                })
+                .collect();
+
+            // Phase 3: update tile states and gather BakedTiles (sequential).
+            let mut rasterized = 0usize;
+            let mut empty = 0usize;
+            let mut tiles: Vec<BakedTile> = Vec::with_capacity(results.len());
+            for (tile_id, baked) in results {
+                if let Some(tile) = tile_list.arena.get_mut(&tile_id) {
+                    match baked {
+                        Some(b) => {
+                            tile.state = TileState::Clean;
+                            tiles.push(b);
+                            rasterized += 1;
+                        }
+                        None => {
+                            tile.state = TileState::Empty;
+                            empty += 1;
                         }
                     }
                 }
             }
-        }
-        timing_stop!(ts6);
-        log::info!(
-            "[pipeline] stage 6 rasterize:     {:>6.1}ms  ({} clean, {} empty)",
-            t.elapsed().as_secs_f64() * 1000.0,
-            rasterized,
-            empty
-        );
 
-        // Collect all clean tiles into BakedTile structs.
-        let mut tiles: Vec<BakedTile> = Vec::with_capacity(rasterized);
-        for tile in tile_list.arena.values() {
-            if let (Some(texture_id), true) = (tile.texture_id, tile.state == TileState::Clean) {
-                if let Some(tex) = texture_store.get(texture_id) {
-                    tiles.push(BakedTile {
-                        page_x: tile.rect.x,
-                        page_y: tile.rect.y,
-                        width: tex.width as u32,
-                        height: tex.height as u32,
-                        data: Arc::clone(&tex.data),
-                    });
-                }
-            }
-        }
-        tiles
+            timing_stop!(ts6);
+            log::info!(
+                concat!("[pipeline] stage 6 rasterize ", $label, " {:>6.1}ms  ({} clean, {} empty)"),
+                t.elapsed().as_secs_f64() * 1000.0,
+                rasterized,
+                empty
+            );
+            tiles
+        }};
+    }
+
+    #[cfg(feature = "backend_cairo")]
+    let baked_tiles = {
+        use gosub_renderer_cairo::CairoRasterizer;
+        rasterize_parallel!(CairoRasterizer::new(), "(cairo):    ")
     };
 
     #[cfg(all(feature = "backend_skia", not(feature = "backend_cairo")))]
     let baked_tiles = {
-        use gosub_render_pipeline::common::media::MediaStore;
-        use gosub_render_pipeline::common::texture_store::TextureStore;
-        use gosub_render_pipeline::rasterizer::Rasterable;
         use gosub_renderer_skia::SkiaRasterizer;
-
-        let t = Instant::now();
-        let ts6 = timing_start!("pipeline.rasterize");
-        let media_store = MediaStore::new();
-        let mut texture_store = TextureStore::new();
-        let rasterizer = SkiaRasterizer::new(1.0);
-        let mut rasterized = 0usize;
-        let mut empty = 0usize;
-        for &layer_id in &layer_ids {
-            let tile_ids = tile_list.get_intersecting_tiles(layer_id, full_page_rect);
-            for tile_id in tile_ids {
-                if let Some(tile) = tile_list.get_tile_mut(tile_id) {
-                    if tile.state == TileState::Dirty {
-                        match rasterizer.rasterize(tile, &mut texture_store, &media_store) {
-                            Some(texture_id) => {
-                                tile.texture_id = Some(texture_id);
-                                tile.state = TileState::Clean;
-                                rasterized += 1;
-                            }
-                            None => {
-                                tile.state = TileState::Empty;
-                                empty += 1;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        timing_stop!(ts6);
-        log::info!(
-            "[pipeline] stage 6 rasterize (skia): {:>6.1}ms  ({} clean, {} empty)",
-            t.elapsed().as_secs_f64() * 1000.0,
-            rasterized,
-            empty
-        );
-
-        let mut tiles: Vec<BakedTile> = Vec::with_capacity(rasterized);
-        for tile in tile_list.arena.values() {
-            if let (Some(texture_id), true) = (tile.texture_id, tile.state == TileState::Clean) {
-                if let Some(tex) = texture_store.get(texture_id) {
-                    tiles.push(BakedTile {
-                        page_x: tile.rect.x,
-                        page_y: tile.rect.y,
-                        width: tex.width as u32,
-                        height: tex.height as u32,
-                        data: Arc::clone(&tex.data),
-                    });
-                }
-            }
-        }
-        tiles
+        rasterize_parallel!(SkiaRasterizer::new(1.0), "(skia):     ")
     };
 
     #[cfg(all(

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -272,7 +272,9 @@ impl BrowsingContext {
         }
         if self.render_dirty {
             if let Some(doc) = &self.document {
-                let prev_tile_cache = self.pipeline_cache.as_mut()
+                let prev_tile_cache = self
+                    .pipeline_cache
+                    .as_mut()
                     .map(|c| std::mem::take(&mut c.tile_pixel_cache))
                     .unwrap_or_default();
                 self.pipeline_cache = Some(pipeline_build_cache(
@@ -303,7 +305,9 @@ impl BrowsingContext {
         {
             if self.render_dirty {
                 if let Some(doc) = &self.document {
-                    let prev_tile_cache = self.pipeline_cache.as_mut()
+                    let prev_tile_cache = self
+                        .pipeline_cache
+                        .as_mut()
                         .map(|c| std::mem::take(&mut c.tile_pixel_cache))
                         .unwrap_or_default();
                     self.pipeline_cache = Some(pipeline_build_cache(
@@ -480,69 +484,130 @@ impl RenderContext for BrowsingContext {
 #[cfg(any(feature = "backend_cairo", feature = "backend_skia"))]
 fn tile_cache_key(tile: &gosub_render_pipeline::tiler::Tile) -> TileCacheKey {
     use gosub_render_pipeline::painter::commands::{
-        PaintCommand,
         border::{BorderRadius, BorderStyle},
         brush::Brush,
+        PaintCommand,
     };
 
     // Minimal inline FNV-1a hasher — no trait bounds needed on the types being hashed.
     let mut h: u64 = 14695981039346656037;
     macro_rules! fnv {
         ($bytes:expr) => {
-            for b in $bytes { h ^= *b as u64; h = h.wrapping_mul(1099511628211); }
+            for b in $bytes {
+                h ^= *b as u64;
+                h = h.wrapping_mul(1099511628211);
+            }
         };
     }
-    macro_rules! hf32  { ($v:expr) => { fnv!(&$v.to_bits().to_le_bytes()) } }
-    macro_rules! hf64  { ($v:expr) => { fnv!(&$v.to_bits().to_le_bytes()) } }
-    macro_rules! hu64  { ($v:expr) => { fnv!(&($v as u64).to_le_bytes()) } }
-    macro_rules! hbool { ($v:expr) => { fnv!(&[$v as u8]) } }
-    macro_rules! hstr  { ($s:expr) => { fnv!($s.as_bytes()); fnv!(&[0u8]) } }
+    macro_rules! hf32 {
+        ($v:expr) => {
+            fnv!(&$v.to_bits().to_le_bytes())
+        };
+    }
+    macro_rules! hf64 {
+        ($v:expr) => {
+            fnv!(&$v.to_bits().to_le_bytes())
+        };
+    }
+    macro_rules! hu64 {
+        ($v:expr) => {
+            fnv!(&($v as u64).to_le_bytes())
+        };
+    }
+    macro_rules! hbool {
+        ($v:expr) => {
+            fnv!(&[$v as u8])
+        };
+    }
+    macro_rules! hstr {
+        ($s:expr) => {
+            fnv!($s.as_bytes());
+            fnv!(&[0u8])
+        };
+    }
 
     macro_rules! hash_brush {
         ($b:expr) => {
             match $b {
-                Brush::Solid(c) => { fnv!(&[0]); hf32!(c.r()); hf32!(c.g()); hf32!(c.b()); hf32!(c.a()); }
-                Brush::Image(m) => { fnv!(&[1]); hu64!(m.as_u64()); }
+                Brush::Solid(c) => {
+                    fnv!(&[0]);
+                    hf32!(c.r());
+                    hf32!(c.g());
+                    hf32!(c.b());
+                    hf32!(c.a());
+                }
+                Brush::Image(m) => {
+                    fnv!(&[1]);
+                    hu64!(m.as_u64());
+                }
             }
         };
     }
 
     // Hash tile background.
     match tile.bgcolor {
-        Some((r, g, b, a)) => { hbool!(true); hf32!(r); hf32!(g); hf32!(b); hf32!(a); }
+        Some((r, g, b, a)) => {
+            hbool!(true);
+            hf32!(r);
+            hf32!(g);
+            hf32!(b);
+            hf32!(a);
+        }
         None => hbool!(false),
     }
 
     for elem in &tile.elements {
         hu64!(elem.id.as_u64());
-        hf64!(elem.rect.x); hf64!(elem.rect.y); hf64!(elem.rect.width); hf64!(elem.rect.height);
+        hf64!(elem.rect.x);
+        hf64!(elem.rect.y);
+        hf64!(elem.rect.width);
+        hf64!(elem.rect.height);
 
         for cmd in &elem.paint_commands {
             match cmd {
                 PaintCommand::Rectangle(r) => {
                     fnv!(&[0u8]);
                     let rect = r.rect();
-                    hf64!(rect.x); hf64!(rect.y); hf64!(rect.width); hf64!(rect.height);
+                    hf64!(rect.x);
+                    hf64!(rect.y);
+                    hf64!(rect.width);
+                    hf64!(rect.height);
                     match r.background() {
                         None => hbool!(false),
-                        Some(b) => { hbool!(true); hash_brush!(b); }
+                        Some(b) => {
+                            hbool!(true);
+                            hash_brush!(b);
+                        }
                     }
                     let border = r.border();
                     hf32!(border.width());
                     fnv!(&[match border.style() {
-                        BorderStyle::Solid => 1, BorderStyle::Dashed => 2, BorderStyle::Dotted => 3,
-                        BorderStyle::Double => 4, BorderStyle::Groove => 5, BorderStyle::Ridge => 6,
-                        BorderStyle::Inset => 7, BorderStyle::Outset => 8, BorderStyle::Hidden => 9,
+                        BorderStyle::Solid => 1,
+                        BorderStyle::Dashed => 2,
+                        BorderStyle::Dotted => 3,
+                        BorderStyle::Double => 4,
+                        BorderStyle::Groove => 5,
+                        BorderStyle::Ridge => 6,
+                        BorderStyle::Inset => 7,
+                        BorderStyle::Outset => 8,
+                        BorderStyle::Hidden => 9,
                         BorderStyle::None => 0,
                     }]);
-                    for b in border.brushes() { hash_brush!(&b); }
+                    for b in border.brushes() {
+                        hash_brush!(&b);
+                    }
                     if let Some(tr) = border.radius() {
                         hbool!(true);
                         for br in [&tr.top, &tr.right, &tr.bottom, &tr.left] {
                             match br {
-                                BorderRadius::Uniform(v) => { fnv!(&[0]); hf32!(*v); }
+                                BorderRadius::Uniform(v) => {
+                                    fnv!(&[0]);
+                                    hf32!(*v);
+                                }
                                 BorderRadius::Elliptical { horizontal, vertical } => {
-                                    fnv!(&[1]); hf32!(*horizontal); hf32!(*vertical);
+                                    fnv!(&[1]);
+                                    hf32!(*horizontal);
+                                    hf32!(*vertical);
                                 }
                             }
                         }
@@ -550,13 +615,22 @@ fn tile_cache_key(tile: &gosub_render_pipeline::tiler::Tile) -> TileCacheKey {
                         hbool!(false);
                     }
                     let (tl, tr, br, bl) = r.radius_x();
-                    hf64!(tl); hf64!(tr); hf64!(br); hf64!(bl);
+                    hf64!(tl);
+                    hf64!(tr);
+                    hf64!(br);
+                    hf64!(bl);
                     let (tl, tr, br, bl) = r.radius_y();
-                    hf64!(tl); hf64!(tr); hf64!(br); hf64!(bl);
+                    hf64!(tl);
+                    hf64!(tr);
+                    hf64!(br);
+                    hf64!(bl);
                 }
                 PaintCommand::Text(t) => {
                     fnv!(&[1u8]);
-                    hf64!(t.rect.x); hf64!(t.rect.y); hf64!(t.rect.width); hf64!(t.rect.height);
+                    hf64!(t.rect.x);
+                    hf64!(t.rect.y);
+                    hf64!(t.rect.width);
+                    hf64!(t.rect.height);
                     hstr!(&t.text);
                     hstr!(&t.font_info.family);
                     hf64!(t.font_info.size);
@@ -572,7 +646,10 @@ fn tile_cache_key(tile: &gosub_render_pipeline::tiler::Tile) -> TileCacheKey {
                     fnv!(&[2u8]);
                     hu64!(s.media_id.as_u64());
                     let rect = s.rect.rect();
-                    hf64!(rect.x); hf64!(rect.y); hf64!(rect.width); hf64!(rect.height);
+                    hf64!(rect.x);
+                    hf64!(rect.y);
+                    hf64!(rect.width);
+                    hf64!(rect.height);
                 }
             }
         }
@@ -777,7 +854,8 @@ fn pipeline_build_cache(
 
                     // Cache miss: rasterize and emit a new cache entry.
                     let mut local_store = TextureStore::new();
-                    let baked = rasterizer.rasterize(tile, &mut local_store, &media_store)
+                    let baked = rasterizer
+                        .rasterize(tile, &mut local_store, &media_store)
                         .and_then(|tid| local_store.get(tid))
                         .map(|tex| BakedTile {
                             page_x: tile.rect.x,
@@ -787,8 +865,7 @@ fn pipeline_build_cache(
                             data: Arc::clone(&tex.data),
                         });
 
-                    let cache_entry = baked.as_ref()
-                        .map(|b| (key, (b.width, b.height, Arc::clone(&b.data))));
+                    let cache_entry = baked.as_ref().map(|b| (key, (b.width, b.height, Arc::clone(&b.data))));
                     (tile_id, baked, cache_entry)
                 })
                 .collect();
@@ -824,7 +901,11 @@ fn pipeline_build_cache(
 
             timing_stop!(ts6);
             log::info!(
-                concat!("[pipeline] stage 6 rasterize ", $label, " {:>6.1}ms  ({} rasterized, {} hits, {} empty)"),
+                concat!(
+                    "[pipeline] stage 6 rasterize ",
+                    $label,
+                    " {:>6.1}ms  ({} rasterized, {} hits, {} empty)"
+                ),
                 t.elapsed().as_secs_f64() * 1000.0,
                 rasterized,
                 cache_hits,
@@ -916,7 +997,11 @@ fn pipeline_build_cache(
         tiles
     };
     // Vello uses sequential rasterization; dirty-tile cache not yet implemented.
-    #[cfg(all(feature = "backend_vello", not(feature = "backend_cairo"), not(feature = "backend_skia")))]
+    #[cfg(all(
+        feature = "backend_vello",
+        not(feature = "backend_cairo"),
+        not(feature = "backend_skia")
+    ))]
     let new_tile_cache: std::collections::HashMap<TileCacheKey, (u32, u32, Arc<Vec<u8>>)> =
         std::collections::HashMap::new();
 

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -589,7 +589,7 @@ fn tile_cache_key(tile: &gosub_render_pipeline::tiler::Tile) -> TileCacheKey {
 fn pipeline_build_cache(
     doc: Arc<EngineDocument>,
     viewport: &Viewport,
-    #[cfg(feature = "backend_vello")] vello_resources: Option<
+    #[cfg(feature = "backend_vello")] _vello_resources: Option<
         std::sync::Arc<gosub_render_pipeline::render::backends::vello::WgpuResources>,
     >,
     prev_tile_cache: std::collections::HashMap<TileCacheKey, (u32, u32, Arc<Vec<u8>>)>,
@@ -864,7 +864,7 @@ fn pipeline_build_cache(
         let mut rasterized = 0usize;
         let mut empty = 0usize;
 
-        let tiles = if let Some(ref resources) = vello_resources {
+        let tiles = if let Some(ref resources) = _vello_resources {
             let rasterizer = VelloRasterizer::new(std::sync::Arc::clone(resources));
             for &layer_id in &layer_ids {
                 let tile_ids = tile_list.get_intersecting_tiles(layer_id, full_page_rect);

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -645,7 +645,7 @@ fn pipeline_build_cache(
                         page_y: tile.rect.y,
                         width: tex.width as u32,
                         height: tex.height as u32,
-                        data: Arc::new(tex.data.clone()),
+                        data: Arc::clone(&tex.data),
                     });
                 }
             }
@@ -704,7 +704,7 @@ fn pipeline_build_cache(
                         page_y: tile.rect.y,
                         width: tex.width as u32,
                         height: tex.height as u32,
-                        data: Arc::new(tex.data.clone()),
+                        data: Arc::clone(&tex.data),
                     });
                 }
             }
@@ -761,7 +761,7 @@ fn pipeline_build_cache(
                             page_y: tile.rect.y,
                             width: tex.width as u32,
                             height: tex.height as u32,
-                            data: Arc::new(tex.data.clone()),
+                            data: Arc::clone(&tex.data),
                         });
                     }
                 }

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -68,6 +68,11 @@ struct BakedTile {
     data: Arc<Vec<u8>>,
 }
 
+/// Key that uniquely identifies a tile's content for cache lookup.
+/// Format: (page_x bits, page_y bits, layer_id, paint-command hash).
+#[cfg(feature = "pipeline")]
+type TileCacheKey = (u64, u64, u64, u64);
+
 /// Cached output of stages 1–6 for the whole page. Re-used on every scroll tick.
 #[cfg(feature = "pipeline")]
 struct PipelineCache {
@@ -77,6 +82,10 @@ struct PipelineCache {
     cached_tiles: Arc<Vec<CachedTile>>,
     /// Layer list retained for hit-testing (hover).
     layer_list: Arc<LayerList>,
+    /// Rasterized tile data keyed by (page_x, page_y, layer_id, content_hash).
+    /// Passed to the next render so unchanged tiles skip rasterization.
+    /// Value is (physical_width, physical_height, pixel_data).
+    tile_pixel_cache: std::collections::HashMap<TileCacheKey, (u32, u32, Arc<Vec<u8>>)>,
 }
 
 /// BrowsingContext dedicated to a specific tab
@@ -263,11 +272,15 @@ impl BrowsingContext {
         }
         if self.render_dirty {
             if let Some(doc) = &self.document {
+                let prev_tile_cache = self.pipeline_cache.as_mut()
+                    .map(|c| std::mem::take(&mut c.tile_pixel_cache))
+                    .unwrap_or_default();
                 self.pipeline_cache = Some(pipeline_build_cache(
                     doc.clone(),
                     &self.viewport,
                     #[cfg(feature = "backend_vello")]
                     self.vello_resources.clone(),
+                    prev_tile_cache,
                 ));
             }
             self.render_dirty = false;
@@ -290,11 +303,15 @@ impl BrowsingContext {
         {
             if self.render_dirty {
                 if let Some(doc) = &self.document {
+                    let prev_tile_cache = self.pipeline_cache.as_mut()
+                        .map(|c| std::mem::take(&mut c.tile_pixel_cache))
+                        .unwrap_or_default();
                     self.pipeline_cache = Some(pipeline_build_cache(
                         doc.clone(),
                         &self.viewport,
                         #[cfg(feature = "backend_vello")]
                         self.vello_resources.clone(),
+                        prev_tile_cache,
                     ));
                 }
                 self.render_dirty = false;
@@ -458,6 +475,112 @@ impl RenderContext for BrowsingContext {
 }
 
 /// Runs pipeline stages 1–6 for the **entire page** (all tiles, not just the viewport slice)
+/// Compute a stable cache key for a tile: (page_x bits, page_y bits, layer_id, content hash).
+/// The content hash covers all paint commands so any visual change produces a different key.
+#[cfg(any(feature = "backend_cairo", feature = "backend_skia"))]
+fn tile_cache_key(tile: &gosub_render_pipeline::tiler::Tile) -> TileCacheKey {
+    use gosub_render_pipeline::painter::commands::{
+        PaintCommand,
+        border::{BorderRadius, BorderStyle},
+        brush::Brush,
+    };
+
+    // Minimal inline FNV-1a hasher — no trait bounds needed on the types being hashed.
+    let mut h: u64 = 14695981039346656037;
+    macro_rules! fnv {
+        ($bytes:expr) => {
+            for b in $bytes { h ^= *b as u64; h = h.wrapping_mul(1099511628211); }
+        };
+    }
+    macro_rules! hf32  { ($v:expr) => { fnv!(&$v.to_bits().to_le_bytes()) } }
+    macro_rules! hf64  { ($v:expr) => { fnv!(&$v.to_bits().to_le_bytes()) } }
+    macro_rules! hu64  { ($v:expr) => { fnv!(&($v as u64).to_le_bytes()) } }
+    macro_rules! hbool { ($v:expr) => { fnv!(&[$v as u8]) } }
+    macro_rules! hstr  { ($s:expr) => { fnv!($s.as_bytes()); fnv!(&[0u8]) } }
+
+    macro_rules! hash_brush {
+        ($b:expr) => {
+            match $b {
+                Brush::Solid(c) => { fnv!(&[0]); hf32!(c.r()); hf32!(c.g()); hf32!(c.b()); hf32!(c.a()); }
+                Brush::Image(m) => { fnv!(&[1]); hu64!(m.as_u64()); }
+            }
+        };
+    }
+
+    // Hash tile background.
+    match tile.bgcolor {
+        Some((r, g, b, a)) => { hbool!(true); hf32!(r); hf32!(g); hf32!(b); hf32!(a); }
+        None => hbool!(false),
+    }
+
+    for elem in &tile.elements {
+        hu64!(elem.id.as_u64());
+        hf64!(elem.rect.x); hf64!(elem.rect.y); hf64!(elem.rect.width); hf64!(elem.rect.height);
+
+        for cmd in &elem.paint_commands {
+            match cmd {
+                PaintCommand::Rectangle(r) => {
+                    fnv!(&[0u8]);
+                    let rect = r.rect();
+                    hf64!(rect.x); hf64!(rect.y); hf64!(rect.width); hf64!(rect.height);
+                    match r.background() {
+                        None => hbool!(false),
+                        Some(b) => { hbool!(true); hash_brush!(b); }
+                    }
+                    let border = r.border();
+                    hf32!(border.width());
+                    fnv!(&[match border.style() {
+                        BorderStyle::Solid => 1, BorderStyle::Dashed => 2, BorderStyle::Dotted => 3,
+                        BorderStyle::Double => 4, BorderStyle::Groove => 5, BorderStyle::Ridge => 6,
+                        BorderStyle::Inset => 7, BorderStyle::Outset => 8, BorderStyle::Hidden => 9,
+                        BorderStyle::None => 0,
+                    }]);
+                    for b in border.brushes() { hash_brush!(&b); }
+                    if let Some(tr) = border.radius() {
+                        hbool!(true);
+                        for br in [&tr.top, &tr.right, &tr.bottom, &tr.left] {
+                            match br {
+                                BorderRadius::Uniform(v) => { fnv!(&[0]); hf32!(*v); }
+                                BorderRadius::Elliptical { horizontal, vertical } => {
+                                    fnv!(&[1]); hf32!(*horizontal); hf32!(*vertical);
+                                }
+                            }
+                        }
+                    } else {
+                        hbool!(false);
+                    }
+                    let (tl, tr, br, bl) = r.radius_x();
+                    hf64!(tl); hf64!(tr); hf64!(br); hf64!(bl);
+                    let (tl, tr, br, bl) = r.radius_y();
+                    hf64!(tl); hf64!(tr); hf64!(br); hf64!(bl);
+                }
+                PaintCommand::Text(t) => {
+                    fnv!(&[1u8]);
+                    hf64!(t.rect.x); hf64!(t.rect.y); hf64!(t.rect.width); hf64!(t.rect.height);
+                    hstr!(&t.text);
+                    hstr!(&t.font_info.family);
+                    hf64!(t.font_info.size);
+                    hf64!(t.font_info.line_height);
+                    hu64!(t.font_info.weight as u64);
+                    hu64!(t.font_info.width as u64);
+                    hu64!(t.font_info.slant as u64);
+                    hbool!(t.font_info.underline);
+                    hbool!(t.font_info.line_through);
+                    hash_brush!(&t.brush);
+                }
+                PaintCommand::Svg(s) => {
+                    fnv!(&[2u8]);
+                    hu64!(s.media_id.as_u64());
+                    let rect = s.rect.rect();
+                    hf64!(rect.x); hf64!(rect.y); hf64!(rect.width); hf64!(rect.height);
+                }
+            }
+        }
+    }
+
+    (tile.rect.x.to_bits(), tile.rect.y.to_bits(), tile.layer_id.as_u64(), h)
+}
+
 /// and returns a `PipelineCache` of rasterized tiles ready for repeated compositing.
 ///
 /// Splitting the full pipeline from compositing lets scroll re-use the cached tiles without
@@ -466,9 +589,10 @@ impl RenderContext for BrowsingContext {
 fn pipeline_build_cache(
     doc: Arc<EngineDocument>,
     viewport: &Viewport,
-    #[cfg(feature = "backend_vello")] _vello_resources: Option<
+    #[cfg(feature = "backend_vello")] vello_resources: Option<
         std::sync::Arc<gosub_render_pipeline::render::backends::vello::WgpuResources>,
     >,
+    prev_tile_cache: std::collections::HashMap<TileCacheKey, (u32, u32, Arc<Vec<u8>>)>,
 ) -> PipelineCache {
     use gosub_render_pipeline::common::browser_state::{BrowserState, WireframeState};
     use gosub_render_pipeline::common::document::pipeline_doc::GosubDocumentAdapter;
@@ -478,7 +602,7 @@ fn pipeline_build_cache(
     use gosub_render_pipeline::layouter::CanLayout;
     use gosub_render_pipeline::painter::Painter;
     use gosub_render_pipeline::rendertree_builder::RenderTree;
-    use gosub_render_pipeline::tiler::{TileList, TileState};
+    use gosub_render_pipeline::tiler::{TileId, TileList, TileState};
     use gosub_shared::{timing_start, timing_stop};
     use std::time::Instant;
 
@@ -625,37 +749,70 @@ fn pipeline_build_cache(
                 .filter(|&id| tile_list.arena.get(&id).map_or(false, |t| t.state == TileState::Dirty))
                 .collect();
 
-            // Phase 2: parallel rasterization — no shared mutable state.
-            let results: Vec<(TileId, Option<BakedTile>)> = dirty_ids
+            // Phase 2: parallel rasterization with dirty-tile cache.
+            // For each tile: compute a content hash; if it matches the previous render's cached
+            // pixels, reuse them (cache hit). Otherwise rasterize on this thread.
+            // Result: (tile_id, Option<BakedTile>, Option<new_cache_entry>)
+            type CacheEntry = (TileCacheKey, (u32, u32, Arc<Vec<u8>>));
+            let results: Vec<(TileId, Option<BakedTile>, Option<CacheEntry>)> = dirty_ids
                 .par_iter()
                 .map(|&tile_id| {
-                    let baked = tile_list.arena.get(&tile_id).and_then(|tile| {
-                        let mut local_store = TextureStore::new();
-                        let tex_id = rasterizer.rasterize(tile, &mut local_store, &media_store)?;
-                        let tex = local_store.get(tex_id)?;
-                        Some(BakedTile {
+                    let Some(tile) = tile_list.arena.get(&tile_id) else {
+                        return (tile_id, None, None);
+                    };
+
+                    let key = tile_cache_key(tile);
+
+                    // Cache hit: same content as the previous render — reuse pixels.
+                    if let Some(&(w, h, ref data)) = prev_tile_cache.get(&key) {
+                        let baked = BakedTile {
+                            page_x: tile.rect.x,
+                            page_y: tile.rect.y,
+                            width: w,
+                            height: h,
+                            data: Arc::clone(data),
+                        };
+                        return (tile_id, Some(baked), None);
+                    }
+
+                    // Cache miss: rasterize and emit a new cache entry.
+                    let mut local_store = TextureStore::new();
+                    let baked = rasterizer.rasterize(tile, &mut local_store, &media_store)
+                        .and_then(|tid| local_store.get(tid))
+                        .map(|tex| BakedTile {
                             page_x: tile.rect.x,
                             page_y: tile.rect.y,
                             width: tex.width as u32,
                             height: tex.height as u32,
                             data: Arc::clone(&tex.data),
-                        })
-                    });
-                    (tile_id, baked)
+                        });
+
+                    let cache_entry = baked.as_ref()
+                        .map(|b| (key, (b.width, b.height, Arc::clone(&b.data))));
+                    (tile_id, baked, cache_entry)
                 })
                 .collect();
 
-            // Phase 3: update tile states and gather BakedTiles (sequential).
+            // Phase 3: update tile states, gather BakedTiles, and build the new tile cache.
             let mut rasterized = 0usize;
+            let mut cache_hits = 0usize;
             let mut empty = 0usize;
             let mut tiles: Vec<BakedTile> = Vec::with_capacity(results.len());
-            for (tile_id, baked) in results {
+            let mut new_tile_cache: std::collections::HashMap<TileCacheKey, (u32, u32, Arc<Vec<u8>>)> =
+                std::collections::HashMap::with_capacity(results.len());
+
+            for (tile_id, baked, cache_entry) in results {
                 if let Some(tile) = tile_list.arena.get_mut(&tile_id) {
                     match baked {
                         Some(b) => {
                             tile.state = TileState::Clean;
+                            if let Some(entry) = cache_entry {
+                                new_tile_cache.insert(entry.0, entry.1);
+                                rasterized += 1;
+                            } else {
+                                cache_hits += 1;
+                            }
                             tiles.push(b);
-                            rasterized += 1;
                         }
                         None => {
                             tile.state = TileState::Empty;
@@ -667,23 +824,24 @@ fn pipeline_build_cache(
 
             timing_stop!(ts6);
             log::info!(
-                concat!("[pipeline] stage 6 rasterize ", $label, " {:>6.1}ms  ({} clean, {} empty)"),
+                concat!("[pipeline] stage 6 rasterize ", $label, " {:>6.1}ms  ({} rasterized, {} hits, {} empty)"),
                 t.elapsed().as_secs_f64() * 1000.0,
                 rasterized,
+                cache_hits,
                 empty
             );
-            tiles
+            (tiles, new_tile_cache)
         }};
     }
 
     #[cfg(feature = "backend_cairo")]
-    let baked_tiles = {
+    let (baked_tiles, new_tile_cache) = {
         use gosub_renderer_cairo::CairoRasterizer;
         rasterize_parallel!(CairoRasterizer::new(), "(cairo):    ")
     };
 
     #[cfg(all(feature = "backend_skia", not(feature = "backend_cairo")))]
-    let baked_tiles = {
+    let (baked_tiles, new_tile_cache) = {
         use gosub_renderer_skia::SkiaRasterizer;
         rasterize_parallel!(SkiaRasterizer::new(1.0), "(skia):     ")
     };
@@ -706,7 +864,7 @@ fn pipeline_build_cache(
         let mut rasterized = 0usize;
         let mut empty = 0usize;
 
-        let tiles = if let Some(ref resources) = _vello_resources {
+        let tiles = if let Some(ref resources) = vello_resources {
             let rasterizer = VelloRasterizer::new(std::sync::Arc::clone(resources));
             for &layer_id in &layer_ids {
                 let tile_ids = tile_list.get_intersecting_tiles(layer_id, full_page_rect);
@@ -757,9 +915,16 @@ fn pipeline_build_cache(
         );
         tiles
     };
+    // Vello uses sequential rasterization; dirty-tile cache not yet implemented.
+    #[cfg(all(feature = "backend_vello", not(feature = "backend_cairo"), not(feature = "backend_skia")))]
+    let new_tile_cache: std::collections::HashMap<TileCacheKey, (u32, u32, Arc<Vec<u8>>)> =
+        std::collections::HashMap::new();
 
     #[cfg(not(any(feature = "backend_cairo", feature = "backend_skia", feature = "backend_vello")))]
     let baked_tiles: Vec<BakedTile> = Vec::new();
+    #[cfg(not(any(feature = "backend_cairo", feature = "backend_skia", feature = "backend_vello")))]
+    let new_tile_cache: std::collections::HashMap<TileCacheKey, (u32, u32, Arc<Vec<u8>>)> =
+        std::collections::HashMap::new();
 
     timing_stop!(ts_total);
     log::info!(
@@ -787,6 +952,7 @@ fn pipeline_build_cache(
         page_height,
         cached_tiles,
         layer_list: saved_layer_list,
+        tile_pixel_cache: new_tile_cache,
     }
 }
 

--- a/crates/gosub_render_pipeline/src/common/media/media.rs
+++ b/crates/gosub_render_pipeline/src/common/media/media.rs
@@ -10,6 +10,9 @@ impl MediaId {
     pub const fn new(val: u64) -> Self {
         Self(val)
     }
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
 }
 
 impl std::fmt::Display for MediaId {

--- a/crates/gosub_render_pipeline/src/common/texture.rs
+++ b/crates/gosub_render_pipeline/src/common/texture.rs
@@ -25,13 +25,12 @@ impl std::fmt::Display for TextureId {
     }
 }
 
-// Texture is a simple structure that holds the texture data. It's raw data, width, height and an id.
-// Note that we do not specify what the data contains. It could be a specific image format from the
-// used painting backend (like ImageSurface data for cairo)
+/// Raw pixel buffer produced by a rasterizer. Data is Arc-wrapped so it can be shared
+/// zero-copy into BakedTile / CachedTile without any pixel buffer copies.
 #[derive(Debug)]
 pub struct Texture {
     pub id: TextureId,
     pub width: usize,
     pub height: usize,
-    pub data: Vec<u8>,
+    pub data: std::sync::Arc<Vec<u8>>,
 }

--- a/crates/gosub_render_pipeline/src/common/texture_store.rs
+++ b/crates/gosub_render_pipeline/src/common/texture_store.rs
@@ -29,7 +29,7 @@ impl TextureStore {
             id: self.next_id(),
             width,
             height,
-            data,
+            data: std::sync::Arc::new(data),
         };
 
         let id = texture.id;

--- a/crates/gosub_render_pipeline/src/layering/layer.rs
+++ b/crates/gosub_render_pipeline/src/layering/layer.rs
@@ -12,6 +12,9 @@ impl LayerId {
     pub const fn new(val: u64) -> Self {
         Self(val)
     }
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
 }
 
 impl AddAssign<u64> for LayerId {

--- a/crates/gosub_render_pipeline/src/layouter.rs
+++ b/crates/gosub_render_pipeline/src/layouter.rs
@@ -22,6 +22,9 @@ impl LayoutElementId {
     pub const fn new(val: u64) -> Self {
         Self(val)
     }
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
 }
 
 impl AddAssign<u64> for LayoutElementId {

--- a/crates/gosub_render_pipeline/src/painter/commands.rs
+++ b/crates/gosub_render_pipeline/src/painter/commands.rs
@@ -12,10 +12,10 @@ pub mod text;
 /// Generic that defines a top, right, bottom, and left value.
 #[derive(Clone, Debug)]
 pub struct Trbl<T> {
-    top: T,
-    right: T,
-    bottom: T,
-    left: T,
+    pub top: T,
+    pub right: T,
+    pub bottom: T,
+    pub left: T,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/gosub_render_pipeline/src/render/backends/skia.rs
+++ b/crates/gosub_render_pipeline/src/render/backends/skia.rs
@@ -7,6 +7,10 @@ use anyhow::{anyhow, Result};
 use skia_safe::{Color4f, Font, FontMgr, FontStyle, Paint, Rect};
 use std::any::Any;
 
+thread_local! {
+    static FONT_MGR: FontMgr = FontMgr::new();
+}
+
 #[derive(Default)]
 pub struct SkiaBackend;
 
@@ -52,21 +56,11 @@ impl RenderBackend for SkiaBackend {
                         paint.set_anti_alias(true);
                         canvas.draw_rect(Rect::new(*x, *y, x + w, y + h), &paint);
                     }
-                    DisplayItem::TextRun {
-                        x,
-                        y,
-                        text,
-                        size,
-                        color,
-                        ..
-                    } => {
-                        let typeface = FontMgr::new()
-                            .legacy_make_typeface(None, FontStyle::normal())
-                            .unwrap_or_else(|| {
-                                FontMgr::new()
-                                    .legacy_make_typeface("sans-serif", FontStyle::normal())
-                                    .expect("no typeface")
-                            });
+                    DisplayItem::TextRun { x, y, text, size, color, .. } => {
+                        let typeface = FONT_MGR.with(|fm| {
+                            fm.legacy_make_typeface(None, FontStyle::normal())
+                                .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("no typeface"))
+                        });
                         let font = Font::new(typeface, *size);
                         let mut paint = Paint::new(to_color4f(color), None);
                         paint.set_anti_alias(true);
@@ -85,9 +79,11 @@ impl RenderBackend for SkiaBackend {
                             skia_safe::AlphaType::Premul,
                             None,
                         );
-                        if let Some(image) =
-                            skia_safe::images::raster_from_data(&info, skia_safe::Data::new_copy(data), stride)
-                        {
+                        if let Some(image) = skia_safe::images::raster_from_data(
+                            &info,
+                            skia_safe::Data::new_copy(data),
+                            stride,
+                        ) {
                             canvas.draw_image(&image, (*x, *y), None);
                         }
                     }
@@ -111,7 +107,7 @@ impl RenderBackend for SkiaBackend {
             s.pixels.clone(),
             s.size.width,
             s.size.height,
-            s.size.width * 4,
+            (s.size.width * 4) as u32,
             PixelFormat::PreMulArgb32,
         ))
     }
@@ -151,24 +147,14 @@ pub struct SkiaSurface {
 impl SkiaSurface {
     fn new(size: SurfaceSize, present: PresentMode) -> Result<Self> {
         let pixels = vec![0u8; size.width as usize * size.height as usize * 4];
-        Ok(Self {
-            size,
-            pixels,
-            present,
-            frame_id: 0,
-        })
+        Ok(Self { size, pixels, present, frame_id: 0 })
     }
 
     fn with_canvas(&mut self, f: impl FnOnce(&skia_safe::Canvas)) {
-        let Some(mut surface) = skia_safe::surfaces::raster_n32_premul(skia_safe::ISize::new(
-            self.size.width as i32,
-            self.size.height as i32,
-        )) else {
-            log::error!(
-                "SkiaBackend: failed to create raster surface {}x{}",
-                self.size.width,
-                self.size.height
-            );
+        let Some(mut surface) = skia_safe::surfaces::raster_n32_premul(
+            skia_safe::ISize::new(self.size.width as i32, self.size.height as i32),
+        ) else {
+            log::error!("SkiaBackend: failed to create raster surface {}x{}", self.size.width, self.size.height);
             return;
         };
 

--- a/crates/gosub_render_pipeline/src/render/backends/skia.rs
+++ b/crates/gosub_render_pipeline/src/render/backends/skia.rs
@@ -56,10 +56,19 @@ impl RenderBackend for SkiaBackend {
                         paint.set_anti_alias(true);
                         canvas.draw_rect(Rect::new(*x, *y, x + w, y + h), &paint);
                     }
-                    DisplayItem::TextRun { x, y, text, size, color, .. } => {
+                    DisplayItem::TextRun {
+                        x,
+                        y,
+                        text,
+                        size,
+                        color,
+                        ..
+                    } => {
                         let typeface = FONT_MGR.with(|fm| {
-                            fm.legacy_make_typeface(None, FontStyle::normal())
-                                .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("no typeface"))
+                            fm.legacy_make_typeface(None, FontStyle::normal()).unwrap_or_else(|| {
+                                fm.legacy_make_typeface("sans-serif", FontStyle::normal())
+                                    .expect("no typeface")
+                            })
                         });
                         let font = Font::new(typeface, *size);
                         let mut paint = Paint::new(to_color4f(color), None);
@@ -79,11 +88,9 @@ impl RenderBackend for SkiaBackend {
                             skia_safe::AlphaType::Premul,
                             None,
                         );
-                        if let Some(image) = skia_safe::images::raster_from_data(
-                            &info,
-                            skia_safe::Data::new_copy(data),
-                            stride,
-                        ) {
+                        if let Some(image) =
+                            skia_safe::images::raster_from_data(&info, skia_safe::Data::new_copy(data), stride)
+                        {
                             canvas.draw_image(&image, (*x, *y), None);
                         }
                     }
@@ -107,7 +114,7 @@ impl RenderBackend for SkiaBackend {
             s.pixels.clone(),
             s.size.width,
             s.size.height,
-            (s.size.width * 4) as u32,
+            s.size.width * 4,
             PixelFormat::PreMulArgb32,
         ))
     }
@@ -147,14 +154,24 @@ pub struct SkiaSurface {
 impl SkiaSurface {
     fn new(size: SurfaceSize, present: PresentMode) -> Result<Self> {
         let pixels = vec![0u8; size.width as usize * size.height as usize * 4];
-        Ok(Self { size, pixels, present, frame_id: 0 })
+        Ok(Self {
+            size,
+            pixels,
+            present,
+            frame_id: 0,
+        })
     }
 
     fn with_canvas(&mut self, f: impl FnOnce(&skia_safe::Canvas)) {
-        let Some(mut surface) = skia_safe::surfaces::raster_n32_premul(
-            skia_safe::ISize::new(self.size.width as i32, self.size.height as i32),
-        ) else {
-            log::error!("SkiaBackend: failed to create raster surface {}x{}", self.size.width, self.size.height);
+        let Some(mut surface) = skia_safe::surfaces::raster_n32_premul(skia_safe::ISize::new(
+            self.size.width as i32,
+            self.size.height as i32,
+        )) else {
+            log::error!(
+                "SkiaBackend: failed to create raster surface {}x{}",
+                self.size.width,
+                self.size.height
+            );
             return;
         };
 

--- a/crates/gosub_render_pipeline/src/render/backends/skia_gpu.rs
+++ b/crates/gosub_render_pipeline/src/render/backends/skia_gpu.rs
@@ -42,10 +42,8 @@ impl<C: GlContextProvider> SkiaGpuBackend<C> {
     pub fn new(context: Arc<C>) -> Result<Self> {
         context.make_current();
 
-        let interface = skia_safe::gpu::gl::Interface::new_load_with(|name| {
-            context.get_proc_address(name)
-        })
-        .ok_or_else(|| anyhow!("Failed to create Skia GL interface — no GL functions found"))?;
+        let interface = skia_safe::gpu::gl::Interface::new_load_with(|name| context.get_proc_address(name))
+            .ok_or_else(|| anyhow!("Failed to create Skia GL interface — no GL functions found"))?;
 
         let direct_context = skia_safe::gpu::direct_contexts::make_gl(interface, None)
             .ok_or_else(|| anyhow!("Failed to create Skia GL DirectContext — GL context must be current"))?;
@@ -84,9 +82,9 @@ impl<C: GlContextProvider + Send + Sync + 'static> RenderBackend for SkiaGpuBack
 
         // Tile data from SkiaRasterizer is already on CPU; composite into a CPU raster
         // surface to avoid GL-context thread-affinity issues with the GPU path.
-        let Some(mut cpu_surface) = skia_safe::surfaces::raster_n32_premul(
-            skia_safe::ISize::new(s.size.width as i32, s.size.height as i32),
-        ) else {
+        let Some(mut cpu_surface) =
+            skia_safe::surfaces::raster_n32_premul(skia_safe::ISize::new(s.size.width as i32, s.size.height as i32))
+        else {
             return Err(anyhow!("SkiaGpuBackend: failed to create CPU raster surface"));
         };
 
@@ -106,10 +104,19 @@ impl<C: GlContextProvider + Send + Sync + 'static> RenderBackend for SkiaGpuBack
                         paint.set_anti_alias(true);
                         canvas.draw_rect(Rect::new(*x, *y, x + w, y + h), &paint);
                     }
-                    DisplayItem::TextRun { x, y, text, size, color, .. } => {
+                    DisplayItem::TextRun {
+                        x,
+                        y,
+                        text,
+                        size,
+                        color,
+                        ..
+                    } => {
                         let typeface = FONT_MGR.with(|fm| {
-                            fm.legacy_make_typeface(None, FontStyle::normal())
-                                .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("no typeface"))
+                            fm.legacy_make_typeface(None, FontStyle::normal()).unwrap_or_else(|| {
+                                fm.legacy_make_typeface("sans-serif", FontStyle::normal())
+                                    .expect("no typeface")
+                            })
                         });
                         let font = Font::new(typeface, *size);
                         let mut paint = Paint::new(to_color4f(color), None);
@@ -128,11 +135,9 @@ impl<C: GlContextProvider + Send + Sync + 'static> RenderBackend for SkiaGpuBack
                             skia_safe::AlphaType::Premul,
                             None,
                         );
-                        if let Some(image) = skia_safe::images::raster_from_data(
-                            &info,
-                            skia_safe::Data::new_copy(data),
-                            stride,
-                        ) {
+                        if let Some(image) =
+                            skia_safe::images::raster_from_data(&info, skia_safe::Data::new_copy(data), stride)
+                        {
                             canvas.draw_image(&image, (*x, *y), None);
                         }
                     }
@@ -161,7 +166,7 @@ impl<C: GlContextProvider + Send + Sync + 'static> RenderBackend for SkiaGpuBack
             s.pixels.clone(),
             s.size.width,
             s.size.height,
-            (s.size.width * 4) as u32,
+            s.size.width * 4,
             PixelFormat::PreMulArgb32,
         ))
     }
@@ -202,14 +207,25 @@ pub struct SkiaGpuSurface {
 
 impl SkiaGpuSurface {
     fn new(size: SurfaceSize, present: PresentMode) -> Self {
-        Self { size, pixels: Vec::new(), present, frame_id: 0 }
+        Self {
+            size,
+            pixels: Vec::new(),
+            present,
+            frame_id: 0,
+        }
     }
 }
 
 impl ErasedSurface for SkiaGpuSurface {
-    fn as_any(&self) -> &dyn Any { self }
-    fn as_any_mut(&mut self) -> &mut dyn Any { self }
-    fn size(&self) -> SurfaceSize { self.size }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+    fn size(&self) -> SurfaceSize {
+        self.size
+    }
 }
 
 #[inline]
@@ -239,19 +255,29 @@ pub struct SkiaGpuDirectFbBackend {
 
 impl SkiaGpuDirectFbBackend {
     pub fn new() -> Self {
-        Self { pending: Arc::new(Mutex::new(None)) }
+        Self {
+            pending: Arc::new(Mutex::new(None)),
+        }
     }
 }
 
 impl Default for SkiaGpuDirectFbBackend {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl RenderBackend for SkiaGpuDirectFbBackend {
-    fn name(&self) -> &'static str { "skia-gpu-direct-fb" }
+    fn name(&self) -> &'static str {
+        "skia-gpu-direct-fb"
+    }
 
     fn create_surface(&self, size: SurfaceSize, present: PresentMode) -> Result<Box<dyn ErasedSurface + Send>> {
-        Ok(Box::new(SkiaDirectFbSurface { size, frame_id: 0, present }))
+        Ok(Box::new(SkiaDirectFbSurface {
+            size,
+            frame_id: 0,
+            present,
+        }))
     }
 
     fn render(&self, ctx: &mut dyn RenderContext, surface: &mut dyn ErasedSurface) -> Result<()> {
@@ -271,7 +297,9 @@ impl RenderBackend for SkiaGpuDirectFbBackend {
     }
 
     fn snapshot(&self, _surface: &mut dyn ErasedSurface, _max_dim: u32) -> Result<RgbaImage> {
-        Err(anyhow!("SkiaGpuDirectFbBackend: snapshot not supported (frame is on GPU)"))
+        Err(anyhow!(
+            "SkiaGpuDirectFbBackend: snapshot not supported (frame is on GPU)"
+        ))
     }
 
     fn external_handle(&self, surface: &mut dyn ErasedSurface) -> Result<ExternalHandle> {
@@ -291,7 +319,13 @@ struct SkiaDirectFbSurface {
 }
 
 impl ErasedSurface for SkiaDirectFbSurface {
-    fn as_any(&self) -> &dyn Any { self }
-    fn as_any_mut(&mut self) -> &mut dyn Any { self }
-    fn size(&self) -> SurfaceSize { self.size }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+    fn size(&self) -> SurfaceSize {
+        self.size
+    }
 }

--- a/crates/gosub_render_pipeline/src/render/backends/skia_gpu.rs
+++ b/crates/gosub_render_pipeline/src/render/backends/skia_gpu.rs
@@ -5,8 +5,8 @@ use crate::render::render_context::RenderContext;
 use crate::render::render_list::DisplayItem;
 use anyhow::{anyhow, Result};
 use parking_lot::Mutex;
-use skia_safe::gpu::{Budgeted, DirectContext, SurfaceOrigin};
-use skia_safe::{Color4f, Font, FontMgr, FontStyle, ImageInfo, Paint, Rect, Surface};
+use skia_safe::gpu::DirectContext;
+use skia_safe::{Color4f, Font, FontMgr, FontStyle, ImageInfo, Paint, Rect};
 use std::any::Any;
 use std::sync::Arc;
 
@@ -26,12 +26,15 @@ pub trait GlContextProvider: Send + Sync {
 ///
 /// SAFETY: `GlContextProvider::make_current()` is called before every GPU operation,
 /// ensuring the GL context is current on whichever thread the engine uses.
+#[allow(dead_code)]
 struct SendDirectContext(DirectContext);
 unsafe impl Send for SendDirectContext {}
 unsafe impl Sync for SendDirectContext {}
 
 pub struct SkiaGpuBackend<C: GlContextProvider> {
+    #[allow(dead_code)]
     context: Arc<C>,
+    #[allow(dead_code)]
     direct_context: Mutex<SendDirectContext>,
 }
 
@@ -44,7 +47,7 @@ impl<C: GlContextProvider> SkiaGpuBackend<C> {
         })
         .ok_or_else(|| anyhow!("Failed to create Skia GL interface — no GL functions found"))?;
 
-        let direct_context = DirectContext::new_gl(interface, None)
+        let direct_context = skia_safe::gpu::direct_contexts::make_gl(interface, None)
             .ok_or_else(|| anyhow!("Failed to create Skia GL DirectContext — GL context must be current"))?;
 
         Ok(Self {

--- a/crates/gosub_render_pipeline/src/render/backends/skia_gpu.rs
+++ b/crates/gosub_render_pipeline/src/render/backends/skia_gpu.rs
@@ -1,14 +1,216 @@
-use crate::render::backend::{ErasedSurface, ExternalHandle, PresentMode, RenderBackend, RgbaImage, SurfaceSize};
+use crate::render::backend::{
+    ErasedSurface, ExternalHandle, PixelFormat, PresentMode, RenderBackend, RgbaImage, SurfaceSize,
+};
 use crate::render::render_context::RenderContext;
-use crate::render::render_list::{Color, DisplayItem};
+use crate::render::render_list::DisplayItem;
 use anyhow::{anyhow, Result};
 use parking_lot::Mutex;
-use skia_safe::Color4f;
+use skia_safe::gpu::{Budgeted, DirectContext, SurfaceOrigin};
+use skia_safe::{Color4f, Font, FontMgr, FontStyle, ImageInfo, Paint, Rect, Surface};
 use std::any::Any;
 use std::sync::Arc;
 
+thread_local! {
+    static FONT_MGR: FontMgr = FontMgr::new();
+}
+
+/// Trait for providing an OpenGL context to `SkiaGpuBackend`.
+pub trait GlContextProvider: Send + Sync {
+    /// Make the GL context current on the calling thread.
+    fn make_current(&self);
+    /// Return the address of an OpenGL function, or null if not available.
+    fn get_proc_address(&self, name: &str) -> *const std::ffi::c_void;
+}
+
+/// Wraps `DirectContext` to allow crossing thread boundaries.
+///
+/// SAFETY: `GlContextProvider::make_current()` is called before every GPU operation,
+/// ensuring the GL context is current on whichever thread the engine uses.
+struct SendDirectContext(DirectContext);
+unsafe impl Send for SendDirectContext {}
+unsafe impl Sync for SendDirectContext {}
+
+pub struct SkiaGpuBackend<C: GlContextProvider> {
+    context: Arc<C>,
+    direct_context: Mutex<SendDirectContext>,
+}
+
+impl<C: GlContextProvider> SkiaGpuBackend<C> {
+    pub fn new(context: Arc<C>) -> Result<Self> {
+        context.make_current();
+
+        let interface = skia_safe::gpu::gl::Interface::new_load_with(|name| {
+            context.get_proc_address(name)
+        })
+        .ok_or_else(|| anyhow!("Failed to create Skia GL interface — no GL functions found"))?;
+
+        let direct_context = DirectContext::new_gl(interface, None)
+            .ok_or_else(|| anyhow!("Failed to create Skia GL DirectContext — GL context must be current"))?;
+
+        Ok(Self {
+            context,
+            direct_context: Mutex::new(SendDirectContext(direct_context)),
+        })
+    }
+}
+
+impl<C: GlContextProvider + Send + Sync + 'static> RenderBackend for SkiaGpuBackend<C> {
+    fn name(&self) -> &'static str {
+        "skia-gpu"
+    }
+
+    fn create_surface(&self, size: SurfaceSize, present: PresentMode) -> Result<Box<dyn ErasedSurface + Send>> {
+        Ok(Box::new(SkiaGpuSurface::new(size, present)))
+    }
+
+    fn render(&self, ctx: &mut dyn RenderContext, surface: &mut dyn ErasedSurface) -> Result<()> {
+        let s = surface
+            .as_any_mut()
+            .downcast_mut::<SkiaGpuSurface>()
+            .ok_or_else(|| anyhow!("SkiaGpuBackend used with non-SkiaGpu surface"))?;
+
+        if s.size.width == 0 || s.size.height == 0 {
+            return Ok(());
+        }
+
+        let vp = ctx.viewport();
+        let offset_x = vp.x as f32;
+        let offset_y = vp.y as f32;
+        let clip = Rect::new(0.0, 0.0, s.size.width as f32, s.size.height as f32);
+        let items: Vec<DisplayItem> = ctx.render_list().items.to_vec();
+
+        // Tile data from SkiaRasterizer is already on CPU; composite into a CPU raster
+        // surface to avoid GL-context thread-affinity issues with the GPU path.
+        let Some(mut cpu_surface) = skia_safe::surfaces::raster_n32_premul(
+            skia_safe::ISize::new(s.size.width as i32, s.size.height as i32),
+        ) else {
+            return Err(anyhow!("SkiaGpuBackend: failed to create CPU raster surface"));
+        };
+
+        {
+            let canvas = cpu_surface.canvas();
+            canvas.clip_rect(clip, None, None);
+            canvas.save();
+            canvas.translate((-offset_x, -offset_y));
+
+            for item in &items {
+                match item {
+                    DisplayItem::Clear { color } => {
+                        canvas.clear(to_color4f(color));
+                    }
+                    DisplayItem::Rect { x, y, w, h, color } => {
+                        let mut paint = Paint::new(to_color4f(color), None);
+                        paint.set_anti_alias(true);
+                        canvas.draw_rect(Rect::new(*x, *y, x + w, y + h), &paint);
+                    }
+                    DisplayItem::TextRun { x, y, text, size, color, .. } => {
+                        let typeface = FONT_MGR.with(|fm| {
+                            fm.legacy_make_typeface(None, FontStyle::normal())
+                                .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("no typeface"))
+                        });
+                        let font = Font::new(typeface, *size);
+                        let mut paint = Paint::new(to_color4f(color), None);
+                        paint.set_anti_alias(true);
+                        canvas.draw_str(text.as_str(), (*x, *y), &font, &paint);
+                    }
+                    DisplayItem::Blit { x, y, w, h, data } => {
+                        let stride = (*w * 4) as usize;
+                        if data.len() < *h as usize * stride {
+                            log::warn!("SkiaGpuBackend: Blit data too short");
+                            continue;
+                        }
+                        let info = ImageInfo::new(
+                            (*w as i32, *h as i32),
+                            skia_safe::ColorType::BGRA8888,
+                            skia_safe::AlphaType::Premul,
+                            None,
+                        );
+                        if let Some(image) = skia_safe::images::raster_from_data(
+                            &info,
+                            skia_safe::Data::new_copy(data),
+                            stride,
+                        ) {
+                            canvas.draw_image(&image, (*x, *y), None);
+                        }
+                    }
+                }
+            }
+
+            canvas.restore();
+        }
+
+        if let Some(peek) = cpu_surface.canvas().peek_pixels() {
+            if let Some(bytes) = peek.bytes() {
+                s.pixels = bytes.to_vec();
+            }
+        }
+
+        s.frame_id = s.frame_id.wrapping_add(1);
+        Ok(())
+    }
+
+    fn snapshot(&self, surface: &mut dyn ErasedSurface, _max_dim: u32) -> Result<RgbaImage> {
+        let s = surface
+            .as_any_mut()
+            .downcast_mut::<SkiaGpuSurface>()
+            .ok_or_else(|| anyhow!("SkiaGpuBackend used with non-SkiaGpu surface"))?;
+        Ok(RgbaImage::from_raw(
+            s.pixels.clone(),
+            s.size.width,
+            s.size.height,
+            (s.size.width * 4) as u32,
+            PixelFormat::PreMulArgb32,
+        ))
+    }
+
+    fn external_handle(&self, surface: &mut dyn ErasedSurface) -> Result<ExternalHandle> {
+        let s = surface
+            .as_any_mut()
+            .downcast_mut::<SkiaGpuSurface>()
+            .ok_or_else(|| anyhow!("SkiaGpuBackend used with non-SkiaGpu surface"))?;
+
+        if s.size.width == 0 || s.size.height == 0 || s.pixels.is_empty() {
+            return Ok(ExternalHandle::NullHandle {
+                width: s.size.width,
+                height: s.size.height,
+                frame_id: s.frame_id,
+            });
+        }
+
+        Ok(ExternalHandle::CpuPixelsOwned {
+            width: s.size.width,
+            height: s.size.height,
+            stride: s.size.width * 4,
+            pixels: s.pixels.clone(),
+            format: PixelFormat::PreMulArgb32,
+        })
+    }
+}
+
+// ── Surface ───────────────────────────────────────────────────────────────────
+
+pub struct SkiaGpuSurface {
+    size: SurfaceSize,
+    pixels: Vec<u8>,
+    #[allow(dead_code)]
+    present: PresentMode,
+    frame_id: u64,
+}
+
+impl SkiaGpuSurface {
+    fn new(size: SurfaceSize, present: PresentMode) -> Self {
+        Self { size, pixels: Vec::new(), present, frame_id: 0 }
+    }
+}
+
+impl ErasedSurface for SkiaGpuSurface {
+    fn as_any(&self) -> &dyn Any { self }
+    fn as_any_mut(&mut self) -> &mut dyn Any { self }
+    fn size(&self) -> SurfaceSize { self.size }
+}
+
 #[inline]
-pub fn to_color4f(c: &Color) -> Color4f {
+pub fn to_color4f(c: &crate::render::render_list::Color) -> Color4f {
     Color4f::new(c.r, c.g, c.b, c.a)
 }
 
@@ -34,29 +236,19 @@ pub struct SkiaGpuDirectFbBackend {
 
 impl SkiaGpuDirectFbBackend {
     pub fn new() -> Self {
-        Self {
-            pending: Arc::new(Mutex::new(None)),
-        }
+        Self { pending: Arc::new(Mutex::new(None)) }
     }
 }
 
 impl Default for SkiaGpuDirectFbBackend {
-    fn default() -> Self {
-        Self::new()
-    }
+    fn default() -> Self { Self::new() }
 }
 
 impl RenderBackend for SkiaGpuDirectFbBackend {
-    fn name(&self) -> &'static str {
-        "skia-gpu-direct-fb"
-    }
+    fn name(&self) -> &'static str { "skia-gpu-direct-fb" }
 
     fn create_surface(&self, size: SurfaceSize, present: PresentMode) -> Result<Box<dyn ErasedSurface + Send>> {
-        Ok(Box::new(SkiaDirectFbSurface {
-            size,
-            frame_id: 0,
-            present,
-        }))
+        Ok(Box::new(SkiaDirectFbSurface { size, frame_id: 0, present }))
     }
 
     fn render(&self, ctx: &mut dyn RenderContext, surface: &mut dyn ErasedSurface) -> Result<()> {
@@ -76,9 +268,7 @@ impl RenderBackend for SkiaGpuDirectFbBackend {
     }
 
     fn snapshot(&self, _surface: &mut dyn ErasedSurface, _max_dim: u32) -> Result<RgbaImage> {
-        Err(anyhow!(
-            "SkiaGpuDirectFbBackend: snapshot not supported (frame is on GPU)"
-        ))
+        Err(anyhow!("SkiaGpuDirectFbBackend: snapshot not supported (frame is on GPU)"))
     }
 
     fn external_handle(&self, surface: &mut dyn ErasedSurface) -> Result<ExternalHandle> {
@@ -98,13 +288,7 @@ struct SkiaDirectFbSurface {
 }
 
 impl ErasedSurface for SkiaDirectFbSurface {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-    fn size(&self) -> SurfaceSize {
-        self.size
-    }
+    fn as_any(&self) -> &dyn Any { self }
+    fn as_any_mut(&mut self) -> &mut dyn Any { self }
+    fn size(&self) -> SurfaceSize { self.size }
 }

--- a/crates/gosub_render_pipeline/src/render/render_list.rs
+++ b/crates/gosub_render_pipeline/src/render/render_list.rs
@@ -177,8 +177,8 @@ pub enum DisplayItem {
         w: u32,
         /// Tile height in pixels.
         h: u32,
-        /// Raw ARgb32 pixel data (length = `h * w * 4`).
-        data: Vec<u8>,
+        /// Raw ARgb32 pixel data (length = `h * w * 4`). Arc-shared from the rasterizer output.
+        data: std::sync::Arc<Vec<u8>>,
     },
 }
 

--- a/crates/gosub_renderer_cairo/src/compositor/inner.rs
+++ b/crates/gosub_renderer_cairo/src/compositor/inner.rs
@@ -41,7 +41,7 @@ pub fn compose_layer(cr: &cairo::Context, layer_id: LayerId, state: &BrowserStat
         };
 
         let surface = match ImageSurface::create_for_data(
-            texture.data.clone(),
+            (*texture.data).clone(),
             cairo::Format::ARgb32,
             texture.width as i32,
             texture.height as i32,

--- a/crates/gosub_renderer_skia/src/rasterizer/text.rs
+++ b/crates/gosub_renderer_skia/src/rasterizer/text.rs
@@ -3,12 +3,15 @@ use gosub_render_pipeline::painter::commands::text::Text;
 use gosub_render_pipeline::tiler::Tile;
 use skia_safe::{Canvas, Color4f, Font, FontMgr, FontStyle, Paint};
 
+thread_local! {
+    static FONT_MGR: FontMgr = FontMgr::new();
+}
+
 pub fn do_paint_text(canvas: &Canvas, _tile: &Tile, cmd: &Text, _dpi_scale_factor: f32) -> Result<(), anyhow::Error> {
     let color4f = brush_to_color4f(&cmd.brush);
     let mut paint = Paint::new(color4f, None);
     paint.set_anti_alias(true);
 
-    let font_mgr = FontMgr::new();
     let font_style = FontStyle::new(
         skia_safe::font_style::Weight::from(cmd.font_info.weight),
         skia_safe::font_style::Width::from((cmd.font_info.width / 100).clamp(1, 9)),
@@ -19,11 +22,11 @@ pub fn do_paint_text(canvas: &Canvas, _tile: &Tile, cmd: &Text, _dpi_scale_facto
         },
     );
 
-    let Some(typeface) = font_mgr
-        .match_family_style(&cmd.font_info.family, font_style)
-        .or_else(|| font_mgr.legacy_make_typeface(None, font_style))
-        .or_else(|| font_mgr.legacy_make_typeface(None, FontStyle::normal()))
-    else {
+    let Some(typeface) = FONT_MGR.with(|fm| {
+        fm.match_family_style(&cmd.font_info.family, font_style)
+            .or_else(|| fm.legacy_make_typeface(None, font_style))
+            .or_else(|| fm.legacy_make_typeface(None, FontStyle::normal()))
+    }) else {
         return Ok(());
     };
 
@@ -62,7 +65,6 @@ pub fn do_paint_text(canvas: &Canvas, _tile: &Tile, cmd: &Text, _dpi_scale_facto
             canvas.draw_str(line.as_str(), (x, y), &font, &paint);
         }
         y += line_height;
-        // Stop drawing if we've exceeded the rect's bottom.
         if y > (cmd.rect.y + cmd.rect.height) as f32 + line_height {
             break;
         }

--- a/crates/gosub_renderer_vello/src/compositor/inner.rs
+++ b/crates/gosub_renderer_vello/src/compositor/inner.rs
@@ -48,7 +48,7 @@ pub fn compose_layer(scene: &mut vello::Scene, layer_id: LayerId, state: &Browse
         };
 
         let surface = ImageData {
-            data: Blob::from(texture.data.clone()),
+            data: Blob::from((*texture.data).clone()),
             format: ImageFormat::Rgba8,
             alpha_type: ImageAlphaType::AlphaPremultiplied,
             width: texture.width as u32,

--- a/crates/gosub_renderer_vello/src/rasterizer/svg.rs
+++ b/crates/gosub_renderer_vello/src/rasterizer/svg.rs
@@ -37,19 +37,10 @@ pub(crate) fn do_paint_svg(
     let scale_x = target_w as f32 / intrinsic.width().max(1) as f32;
     let scale_y = target_h as f32 / intrinsic.height().max(1) as f32;
     let Some(mut pixmap) = resvg::tiny_skia::Pixmap::new(target_w, target_h) else {
-        log::error!(
-            "Failed to allocate pixmap for SVG {:?} ({}x{})",
-            media_id,
-            target_w,
-            target_h
-        );
+        log::error!("Failed to allocate pixmap for SVG {:?} ({}x{})", media_id, target_w, target_h);
         return;
     };
-    resvg::render(
-        &media.svg.tree,
-        Transform::from_scale(scale_x, scale_y),
-        &mut pixmap.as_mut(),
-    );
+    resvg::render(&media.svg.tree, Transform::from_scale(scale_x, scale_y), &mut pixmap.as_mut());
     let new_data = pixmap.data().to_vec();
 
     let mut cached = media.svg.rendered.write();

--- a/crates/gosub_renderer_vello/src/rasterizer/svg.rs
+++ b/crates/gosub_renderer_vello/src/rasterizer/svg.rs
@@ -37,10 +37,19 @@ pub(crate) fn do_paint_svg(
     let scale_x = target_w as f32 / intrinsic.width().max(1) as f32;
     let scale_y = target_h as f32 / intrinsic.height().max(1) as f32;
     let Some(mut pixmap) = resvg::tiny_skia::Pixmap::new(target_w, target_h) else {
-        log::error!("Failed to allocate pixmap for SVG {:?} ({}x{})", media_id, target_w, target_h);
+        log::error!(
+            "Failed to allocate pixmap for SVG {:?} ({}x{})",
+            media_id,
+            target_w,
+            target_h
+        );
         return;
     };
-    resvg::render(&media.svg.tree, Transform::from_scale(scale_x, scale_y), &mut pixmap.as_mut());
+    resvg::render(
+        &media.svg.tree,
+        Transform::from_scale(scale_x, scale_y),
+        &mut pixmap.as_mut(),
+    );
     let new_data = pixmap.data().to_vec();
 
     let mut cached = media.svg.rendered.write();

--- a/examples/gtk4-skia-gpu/main.rs
+++ b/examples/gtk4-skia-gpu/main.rs
@@ -20,11 +20,9 @@ use gosub_engine::storage::{InMemorySessionStore, PartitionPolicy, SqliteLocalSt
 use gosub_engine::tab::{TabDefaults, TabId};
 use gosub_engine::zone::{ZoneConfig, ZoneId, ZoneServices};
 use gosub_engine::GosubEngine;
-use gosub_render_pipeline::render::backends::skia_gpu::{
-    PendingFrame, SkiaGpuDirectFbBackend, to_color4f,
-};
-use gosub_render_pipeline::render::DefaultCompositor;
+use gosub_render_pipeline::render::backends::skia_gpu::{to_color4f, PendingFrame, SkiaGpuDirectFbBackend};
 use gosub_render_pipeline::render::render_list::DisplayItem;
+use gosub_render_pipeline::render::DefaultCompositor;
 use gtk4::glib;
 use gtk4::prelude::*;
 use gtk4::{Application, ApplicationWindow, Box as GtkBox, Entry, GLArea, Label, Orientation};
@@ -59,18 +57,15 @@ fn get_bound_fbo() -> u32 {
         fn glGetIntegerv(pname: u32, data: *mut i32);
     }
     let mut fbo = 0i32;
-    unsafe { glGetIntegerv(0x8CA6 /* GL_DRAW_FRAMEBUFFER_BINDING */, &mut fbo) };
+    unsafe {
+        glGetIntegerv(0x8CA6 /* GL_DRAW_FRAMEBUFFER_BINDING */, &mut fbo)
+    };
     fbo as u32
 }
 
 // ── Skia GPU rendering ────────────────────────────────────────────────────────
 
-fn render_frame_to_gl(
-    dc: &mut skia_safe::gpu::DirectContext,
-    frame: &PendingFrame,
-    width: i32,
-    height: i32,
-) {
+fn render_frame_to_gl(dc: &mut skia_safe::gpu::DirectContext, frame: &PendingFrame, width: i32, height: i32) {
     if width == 0 || height == 0 {
         return;
     }
@@ -81,12 +76,7 @@ fn render_frame_to_gl(
         format: 0x8058, // GL_RGBA8
         protected: skia_safe::gpu::Protected::No,
     };
-    let target = skia_safe::gpu::backend_render_targets::make_gl(
-        (width, height),
-        None,
-        8,
-        fb_info,
-    );
+    let target = skia_safe::gpu::backend_render_targets::make_gl((width, height), None, 8, fb_info);
 
     let Some(mut surface) = skia_safe::gpu::surfaces::wrap_backend_render_target(
         dc,
@@ -128,11 +118,20 @@ fn render_item(canvas: &skia_safe::Canvas, item: &DisplayItem) {
             paint.set_anti_alias(true);
             canvas.draw_rect(SkRect::new(*x, *y, x + w, y + h), &paint);
         }
-        DisplayItem::TextRun { x, y, text, size, color, .. } => {
+        DisplayItem::TextRun {
+            x,
+            y,
+            text,
+            size,
+            color,
+            ..
+        } => {
             thread_local! { static FONT_MGR: FontMgr = FontMgr::new(); }
             let typeface = FONT_MGR.with(|fm| {
-                fm.legacy_make_typeface(None, FontStyle::normal())
-                    .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("no typeface"))
+                fm.legacy_make_typeface(None, FontStyle::normal()).unwrap_or_else(|| {
+                    fm.legacy_make_typeface("sans-serif", FontStyle::normal())
+                        .expect("no typeface")
+                })
             });
             let font = Font::new(typeface, *size);
             let mut paint = Paint::new(to_color4f(color), None);
@@ -150,11 +149,7 @@ fn render_item(canvas: &skia_safe::Canvas, item: &DisplayItem) {
                 skia_safe::AlphaType::Premul,
                 None,
             );
-            if let Some(image) = skia_safe::images::raster_from_data(
-                &info,
-                skia_safe::Data::new_copy(data),
-                stride,
-            ) {
+            if let Some(image) = skia_safe::images::raster_from_data(&info, skia_safe::Data::new_copy(data), stride) {
                 canvas.draw_image(&image, (*x, *y), None);
             }
         }
@@ -164,15 +159,17 @@ fn render_item(canvas: &skia_safe::Canvas, item: &DisplayItem) {
 // ── Application ───────────────────────────────────────────────────────────────
 
 fn main() {
-    simple_logger::SimpleLogger::new().with_level(log::LevelFilter::Warn).env().init().unwrap_or_default();
+    simple_logger::SimpleLogger::new()
+        .with_level(log::LevelFilter::Warn)
+        .env()
+        .init()
+        .unwrap_or_default();
 
     let initial_url: String = std::env::args()
         .nth(1)
         .unwrap_or_else(|| "https://example.com".to_string());
 
-    let app = Application::builder()
-        .application_id("io.gosub.gtk4-skia-gpu")
-        .build();
+    let app = Application::builder().application_id("io.gosub.gtk4-skia-gpu").build();
 
     app.connect_activate(move |app| {
         let _rt_guard = TOKIO_RT.enter();
@@ -183,7 +180,9 @@ fn main() {
 
         let compositor = Arc::new(RwLock::new(DefaultCompositor::new({
             let tx = tx_redraw.clone();
-            move || { let _ = tx.send(()); }
+            move || {
+                let _ = tx.send(());
+            }
         })));
 
         let backend = SkiaGpuDirectFbBackend::new();
@@ -214,7 +213,11 @@ fn main() {
 
         let tab = TOKIO_RT
             .block_on(zone.borrow_mut().create_tab(
-                TabDefaults { url: None, title: Some("Gosub".to_string()), viewport: None },
+                TabDefaults {
+                    url: None,
+                    title: Some("Gosub".to_string()),
+                    viewport: None,
+                },
                 None,
             ))
             .expect("create_tab");
@@ -233,8 +236,7 @@ fn main() {
         gl_area.set_focusable(true);
 
         // Hold Skia's DirectContext: created in connect_realize, used in connect_render.
-        let dc_holder: Rc<RefCell<Option<skia_safe::gpu::DirectContext>>> =
-            Rc::new(RefCell::new(None));
+        let dc_holder: Rc<RefCell<Option<skia_safe::gpu::DirectContext>>> = Rc::new(RefCell::new(None));
 
         // Initialise Skia's GL DirectContext once the GLArea is realized.
         gl_area.connect_realize({
@@ -247,8 +249,7 @@ fn main() {
                 }
                 let interface = skia_safe::gpu::gl::Interface::new_native()
                     .expect("Skia GL interface — GLArea context must be current");
-                let dc = skia_safe::gpu::direct_contexts::make_gl(interface, None)
-                    .expect("Skia DirectContext");
+                let dc = skia_safe::gpu::direct_contexts::make_gl(interface, None).expect("Skia DirectContext");
                 *dc_holder.borrow_mut() = Some(dc);
                 log::info!("gtk4-skia-gpu: Skia DirectContext initialised");
             }
@@ -260,8 +261,12 @@ fn main() {
             let pending = pending.clone();
             move |area, _ctx| {
                 let mut dc_ref = dc_holder.borrow_mut();
-                let Some(dc) = dc_ref.as_mut() else { return glib::Propagation::Stop; };
-                let Some(frame) = pending.lock().take() else { return glib::Propagation::Stop; };
+                let Some(dc) = dc_ref.as_mut() else {
+                    return glib::Propagation::Stop;
+                };
+                let Some(frame) = pending.lock().take() else {
+                    return glib::Propagation::Stop;
+                };
                 render_frame_to_gl(dc, &frame, area.width(), area.height());
                 glib::Propagation::Stop
             }
@@ -286,7 +291,14 @@ fn main() {
                 local_scroll.set((0.0, 0.0));
                 let tab = tab.borrow().clone();
                 TOKIO_RT.spawn(async move {
-                    let _ = tab.send(TabCommand::SetViewport { x: 0, y: 0, width: w as u32, height: h as u32 }).await;
+                    let _ = tab
+                        .send(TabCommand::SetViewport {
+                            x: 0,
+                            y: 0,
+                            width: w as u32,
+                            height: h as u32,
+                        })
+                        .await;
                 });
             }
         });
@@ -306,7 +318,12 @@ fn main() {
                 local_scroll.set(((px + dx).max(0.0), (py + dy).max(0.0)));
                 let tab = tab.borrow().clone();
                 TOKIO_RT.spawn(async move {
-                    let _ = tab.send(TabCommand::MouseScroll { delta_x: dx, delta_y: dy }).await;
+                    let _ = tab
+                        .send(TabCommand::MouseScroll {
+                            delta_x: dx,
+                            delta_y: dy,
+                        })
+                        .await;
                 });
                 glib::Propagation::Stop
             }
@@ -321,7 +338,12 @@ fn main() {
             move |_, x, y| {
                 let tab = tab.borrow().clone();
                 TOKIO_RT.spawn(async move {
-                    let _ = tab.send(TabCommand::MouseMove { x: x as f32, y: y as f32 }).await;
+                    let _ = tab
+                        .send(TabCommand::MouseMove {
+                            x: x as f32,
+                            y: y as f32,
+                        })
+                        .await;
                 });
             }
         });
@@ -334,10 +356,13 @@ fn main() {
             move |_, _, x, y| {
                 let tab = tab.borrow().clone();
                 TOKIO_RT.spawn(async move {
-                    let _ = tab.send(TabCommand::MouseDown {
-                        x: x as f32, y: y as f32,
-                        button: gosub_engine::events::MouseButton::Left,
-                    }).await;
+                    let _ = tab
+                        .send(TabCommand::MouseDown {
+                            x: x as f32,
+                            y: y as f32,
+                            button: gosub_engine::events::MouseButton::Left,
+                        })
+                        .await;
                 });
             }
         });
@@ -394,7 +419,10 @@ fn main() {
             async move {
                 while let Some(evt) = ui_rx.recv().await {
                     match evt {
-                        EngineEvent::Navigation { event: NavigationEvent::Finished { url, .. }, .. } => {
+                        EngineEvent::Navigation {
+                            event: NavigationEvent::Finished { url, .. },
+                            ..
+                        } => {
                             address_entry.set_text(url.as_str());
                         }
                         EngineEvent::HoverUrl { url, .. } => {

--- a/examples/gtk4-skia-gpu/main.rs
+++ b/examples/gtk4-skia-gpu/main.rs
@@ -20,9 +20,11 @@ use gosub_engine::storage::{InMemorySessionStore, PartitionPolicy, SqliteLocalSt
 use gosub_engine::tab::{TabDefaults, TabId};
 use gosub_engine::zone::{ZoneConfig, ZoneId, ZoneServices};
 use gosub_engine::GosubEngine;
-use gosub_render_pipeline::render::backends::skia_gpu::{to_color4f, PendingFrame, SkiaGpuDirectFbBackend};
-use gosub_render_pipeline::render::render_list::DisplayItem;
+use gosub_render_pipeline::render::backends::skia_gpu::{
+    PendingFrame, SkiaGpuDirectFbBackend, to_color4f,
+};
 use gosub_render_pipeline::render::DefaultCompositor;
+use gosub_render_pipeline::render::render_list::DisplayItem;
 use gtk4::glib;
 use gtk4::prelude::*;
 use gtk4::{Application, ApplicationWindow, Box as GtkBox, Entry, GLArea, Label, Orientation};
@@ -57,15 +59,18 @@ fn get_bound_fbo() -> u32 {
         fn glGetIntegerv(pname: u32, data: *mut i32);
     }
     let mut fbo = 0i32;
-    unsafe {
-        glGetIntegerv(0x8CA6 /* GL_DRAW_FRAMEBUFFER_BINDING */, &mut fbo)
-    };
+    unsafe { glGetIntegerv(0x8CA6 /* GL_DRAW_FRAMEBUFFER_BINDING */, &mut fbo) };
     fbo as u32
 }
 
 // ── Skia GPU rendering ────────────────────────────────────────────────────────
 
-fn render_frame_to_gl(dc: &mut skia_safe::gpu::DirectContext, frame: &PendingFrame, width: i32, height: i32) {
+fn render_frame_to_gl(
+    dc: &mut skia_safe::gpu::DirectContext,
+    frame: &PendingFrame,
+    width: i32,
+    height: i32,
+) {
     if width == 0 || height == 0 {
         return;
     }
@@ -76,7 +81,12 @@ fn render_frame_to_gl(dc: &mut skia_safe::gpu::DirectContext, frame: &PendingFra
         format: 0x8058, // GL_RGBA8
         protected: skia_safe::gpu::Protected::No,
     };
-    let target = skia_safe::gpu::backend_render_targets::make_gl((width, height), None, 8, fb_info);
+    let target = skia_safe::gpu::backend_render_targets::make_gl(
+        (width, height),
+        None,
+        8,
+        fb_info,
+    );
 
     let Some(mut surface) = skia_safe::gpu::surfaces::wrap_backend_render_target(
         dc,
@@ -118,21 +128,12 @@ fn render_item(canvas: &skia_safe::Canvas, item: &DisplayItem) {
             paint.set_anti_alias(true);
             canvas.draw_rect(SkRect::new(*x, *y, x + w, y + h), &paint);
         }
-        DisplayItem::TextRun {
-            x,
-            y,
-            text,
-            size,
-            color,
-            ..
-        } => {
-            let typeface = FontMgr::new()
-                .legacy_make_typeface(None, FontStyle::normal())
-                .unwrap_or_else(|| {
-                    FontMgr::new()
-                        .legacy_make_typeface("sans-serif", FontStyle::normal())
-                        .expect("no typeface")
-                });
+        DisplayItem::TextRun { x, y, text, size, color, .. } => {
+            thread_local! { static FONT_MGR: FontMgr = FontMgr::new(); }
+            let typeface = FONT_MGR.with(|fm| {
+                fm.legacy_make_typeface(None, FontStyle::normal())
+                    .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("no typeface"))
+            });
             let font = Font::new(typeface, *size);
             let mut paint = Paint::new(to_color4f(color), None);
             paint.set_anti_alias(true);
@@ -149,7 +150,11 @@ fn render_item(canvas: &skia_safe::Canvas, item: &DisplayItem) {
                 skia_safe::AlphaType::Premul,
                 None,
             );
-            if let Some(image) = skia_safe::images::raster_from_data(&info, skia_safe::Data::new_copy(data), stride) {
+            if let Some(image) = skia_safe::images::raster_from_data(
+                &info,
+                skia_safe::Data::new_copy(data),
+                stride,
+            ) {
                 canvas.draw_image(&image, (*x, *y), None);
             }
         }
@@ -159,17 +164,15 @@ fn render_item(canvas: &skia_safe::Canvas, item: &DisplayItem) {
 // ── Application ───────────────────────────────────────────────────────────────
 
 fn main() {
-    simple_logger::SimpleLogger::new()
-        .with_level(log::LevelFilter::Warn)
-        .env()
-        .init()
-        .unwrap_or_default();
+    simple_logger::SimpleLogger::new().with_level(log::LevelFilter::Warn).env().init().unwrap_or_default();
 
     let initial_url: String = std::env::args()
         .nth(1)
         .unwrap_or_else(|| "https://example.com".to_string());
 
-    let app = Application::builder().application_id("io.gosub.gtk4-skia-gpu").build();
+    let app = Application::builder()
+        .application_id("io.gosub.gtk4-skia-gpu")
+        .build();
 
     app.connect_activate(move |app| {
         let _rt_guard = TOKIO_RT.enter();
@@ -180,9 +183,7 @@ fn main() {
 
         let compositor = Arc::new(RwLock::new(DefaultCompositor::new({
             let tx = tx_redraw.clone();
-            move || {
-                let _ = tx.send(());
-            }
+            move || { let _ = tx.send(()); }
         })));
 
         let backend = SkiaGpuDirectFbBackend::new();
@@ -213,11 +214,7 @@ fn main() {
 
         let tab = TOKIO_RT
             .block_on(zone.borrow_mut().create_tab(
-                TabDefaults {
-                    url: None,
-                    title: Some("Gosub".to_string()),
-                    viewport: None,
-                },
+                TabDefaults { url: None, title: Some("Gosub".to_string()), viewport: None },
                 None,
             ))
             .expect("create_tab");
@@ -236,7 +233,8 @@ fn main() {
         gl_area.set_focusable(true);
 
         // Hold Skia's DirectContext: created in connect_realize, used in connect_render.
-        let dc_holder: Rc<RefCell<Option<skia_safe::gpu::DirectContext>>> = Rc::new(RefCell::new(None));
+        let dc_holder: Rc<RefCell<Option<skia_safe::gpu::DirectContext>>> =
+            Rc::new(RefCell::new(None));
 
         // Initialise Skia's GL DirectContext once the GLArea is realized.
         gl_area.connect_realize({
@@ -249,7 +247,8 @@ fn main() {
                 }
                 let interface = skia_safe::gpu::gl::Interface::new_native()
                     .expect("Skia GL interface — GLArea context must be current");
-                let dc = skia_safe::gpu::direct_contexts::make_gl(interface, None).expect("Skia DirectContext");
+                let dc = skia_safe::gpu::direct_contexts::make_gl(interface, None)
+                    .expect("Skia DirectContext");
                 *dc_holder.borrow_mut() = Some(dc);
                 log::info!("gtk4-skia-gpu: Skia DirectContext initialised");
             }
@@ -261,12 +260,8 @@ fn main() {
             let pending = pending.clone();
             move |area, _ctx| {
                 let mut dc_ref = dc_holder.borrow_mut();
-                let Some(dc) = dc_ref.as_mut() else {
-                    return glib::Propagation::Stop;
-                };
-                let Some(frame) = pending.lock().take() else {
-                    return glib::Propagation::Stop;
-                };
+                let Some(dc) = dc_ref.as_mut() else { return glib::Propagation::Stop; };
+                let Some(frame) = pending.lock().take() else { return glib::Propagation::Stop; };
                 render_frame_to_gl(dc, &frame, area.width(), area.height());
                 glib::Propagation::Stop
             }
@@ -291,14 +286,7 @@ fn main() {
                 local_scroll.set((0.0, 0.0));
                 let tab = tab.borrow().clone();
                 TOKIO_RT.spawn(async move {
-                    let _ = tab
-                        .send(TabCommand::SetViewport {
-                            x: 0,
-                            y: 0,
-                            width: w as u32,
-                            height: h as u32,
-                        })
-                        .await;
+                    let _ = tab.send(TabCommand::SetViewport { x: 0, y: 0, width: w as u32, height: h as u32 }).await;
                 });
             }
         });
@@ -318,12 +306,7 @@ fn main() {
                 local_scroll.set(((px + dx).max(0.0), (py + dy).max(0.0)));
                 let tab = tab.borrow().clone();
                 TOKIO_RT.spawn(async move {
-                    let _ = tab
-                        .send(TabCommand::MouseScroll {
-                            delta_x: dx,
-                            delta_y: dy,
-                        })
-                        .await;
+                    let _ = tab.send(TabCommand::MouseScroll { delta_x: dx, delta_y: dy }).await;
                 });
                 glib::Propagation::Stop
             }
@@ -338,12 +321,7 @@ fn main() {
             move |_, x, y| {
                 let tab = tab.borrow().clone();
                 TOKIO_RT.spawn(async move {
-                    let _ = tab
-                        .send(TabCommand::MouseMove {
-                            x: x as f32,
-                            y: y as f32,
-                        })
-                        .await;
+                    let _ = tab.send(TabCommand::MouseMove { x: x as f32, y: y as f32 }).await;
                 });
             }
         });
@@ -356,13 +334,10 @@ fn main() {
             move |_, _, x, y| {
                 let tab = tab.borrow().clone();
                 TOKIO_RT.spawn(async move {
-                    let _ = tab
-                        .send(TabCommand::MouseDown {
-                            x: x as f32,
-                            y: y as f32,
-                            button: gosub_engine::events::MouseButton::Left,
-                        })
-                        .await;
+                    let _ = tab.send(TabCommand::MouseDown {
+                        x: x as f32, y: y as f32,
+                        button: gosub_engine::events::MouseButton::Left,
+                    }).await;
                 });
             }
         });
@@ -419,10 +394,7 @@ fn main() {
             async move {
                 while let Some(evt) = ui_rx.recv().await {
                     match evt {
-                        EngineEvent::Navigation {
-                            event: NavigationEvent::Finished { url, .. },
-                            ..
-                        } => {
+                        EngineEvent::Navigation { event: NavigationEvent::Finished { url, .. }, .. } => {
                             address_entry.set_text(url.as_str());
                         }
                         EngineEvent::HoverUrl { url, .. } => {

--- a/examples/winit-skia-gpu/main.rs
+++ b/examples/winit-skia-gpu/main.rs
@@ -10,6 +10,12 @@
 #[link(name = "GL")]
 extern "C" {}
 
+use glutin::config::{Config, GlConfig};
+use glutin::context::{ContextApi, ContextAttributesBuilder, PossiblyCurrentContext};
+use glutin::display::GetGlDisplay;
+use glutin::prelude::{GlDisplay, GlSurface, NotCurrentGlContext as _};
+use glutin::surface::{Surface as GlSurface_, WindowSurface};
+use glutin_winit::{DisplayBuilder, GlWindow};
 use gosub_engine::events::{EngineEvent, MouseButton, NavigationEvent, TabCommand};
 use gosub_engine::storage::{InMemorySessionStore, PartitionPolicy, SqliteLocalStore, StorageService};
 use gosub_engine::tab::{TabDefaults, TabHandle, TabId};
@@ -17,18 +23,12 @@ use gosub_engine::zone::{Zone, ZoneConfig, ZoneId, ZoneServices};
 use gosub_engine::GosubEngine;
 use gosub_render_pipeline::render::backend::{CachedTile, ExternalHandle};
 use gosub_render_pipeline::render::DefaultCompositor;
-use glutin::config::{Config, GlConfig};
-use glutin::context::{ContextApi, ContextAttributesBuilder, PossiblyCurrentContext};
-use glutin::display::GetGlDisplay;
-use glutin::prelude::{GlDisplay, GlSurface, NotCurrentGlContext as _};
-use glutin::surface::{Surface as GlSurface_, WindowSurface};
-use glutin_winit::{DisplayBuilder, GlWindow};
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 use skia_safe::gpu::ganesh::surface_ganesh;
 use skia_safe::gpu::{self, gl::FramebufferInfo, DirectContext, SurfaceOrigin};
 use skia_safe::{Color4f, ColorType, Font, FontMgr, FontStyle, ImageInfo, Paint, Rect as SkRect, Surface};
-use std::ffi::{CString, c_void};
+use std::ffi::CString;
 use std::num::NonZeroU32;
 use std::sync::Arc;
 use tokio::runtime::{Builder, Runtime};
@@ -73,12 +73,7 @@ impl GlState {
             format: skia_safe::gpu::gl::Format::RGBA8.into(),
             ..Default::default()
         };
-        let render_target = gpu::backend_render_targets::make_gl(
-            (width, height),
-            None,
-            8,
-            fb_info,
-        );
+        let render_target = gpu::backend_render_targets::make_gl((width, height), None, 8, fb_info);
         surface_ganesh::wrap_backend_render_target(
             &mut self.direct_context,
             &render_target,
@@ -105,7 +100,8 @@ struct BrowserApp {
     tab: TabHandle,
     tab_id: TabId,
     compositor: Arc<RwLock<DefaultCompositor>>,
-    #[allow(dead_code)] proxy: EventLoopProxy<()>,
+    #[allow(dead_code)]
+    proxy: EventLoopProxy<()>,
 
     window: Option<Arc<Window>>,
     gl: Option<GlState>,
@@ -138,7 +134,9 @@ impl BrowserApp {
     fn redraw(&mut self) {
         let Some(gl) = self.gl.as_mut() else { return };
         let (win_w, win_h) = self.surface_size;
-        if win_w == 0 || win_h == 0 { return; }
+        if win_w == 0 || win_h == 0 {
+            return;
+        }
 
         let Some(mut skia_surface) = gl.skia_surface(win_w as i32, win_h as i32) else {
             return;
@@ -153,20 +151,39 @@ impl BrowserApp {
         {
             let guard = self.compositor.read();
             if let Some(handle) = guard.frame_for(self.tab_id) {
-                composite_tiles(canvas, win_w, ADDRESS_BAR_HEIGHT, content_h, &handle, &mut self.page_height);
+                composite_tiles(
+                    canvas,
+                    win_w,
+                    ADDRESS_BAR_HEIGHT,
+                    content_h,
+                    &handle,
+                    &mut self.page_height,
+                );
             }
         }
 
         // Address bar (drawn on top via Skia)
-        draw_address_bar(canvas, win_w, ADDRESS_BAR_HEIGHT as i32, &self.url_input, self.addr_focused);
+        draw_address_bar(
+            canvas,
+            win_w,
+            ADDRESS_BAR_HEIGHT as i32,
+            &self.url_input,
+            self.addr_focused,
+        );
 
         drop(skia_surface);
         gl.flush();
     }
 
-    fn is_addr_bar(&self, y: f64) -> bool { y < ADDRESS_BAR_HEIGHT as f64 }
-    fn css_x(&self, x: f64) -> f32 { (x + self.scroll.0 as f64) as f32 }
-    fn css_y(&self, y: f64) -> f32 { (y - ADDRESS_BAR_HEIGHT as f64 + self.scroll.1 as f64) as f32 }
+    fn is_addr_bar(&self, y: f64) -> bool {
+        y < ADDRESS_BAR_HEIGHT as f64
+    }
+    fn css_x(&self, x: f64) -> f32 {
+        (x + self.scroll.0 as f64) as f32
+    }
+    fn css_y(&self, y: f64) -> f32 {
+        (y - ADDRESS_BAR_HEIGHT as f64 + self.scroll.1 as f64) as f32
+    }
 }
 
 impl ApplicationHandler<()> for BrowserApp {
@@ -176,7 +193,9 @@ impl ApplicationHandler<()> for BrowserApp {
     }
 
     fn user_event(&mut self, _: &ActiveEventLoop, _: ()) {
-        if let Some(w) = &self.window { w.request_redraw(); }
+        if let Some(w) = &self.window {
+            w.request_redraw();
+        }
     }
 
     fn window_event(&mut self, event_loop: &ActiveEventLoop, _: WindowId, event: WindowEvent) {
@@ -185,7 +204,9 @@ impl ApplicationHandler<()> for BrowserApp {
             WindowEvent::RedrawRequested => self.redraw(),
 
             WindowEvent::Resized(PhysicalSize { width, height }) => {
-                if width == 0 || height == 0 { return; }
+                if width == 0 || height == 0 {
+                    return;
+                }
                 self.surface_size = (width, height);
                 let content_h = height.saturating_sub(ADDRESS_BAR_HEIGHT as u32);
                 self.viewport = (width, content_h);
@@ -199,9 +220,18 @@ impl ApplicationHandler<()> for BrowserApp {
                 }
                 let tab = self.tab.clone();
                 TOKIO_RT.spawn(async move {
-                    let _ = tab.send(TabCommand::SetViewport { x: 0, y: 0, width, height: content_h }).await;
+                    let _ = tab
+                        .send(TabCommand::SetViewport {
+                            x: 0,
+                            y: 0,
+                            width,
+                            height: content_h,
+                        })
+                        .await;
                 });
-                if let Some(w) = &self.window { w.request_redraw(); }
+                if let Some(w) = &self.window {
+                    w.request_redraw();
+                }
             }
 
             WindowEvent::CursorMoved { position, .. } => {
@@ -209,20 +239,34 @@ impl ApplicationHandler<()> for BrowserApp {
                 if !self.is_addr_bar(position.y) {
                     let (x, y) = (self.css_x(position.x), self.css_y(position.y));
                     let tab = self.tab.clone();
-                    TOKIO_RT.spawn(async move { let _ = tab.send(TabCommand::MouseMove { x, y }).await; });
+                    TOKIO_RT.spawn(async move {
+                        let _ = tab.send(TabCommand::MouseMove { x, y }).await;
+                    });
                 }
             }
 
-            WindowEvent::MouseInput { state: ElementState::Pressed, button: WinitMouseButton::Left, .. } => {
+            WindowEvent::MouseInput {
+                state: ElementState::Pressed,
+                button: WinitMouseButton::Left,
+                ..
+            } => {
                 if self.is_addr_bar(self.cursor.y) {
                     self.addr_focused = true;
-                    if let Some(w) = &self.window { w.request_redraw(); }
+                    if let Some(w) = &self.window {
+                        w.request_redraw();
+                    }
                 } else {
                     self.addr_focused = false;
                     let (x, y) = (self.css_x(self.cursor.x), self.css_y(self.cursor.y));
                     let tab = self.tab.clone();
                     TOKIO_RT.spawn(async move {
-                        let _ = tab.send(TabCommand::MouseDown { x, y, button: MouseButton::Left }).await;
+                        let _ = tab
+                            .send(TabCommand::MouseDown {
+                                x,
+                                y,
+                                button: MouseButton::Left,
+                            })
+                            .await;
                     });
                 }
             }
@@ -236,33 +280,51 @@ impl ApplicationHandler<()> for BrowserApp {
                 self.scroll.0 = (self.scroll.0 + dx).max(0.0);
                 self.scroll.1 = (self.scroll.1 + dy).clamp(0.0, max_y);
                 let tab = self.tab.clone();
-                TOKIO_RT.spawn(async move { let _ = tab.send(TabCommand::MouseScroll { delta_x: dx, delta_y: dy }).await; });
-                if let Some(w) = &self.window { w.request_redraw(); }
+                TOKIO_RT.spawn(async move {
+                    let _ = tab
+                        .send(TabCommand::MouseScroll {
+                            delta_x: dx,
+                            delta_y: dy,
+                        })
+                        .await;
+                });
+                if let Some(w) = &self.window {
+                    w.request_redraw();
+                }
             }
 
             WindowEvent::KeyboardInput {
-                event: KeyEvent { logical_key, text, state: ElementState::Pressed, .. }, ..
-            } => {
-                if self.addr_focused {
-                    match &logical_key {
-                        Key::Named(NamedKey::Enter) => self.navigate(),
-                        Key::Named(NamedKey::Escape) => {
-                            self.addr_focused = false;
-                            if let Some(w) = &self.window { w.request_redraw(); }
-                        }
-                        Key::Named(NamedKey::Backspace) => {
-                            self.url_input.pop();
-                            if let Some(w) = &self.window { w.request_redraw(); }
-                        }
-                        _ => {
-                            if let Some(t) = &text {
-                                self.url_input.push_str(t.as_str());
-                                if let Some(w) = &self.window { w.request_redraw(); }
-                            }
+                event:
+                    KeyEvent {
+                        logical_key,
+                        text,
+                        state: ElementState::Pressed,
+                        ..
+                    },
+                ..
+            } if self.addr_focused => match &logical_key {
+                Key::Named(NamedKey::Enter) => self.navigate(),
+                Key::Named(NamedKey::Escape) => {
+                    self.addr_focused = false;
+                    if let Some(w) = &self.window {
+                        w.request_redraw();
+                    }
+                }
+                Key::Named(NamedKey::Backspace) => {
+                    self.url_input.pop();
+                    if let Some(w) = &self.window {
+                        w.request_redraw();
+                    }
+                }
+                _ => {
+                    if let Some(t) = &text {
+                        self.url_input.push_str(t.as_str());
+                        if let Some(w) = &self.window {
+                            w.request_redraw();
                         }
                     }
                 }
-            }
+            },
 
             _ => {}
         }
@@ -279,7 +341,14 @@ fn composite_tiles(
     handle: &ExternalHandle,
     page_height: &mut f32,
 ) {
-    let ExternalHandle::TileCache { tiles, page_height: ph, scroll_x: sx, scroll_y: sy, .. } = handle else {
+    let ExternalHandle::TileCache {
+        tiles,
+        page_height: ph,
+        scroll_x: sx,
+        scroll_y: sy,
+        ..
+    } = handle
+    else {
         return;
     };
     *page_height = *ph;
@@ -287,7 +356,8 @@ fn composite_tiles(
     canvas.save();
     canvas.clip_rect(
         SkRect::from_xywh(0.0, addr_h, win_w as f32, content_h as f32),
-        None, None,
+        None,
+        None,
     );
 
     for tile in tiles.iter() {
@@ -297,10 +367,18 @@ fn composite_tiles(
         let screen_y = tile.page_y - sy + addr_h;
 
         // Cull tiles outside the viewport
-        if screen_x + tile.width as f32 <= 0.0 { continue; }
-        if screen_y + tile.height as f32 <= addr_h { continue; }
-        if screen_x >= win_w as f32 { continue; }
-        if screen_y >= addr_h + content_h as f32 { continue; }
+        if screen_x + tile.width as f32 <= 0.0 {
+            continue;
+        }
+        if screen_y + tile.height as f32 <= addr_h {
+            continue;
+        }
+        if screen_x >= win_w as f32 {
+            continue;
+        }
+        if screen_y >= addr_h + content_h as f32 {
+            continue;
+        }
 
         blit_tile(canvas, tile, screen_x, screen_y);
     }
@@ -315,11 +393,9 @@ fn blit_tile(canvas: &skia_safe::Canvas, tile: &CachedTile, x: f32, y: f32) {
         skia_safe::AlphaType::Premul,
         None,
     );
-    if let Some(image) = skia_safe::images::raster_from_data(
-        &info,
-        skia_safe::Data::new_copy(&tile.data),
-        (tile.width * 4) as usize,
-    ) {
+    if let Some(image) =
+        skia_safe::images::raster_from_data(&info, skia_safe::Data::new_copy(&tile.data), (tile.width * 4) as usize)
+    {
         canvas.draw_image(&image, (x, y), None);
     }
 }
@@ -330,16 +406,28 @@ fn draw_address_bar(canvas: &skia_safe::Canvas, win_w: u32, h: i32, url: &str, f
     let w = win_w as f32;
     let hf = h as f32;
 
-    let bg = if focused { Color4f::new(0.98, 0.98, 0.98, 1.0) } else { Color4f::new(0.93, 0.93, 0.93, 1.0) };
+    let bg = if focused {
+        Color4f::new(0.98, 0.98, 0.98, 1.0)
+    } else {
+        Color4f::new(0.93, 0.93, 0.93, 1.0)
+    };
     let mut paint = Paint::new(bg, None);
     canvas.draw_rect(SkRect::from_xywh(0.0, 0.0, w, hf), &paint);
 
-    let field_bg = if focused { Color4f::new(1.0, 1.0, 1.0, 1.0) } else { Color4f::new(0.97, 0.97, 0.97, 1.0) };
+    let field_bg = if focused {
+        Color4f::new(1.0, 1.0, 1.0, 1.0)
+    } else {
+        Color4f::new(0.97, 0.97, 0.97, 1.0)
+    };
     paint.set_color4f(field_bg, None);
     paint.set_anti_alias(true);
     canvas.draw_round_rect(SkRect::from_xywh(6.0, 5.0, w - 12.0, hf - 10.0), 4.0, 4.0, &paint);
 
-    let border = if focused { Color4f::new(0.26, 0.52, 0.96, 1.0) } else { Color4f::new(0.7, 0.7, 0.7, 1.0) };
+    let border = if focused {
+        Color4f::new(0.26, 0.52, 0.96, 1.0)
+    } else {
+        Color4f::new(0.7, 0.7, 0.7, 1.0)
+    };
     paint.set_color4f(border, None);
     paint.set_style(skia_safe::PaintStyle::Stroke);
     paint.set_stroke_width(1.0);
@@ -347,8 +435,10 @@ fn draw_address_bar(canvas: &skia_safe::Canvas, win_w: u32, h: i32, url: &str, f
 
     thread_local! { static FONT_MGR: FontMgr = FontMgr::new(); }
     let typeface = FONT_MGR.with(|fm| {
-        fm.legacy_make_typeface(None, FontStyle::normal())
-            .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("typeface"))
+        fm.legacy_make_typeface(None, FontStyle::normal()).unwrap_or_else(|| {
+            fm.legacy_make_typeface("sans-serif", FontStyle::normal())
+                .expect("typeface")
+        })
     });
     let font = Font::new(typeface, 14.0);
     paint.set_color4f(Color4f::new(0.0, 0.0, 0.0, 1.0), None);
@@ -359,11 +449,21 @@ fn draw_address_bar(canvas: &skia_safe::Canvas, win_w: u32, h: i32, url: &str, f
 // ── main ──────────────────────────────────────────────────────────────────────
 
 fn main() {
-    simple_logger::SimpleLogger::new().with_level(log::LevelFilter::Warn).env().init().unwrap_or_default();
+    simple_logger::SimpleLogger::new()
+        .with_level(log::LevelFilter::Warn)
+        .env()
+        .init()
+        .unwrap_or_default();
 
     let initial_url = {
-        let raw = std::env::args().nth(1).unwrap_or_else(|| "https://example.com".to_string());
-        if raw.contains("://") { raw } else { format!("https://{raw}") }
+        let raw = std::env::args()
+            .nth(1)
+            .unwrap_or_else(|| "https://example.com".to_string());
+        if raw.contains("://") {
+            raw
+        } else {
+            format!("https://{raw}")
+        }
     };
 
     let _rt_guard = TOKIO_RT.enter();
@@ -392,23 +492,37 @@ fn main() {
 
     let not_current = unsafe { gl_display.create_context(&gl_config, &ctx_attrs).expect("GL context") };
 
-    let surf_attrs = gl_window.build_surface_attributes(Default::default()).expect("surface attrs");
-    let gl_surface = unsafe { gl_display.create_window_surface(&gl_config, &surf_attrs).expect("GL surface") };
+    let surf_attrs = gl_window
+        .build_surface_attributes(Default::default())
+        .expect("surface attrs");
+    let gl_surface = unsafe {
+        gl_display
+            .create_window_surface(&gl_config, &surf_attrs)
+            .expect("GL surface")
+    };
     let gl_context = not_current.make_current(&gl_surface).expect("make current");
 
     // Build Skia DirectContext using the GL interface.
     let interface = skia_safe::gpu::gl::Interface::new_load_with(|name| {
         let c = CString::new(name).unwrap_or_default();
-        gl_display.get_proc_address(&c) as *const c_void
-    }).expect("GL interface");
+        gl_display.get_proc_address(&c)
+    })
+    .expect("GL interface");
     let direct_context = skia_safe::gpu::direct_contexts::make_gl(interface, None).expect("Skia DirectContext");
 
-    let gl_state = GlState { gl_context, gl_surface, gl_config, direct_context };
+    let gl_state = GlState {
+        gl_context,
+        gl_surface,
+        gl_config,
+        direct_context,
+    };
 
     // Engine + compositor
     let compositor = Arc::new(RwLock::new(DefaultCompositor::new({
         let p = proxy.clone();
-        move || { let _ = p.send_event(()); }
+        move || {
+            let _ = p.send_event(());
+        }
     })));
 
     // Use a null render backend — TileCache frames are submitted directly by the engine
@@ -422,7 +536,10 @@ fn main() {
     TOKIO_RT.spawn(async move {
         loop {
             match event_rx.recv().await {
-                Ok(EngineEvent::Navigation { event: NavigationEvent::Finished { .. } | NavigationEvent::Started { .. }, .. }) => {
+                Ok(EngineEvent::Navigation {
+                    event: NavigationEvent::Finished { .. } | NavigationEvent::Started { .. },
+                    ..
+                }) => {
                     let _ = proxy_ev.send_event(());
                 }
                 Ok(_) => {}
@@ -443,22 +560,40 @@ fn main() {
         partition_policy: PartitionPolicy::None,
     };
 
-    let mut zone = engine.create_zone(zone_cfg, zone_services, Some(ZoneId::from(DEFAULT_ZONE))).expect("zone");
+    let mut zone = engine
+        .create_zone(zone_cfg, zone_services, Some(ZoneId::from(DEFAULT_ZONE)))
+        .expect("zone");
     let tab = TOKIO_RT
-        .block_on(zone.create_tab(TabDefaults { url: None, title: Some("Gosub".to_string()), viewport: None }, None))
+        .block_on(zone.create_tab(
+            TabDefaults {
+                url: None,
+                title: Some("Gosub".to_string()),
+                viewport: None,
+            },
+            None,
+        ))
         .expect("tab");
 
     let tab_id = tab.tab_id;
     let nav_tab = tab.clone();
     let nav_url = initial_url.clone();
-    TOKIO_RT.spawn(async move { let _ = nav_tab.send(TabCommand::Navigate { url: nav_url }).await; });
+    TOKIO_RT.spawn(async move {
+        let _ = nav_tab.send(TabCommand::Navigate { url: nav_url }).await;
+    });
 
     let size = gl_window.inner_size();
     let content_h = size.height.saturating_sub(ADDRESS_BAR_HEIGHT as u32);
     {
         let t = tab.clone();
         TOKIO_RT.block_on(async move {
-            let _ = t.send(TabCommand::SetViewport { x: 0, y: 0, width: size.width, height: content_h }).await;
+            let _ = t
+                .send(TabCommand::SetViewport {
+                    x: 0,
+                    y: 0,
+                    width: size.width,
+                    height: content_h,
+                })
+                .await;
             let _ = t.send(TabCommand::ResumeDrawing { fps: 30 }).await;
         });
     }
@@ -466,7 +601,12 @@ fn main() {
     let window = Arc::new(gl_window);
 
     let mut app = BrowserApp {
-        engine, zone, tab, tab_id, compositor, proxy,
+        engine,
+        zone,
+        tab,
+        tab_id,
+        compositor,
+        proxy,
         window: Some(window),
         gl: Some(gl_state),
         surface_size: (size.width, size.height),

--- a/examples/winit-skia-gpu/main.rs
+++ b/examples/winit-skia-gpu/main.rs
@@ -10,12 +10,6 @@
 #[link(name = "GL")]
 extern "C" {}
 
-use glutin::config::{Config, GlConfig};
-use glutin::context::{ContextApi, ContextAttributesBuilder, PossiblyCurrentContext};
-use glutin::display::GetGlDisplay;
-use glutin::prelude::{GlDisplay, GlSurface, NotCurrentGlContext as _};
-use glutin::surface::{Surface as GlSurface_, WindowSurface};
-use glutin_winit::{DisplayBuilder, GlWindow};
 use gosub_engine::events::{EngineEvent, MouseButton, NavigationEvent, TabCommand};
 use gosub_engine::storage::{InMemorySessionStore, PartitionPolicy, SqliteLocalStore, StorageService};
 use gosub_engine::tab::{TabDefaults, TabHandle, TabId};
@@ -23,12 +17,18 @@ use gosub_engine::zone::{Zone, ZoneConfig, ZoneId, ZoneServices};
 use gosub_engine::GosubEngine;
 use gosub_render_pipeline::render::backend::{CachedTile, ExternalHandle};
 use gosub_render_pipeline::render::DefaultCompositor;
+use glutin::config::{Config, GlConfig};
+use glutin::context::{ContextApi, ContextAttributesBuilder, NotCurrentGlContext, PossiblyCurrentContext};
+use glutin::display::GetGlDisplay;
+use glutin::prelude::{GlDisplay, GlSurface, NotCurrentGlContext as _};
+use glutin::surface::{Surface as GlSurface_, SurfaceAttributesBuilder, WindowSurface};
+use glutin_winit::{DisplayBuilder, GlWindow};
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 use skia_safe::gpu::ganesh::surface_ganesh;
-use skia_safe::gpu::{self, gl::FramebufferInfo, DirectContext, SurfaceOrigin};
+use skia_safe::gpu::{self, gl::FramebufferInfo, Budgeted, DirectContext, SurfaceOrigin};
 use skia_safe::{Color4f, ColorType, Font, FontMgr, FontStyle, ImageInfo, Paint, Rect as SkRect, Surface};
-use std::ffi::CString;
+use std::ffi::{CString, c_void};
 use std::num::NonZeroU32;
 use std::sync::Arc;
 use tokio::runtime::{Builder, Runtime};
@@ -60,7 +60,6 @@ static TOKIO_RT: Lazy<Runtime> = Lazy::new(|| {
 struct GlState {
     gl_context: PossiblyCurrentContext,
     gl_surface: GlSurface_<WindowSurface>,
-    #[allow(dead_code)]
     gl_config: Config,
     direct_context: DirectContext,
 }
@@ -73,7 +72,12 @@ impl GlState {
             format: skia_safe::gpu::gl::Format::RGBA8.into(),
             ..Default::default()
         };
-        let render_target = gpu::backend_render_targets::make_gl((width, height), None, 8, fb_info);
+        let render_target = gpu::backend_render_targets::make_gl(
+            (width, height),
+            None,
+            8,
+            fb_info,
+        );
         surface_ganesh::wrap_backend_render_target(
             &mut self.direct_context,
             &render_target,
@@ -100,7 +104,6 @@ struct BrowserApp {
     tab: TabHandle,
     tab_id: TabId,
     compositor: Arc<RwLock<DefaultCompositor>>,
-    #[allow(dead_code)]
     proxy: EventLoopProxy<()>,
 
     window: Option<Arc<Window>>,
@@ -134,9 +137,7 @@ impl BrowserApp {
     fn redraw(&mut self) {
         let Some(gl) = self.gl.as_mut() else { return };
         let (win_w, win_h) = self.surface_size;
-        if win_w == 0 || win_h == 0 {
-            return;
-        }
+        if win_w == 0 || win_h == 0 { return; }
 
         let Some(mut skia_surface) = gl.skia_surface(win_w as i32, win_h as i32) else {
             return;
@@ -151,39 +152,20 @@ impl BrowserApp {
         {
             let guard = self.compositor.read();
             if let Some(handle) = guard.frame_for(self.tab_id) {
-                composite_tiles(
-                    canvas,
-                    win_w,
-                    ADDRESS_BAR_HEIGHT,
-                    content_h,
-                    &handle,
-                    &mut self.page_height,
-                );
+                composite_tiles(canvas, win_w, ADDRESS_BAR_HEIGHT, content_h, &handle, &mut self.page_height);
             }
         }
 
         // Address bar (drawn on top via Skia)
-        draw_address_bar(
-            canvas,
-            win_w,
-            ADDRESS_BAR_HEIGHT as i32,
-            &self.url_input,
-            self.addr_focused,
-        );
+        draw_address_bar(canvas, win_w, ADDRESS_BAR_HEIGHT as i32, &self.url_input, self.addr_focused);
 
         drop(skia_surface);
         gl.flush();
     }
 
-    fn is_addr_bar(&self, y: f64) -> bool {
-        y < ADDRESS_BAR_HEIGHT as f64
-    }
-    fn css_x(&self, x: f64) -> f32 {
-        (x + self.scroll.0 as f64) as f32
-    }
-    fn css_y(&self, y: f64) -> f32 {
-        (y - ADDRESS_BAR_HEIGHT as f64 + self.scroll.1 as f64) as f32
-    }
+    fn is_addr_bar(&self, y: f64) -> bool { y < ADDRESS_BAR_HEIGHT as f64 }
+    fn css_x(&self, x: f64) -> f32 { (x + self.scroll.0 as f64) as f32 }
+    fn css_y(&self, y: f64) -> f32 { (y - ADDRESS_BAR_HEIGHT as f64 + self.scroll.1 as f64) as f32 }
 }
 
 impl ApplicationHandler<()> for BrowserApp {
@@ -193,9 +175,7 @@ impl ApplicationHandler<()> for BrowserApp {
     }
 
     fn user_event(&mut self, _: &ActiveEventLoop, _: ()) {
-        if let Some(w) = &self.window {
-            w.request_redraw();
-        }
+        if let Some(w) = &self.window { w.request_redraw(); }
     }
 
     fn window_event(&mut self, event_loop: &ActiveEventLoop, _: WindowId, event: WindowEvent) {
@@ -204,9 +184,7 @@ impl ApplicationHandler<()> for BrowserApp {
             WindowEvent::RedrawRequested => self.redraw(),
 
             WindowEvent::Resized(PhysicalSize { width, height }) => {
-                if width == 0 || height == 0 {
-                    return;
-                }
+                if width == 0 || height == 0 { return; }
                 self.surface_size = (width, height);
                 let content_h = height.saturating_sub(ADDRESS_BAR_HEIGHT as u32);
                 self.viewport = (width, content_h);
@@ -220,18 +198,9 @@ impl ApplicationHandler<()> for BrowserApp {
                 }
                 let tab = self.tab.clone();
                 TOKIO_RT.spawn(async move {
-                    let _ = tab
-                        .send(TabCommand::SetViewport {
-                            x: 0,
-                            y: 0,
-                            width,
-                            height: content_h,
-                        })
-                        .await;
+                    let _ = tab.send(TabCommand::SetViewport { x: 0, y: 0, width, height: content_h }).await;
                 });
-                if let Some(w) = &self.window {
-                    w.request_redraw();
-                }
+                if let Some(w) = &self.window { w.request_redraw(); }
             }
 
             WindowEvent::CursorMoved { position, .. } => {
@@ -239,34 +208,20 @@ impl ApplicationHandler<()> for BrowserApp {
                 if !self.is_addr_bar(position.y) {
                     let (x, y) = (self.css_x(position.x), self.css_y(position.y));
                     let tab = self.tab.clone();
-                    TOKIO_RT.spawn(async move {
-                        let _ = tab.send(TabCommand::MouseMove { x, y }).await;
-                    });
+                    TOKIO_RT.spawn(async move { let _ = tab.send(TabCommand::MouseMove { x, y }).await; });
                 }
             }
 
-            WindowEvent::MouseInput {
-                state: ElementState::Pressed,
-                button: WinitMouseButton::Left,
-                ..
-            } => {
+            WindowEvent::MouseInput { state: ElementState::Pressed, button: WinitMouseButton::Left, .. } => {
                 if self.is_addr_bar(self.cursor.y) {
                     self.addr_focused = true;
-                    if let Some(w) = &self.window {
-                        w.request_redraw();
-                    }
+                    if let Some(w) = &self.window { w.request_redraw(); }
                 } else {
                     self.addr_focused = false;
                     let (x, y) = (self.css_x(self.cursor.x), self.css_y(self.cursor.y));
                     let tab = self.tab.clone();
                     TOKIO_RT.spawn(async move {
-                        let _ = tab
-                            .send(TabCommand::MouseDown {
-                                x,
-                                y,
-                                button: MouseButton::Left,
-                            })
-                            .await;
+                        let _ = tab.send(TabCommand::MouseDown { x, y, button: MouseButton::Left }).await;
                     });
                 }
             }
@@ -280,51 +235,33 @@ impl ApplicationHandler<()> for BrowserApp {
                 self.scroll.0 = (self.scroll.0 + dx).max(0.0);
                 self.scroll.1 = (self.scroll.1 + dy).clamp(0.0, max_y);
                 let tab = self.tab.clone();
-                TOKIO_RT.spawn(async move {
-                    let _ = tab
-                        .send(TabCommand::MouseScroll {
-                            delta_x: dx,
-                            delta_y: dy,
-                        })
-                        .await;
-                });
-                if let Some(w) = &self.window {
-                    w.request_redraw();
-                }
+                TOKIO_RT.spawn(async move { let _ = tab.send(TabCommand::MouseScroll { delta_x: dx, delta_y: dy }).await; });
+                if let Some(w) = &self.window { w.request_redraw(); }
             }
 
             WindowEvent::KeyboardInput {
-                event:
-                    KeyEvent {
-                        logical_key,
-                        text,
-                        state: ElementState::Pressed,
-                        ..
-                    },
-                ..
-            } if self.addr_focused => match &logical_key {
-                Key::Named(NamedKey::Enter) => self.navigate(),
-                Key::Named(NamedKey::Escape) => {
-                    self.addr_focused = false;
-                    if let Some(w) = &self.window {
-                        w.request_redraw();
-                    }
-                }
-                Key::Named(NamedKey::Backspace) => {
-                    self.url_input.pop();
-                    if let Some(w) = &self.window {
-                        w.request_redraw();
-                    }
-                }
-                _ => {
-                    if let Some(t) = &text {
-                        self.url_input.push_str(t.as_str());
-                        if let Some(w) = &self.window {
-                            w.request_redraw();
+                event: KeyEvent { logical_key, text, state: ElementState::Pressed, .. }, ..
+            } => {
+                if self.addr_focused {
+                    match &logical_key {
+                        Key::Named(NamedKey::Enter) => self.navigate(),
+                        Key::Named(NamedKey::Escape) => {
+                            self.addr_focused = false;
+                            if let Some(w) = &self.window { w.request_redraw(); }
+                        }
+                        Key::Named(NamedKey::Backspace) => {
+                            self.url_input.pop();
+                            if let Some(w) = &self.window { w.request_redraw(); }
+                        }
+                        _ => {
+                            if let Some(t) = &text {
+                                self.url_input.push_str(t.as_str());
+                                if let Some(w) = &self.window { w.request_redraw(); }
+                            }
                         }
                     }
                 }
-            },
+            }
 
             _ => {}
         }
@@ -341,14 +278,7 @@ fn composite_tiles(
     handle: &ExternalHandle,
     page_height: &mut f32,
 ) {
-    let ExternalHandle::TileCache {
-        tiles,
-        page_height: ph,
-        scroll_x: sx,
-        scroll_y: sy,
-        ..
-    } = handle
-    else {
+    let ExternalHandle::TileCache { tiles, page_height: ph, scroll_x: sx, scroll_y: sy, .. } = handle else {
         return;
     };
     *page_height = *ph;
@@ -356,8 +286,7 @@ fn composite_tiles(
     canvas.save();
     canvas.clip_rect(
         SkRect::from_xywh(0.0, addr_h, win_w as f32, content_h as f32),
-        None,
-        None,
+        None, None,
     );
 
     for tile in tiles.iter() {
@@ -367,18 +296,10 @@ fn composite_tiles(
         let screen_y = tile.page_y - sy + addr_h;
 
         // Cull tiles outside the viewport
-        if screen_x + tile.width as f32 <= 0.0 {
-            continue;
-        }
-        if screen_y + tile.height as f32 <= addr_h {
-            continue;
-        }
-        if screen_x >= win_w as f32 {
-            continue;
-        }
-        if screen_y >= addr_h + content_h as f32 {
-            continue;
-        }
+        if screen_x + tile.width as f32 <= 0.0 { continue; }
+        if screen_y + tile.height as f32 <= addr_h { continue; }
+        if screen_x >= win_w as f32 { continue; }
+        if screen_y >= addr_h + content_h as f32 { continue; }
 
         blit_tile(canvas, tile, screen_x, screen_y);
     }
@@ -393,9 +314,11 @@ fn blit_tile(canvas: &skia_safe::Canvas, tile: &CachedTile, x: f32, y: f32) {
         skia_safe::AlphaType::Premul,
         None,
     );
-    if let Some(image) =
-        skia_safe::images::raster_from_data(&info, skia_safe::Data::new_copy(&tile.data), (tile.width * 4) as usize)
-    {
+    if let Some(image) = skia_safe::images::raster_from_data(
+        &info,
+        skia_safe::Data::new_copy(&tile.data),
+        (tile.width * 4) as usize,
+    ) {
         canvas.draw_image(&image, (x, y), None);
     }
 }
@@ -406,40 +329,26 @@ fn draw_address_bar(canvas: &skia_safe::Canvas, win_w: u32, h: i32, url: &str, f
     let w = win_w as f32;
     let hf = h as f32;
 
-    let bg = if focused {
-        Color4f::new(0.98, 0.98, 0.98, 1.0)
-    } else {
-        Color4f::new(0.93, 0.93, 0.93, 1.0)
-    };
+    let bg = if focused { Color4f::new(0.98, 0.98, 0.98, 1.0) } else { Color4f::new(0.93, 0.93, 0.93, 1.0) };
     let mut paint = Paint::new(bg, None);
     canvas.draw_rect(SkRect::from_xywh(0.0, 0.0, w, hf), &paint);
 
-    let field_bg = if focused {
-        Color4f::new(1.0, 1.0, 1.0, 1.0)
-    } else {
-        Color4f::new(0.97, 0.97, 0.97, 1.0)
-    };
+    let field_bg = if focused { Color4f::new(1.0, 1.0, 1.0, 1.0) } else { Color4f::new(0.97, 0.97, 0.97, 1.0) };
     paint.set_color4f(field_bg, None);
     paint.set_anti_alias(true);
     canvas.draw_round_rect(SkRect::from_xywh(6.0, 5.0, w - 12.0, hf - 10.0), 4.0, 4.0, &paint);
 
-    let border = if focused {
-        Color4f::new(0.26, 0.52, 0.96, 1.0)
-    } else {
-        Color4f::new(0.7, 0.7, 0.7, 1.0)
-    };
+    let border = if focused { Color4f::new(0.26, 0.52, 0.96, 1.0) } else { Color4f::new(0.7, 0.7, 0.7, 1.0) };
     paint.set_color4f(border, None);
     paint.set_style(skia_safe::PaintStyle::Stroke);
     paint.set_stroke_width(1.0);
     canvas.draw_round_rect(SkRect::from_xywh(6.5, 5.5, w - 13.0, hf - 11.0), 4.0, 4.0, &paint);
 
-    let typeface = FontMgr::new()
-        .legacy_make_typeface(None, FontStyle::normal())
-        .unwrap_or_else(|| {
-            FontMgr::new()
-                .legacy_make_typeface("sans-serif", FontStyle::normal())
-                .expect("typeface")
-        });
+    thread_local! { static FONT_MGR: FontMgr = FontMgr::new(); }
+    let typeface = FONT_MGR.with(|fm| {
+        fm.legacy_make_typeface(None, FontStyle::normal())
+            .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("typeface"))
+    });
     let font = Font::new(typeface, 14.0);
     paint.set_color4f(Color4f::new(0.0, 0.0, 0.0, 1.0), None);
     paint.set_style(skia_safe::PaintStyle::Fill);
@@ -449,21 +358,11 @@ fn draw_address_bar(canvas: &skia_safe::Canvas, win_w: u32, h: i32, url: &str, f
 // ── main ──────────────────────────────────────────────────────────────────────
 
 fn main() {
-    simple_logger::SimpleLogger::new()
-        .with_level(log::LevelFilter::Warn)
-        .env()
-        .init()
-        .unwrap_or_default();
+    simple_logger::SimpleLogger::new().with_level(log::LevelFilter::Warn).env().init().unwrap_or_default();
 
     let initial_url = {
-        let raw = std::env::args()
-            .nth(1)
-            .unwrap_or_else(|| "https://example.com".to_string());
-        if raw.contains("://") {
-            raw
-        } else {
-            format!("https://{raw}")
-        }
+        let raw = std::env::args().nth(1).unwrap_or_else(|| "https://example.com".to_string());
+        if raw.contains("://") { raw } else { format!("https://{raw}") }
     };
 
     let _rt_guard = TOKIO_RT.enter();
@@ -492,37 +391,23 @@ fn main() {
 
     let not_current = unsafe { gl_display.create_context(&gl_config, &ctx_attrs).expect("GL context") };
 
-    let surf_attrs = gl_window
-        .build_surface_attributes(Default::default())
-        .expect("surface attrs");
-    let gl_surface = unsafe {
-        gl_display
-            .create_window_surface(&gl_config, &surf_attrs)
-            .expect("GL surface")
-    };
+    let surf_attrs = gl_window.build_surface_attributes(Default::default()).expect("surface attrs");
+    let gl_surface = unsafe { gl_display.create_window_surface(&gl_config, &surf_attrs).expect("GL surface") };
     let gl_context = not_current.make_current(&gl_surface).expect("make current");
 
     // Build Skia DirectContext using the GL interface.
     let interface = skia_safe::gpu::gl::Interface::new_load_with(|name| {
         let c = CString::new(name).unwrap_or_default();
-        gl_display.get_proc_address(&c)
-    })
-    .expect("GL interface");
-    let direct_context = gpu::direct_contexts::make_gl(interface, None).expect("Skia DirectContext");
+        gl_display.get_proc_address(&c) as *const c_void
+    }).expect("GL interface");
+    let direct_context = DirectContext::new_gl(interface, None).expect("Skia DirectContext");
 
-    let gl_state = GlState {
-        gl_context,
-        gl_surface,
-        gl_config,
-        direct_context,
-    };
+    let gl_state = GlState { gl_context, gl_surface, gl_config, direct_context };
 
     // Engine + compositor
     let compositor = Arc::new(RwLock::new(DefaultCompositor::new({
         let p = proxy.clone();
-        move || {
-            let _ = p.send_event(());
-        }
+        move || { let _ = p.send_event(()); }
     })));
 
     // Use a null render backend — TileCache frames are submitted directly by the engine
@@ -536,10 +421,7 @@ fn main() {
     TOKIO_RT.spawn(async move {
         loop {
             match event_rx.recv().await {
-                Ok(EngineEvent::Navigation {
-                    event: NavigationEvent::Finished { .. } | NavigationEvent::Started { .. },
-                    ..
-                }) => {
+                Ok(EngineEvent::Navigation { event: NavigationEvent::Finished { .. } | NavigationEvent::Started { .. }, .. }) => {
                     let _ = proxy_ev.send_event(());
                 }
                 Ok(_) => {}
@@ -560,40 +442,22 @@ fn main() {
         partition_policy: PartitionPolicy::None,
     };
 
-    let mut zone = engine
-        .create_zone(zone_cfg, zone_services, Some(ZoneId::from(DEFAULT_ZONE)))
-        .expect("zone");
+    let mut zone = engine.create_zone(zone_cfg, zone_services, Some(ZoneId::from(DEFAULT_ZONE))).expect("zone");
     let tab = TOKIO_RT
-        .block_on(zone.create_tab(
-            TabDefaults {
-                url: None,
-                title: Some("Gosub".to_string()),
-                viewport: None,
-            },
-            None,
-        ))
+        .block_on(zone.create_tab(TabDefaults { url: None, title: Some("Gosub".to_string()), viewport: None }, None))
         .expect("tab");
 
     let tab_id = tab.tab_id;
     let nav_tab = tab.clone();
     let nav_url = initial_url.clone();
-    TOKIO_RT.spawn(async move {
-        let _ = nav_tab.send(TabCommand::Navigate { url: nav_url }).await;
-    });
+    TOKIO_RT.spawn(async move { let _ = nav_tab.send(TabCommand::Navigate { url: nav_url }).await; });
 
     let size = gl_window.inner_size();
     let content_h = size.height.saturating_sub(ADDRESS_BAR_HEIGHT as u32);
     {
         let t = tab.clone();
         TOKIO_RT.block_on(async move {
-            let _ = t
-                .send(TabCommand::SetViewport {
-                    x: 0,
-                    y: 0,
-                    width: size.width,
-                    height: content_h,
-                })
-                .await;
+            let _ = t.send(TabCommand::SetViewport { x: 0, y: 0, width: size.width, height: content_h }).await;
             let _ = t.send(TabCommand::ResumeDrawing { fps: 30 }).await;
         });
     }
@@ -601,12 +465,7 @@ fn main() {
     let window = Arc::new(gl_window);
 
     let mut app = BrowserApp {
-        engine,
-        zone,
-        tab,
-        tab_id,
-        compositor,
-        proxy,
+        engine, zone, tab, tab_id, compositor, proxy,
         window: Some(window),
         gl: Some(gl_state),
         surface_size: (size.width, size.height),

--- a/examples/winit-skia-gpu/main.rs
+++ b/examples/winit-skia-gpu/main.rs
@@ -18,15 +18,15 @@ use gosub_engine::GosubEngine;
 use gosub_render_pipeline::render::backend::{CachedTile, ExternalHandle};
 use gosub_render_pipeline::render::DefaultCompositor;
 use glutin::config::{Config, GlConfig};
-use glutin::context::{ContextApi, ContextAttributesBuilder, NotCurrentGlContext, PossiblyCurrentContext};
+use glutin::context::{ContextApi, ContextAttributesBuilder, PossiblyCurrentContext};
 use glutin::display::GetGlDisplay;
 use glutin::prelude::{GlDisplay, GlSurface, NotCurrentGlContext as _};
-use glutin::surface::{Surface as GlSurface_, SurfaceAttributesBuilder, WindowSurface};
+use glutin::surface::{Surface as GlSurface_, WindowSurface};
 use glutin_winit::{DisplayBuilder, GlWindow};
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 use skia_safe::gpu::ganesh::surface_ganesh;
-use skia_safe::gpu::{self, gl::FramebufferInfo, Budgeted, DirectContext, SurfaceOrigin};
+use skia_safe::gpu::{self, gl::FramebufferInfo, DirectContext, SurfaceOrigin};
 use skia_safe::{Color4f, ColorType, Font, FontMgr, FontStyle, ImageInfo, Paint, Rect as SkRect, Surface};
 use std::ffi::{CString, c_void};
 use std::num::NonZeroU32;
@@ -57,6 +57,7 @@ static TOKIO_RT: Lazy<Runtime> = Lazy::new(|| {
 
 // ── GL state kept on the main thread ─────────────────────────────────────────
 
+#[allow(dead_code)]
 struct GlState {
     gl_context: PossiblyCurrentContext,
     gl_surface: GlSurface_<WindowSurface>,
@@ -104,7 +105,7 @@ struct BrowserApp {
     tab: TabHandle,
     tab_id: TabId,
     compositor: Arc<RwLock<DefaultCompositor>>,
-    proxy: EventLoopProxy<()>,
+    #[allow(dead_code)] proxy: EventLoopProxy<()>,
 
     window: Option<Arc<Window>>,
     gl: Option<GlState>,
@@ -400,7 +401,7 @@ fn main() {
         let c = CString::new(name).unwrap_or_default();
         gl_display.get_proc_address(&c) as *const c_void
     }).expect("GL interface");
-    let direct_context = DirectContext::new_gl(interface, None).expect("Skia DirectContext");
+    let direct_context = skia_safe::gpu::direct_contexts::make_gl(interface, None).expect("Skia DirectContext");
 
     let gl_state = GlState { gl_context, gl_surface, gl_config, direct_context };
 

--- a/examples/winit-skia/main.rs
+++ b/examples/winit-skia/main.rs
@@ -15,7 +15,7 @@ use gosub_render_pipeline::render::backends::skia::SkiaBackend;
 use gosub_render_pipeline::render::DefaultCompositor;
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
-use skia_safe::{Color4f, Font, FontMgr, FontStyle, Paint, Rect as SkRect, surfaces};
+use skia_safe::{surfaces, Color4f, Font, FontMgr, FontStyle, Paint, Rect as SkRect};
 use softbuffer::Surface;
 use std::num::NonZeroU32;
 use std::sync::Arc;
@@ -85,11 +85,15 @@ impl BrowserApp {
     fn redraw(&mut self) {
         let Some(surface) = &mut self.surface else { return };
         let (win_w, win_h) = self.surface_size;
-        if win_w == 0 || win_h == 0 { return; }
+        if win_w == 0 || win_h == 0 {
+            return;
+        }
 
         let Ok(nw) = NonZeroU32::try_from(win_w) else { return };
         let Ok(nh) = NonZeroU32::try_from(win_h) else { return };
-        if surface.resize(nw, nh).is_err() { return; }
+        if surface.resize(nw, nh).is_err() {
+            return;
+        }
 
         let Ok(mut buf) = surface.buffer_mut() else { return };
         buf.fill(0x00FF_FFFF);
@@ -98,7 +102,14 @@ impl BrowserApp {
         if content_h > 0 {
             let guard = self.compositor.read();
             if let Some(handle) = guard.frame_for(self.tab_id) {
-                blit_to_buffer(&mut buf, win_w, ADDRESS_BAR_HEIGHT, content_h, handle, &mut self.page_height);
+                blit_to_buffer(
+                    &mut buf,
+                    win_w,
+                    ADDRESS_BAR_HEIGHT,
+                    content_h,
+                    handle,
+                    &mut self.page_height,
+                );
             }
         }
 
@@ -121,7 +132,9 @@ impl BrowserApp {
 
 impl ApplicationHandler<()> for BrowserApp {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
-        if self.window.is_some() { return; }
+        if self.window.is_some() {
+            return;
+        }
 
         let attrs = WindowAttributes::default()
             .with_title("Gosub Browser — winit + Skia")
@@ -138,7 +151,14 @@ impl ApplicationHandler<()> for BrowserApp {
 
         let tab = self.tab.clone();
         TOKIO_RT.spawn(async move {
-            let _ = tab.send(TabCommand::SetViewport { x: 0, y: 0, width: size.width, height: content_h }).await;
+            let _ = tab
+                .send(TabCommand::SetViewport {
+                    x: 0,
+                    y: 0,
+                    width: size.width,
+                    height: content_h,
+                })
+                .await;
             let _ = tab.send(TabCommand::ResumeDrawing { fps: 30 }).await;
         });
 
@@ -147,7 +167,9 @@ impl ApplicationHandler<()> for BrowserApp {
     }
 
     fn user_event(&mut self, _: &ActiveEventLoop, _: ()) {
-        if let Some(w) = &self.window { w.request_redraw(); }
+        if let Some(w) = &self.window {
+            w.request_redraw();
+        }
     }
 
     fn window_event(&mut self, event_loop: &ActiveEventLoop, _: WindowId, event: WindowEvent) {
@@ -156,16 +178,27 @@ impl ApplicationHandler<()> for BrowserApp {
             WindowEvent::RedrawRequested => self.redraw(),
 
             WindowEvent::Resized(PhysicalSize { width, height }) => {
-                if width == 0 || height == 0 { return; }
+                if width == 0 || height == 0 {
+                    return;
+                }
                 self.surface_size = (width, height);
                 let content_h = height.saturating_sub(ADDRESS_BAR_HEIGHT);
                 self.viewport = (width, content_h);
                 self.scroll = (0.0, 0.0);
                 let tab = self.tab.clone();
                 TOKIO_RT.spawn(async move {
-                    let _ = tab.send(TabCommand::SetViewport { x: 0, y: 0, width, height: content_h }).await;
+                    let _ = tab
+                        .send(TabCommand::SetViewport {
+                            x: 0,
+                            y: 0,
+                            width,
+                            height: content_h,
+                        })
+                        .await;
                 });
-                if let Some(w) = &self.window { w.request_redraw(); }
+                if let Some(w) = &self.window {
+                    w.request_redraw();
+                }
             }
 
             WindowEvent::CursorMoved { position, .. } => {
@@ -173,20 +206,34 @@ impl ApplicationHandler<()> for BrowserApp {
                 if !self.is_in_address_bar(position.y) {
                     let (x, y) = (self.to_css_x(position.x), self.to_css_y(position.y));
                     let tab = self.tab.clone();
-                    TOKIO_RT.spawn(async move { let _ = tab.send(TabCommand::MouseMove { x, y }).await; });
+                    TOKIO_RT.spawn(async move {
+                        let _ = tab.send(TabCommand::MouseMove { x, y }).await;
+                    });
                 }
             }
 
-            WindowEvent::MouseInput { state: ElementState::Pressed, button: WinitMouseButton::Left, .. } => {
+            WindowEvent::MouseInput {
+                state: ElementState::Pressed,
+                button: WinitMouseButton::Left,
+                ..
+            } => {
                 if self.is_in_address_bar(self.cursor.y) {
                     self.addr_focused = true;
-                    if let Some(w) = &self.window { w.request_redraw(); }
+                    if let Some(w) = &self.window {
+                        w.request_redraw();
+                    }
                 } else {
                     self.addr_focused = false;
                     let (x, y) = (self.to_css_x(self.cursor.x), self.to_css_y(self.cursor.y));
                     let tab = self.tab.clone();
                     TOKIO_RT.spawn(async move {
-                        let _ = tab.send(TabCommand::MouseDown { x, y, button: MouseButton::Left }).await;
+                        let _ = tab
+                            .send(TabCommand::MouseDown {
+                                x,
+                                y,
+                                button: MouseButton::Left,
+                            })
+                            .await;
                     });
                 }
             }
@@ -200,33 +247,51 @@ impl ApplicationHandler<()> for BrowserApp {
                 self.scroll.0 = (self.scroll.0 + dx).max(0.0);
                 self.scroll.1 = (self.scroll.1 + dy).clamp(0.0, max_y);
                 let tab = self.tab.clone();
-                TOKIO_RT.spawn(async move { let _ = tab.send(TabCommand::MouseScroll { delta_x: dx, delta_y: dy }).await; });
-                if let Some(w) = &self.window { w.request_redraw(); }
+                TOKIO_RT.spawn(async move {
+                    let _ = tab
+                        .send(TabCommand::MouseScroll {
+                            delta_x: dx,
+                            delta_y: dy,
+                        })
+                        .await;
+                });
+                if let Some(w) = &self.window {
+                    w.request_redraw();
+                }
             }
 
             WindowEvent::KeyboardInput {
-                event: KeyEvent { logical_key, text, state: ElementState::Pressed, .. }, ..
-            } => {
-                if self.addr_focused {
-                    match &logical_key {
-                        Key::Named(NamedKey::Enter) => self.navigate(),
-                        Key::Named(NamedKey::Escape) => {
-                            self.addr_focused = false;
-                            if let Some(w) = &self.window { w.request_redraw(); }
-                        }
-                        Key::Named(NamedKey::Backspace) => {
-                            self.url_input.pop();
-                            if let Some(w) = &self.window { w.request_redraw(); }
-                        }
-                        _ => {
-                            if let Some(t) = &text {
-                                self.url_input.push_str(t.as_str());
-                                if let Some(w) = &self.window { w.request_redraw(); }
-                            }
+                event:
+                    KeyEvent {
+                        logical_key,
+                        text,
+                        state: ElementState::Pressed,
+                        ..
+                    },
+                ..
+            } if self.addr_focused => match &logical_key {
+                Key::Named(NamedKey::Enter) => self.navigate(),
+                Key::Named(NamedKey::Escape) => {
+                    self.addr_focused = false;
+                    if let Some(w) = &self.window {
+                        w.request_redraw();
+                    }
+                }
+                Key::Named(NamedKey::Backspace) => {
+                    self.url_input.pop();
+                    if let Some(w) = &self.window {
+                        w.request_redraw();
+                    }
+                }
+                _ => {
+                    if let Some(t) = &text {
+                        self.url_input.push_str(t.as_str());
+                        if let Some(w) = &self.window {
+                            w.request_redraw();
                         }
                     }
                 }
-            }
+            },
 
             _ => {}
         }
@@ -242,8 +307,14 @@ fn blit_to_buffer(
     page_height: &mut f32,
 ) {
     match handle {
-        ExternalHandle::CpuPixelsOwned { width, height, stride, pixels, .. } => {
-            let copy_rows = (height as u32).min(content_h) as usize;
+        ExternalHandle::CpuPixelsOwned {
+            width,
+            height,
+            stride,
+            pixels,
+            ..
+        } => {
+            let copy_rows = height.min(content_h) as usize;
             for row in 0..copy_rows {
                 for col in 0..(width as usize).min(win_w as usize) {
                     let off = row * stride as usize + col * 4;
@@ -251,11 +322,20 @@ fn blit_to_buffer(
                     let g = pixels[off + 1] as u32;
                     let r = pixels[off + 2] as u32;
                     let idx = (addr_h as usize + row) * win_w as usize + col;
-                    if idx < buf.len() { buf[idx] = (r << 16) | (g << 8) | b; }
+                    if idx < buf.len() {
+                        buf[idx] = (r << 16) | (g << 8) | b;
+                    }
                 }
             }
         }
-        ExternalHandle::TileCache { tiles, page_height: ph, scroll_x, scroll_y, dpr, .. } => {
+        ExternalHandle::TileCache {
+            tiles,
+            page_height: ph,
+            scroll_x,
+            scroll_y,
+            dpr,
+            ..
+        } => {
             *page_height = ph;
             let d = dpr as usize;
             let sx = scroll_x as usize * d;
@@ -265,21 +345,26 @@ fn blit_to_buffer(
                 let screen_y = (tile.page_y as usize * d).saturating_sub(sy);
                 let tw = tile.width as usize;
                 let th = tile.height as usize;
-                let tile_u32 = unsafe {
-                    std::slice::from_raw_parts(tile.data.as_ptr() as *const u32, tile.data.len() / 4)
-                };
+                let tile_u32 =
+                    unsafe { std::slice::from_raw_parts(tile.data.as_ptr() as *const u32, tile.data.len() / 4) };
                 for row in 0..th {
                     let dst_y = addr_h as usize + screen_y + row;
-                    if dst_y >= (addr_h + content_h) as usize { break; }
+                    if dst_y >= (addr_h + content_h) as usize {
+                        break;
+                    }
                     let cw = tw.min(win_w as usize - screen_x.min(win_w as usize));
-                    if cw == 0 { break; }
+                    if cw == 0 {
+                        break;
+                    }
                     for col in 0..cw {
                         let px = tile_u32[row * tw + col];
                         let b = px & 0xFF;
                         let g = (px >> 8) & 0xFF;
                         let r = (px >> 16) & 0xFF;
                         let idx = dst_y * win_w as usize + screen_x + col;
-                        if idx < buf.len() { buf[idx] = (r << 16) | (g << 8) | b; }
+                        if idx < buf.len() {
+                            buf[idx] = (r << 16) | (g << 8) | b;
+                        }
                     }
                 }
             }
@@ -300,14 +385,26 @@ fn draw_address_bar(buf: &mut softbuffer::Buffer<Arc<Window>, Arc<Window>>, win_
 
     let canvas = surface.canvas();
 
-    canvas.clear(if focused { Color4f::new(0.98, 0.98, 0.98, 1.0) } else { Color4f::new(0.93, 0.93, 0.93, 1.0) });
+    canvas.clear(if focused {
+        Color4f::new(0.98, 0.98, 0.98, 1.0)
+    } else {
+        Color4f::new(0.93, 0.93, 0.93, 1.0)
+    });
 
-    let box_color = if focused { Color4f::new(1.0, 1.0, 1.0, 1.0) } else { Color4f::new(0.97, 0.97, 0.97, 1.0) };
+    let box_color = if focused {
+        Color4f::new(1.0, 1.0, 1.0, 1.0)
+    } else {
+        Color4f::new(0.97, 0.97, 0.97, 1.0)
+    };
     let mut bg = Paint::new(box_color, None);
     bg.set_anti_alias(true);
     canvas.draw_rect(SkRect::new(4.0, 5.0, (w - 4) as f32, (h - 5) as f32), &bg);
 
-    let border_color = if focused { Color4f::new(0.26, 0.52, 0.96, 1.0) } else { Color4f::new(0.7, 0.7, 0.7, 1.0) };
+    let border_color = if focused {
+        Color4f::new(0.26, 0.52, 0.96, 1.0)
+    } else {
+        Color4f::new(0.7, 0.7, 0.7, 1.0)
+    };
     let mut border = Paint::new(border_color, None);
     border.set_anti_alias(true);
     border.set_style(skia_safe::PaintStyle::Stroke);
@@ -316,8 +413,10 @@ fn draw_address_bar(buf: &mut softbuffer::Buffer<Arc<Window>, Arc<Window>>, win_
 
     thread_local! { static FONT_MGR: FontMgr = FontMgr::new(); }
     let typeface = FONT_MGR.with(|fm| {
-        fm.legacy_make_typeface(None, FontStyle::normal())
-            .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("no typeface"))
+        fm.legacy_make_typeface(None, FontStyle::normal()).unwrap_or_else(|| {
+            fm.legacy_make_typeface("sans-serif", FontStyle::normal())
+                .expect("no typeface")
+        })
     });
     let font = Font::new(typeface, 14.0);
     let mut text_paint = Paint::new(Color4f::new(0.0, 0.0, 0.0, 1.0), None);
@@ -342,11 +441,21 @@ fn draw_address_bar(buf: &mut softbuffer::Buffer<Arc<Window>, Arc<Window>>, win_
 }
 
 fn main() {
-    simple_logger::SimpleLogger::new().with_level(log::LevelFilter::Warn).env().init().unwrap_or_default();
+    simple_logger::SimpleLogger::new()
+        .with_level(log::LevelFilter::Warn)
+        .env()
+        .init()
+        .unwrap_or_default();
 
     let initial_url = {
-        let raw = std::env::args().nth(1).unwrap_or_else(|| "https://example.com".to_string());
-        if raw.contains("://") { raw } else { format!("https://{raw}") }
+        let raw = std::env::args()
+            .nth(1)
+            .unwrap_or_else(|| "https://example.com".to_string());
+        if raw.contains("://") {
+            raw
+        } else {
+            format!("https://{raw}")
+        }
     };
 
     let _rt_guard = TOKIO_RT.enter();
@@ -355,7 +464,9 @@ fn main() {
 
     let compositor = Arc::new(RwLock::new(DefaultCompositor::new({
         let p = proxy.clone();
-        move || { let _ = p.send_event(()); }
+        move || {
+            let _ = p.send_event(());
+        }
     })));
 
     let backend = SkiaBackend::new();
@@ -367,7 +478,10 @@ fn main() {
     TOKIO_RT.spawn(async move {
         loop {
             match event_rx.recv().await {
-                Ok(EngineEvent::Navigation { event: NavigationEvent::Finished { .. } | NavigationEvent::Started { .. }, .. }) => {
+                Ok(EngineEvent::Navigation {
+                    event: NavigationEvent::Finished { .. } | NavigationEvent::Started { .. },
+                    ..
+                }) => {
                     let _ = proxy_ev.send_event(());
                 }
                 Ok(_) => {}
@@ -393,13 +507,22 @@ fn main() {
         .expect("create_zone");
 
     let tab = TOKIO_RT
-        .block_on(zone.create_tab(TabDefaults { url: None, title: Some("Gosub".to_string()), viewport: None }, None))
+        .block_on(zone.create_tab(
+            TabDefaults {
+                url: None,
+                title: Some("Gosub".to_string()),
+                viewport: None,
+            },
+            None,
+        ))
         .expect("create_tab");
 
     let tab_id = tab.tab_id;
     let nav_tab = tab.clone();
     let nav_url = initial_url.clone();
-    TOKIO_RT.spawn(async move { let _ = nav_tab.send(TabCommand::Navigate { url: nav_url }).await; });
+    TOKIO_RT.spawn(async move {
+        let _ = nav_tab.send(TabCommand::Navigate { url: nav_url }).await;
+    });
 
     let mut app = BrowserApp {
         engine,

--- a/examples/winit-skia/main.rs
+++ b/examples/winit-skia/main.rs
@@ -15,7 +15,7 @@ use gosub_render_pipeline::render::backends::skia::SkiaBackend;
 use gosub_render_pipeline::render::DefaultCompositor;
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
-use skia_safe::{surfaces, Color4f, Font, FontMgr, FontStyle, Paint, Rect as SkRect};
+use skia_safe::{Color4f, Font, FontMgr, FontStyle, Paint, Rect as SkRect, surfaces};
 use softbuffer::Surface;
 use std::num::NonZeroU32;
 use std::sync::Arc;
@@ -85,15 +85,11 @@ impl BrowserApp {
     fn redraw(&mut self) {
         let Some(surface) = &mut self.surface else { return };
         let (win_w, win_h) = self.surface_size;
-        if win_w == 0 || win_h == 0 {
-            return;
-        }
+        if win_w == 0 || win_h == 0 { return; }
 
         let Ok(nw) = NonZeroU32::try_from(win_w) else { return };
         let Ok(nh) = NonZeroU32::try_from(win_h) else { return };
-        if surface.resize(nw, nh).is_err() {
-            return;
-        }
+        if surface.resize(nw, nh).is_err() { return; }
 
         let Ok(mut buf) = surface.buffer_mut() else { return };
         buf.fill(0x00FF_FFFF);
@@ -102,14 +98,7 @@ impl BrowserApp {
         if content_h > 0 {
             let guard = self.compositor.read();
             if let Some(handle) = guard.frame_for(self.tab_id) {
-                blit_to_buffer(
-                    &mut buf,
-                    win_w,
-                    ADDRESS_BAR_HEIGHT,
-                    content_h,
-                    handle,
-                    &mut self.page_height,
-                );
+                blit_to_buffer(&mut buf, win_w, ADDRESS_BAR_HEIGHT, content_h, handle, &mut self.page_height);
             }
         }
 
@@ -132,9 +121,7 @@ impl BrowserApp {
 
 impl ApplicationHandler<()> for BrowserApp {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
-        if self.window.is_some() {
-            return;
-        }
+        if self.window.is_some() { return; }
 
         let attrs = WindowAttributes::default()
             .with_title("Gosub Browser — winit + Skia")
@@ -151,14 +138,7 @@ impl ApplicationHandler<()> for BrowserApp {
 
         let tab = self.tab.clone();
         TOKIO_RT.spawn(async move {
-            let _ = tab
-                .send(TabCommand::SetViewport {
-                    x: 0,
-                    y: 0,
-                    width: size.width,
-                    height: content_h,
-                })
-                .await;
+            let _ = tab.send(TabCommand::SetViewport { x: 0, y: 0, width: size.width, height: content_h }).await;
             let _ = tab.send(TabCommand::ResumeDrawing { fps: 30 }).await;
         });
 
@@ -167,9 +147,7 @@ impl ApplicationHandler<()> for BrowserApp {
     }
 
     fn user_event(&mut self, _: &ActiveEventLoop, _: ()) {
-        if let Some(w) = &self.window {
-            w.request_redraw();
-        }
+        if let Some(w) = &self.window { w.request_redraw(); }
     }
 
     fn window_event(&mut self, event_loop: &ActiveEventLoop, _: WindowId, event: WindowEvent) {
@@ -178,27 +156,16 @@ impl ApplicationHandler<()> for BrowserApp {
             WindowEvent::RedrawRequested => self.redraw(),
 
             WindowEvent::Resized(PhysicalSize { width, height }) => {
-                if width == 0 || height == 0 {
-                    return;
-                }
+                if width == 0 || height == 0 { return; }
                 self.surface_size = (width, height);
                 let content_h = height.saturating_sub(ADDRESS_BAR_HEIGHT);
                 self.viewport = (width, content_h);
                 self.scroll = (0.0, 0.0);
                 let tab = self.tab.clone();
                 TOKIO_RT.spawn(async move {
-                    let _ = tab
-                        .send(TabCommand::SetViewport {
-                            x: 0,
-                            y: 0,
-                            width,
-                            height: content_h,
-                        })
-                        .await;
+                    let _ = tab.send(TabCommand::SetViewport { x: 0, y: 0, width, height: content_h }).await;
                 });
-                if let Some(w) = &self.window {
-                    w.request_redraw();
-                }
+                if let Some(w) = &self.window { w.request_redraw(); }
             }
 
             WindowEvent::CursorMoved { position, .. } => {
@@ -206,34 +173,20 @@ impl ApplicationHandler<()> for BrowserApp {
                 if !self.is_in_address_bar(position.y) {
                     let (x, y) = (self.to_css_x(position.x), self.to_css_y(position.y));
                     let tab = self.tab.clone();
-                    TOKIO_RT.spawn(async move {
-                        let _ = tab.send(TabCommand::MouseMove { x, y }).await;
-                    });
+                    TOKIO_RT.spawn(async move { let _ = tab.send(TabCommand::MouseMove { x, y }).await; });
                 }
             }
 
-            WindowEvent::MouseInput {
-                state: ElementState::Pressed,
-                button: WinitMouseButton::Left,
-                ..
-            } => {
+            WindowEvent::MouseInput { state: ElementState::Pressed, button: WinitMouseButton::Left, .. } => {
                 if self.is_in_address_bar(self.cursor.y) {
                     self.addr_focused = true;
-                    if let Some(w) = &self.window {
-                        w.request_redraw();
-                    }
+                    if let Some(w) = &self.window { w.request_redraw(); }
                 } else {
                     self.addr_focused = false;
                     let (x, y) = (self.to_css_x(self.cursor.x), self.to_css_y(self.cursor.y));
                     let tab = self.tab.clone();
                     TOKIO_RT.spawn(async move {
-                        let _ = tab
-                            .send(TabCommand::MouseDown {
-                                x,
-                                y,
-                                button: MouseButton::Left,
-                            })
-                            .await;
+                        let _ = tab.send(TabCommand::MouseDown { x, y, button: MouseButton::Left }).await;
                     });
                 }
             }
@@ -247,51 +200,33 @@ impl ApplicationHandler<()> for BrowserApp {
                 self.scroll.0 = (self.scroll.0 + dx).max(0.0);
                 self.scroll.1 = (self.scroll.1 + dy).clamp(0.0, max_y);
                 let tab = self.tab.clone();
-                TOKIO_RT.spawn(async move {
-                    let _ = tab
-                        .send(TabCommand::MouseScroll {
-                            delta_x: dx,
-                            delta_y: dy,
-                        })
-                        .await;
-                });
-                if let Some(w) = &self.window {
-                    w.request_redraw();
-                }
+                TOKIO_RT.spawn(async move { let _ = tab.send(TabCommand::MouseScroll { delta_x: dx, delta_y: dy }).await; });
+                if let Some(w) = &self.window { w.request_redraw(); }
             }
 
             WindowEvent::KeyboardInput {
-                event:
-                    KeyEvent {
-                        logical_key,
-                        text,
-                        state: ElementState::Pressed,
-                        ..
-                    },
-                ..
-            } if self.addr_focused => match &logical_key {
-                Key::Named(NamedKey::Enter) => self.navigate(),
-                Key::Named(NamedKey::Escape) => {
-                    self.addr_focused = false;
-                    if let Some(w) = &self.window {
-                        w.request_redraw();
-                    }
-                }
-                Key::Named(NamedKey::Backspace) => {
-                    self.url_input.pop();
-                    if let Some(w) = &self.window {
-                        w.request_redraw();
-                    }
-                }
-                _ => {
-                    if let Some(t) = &text {
-                        self.url_input.push_str(t.as_str());
-                        if let Some(w) = &self.window {
-                            w.request_redraw();
+                event: KeyEvent { logical_key, text, state: ElementState::Pressed, .. }, ..
+            } => {
+                if self.addr_focused {
+                    match &logical_key {
+                        Key::Named(NamedKey::Enter) => self.navigate(),
+                        Key::Named(NamedKey::Escape) => {
+                            self.addr_focused = false;
+                            if let Some(w) = &self.window { w.request_redraw(); }
+                        }
+                        Key::Named(NamedKey::Backspace) => {
+                            self.url_input.pop();
+                            if let Some(w) = &self.window { w.request_redraw(); }
+                        }
+                        _ => {
+                            if let Some(t) = &text {
+                                self.url_input.push_str(t.as_str());
+                                if let Some(w) = &self.window { w.request_redraw(); }
+                            }
                         }
                     }
                 }
-            },
+            }
 
             _ => {}
         }
@@ -307,14 +242,8 @@ fn blit_to_buffer(
     page_height: &mut f32,
 ) {
     match handle {
-        ExternalHandle::CpuPixelsOwned {
-            width,
-            height,
-            stride,
-            pixels,
-            ..
-        } => {
-            let copy_rows = height.min(content_h) as usize;
+        ExternalHandle::CpuPixelsOwned { width, height, stride, pixels, .. } => {
+            let copy_rows = (height as u32).min(content_h) as usize;
             for row in 0..copy_rows {
                 for col in 0..(width as usize).min(win_w as usize) {
                     let off = row * stride as usize + col * 4;
@@ -322,20 +251,11 @@ fn blit_to_buffer(
                     let g = pixels[off + 1] as u32;
                     let r = pixels[off + 2] as u32;
                     let idx = (addr_h as usize + row) * win_w as usize + col;
-                    if idx < buf.len() {
-                        buf[idx] = (r << 16) | (g << 8) | b;
-                    }
+                    if idx < buf.len() { buf[idx] = (r << 16) | (g << 8) | b; }
                 }
             }
         }
-        ExternalHandle::TileCache {
-            tiles,
-            page_height: ph,
-            scroll_x,
-            scroll_y,
-            dpr,
-            ..
-        } => {
+        ExternalHandle::TileCache { tiles, page_height: ph, scroll_x, scroll_y, dpr, .. } => {
             *page_height = ph;
             let d = dpr as usize;
             let sx = scroll_x as usize * d;
@@ -345,26 +265,21 @@ fn blit_to_buffer(
                 let screen_y = (tile.page_y as usize * d).saturating_sub(sy);
                 let tw = tile.width as usize;
                 let th = tile.height as usize;
-                let tile_u32 =
-                    unsafe { std::slice::from_raw_parts(tile.data.as_ptr() as *const u32, tile.data.len() / 4) };
+                let tile_u32 = unsafe {
+                    std::slice::from_raw_parts(tile.data.as_ptr() as *const u32, tile.data.len() / 4)
+                };
                 for row in 0..th {
                     let dst_y = addr_h as usize + screen_y + row;
-                    if dst_y >= (addr_h + content_h) as usize {
-                        break;
-                    }
+                    if dst_y >= (addr_h + content_h) as usize { break; }
                     let cw = tw.min(win_w as usize - screen_x.min(win_w as usize));
-                    if cw == 0 {
-                        break;
-                    }
+                    if cw == 0 { break; }
                     for col in 0..cw {
                         let px = tile_u32[row * tw + col];
                         let b = px & 0xFF;
                         let g = (px >> 8) & 0xFF;
                         let r = (px >> 16) & 0xFF;
                         let idx = dst_y * win_w as usize + screen_x + col;
-                        if idx < buf.len() {
-                            buf[idx] = (r << 16) | (g << 8) | b;
-                        }
+                        if idx < buf.len() { buf[idx] = (r << 16) | (g << 8) | b; }
                     }
                 }
             }
@@ -385,39 +300,25 @@ fn draw_address_bar(buf: &mut softbuffer::Buffer<Arc<Window>, Arc<Window>>, win_
 
     let canvas = surface.canvas();
 
-    canvas.clear(if focused {
-        Color4f::new(0.98, 0.98, 0.98, 1.0)
-    } else {
-        Color4f::new(0.93, 0.93, 0.93, 1.0)
-    });
+    canvas.clear(if focused { Color4f::new(0.98, 0.98, 0.98, 1.0) } else { Color4f::new(0.93, 0.93, 0.93, 1.0) });
 
-    let box_color = if focused {
-        Color4f::new(1.0, 1.0, 1.0, 1.0)
-    } else {
-        Color4f::new(0.97, 0.97, 0.97, 1.0)
-    };
+    let box_color = if focused { Color4f::new(1.0, 1.0, 1.0, 1.0) } else { Color4f::new(0.97, 0.97, 0.97, 1.0) };
     let mut bg = Paint::new(box_color, None);
     bg.set_anti_alias(true);
     canvas.draw_rect(SkRect::new(4.0, 5.0, (w - 4) as f32, (h - 5) as f32), &bg);
 
-    let border_color = if focused {
-        Color4f::new(0.26, 0.52, 0.96, 1.0)
-    } else {
-        Color4f::new(0.7, 0.7, 0.7, 1.0)
-    };
+    let border_color = if focused { Color4f::new(0.26, 0.52, 0.96, 1.0) } else { Color4f::new(0.7, 0.7, 0.7, 1.0) };
     let mut border = Paint::new(border_color, None);
     border.set_anti_alias(true);
     border.set_style(skia_safe::PaintStyle::Stroke);
     border.set_stroke_width(1.0);
     canvas.draw_rect(SkRect::new(4.5, 5.5, (w - 5) as f32, (h - 5) as f32), &border);
 
-    let typeface = FontMgr::new()
-        .legacy_make_typeface(None, FontStyle::normal())
-        .unwrap_or_else(|| {
-            FontMgr::new()
-                .legacy_make_typeface("sans-serif", FontStyle::normal())
-                .expect("no typeface")
-        });
+    thread_local! { static FONT_MGR: FontMgr = FontMgr::new(); }
+    let typeface = FONT_MGR.with(|fm| {
+        fm.legacy_make_typeface(None, FontStyle::normal())
+            .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("no typeface"))
+    });
     let font = Font::new(typeface, 14.0);
     let mut text_paint = Paint::new(Color4f::new(0.0, 0.0, 0.0, 1.0), None);
     text_paint.set_anti_alias(true);
@@ -441,21 +342,11 @@ fn draw_address_bar(buf: &mut softbuffer::Buffer<Arc<Window>, Arc<Window>>, win_
 }
 
 fn main() {
-    simple_logger::SimpleLogger::new()
-        .with_level(log::LevelFilter::Warn)
-        .env()
-        .init()
-        .unwrap_or_default();
+    simple_logger::SimpleLogger::new().with_level(log::LevelFilter::Warn).env().init().unwrap_or_default();
 
     let initial_url = {
-        let raw = std::env::args()
-            .nth(1)
-            .unwrap_or_else(|| "https://example.com".to_string());
-        if raw.contains("://") {
-            raw
-        } else {
-            format!("https://{raw}")
-        }
+        let raw = std::env::args().nth(1).unwrap_or_else(|| "https://example.com".to_string());
+        if raw.contains("://") { raw } else { format!("https://{raw}") }
     };
 
     let _rt_guard = TOKIO_RT.enter();
@@ -464,9 +355,7 @@ fn main() {
 
     let compositor = Arc::new(RwLock::new(DefaultCompositor::new({
         let p = proxy.clone();
-        move || {
-            let _ = p.send_event(());
-        }
+        move || { let _ = p.send_event(()); }
     })));
 
     let backend = SkiaBackend::new();
@@ -478,10 +367,7 @@ fn main() {
     TOKIO_RT.spawn(async move {
         loop {
             match event_rx.recv().await {
-                Ok(EngineEvent::Navigation {
-                    event: NavigationEvent::Finished { .. } | NavigationEvent::Started { .. },
-                    ..
-                }) => {
+                Ok(EngineEvent::Navigation { event: NavigationEvent::Finished { .. } | NavigationEvent::Started { .. }, .. }) => {
                     let _ = proxy_ev.send_event(());
                 }
                 Ok(_) => {}
@@ -507,22 +393,13 @@ fn main() {
         .expect("create_zone");
 
     let tab = TOKIO_RT
-        .block_on(zone.create_tab(
-            TabDefaults {
-                url: None,
-                title: Some("Gosub".to_string()),
-                viewport: None,
-            },
-            None,
-        ))
+        .block_on(zone.create_tab(TabDefaults { url: None, title: Some("Gosub".to_string()), viewport: None }, None))
         .expect("create_tab");
 
     let tab_id = tab.tab_id;
     let nav_tab = tab.clone();
     let nav_url = initial_url.clone();
-    TOKIO_RT.spawn(async move {
-        let _ = nav_tab.send(TabCommand::Navigate { url: nav_url }).await;
-    });
+    TOKIO_RT.spawn(async move { let _ = nav_tab.send(TabCommand::Navigate { url: nav_url }).await; });
 
     let mut app = BrowserApp {
         engine,


### PR DESCRIPTION
## Summary

- Add static font manager
- Move pixel buffers to Arc to reduce cloning
- Add parallel rasterizers for tiles
- Remove redundant pixel buffer copies
- Fix code warnings

> **Note:** This PR is stacked on top of #1027 (`example-fixes`) and should be merged after that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skia-based text rasterization implemented across renderers.

* **Bug Fixes**
  * Removed text-rendering placeholder; text now renders correctly and wraps.

* **Performance**
  * Per-tile pixel caching to avoid redundant rasterization.
  * Per-thread font manager caching to speed text layout/render.
  * Shared, zero-copy pixel buffers to reduce memory use and copying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->