### PR TITLE
Increased tile performance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3267,6 +3267,7 @@ dependencies = [
  "r2d2",
  "r2d2_sqlite",
  "rand 0.10.1",
+ "rayon",
  "regex",
  "reqwest",
  "serde",

--- a/crates/gosub_engine/Cargo.toml
+++ b/crates/gosub_engine/Cargo.toml
@@ -57,6 +57,7 @@ winit = { version = "0.30.12", optional = true }
 eframe = { version = "0.34.3", optional = true, features = ["wgpu"] }
 egui = { version = "0.34.3", optional = true }
 num_cpus = "1.17.0"
+rayon = "1"
 time = "0.3.41"
 tokio-util = { version = "0.7.16", features = ["io"] }
 tempfile = "3.21.0"

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -844,7 +844,7 @@ fn pipeline_composite(cache: &PipelineCache, scroll_x: f64, scroll_y: f64, vp_w:
             y: (tile.page_y - scroll_y) as f32,
             w: tile.width,
             h: tile.height,
-            data: (*tile.data).clone(),
+            data: Arc::clone(&tile.data),
         });
         blits += 1;
     }

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -593,123 +593,99 @@ fn pipeline_build_cache(
     );
 
     // Stage 6: rasterize ALL tiles → collect into BakedTile vec.
-    #[cfg(feature = "backend_cairo")]
-    let baked_tiles = {
-        use gosub_render_pipeline::common::media::MediaStore;
-        use gosub_render_pipeline::common::texture_store::TextureStore;
-        use gosub_render_pipeline::rasterizer::Rasterable;
-        use gosub_renderer_cairo::CairoRasterizer;
+    //
+    // Cairo and Skia rasterize tiles independently (no shared GPU state), so we use
+    // rayon to spread the work across all available CPU cores.  Each worker gets its
+    // own temporary TextureStore so there is zero shared mutable state in the hot loop.
+    //
+    // Three phases:
+    //   1. Collect IDs of dirty tiles (sequential — cheap iteration).
+    //   2. Rasterize each tile in parallel → Option<BakedTile>.
+    //   3. Update tile states and gather results (sequential — trivial).
+    //
+    // Vello stays sequential because all tiles share a Mutex<Renderer>; batching
+    // (not parallelism) is the fix there.
+    #[cfg(any(feature = "backend_cairo", feature = "backend_skia"))]
+    macro_rules! rasterize_parallel {
+        ($rasterizer:expr, $label:literal) => {{
+            use gosub_render_pipeline::common::media::MediaStore;
+            use gosub_render_pipeline::common::texture_store::TextureStore;
+            use gosub_render_pipeline::rasterizer::Rasterable;
+            use rayon::prelude::*;
 
-        let t = Instant::now();
-        let ts6 = timing_start!("pipeline.rasterize");
-        let media_store = MediaStore::new();
-        let mut texture_store = TextureStore::new();
-        let rasterizer = CairoRasterizer::new();
-        let mut rasterized = 0usize;
-        let mut empty = 0usize;
-        for &layer_id in &layer_ids {
-            let tile_ids = tile_list.get_intersecting_tiles(layer_id, full_page_rect);
-            for tile_id in tile_ids {
-                if let Some(tile) = tile_list.get_tile_mut(tile_id) {
-                    if tile.state == TileState::Dirty {
-                        match rasterizer.rasterize(tile, &mut texture_store, &media_store) {
-                            Some(texture_id) => {
-                                tile.texture_id = Some(texture_id);
-                                tile.state = TileState::Clean;
-                                rasterized += 1;
-                            }
-                            None => {
-                                tile.state = TileState::Empty;
-                                empty += 1;
-                            }
+            let t = Instant::now();
+            let ts6 = timing_start!("pipeline.rasterize");
+            let media_store = MediaStore::new();
+            let rasterizer = $rasterizer;
+
+            // Phase 1: collect IDs of dirty tiles across all layers.
+            let dirty_ids: Vec<TileId> = layer_ids
+                .iter()
+                .flat_map(|&layer_id| tile_list.get_intersecting_tiles(layer_id, full_page_rect))
+                .filter(|&id| tile_list.arena.get(&id).map_or(false, |t| t.state == TileState::Dirty))
+                .collect();
+
+            // Phase 2: parallel rasterization — no shared mutable state.
+            let results: Vec<(TileId, Option<BakedTile>)> = dirty_ids
+                .par_iter()
+                .map(|&tile_id| {
+                    let baked = tile_list.arena.get(&tile_id).and_then(|tile| {
+                        let mut local_store = TextureStore::new();
+                        let tex_id = rasterizer.rasterize(tile, &mut local_store, &media_store)?;
+                        let tex = local_store.get(tex_id)?;
+                        Some(BakedTile {
+                            page_x: tile.rect.x,
+                            page_y: tile.rect.y,
+                            width: tex.width as u32,
+                            height: tex.height as u32,
+                            data: Arc::clone(&tex.data),
+                        })
+                    });
+                    (tile_id, baked)
+                })
+                .collect();
+
+            // Phase 3: update tile states and gather BakedTiles (sequential).
+            let mut rasterized = 0usize;
+            let mut empty = 0usize;
+            let mut tiles: Vec<BakedTile> = Vec::with_capacity(results.len());
+            for (tile_id, baked) in results {
+                if let Some(tile) = tile_list.arena.get_mut(&tile_id) {
+                    match baked {
+                        Some(b) => {
+                            tile.state = TileState::Clean;
+                            tiles.push(b);
+                            rasterized += 1;
+                        }
+                        None => {
+                            tile.state = TileState::Empty;
+                            empty += 1;
                         }
                     }
                 }
             }
-        }
-        timing_stop!(ts6);
-        log::info!(
-            "[pipeline] stage 6 rasterize:     {:>6.1}ms  ({} clean, {} empty)",
-            t.elapsed().as_secs_f64() * 1000.0,
-            rasterized,
-            empty
-        );
 
-        // Collect all clean tiles into BakedTile structs.
-        let mut tiles: Vec<BakedTile> = Vec::with_capacity(rasterized);
-        for tile in tile_list.arena.values() {
-            if let (Some(texture_id), true) = (tile.texture_id, tile.state == TileState::Clean) {
-                if let Some(tex) = texture_store.get(texture_id) {
-                    tiles.push(BakedTile {
-                        page_x: tile.rect.x,
-                        page_y: tile.rect.y,
-                        width: tex.width as u32,
-                        height: tex.height as u32,
-                        data: Arc::clone(&tex.data),
-                    });
-                }
-            }
-        }
-        tiles
+            timing_stop!(ts6);
+            log::info!(
+                concat!("[pipeline] stage 6 rasterize ", $label, " {:>6.1}ms  ({} clean, {} empty)"),
+                t.elapsed().as_secs_f64() * 1000.0,
+                rasterized,
+                empty
+            );
+            tiles
+        }};
+    }
+
+    #[cfg(feature = "backend_cairo")]
+    let baked_tiles = {
+        use gosub_renderer_cairo::CairoRasterizer;
+        rasterize_parallel!(CairoRasterizer::new(), "(cairo):    ")
     };
 
     #[cfg(all(feature = "backend_skia", not(feature = "backend_cairo")))]
     let baked_tiles = {
-        use gosub_render_pipeline::common::media::MediaStore;
-        use gosub_render_pipeline::common::texture_store::TextureStore;
-        use gosub_render_pipeline::rasterizer::Rasterable;
         use gosub_renderer_skia::SkiaRasterizer;
-
-        let t = Instant::now();
-        let ts6 = timing_start!("pipeline.rasterize");
-        let media_store = MediaStore::new();
-        let mut texture_store = TextureStore::new();
-        let rasterizer = SkiaRasterizer::new(1.0);
-        let mut rasterized = 0usize;
-        let mut empty = 0usize;
-        for &layer_id in &layer_ids {
-            let tile_ids = tile_list.get_intersecting_tiles(layer_id, full_page_rect);
-            for tile_id in tile_ids {
-                if let Some(tile) = tile_list.get_tile_mut(tile_id) {
-                    if tile.state == TileState::Dirty {
-                        match rasterizer.rasterize(tile, &mut texture_store, &media_store) {
-                            Some(texture_id) => {
-                                tile.texture_id = Some(texture_id);
-                                tile.state = TileState::Clean;
-                                rasterized += 1;
-                            }
-                            None => {
-                                tile.state = TileState::Empty;
-                                empty += 1;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        timing_stop!(ts6);
-        log::info!(
-            "[pipeline] stage 6 rasterize (skia): {:>6.1}ms  ({} clean, {} empty)",
-            t.elapsed().as_secs_f64() * 1000.0,
-            rasterized,
-            empty
-        );
-
-        let mut tiles: Vec<BakedTile> = Vec::with_capacity(rasterized);
-        for tile in tile_list.arena.values() {
-            if let (Some(texture_id), true) = (tile.texture_id, tile.state == TileState::Clean) {
-                if let Some(tex) = texture_store.get(texture_id) {
-                    tiles.push(BakedTile {
-                        page_x: tile.rect.x,
-                        page_y: tile.rect.y,
-                        width: tex.width as u32,
-                        height: tex.height as u32,
-                        data: Arc::clone(&tex.data),
-                    });
-                }
-            }
-        }
-        tiles
+        rasterize_parallel!(SkiaRasterizer::new(1.0), "(skia):     ")
     };
 
     #[cfg(all(

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -272,7 +272,9 @@ impl BrowsingContext {
         }
         if self.render_dirty {
             if let Some(doc) = &self.document {
-                let prev_tile_cache = self.pipeline_cache.as_mut()
+                let prev_tile_cache = self
+                    .pipeline_cache
+                    .as_mut()
                     .map(|c| std::mem::take(&mut c.tile_pixel_cache))
                     .unwrap_or_default();
                 self.pipeline_cache = Some(pipeline_build_cache(
@@ -303,7 +305,9 @@ impl BrowsingContext {
         {
             if self.render_dirty {
                 if let Some(doc) = &self.document {
-                    let prev_tile_cache = self.pipeline_cache.as_mut()
+                    let prev_tile_cache = self
+                        .pipeline_cache
+                        .as_mut()
                         .map(|c| std::mem::take(&mut c.tile_pixel_cache))
                         .unwrap_or_default();
                     self.pipeline_cache = Some(pipeline_build_cache(
@@ -480,69 +484,130 @@ impl RenderContext for BrowsingContext {
 #[cfg(any(feature = "backend_cairo", feature = "backend_skia"))]
 fn tile_cache_key(tile: &gosub_render_pipeline::tiler::Tile) -> TileCacheKey {
     use gosub_render_pipeline::painter::commands::{
-        PaintCommand,
         border::{BorderRadius, BorderStyle},
         brush::Brush,
+        PaintCommand,
     };
 
     // Minimal inline FNV-1a hasher — no trait bounds needed on the types being hashed.
     let mut h: u64 = 14695981039346656037;
     macro_rules! fnv {
         ($bytes:expr) => {
-            for b in $bytes { h ^= *b as u64; h = h.wrapping_mul(1099511628211); }
+            for b in $bytes {
+                h ^= *b as u64;
+                h = h.wrapping_mul(1099511628211);
+            }
         };
     }
-    macro_rules! hf32  { ($v:expr) => { fnv!(&$v.to_bits().to_le_bytes()) } }
-    macro_rules! hf64  { ($v:expr) => { fnv!(&$v.to_bits().to_le_bytes()) } }
-    macro_rules! hu64  { ($v:expr) => { fnv!(&($v as u64).to_le_bytes()) } }
-    macro_rules! hbool { ($v:expr) => { fnv!(&[$v as u8]) } }
-    macro_rules! hstr  { ($s:expr) => { fnv!($s.as_bytes()); fnv!(&[0u8]) } }
+    macro_rules! hf32 {
+        ($v:expr) => {
+            fnv!(&$v.to_bits().to_le_bytes())
+        };
+    }
+    macro_rules! hf64 {
+        ($v:expr) => {
+            fnv!(&$v.to_bits().to_le_bytes())
+        };
+    }
+    macro_rules! hu64 {
+        ($v:expr) => {
+            fnv!(&($v as u64).to_le_bytes())
+        };
+    }
+    macro_rules! hbool {
+        ($v:expr) => {
+            fnv!(&[$v as u8])
+        };
+    }
+    macro_rules! hstr {
+        ($s:expr) => {
+            fnv!($s.as_bytes());
+            fnv!(&[0u8])
+        };
+    }
 
     macro_rules! hash_brush {
         ($b:expr) => {
             match $b {
-                Brush::Solid(c) => { fnv!(&[0]); hf32!(c.r()); hf32!(c.g()); hf32!(c.b()); hf32!(c.a()); }
-                Brush::Image(m) => { fnv!(&[1]); hu64!(m.as_u64()); }
+                Brush::Solid(c) => {
+                    fnv!(&[0]);
+                    hf32!(c.r());
+                    hf32!(c.g());
+                    hf32!(c.b());
+                    hf32!(c.a());
+                }
+                Brush::Image(m) => {
+                    fnv!(&[1]);
+                    hu64!(m.as_u64());
+                }
             }
         };
     }
 
     // Hash tile background.
     match tile.bgcolor {
-        Some((r, g, b, a)) => { hbool!(true); hf32!(r); hf32!(g); hf32!(b); hf32!(a); }
+        Some((r, g, b, a)) => {
+            hbool!(true);
+            hf32!(r);
+            hf32!(g);
+            hf32!(b);
+            hf32!(a);
+        }
         None => hbool!(false),
     }
 
     for elem in &tile.elements {
         hu64!(elem.id.as_u64());
-        hf64!(elem.rect.x); hf64!(elem.rect.y); hf64!(elem.rect.width); hf64!(elem.rect.height);
+        hf64!(elem.rect.x);
+        hf64!(elem.rect.y);
+        hf64!(elem.rect.width);
+        hf64!(elem.rect.height);
 
         for cmd in &elem.paint_commands {
             match cmd {
                 PaintCommand::Rectangle(r) => {
                     fnv!(&[0u8]);
                     let rect = r.rect();
-                    hf64!(rect.x); hf64!(rect.y); hf64!(rect.width); hf64!(rect.height);
+                    hf64!(rect.x);
+                    hf64!(rect.y);
+                    hf64!(rect.width);
+                    hf64!(rect.height);
                     match r.background() {
                         None => hbool!(false),
-                        Some(b) => { hbool!(true); hash_brush!(b); }
+                        Some(b) => {
+                            hbool!(true);
+                            hash_brush!(b);
+                        }
                     }
                     let border = r.border();
                     hf32!(border.width());
                     fnv!(&[match border.style() {
-                        BorderStyle::Solid => 1, BorderStyle::Dashed => 2, BorderStyle::Dotted => 3,
-                        BorderStyle::Double => 4, BorderStyle::Groove => 5, BorderStyle::Ridge => 6,
-                        BorderStyle::Inset => 7, BorderStyle::Outset => 8, BorderStyle::Hidden => 9,
+                        BorderStyle::Solid => 1,
+                        BorderStyle::Dashed => 2,
+                        BorderStyle::Dotted => 3,
+                        BorderStyle::Double => 4,
+                        BorderStyle::Groove => 5,
+                        BorderStyle::Ridge => 6,
+                        BorderStyle::Inset => 7,
+                        BorderStyle::Outset => 8,
+                        BorderStyle::Hidden => 9,
                         BorderStyle::None => 0,
                     }]);
-                    for b in border.brushes() { hash_brush!(&b); }
+                    for b in border.brushes() {
+                        hash_brush!(&b);
+                    }
                     if let Some(tr) = border.radius() {
                         hbool!(true);
                         for br in [&tr.top, &tr.right, &tr.bottom, &tr.left] {
                             match br {
-                                BorderRadius::Uniform(v) => { fnv!(&[0]); hf32!(*v); }
+                                BorderRadius::Uniform(v) => {
+                                    fnv!(&[0]);
+                                    hf32!(*v);
+                                }
                                 BorderRadius::Elliptical { horizontal, vertical } => {
-                                    fnv!(&[1]); hf32!(*horizontal); hf32!(*vertical);
+                                    fnv!(&[1]);
+                                    hf32!(*horizontal);
+                                    hf32!(*vertical);
                                 }
                             }
                         }
@@ -550,13 +615,22 @@ fn tile_cache_key(tile: &gosub_render_pipeline::tiler::Tile) -> TileCacheKey {
                         hbool!(false);
                     }
                     let (tl, tr, br, bl) = r.radius_x();
-                    hf64!(tl); hf64!(tr); hf64!(br); hf64!(bl);
+                    hf64!(tl);
+                    hf64!(tr);
+                    hf64!(br);
+                    hf64!(bl);
                     let (tl, tr, br, bl) = r.radius_y();
-                    hf64!(tl); hf64!(tr); hf64!(br); hf64!(bl);
+                    hf64!(tl);
+                    hf64!(tr);
+                    hf64!(br);
+                    hf64!(bl);
                 }
                 PaintCommand::Text(t) => {
                     fnv!(&[1u8]);
-                    hf64!(t.rect.x); hf64!(t.rect.y); hf64!(t.rect.width); hf64!(t.rect.height);
+                    hf64!(t.rect.x);
+                    hf64!(t.rect.y);
+                    hf64!(t.rect.width);
+                    hf64!(t.rect.height);
                     hstr!(&t.text);
                     hstr!(&t.font_info.family);
                     hf64!(t.font_info.size);
@@ -572,7 +646,10 @@ fn tile_cache_key(tile: &gosub_render_pipeline::tiler::Tile) -> TileCacheKey {
                     fnv!(&[2u8]);
                     hu64!(s.media_id.as_u64());
                     let rect = s.rect.rect();
-                    hf64!(rect.x); hf64!(rect.y); hf64!(rect.width); hf64!(rect.height);
+                    hf64!(rect.x);
+                    hf64!(rect.y);
+                    hf64!(rect.width);
+                    hf64!(rect.height);
                 }
             }
         }
@@ -777,7 +854,8 @@ fn pipeline_build_cache(
 
                     // Cache miss: rasterize and emit a new cache entry.
                     let mut local_store = TextureStore::new();
-                    let baked = rasterizer.rasterize(tile, &mut local_store, &media_store)
+                    let baked = rasterizer
+                        .rasterize(tile, &mut local_store, &media_store)
                         .and_then(|tid| local_store.get(tid))
                         .map(|tex| BakedTile {
                             page_x: tile.rect.x,
@@ -787,8 +865,7 @@ fn pipeline_build_cache(
                             data: Arc::clone(&tex.data),
                         });
 
-                    let cache_entry = baked.as_ref()
-                        .map(|b| (key, (b.width, b.height, Arc::clone(&b.data))));
+                    let cache_entry = baked.as_ref().map(|b| (key, (b.width, b.height, Arc::clone(&b.data))));
                     (tile_id, baked, cache_entry)
                 })
                 .collect();
@@ -824,7 +901,11 @@ fn pipeline_build_cache(
 
             timing_stop!(ts6);
             log::info!(
-                concat!("[pipeline] stage 6 rasterize ", $label, " {:>6.1}ms  ({} rasterized, {} hits, {} empty)"),
+                concat!(
+                    "[pipeline] stage 6 rasterize ",
+                    $label,
+                    " {:>6.1}ms  ({} rasterized, {} hits, {} empty)"
+                ),
                 t.elapsed().as_secs_f64() * 1000.0,
                 rasterized,
                 cache_hits,
@@ -916,7 +997,11 @@ fn pipeline_build_cache(
         tiles
     };
     // Vello uses sequential rasterization; dirty-tile cache not yet implemented.
-    #[cfg(all(feature = "backend_vello", not(feature = "backend_cairo"), not(feature = "backend_skia")))]
+    #[cfg(all(
+        feature = "backend_vello",
+        not(feature = "backend_cairo"),
+        not(feature = "backend_skia")
+    ))]
     let new_tile_cache: std::collections::HashMap<TileCacheKey, (u32, u32, Arc<Vec<u8>>)> =
         std::collections::HashMap::new();
 

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -68,6 +68,11 @@ struct BakedTile {
     data: Arc<Vec<u8>>,
 }
 
+/// Key that uniquely identifies a tile's content for cache lookup.
+/// Format: (page_x bits, page_y bits, layer_id, paint-command hash).
+#[cfg(feature = "pipeline")]
+type TileCacheKey = (u64, u64, u64, u64);
+
 /// Cached output of stages 1–6 for the whole page. Re-used on every scroll tick.
 #[cfg(feature = "pipeline")]
 struct PipelineCache {
@@ -77,6 +82,10 @@ struct PipelineCache {
     cached_tiles: Arc<Vec<CachedTile>>,
     /// Layer list retained for hit-testing (hover).
     layer_list: Arc<LayerList>,
+    /// Rasterized tile data keyed by (page_x, page_y, layer_id, content_hash).
+    /// Passed to the next render so unchanged tiles skip rasterization.
+    /// Value is (physical_width, physical_height, pixel_data).
+    tile_pixel_cache: std::collections::HashMap<TileCacheKey, (u32, u32, Arc<Vec<u8>>)>,
 }
 
 /// BrowsingContext dedicated to a specific tab
@@ -263,11 +272,15 @@ impl BrowsingContext {
         }
         if self.render_dirty {
             if let Some(doc) = &self.document {
+                let prev_tile_cache = self.pipeline_cache.as_mut()
+                    .map(|c| std::mem::take(&mut c.tile_pixel_cache))
+                    .unwrap_or_default();
                 self.pipeline_cache = Some(pipeline_build_cache(
                     doc.clone(),
                     &self.viewport,
                     #[cfg(feature = "backend_vello")]
                     self.vello_resources.clone(),
+                    prev_tile_cache,
                 ));
             }
             self.render_dirty = false;
@@ -290,11 +303,15 @@ impl BrowsingContext {
         {
             if self.render_dirty {
                 if let Some(doc) = &self.document {
+                    let prev_tile_cache = self.pipeline_cache.as_mut()
+                        .map(|c| std::mem::take(&mut c.tile_pixel_cache))
+                        .unwrap_or_default();
                     self.pipeline_cache = Some(pipeline_build_cache(
                         doc.clone(),
                         &self.viewport,
                         #[cfg(feature = "backend_vello")]
                         self.vello_resources.clone(),
+                        prev_tile_cache,
                     ));
                 }
                 self.render_dirty = false;
@@ -458,6 +475,112 @@ impl RenderContext for BrowsingContext {
 }
 
 /// Runs pipeline stages 1–6 for the **entire page** (all tiles, not just the viewport slice)
+/// Compute a stable cache key for a tile: (page_x bits, page_y bits, layer_id, content hash).
+/// The content hash covers all paint commands so any visual change produces a different key.
+#[cfg(any(feature = "backend_cairo", feature = "backend_skia"))]
+fn tile_cache_key(tile: &gosub_render_pipeline::tiler::Tile) -> TileCacheKey {
+    use gosub_render_pipeline::painter::commands::{
+        PaintCommand,
+        border::{BorderRadius, BorderStyle},
+        brush::Brush,
+    };
+
+    // Minimal inline FNV-1a hasher — no trait bounds needed on the types being hashed.
+    let mut h: u64 = 14695981039346656037;
+    macro_rules! fnv {
+        ($bytes:expr) => {
+            for b in $bytes { h ^= *b as u64; h = h.wrapping_mul(1099511628211); }
+        };
+    }
+    macro_rules! hf32  { ($v:expr) => { fnv!(&$v.to_bits().to_le_bytes()) } }
+    macro_rules! hf64  { ($v:expr) => { fnv!(&$v.to_bits().to_le_bytes()) } }
+    macro_rules! hu64  { ($v:expr) => { fnv!(&($v as u64).to_le_bytes()) } }
+    macro_rules! hbool { ($v:expr) => { fnv!(&[$v as u8]) } }
+    macro_rules! hstr  { ($s:expr) => { fnv!($s.as_bytes()); fnv!(&[0u8]) } }
+
+    macro_rules! hash_brush {
+        ($b:expr) => {
+            match $b {
+                Brush::Solid(c) => { fnv!(&[0]); hf32!(c.r()); hf32!(c.g()); hf32!(c.b()); hf32!(c.a()); }
+                Brush::Image(m) => { fnv!(&[1]); hu64!(m.as_u64()); }
+            }
+        };
+    }
+
+    // Hash tile background.
+    match tile.bgcolor {
+        Some((r, g, b, a)) => { hbool!(true); hf32!(r); hf32!(g); hf32!(b); hf32!(a); }
+        None => hbool!(false),
+    }
+
+    for elem in &tile.elements {
+        hu64!(elem.id.as_u64());
+        hf64!(elem.rect.x); hf64!(elem.rect.y); hf64!(elem.rect.width); hf64!(elem.rect.height);
+
+        for cmd in &elem.paint_commands {
+            match cmd {
+                PaintCommand::Rectangle(r) => {
+                    fnv!(&[0u8]);
+                    let rect = r.rect();
+                    hf64!(rect.x); hf64!(rect.y); hf64!(rect.width); hf64!(rect.height);
+                    match r.background() {
+                        None => hbool!(false),
+                        Some(b) => { hbool!(true); hash_brush!(b); }
+                    }
+                    let border = r.border();
+                    hf32!(border.width());
+                    fnv!(&[match border.style() {
+                        BorderStyle::Solid => 1, BorderStyle::Dashed => 2, BorderStyle::Dotted => 3,
+                        BorderStyle::Double => 4, BorderStyle::Groove => 5, BorderStyle::Ridge => 6,
+                        BorderStyle::Inset => 7, BorderStyle::Outset => 8, BorderStyle::Hidden => 9,
+                        BorderStyle::None => 0,
+                    }]);
+                    for b in border.brushes() { hash_brush!(&b); }
+                    if let Some(tr) = border.radius() {
+                        hbool!(true);
+                        for br in [&tr.top, &tr.right, &tr.bottom, &tr.left] {
+                            match br {
+                                BorderRadius::Uniform(v) => { fnv!(&[0]); hf32!(*v); }
+                                BorderRadius::Elliptical { horizontal, vertical } => {
+                                    fnv!(&[1]); hf32!(*horizontal); hf32!(*vertical);
+                                }
+                            }
+                        }
+                    } else {
+                        hbool!(false);
+                    }
+                    let (tl, tr, br, bl) = r.radius_x();
+                    hf64!(tl); hf64!(tr); hf64!(br); hf64!(bl);
+                    let (tl, tr, br, bl) = r.radius_y();
+                    hf64!(tl); hf64!(tr); hf64!(br); hf64!(bl);
+                }
+                PaintCommand::Text(t) => {
+                    fnv!(&[1u8]);
+                    hf64!(t.rect.x); hf64!(t.rect.y); hf64!(t.rect.width); hf64!(t.rect.height);
+                    hstr!(&t.text);
+                    hstr!(&t.font_info.family);
+                    hf64!(t.font_info.size);
+                    hf64!(t.font_info.line_height);
+                    hu64!(t.font_info.weight as u64);
+                    hu64!(t.font_info.width as u64);
+                    hu64!(t.font_info.slant as u64);
+                    hbool!(t.font_info.underline);
+                    hbool!(t.font_info.line_through);
+                    hash_brush!(&t.brush);
+                }
+                PaintCommand::Svg(s) => {
+                    fnv!(&[2u8]);
+                    hu64!(s.media_id.as_u64());
+                    let rect = s.rect.rect();
+                    hf64!(rect.x); hf64!(rect.y); hf64!(rect.width); hf64!(rect.height);
+                }
+            }
+        }
+    }
+
+    (tile.rect.x.to_bits(), tile.rect.y.to_bits(), tile.layer_id.as_u64(), h)
+}
+
 /// and returns a `PipelineCache` of rasterized tiles ready for repeated compositing.
 ///
 /// Splitting the full pipeline from compositing lets scroll re-use the cached tiles without
@@ -469,6 +592,7 @@ fn pipeline_build_cache(
     #[cfg(feature = "backend_vello")] _vello_resources: Option<
         std::sync::Arc<gosub_render_pipeline::render::backends::vello::WgpuResources>,
     >,
+    prev_tile_cache: std::collections::HashMap<TileCacheKey, (u32, u32, Arc<Vec<u8>>)>,
 ) -> PipelineCache {
     use gosub_render_pipeline::common::browser_state::{BrowserState, WireframeState};
     use gosub_render_pipeline::common::document::pipeline_doc::GosubDocumentAdapter;
@@ -478,7 +602,7 @@ fn pipeline_build_cache(
     use gosub_render_pipeline::layouter::CanLayout;
     use gosub_render_pipeline::painter::Painter;
     use gosub_render_pipeline::rendertree_builder::RenderTree;
-    use gosub_render_pipeline::tiler::{TileList, TileState};
+    use gosub_render_pipeline::tiler::{TileId, TileList, TileState};
     use gosub_shared::{timing_start, timing_stop};
     use std::time::Instant;
 
@@ -625,37 +749,70 @@ fn pipeline_build_cache(
                 .filter(|&id| tile_list.arena.get(&id).map_or(false, |t| t.state == TileState::Dirty))
                 .collect();
 
-            // Phase 2: parallel rasterization — no shared mutable state.
-            let results: Vec<(TileId, Option<BakedTile>)> = dirty_ids
+            // Phase 2: parallel rasterization with dirty-tile cache.
+            // For each tile: compute a content hash; if it matches the previous render's cached
+            // pixels, reuse them (cache hit). Otherwise rasterize on this thread.
+            // Result: (tile_id, Option<BakedTile>, Option<new_cache_entry>)
+            type CacheEntry = (TileCacheKey, (u32, u32, Arc<Vec<u8>>));
+            let results: Vec<(TileId, Option<BakedTile>, Option<CacheEntry>)> = dirty_ids
                 .par_iter()
                 .map(|&tile_id| {
-                    let baked = tile_list.arena.get(&tile_id).and_then(|tile| {
-                        let mut local_store = TextureStore::new();
-                        let tex_id = rasterizer.rasterize(tile, &mut local_store, &media_store)?;
-                        let tex = local_store.get(tex_id)?;
-                        Some(BakedTile {
+                    let Some(tile) = tile_list.arena.get(&tile_id) else {
+                        return (tile_id, None, None);
+                    };
+
+                    let key = tile_cache_key(tile);
+
+                    // Cache hit: same content as the previous render — reuse pixels.
+                    if let Some(&(w, h, ref data)) = prev_tile_cache.get(&key) {
+                        let baked = BakedTile {
+                            page_x: tile.rect.x,
+                            page_y: tile.rect.y,
+                            width: w,
+                            height: h,
+                            data: Arc::clone(data),
+                        };
+                        return (tile_id, Some(baked), None);
+                    }
+
+                    // Cache miss: rasterize and emit a new cache entry.
+                    let mut local_store = TextureStore::new();
+                    let baked = rasterizer.rasterize(tile, &mut local_store, &media_store)
+                        .and_then(|tid| local_store.get(tid))
+                        .map(|tex| BakedTile {
                             page_x: tile.rect.x,
                             page_y: tile.rect.y,
                             width: tex.width as u32,
                             height: tex.height as u32,
                             data: Arc::clone(&tex.data),
-                        })
-                    });
-                    (tile_id, baked)
+                        });
+
+                    let cache_entry = baked.as_ref()
+                        .map(|b| (key, (b.width, b.height, Arc::clone(&b.data))));
+                    (tile_id, baked, cache_entry)
                 })
                 .collect();
 
-            // Phase 3: update tile states and gather BakedTiles (sequential).
+            // Phase 3: update tile states, gather BakedTiles, and build the new tile cache.
             let mut rasterized = 0usize;
+            let mut cache_hits = 0usize;
             let mut empty = 0usize;
             let mut tiles: Vec<BakedTile> = Vec::with_capacity(results.len());
-            for (tile_id, baked) in results {
+            let mut new_tile_cache: std::collections::HashMap<TileCacheKey, (u32, u32, Arc<Vec<u8>>)> =
+                std::collections::HashMap::with_capacity(results.len());
+
+            for (tile_id, baked, cache_entry) in results {
                 if let Some(tile) = tile_list.arena.get_mut(&tile_id) {
                     match baked {
                         Some(b) => {
                             tile.state = TileState::Clean;
+                            if let Some(entry) = cache_entry {
+                                new_tile_cache.insert(entry.0, entry.1);
+                                rasterized += 1;
+                            } else {
+                                cache_hits += 1;
+                            }
                             tiles.push(b);
-                            rasterized += 1;
                         }
                         None => {
                             tile.state = TileState::Empty;
@@ -667,23 +824,24 @@ fn pipeline_build_cache(
 
             timing_stop!(ts6);
             log::info!(
-                concat!("[pipeline] stage 6 rasterize ", $label, " {:>6.1}ms  ({} clean, {} empty)"),
+                concat!("[pipeline] stage 6 rasterize ", $label, " {:>6.1}ms  ({} rasterized, {} hits, {} empty)"),
                 t.elapsed().as_secs_f64() * 1000.0,
                 rasterized,
+                cache_hits,
                 empty
             );
-            tiles
+            (tiles, new_tile_cache)
         }};
     }
 
     #[cfg(feature = "backend_cairo")]
-    let baked_tiles = {
+    let (baked_tiles, new_tile_cache) = {
         use gosub_renderer_cairo::CairoRasterizer;
         rasterize_parallel!(CairoRasterizer::new(), "(cairo):    ")
     };
 
     #[cfg(all(feature = "backend_skia", not(feature = "backend_cairo")))]
-    let baked_tiles = {
+    let (baked_tiles, new_tile_cache) = {
         use gosub_renderer_skia::SkiaRasterizer;
         rasterize_parallel!(SkiaRasterizer::new(1.0), "(skia):     ")
     };
@@ -757,9 +915,16 @@ fn pipeline_build_cache(
         );
         tiles
     };
+    // Vello uses sequential rasterization; dirty-tile cache not yet implemented.
+    #[cfg(all(feature = "backend_vello", not(feature = "backend_cairo"), not(feature = "backend_skia")))]
+    let new_tile_cache: std::collections::HashMap<TileCacheKey, (u32, u32, Arc<Vec<u8>>)> =
+        std::collections::HashMap::new();
 
     #[cfg(not(any(feature = "backend_cairo", feature = "backend_skia", feature = "backend_vello")))]
     let baked_tiles: Vec<BakedTile> = Vec::new();
+    #[cfg(not(any(feature = "backend_cairo", feature = "backend_skia", feature = "backend_vello")))]
+    let new_tile_cache: std::collections::HashMap<TileCacheKey, (u32, u32, Arc<Vec<u8>>)> =
+        std::collections::HashMap::new();
 
     timing_stop!(ts_total);
     log::info!(
@@ -787,6 +952,7 @@ fn pipeline_build_cache(
         page_height,
         cached_tiles,
         layer_list: saved_layer_list,
+        tile_pixel_cache: new_tile_cache,
     }
 }
 

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -645,7 +645,7 @@ fn pipeline_build_cache(
                         page_y: tile.rect.y,
                         width: tex.width as u32,
                         height: tex.height as u32,
-                        data: Arc::new(tex.data.clone()),
+                        data: Arc::clone(&tex.data),
                     });
                 }
             }
@@ -704,7 +704,7 @@ fn pipeline_build_cache(
                         page_y: tile.rect.y,
                         width: tex.width as u32,
                         height: tex.height as u32,
-                        data: Arc::new(tex.data.clone()),
+                        data: Arc::clone(&tex.data),
                     });
                 }
             }
@@ -761,7 +761,7 @@ fn pipeline_build_cache(
                             page_y: tile.rect.y,
                             width: tex.width as u32,
                             height: tex.height as u32,
-                            data: Arc::new(tex.data.clone()),
+                            data: Arc::clone(&tex.data),
                         });
                     }
                 }

--- a/crates/gosub_render_pipeline/src/common/media/media.rs
+++ b/crates/gosub_render_pipeline/src/common/media/media.rs
@@ -10,6 +10,9 @@ impl MediaId {
     pub const fn new(val: u64) -> Self {
         Self(val)
     }
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
 }
 
 impl std::fmt::Display for MediaId {

--- a/crates/gosub_render_pipeline/src/common/texture.rs
+++ b/crates/gosub_render_pipeline/src/common/texture.rs
@@ -25,13 +25,12 @@ impl std::fmt::Display for TextureId {
     }
 }
 
-// Texture is a simple structure that holds the texture data. It's raw data, width, height and an id.
-// Note that we do not specify what the data contains. It could be a specific image format from the
-// used painting backend (like ImageSurface data for cairo)
+/// Raw pixel buffer produced by a rasterizer. Data is Arc-wrapped so it can be shared
+/// zero-copy into BakedTile / CachedTile without any pixel buffer copies.
 #[derive(Debug)]
 pub struct Texture {
     pub id: TextureId,
     pub width: usize,
     pub height: usize,
-    pub data: Vec<u8>,
+    pub data: std::sync::Arc<Vec<u8>>,
 }

--- a/crates/gosub_render_pipeline/src/common/texture_store.rs
+++ b/crates/gosub_render_pipeline/src/common/texture_store.rs
@@ -29,7 +29,7 @@ impl TextureStore {
             id: self.next_id(),
             width,
             height,
-            data,
+            data: std::sync::Arc::new(data),
         };
 
         let id = texture.id;

--- a/crates/gosub_render_pipeline/src/layering/layer.rs
+++ b/crates/gosub_render_pipeline/src/layering/layer.rs
@@ -12,6 +12,9 @@ impl LayerId {
     pub const fn new(val: u64) -> Self {
         Self(val)
     }
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
 }
 
 impl AddAssign<u64> for LayerId {

--- a/crates/gosub_render_pipeline/src/layouter.rs
+++ b/crates/gosub_render_pipeline/src/layouter.rs
@@ -22,6 +22,9 @@ impl LayoutElementId {
     pub const fn new(val: u64) -> Self {
         Self(val)
     }
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
 }
 
 impl AddAssign<u64> for LayoutElementId {

--- a/crates/gosub_render_pipeline/src/painter/commands.rs
+++ b/crates/gosub_render_pipeline/src/painter/commands.rs
@@ -12,10 +12,10 @@ pub mod text;
 /// Generic that defines a top, right, bottom, and left value.
 #[derive(Clone, Debug)]
 pub struct Trbl<T> {
-    top: T,
-    right: T,
-    bottom: T,
-    left: T,
+    pub top: T,
+    pub right: T,
+    pub bottom: T,
+    pub left: T,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/gosub_render_pipeline/src/render/backends/skia.rs
+++ b/crates/gosub_render_pipeline/src/render/backends/skia.rs
@@ -56,10 +56,19 @@ impl RenderBackend for SkiaBackend {
                         paint.set_anti_alias(true);
                         canvas.draw_rect(Rect::new(*x, *y, x + w, y + h), &paint);
                     }
-                    DisplayItem::TextRun { x, y, text, size, color, .. } => {
+                    DisplayItem::TextRun {
+                        x,
+                        y,
+                        text,
+                        size,
+                        color,
+                        ..
+                    } => {
                         let typeface = FONT_MGR.with(|fm| {
-                            fm.legacy_make_typeface(None, FontStyle::normal())
-                                .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("no typeface"))
+                            fm.legacy_make_typeface(None, FontStyle::normal()).unwrap_or_else(|| {
+                                fm.legacy_make_typeface("sans-serif", FontStyle::normal())
+                                    .expect("no typeface")
+                            })
                         });
                         let font = Font::new(typeface, *size);
                         let mut paint = Paint::new(to_color4f(color), None);

--- a/crates/gosub_render_pipeline/src/render/backends/skia.rs
+++ b/crates/gosub_render_pipeline/src/render/backends/skia.rs
@@ -7,6 +7,10 @@ use anyhow::{anyhow, Result};
 use skia_safe::{Color4f, Font, FontMgr, FontStyle, Paint, Rect};
 use std::any::Any;
 
+thread_local! {
+    static FONT_MGR: FontMgr = FontMgr::new();
+}
+
 #[derive(Default)]
 pub struct SkiaBackend;
 
@@ -52,21 +56,11 @@ impl RenderBackend for SkiaBackend {
                         paint.set_anti_alias(true);
                         canvas.draw_rect(Rect::new(*x, *y, x + w, y + h), &paint);
                     }
-                    DisplayItem::TextRun {
-                        x,
-                        y,
-                        text,
-                        size,
-                        color,
-                        ..
-                    } => {
-                        let typeface = FontMgr::new()
-                            .legacy_make_typeface(None, FontStyle::normal())
-                            .unwrap_or_else(|| {
-                                FontMgr::new()
-                                    .legacy_make_typeface("sans-serif", FontStyle::normal())
-                                    .expect("no typeface")
-                            });
+                    DisplayItem::TextRun { x, y, text, size, color, .. } => {
+                        let typeface = FONT_MGR.with(|fm| {
+                            fm.legacy_make_typeface(None, FontStyle::normal())
+                                .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("no typeface"))
+                        });
                         let font = Font::new(typeface, *size);
                         let mut paint = Paint::new(to_color4f(color), None);
                         paint.set_anti_alias(true);

--- a/crates/gosub_render_pipeline/src/render/backends/skia_gpu.rs
+++ b/crates/gosub_render_pipeline/src/render/backends/skia_gpu.rs
@@ -1,9 +1,12 @@
-use crate::render::backend::{ErasedSurface, ExternalHandle, PresentMode, RenderBackend, RgbaImage, SurfaceSize};
+use crate::render::backend::{
+    ErasedSurface, ExternalHandle, PixelFormat, PresentMode, RenderBackend, RgbaImage, SurfaceSize,
+};
 use crate::render::render_context::RenderContext;
 use crate::render::render_list::{Color, DisplayItem};
 use anyhow::{anyhow, Result};
 use parking_lot::Mutex;
-use skia_safe::Color4f;
+use skia_safe::gpu::DirectContext;
+use skia_safe::{Color4f, Font, FontMgr, FontStyle, ImageInfo, Paint, Rect};
 use std::any::Any;
 use std::sync::Arc;
 
@@ -23,12 +26,14 @@ pub trait GlContextProvider: Send + Sync {
 ///
 /// SAFETY: `GlContextProvider::make_current()` is called before every GPU operation,
 /// ensuring the GL context is current on whichever thread the engine uses.
-struct SendDirectContext(DirectContext);
+struct SendDirectContext(#[allow(dead_code)] DirectContext);
 unsafe impl Send for SendDirectContext {}
 unsafe impl Sync for SendDirectContext {}
 
 pub struct SkiaGpuBackend<C: GlContextProvider> {
+    #[allow(dead_code)]
     context: Arc<C>,
+    #[allow(dead_code)]
     direct_context: Mutex<SendDirectContext>,
 }
 
@@ -36,12 +41,10 @@ impl<C: GlContextProvider> SkiaGpuBackend<C> {
     pub fn new(context: Arc<C>) -> Result<Self> {
         context.make_current();
 
-        let interface = skia_safe::gpu::gl::Interface::new_load_with(|name| {
-            context.get_proc_address(name)
-        })
-        .ok_or_else(|| anyhow!("Failed to create Skia GL interface — no GL functions found"))?;
+        let interface = skia_safe::gpu::gl::Interface::new_load_with(|name| context.get_proc_address(name))
+            .ok_or_else(|| anyhow!("Failed to create Skia GL interface — no GL functions found"))?;
 
-        let direct_context = DirectContext::new_gl(interface, None)
+        let direct_context = skia_safe::gpu::direct_contexts::make_gl(interface, None)
             .ok_or_else(|| anyhow!("Failed to create Skia GL DirectContext — GL context must be current"))?;
 
         Ok(Self {
@@ -78,9 +81,9 @@ impl<C: GlContextProvider + Send + Sync + 'static> RenderBackend for SkiaGpuBack
 
         // Tile data from SkiaRasterizer is already on CPU; composite into a CPU raster
         // surface to avoid GL-context thread-affinity issues with the GPU path.
-        let Some(mut cpu_surface) = skia_safe::surfaces::raster_n32_premul(
-            skia_safe::ISize::new(s.size.width as i32, s.size.height as i32),
-        ) else {
+        let Some(mut cpu_surface) =
+            skia_safe::surfaces::raster_n32_premul(skia_safe::ISize::new(s.size.width as i32, s.size.height as i32))
+        else {
             return Err(anyhow!("SkiaGpuBackend: failed to create CPU raster surface"));
         };
 
@@ -100,10 +103,19 @@ impl<C: GlContextProvider + Send + Sync + 'static> RenderBackend for SkiaGpuBack
                         paint.set_anti_alias(true);
                         canvas.draw_rect(Rect::new(*x, *y, x + w, y + h), &paint);
                     }
-                    DisplayItem::TextRun { x, y, text, size, color, .. } => {
+                    DisplayItem::TextRun {
+                        x,
+                        y,
+                        text,
+                        size,
+                        color,
+                        ..
+                    } => {
                         let typeface = FONT_MGR.with(|fm| {
-                            fm.legacy_make_typeface(None, FontStyle::normal())
-                                .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("no typeface"))
+                            fm.legacy_make_typeface(None, FontStyle::normal()).unwrap_or_else(|| {
+                                fm.legacy_make_typeface("sans-serif", FontStyle::normal())
+                                    .expect("no typeface")
+                            })
                         });
                         let font = Font::new(typeface, *size);
                         let mut paint = Paint::new(to_color4f(color), None);
@@ -122,11 +134,9 @@ impl<C: GlContextProvider + Send + Sync + 'static> RenderBackend for SkiaGpuBack
                             skia_safe::AlphaType::Premul,
                             None,
                         );
-                        if let Some(image) = skia_safe::images::raster_from_data(
-                            &info,
-                            skia_safe::Data::new_copy(data),
-                            stride,
-                        ) {
+                        if let Some(image) =
+                            skia_safe::images::raster_from_data(&info, skia_safe::Data::new_copy(data), stride)
+                        {
                             canvas.draw_image(&image, (*x, *y), None);
                         }
                     }
@@ -155,7 +165,7 @@ impl<C: GlContextProvider + Send + Sync + 'static> RenderBackend for SkiaGpuBack
             s.pixels.clone(),
             s.size.width,
             s.size.height,
-            (s.size.width * 4) as u32,
+            s.size.width * 4,
             PixelFormat::PreMulArgb32,
         ))
     }
@@ -196,14 +206,25 @@ pub struct SkiaGpuSurface {
 
 impl SkiaGpuSurface {
     fn new(size: SurfaceSize, present: PresentMode) -> Self {
-        Self { size, pixels: Vec::new(), present, frame_id: 0 }
+        Self {
+            size,
+            pixels: Vec::new(),
+            present,
+            frame_id: 0,
+        }
     }
 }
 
 impl ErasedSurface for SkiaGpuSurface {
-    fn as_any(&self) -> &dyn Any { self }
-    fn as_any_mut(&mut self) -> &mut dyn Any { self }
-    fn size(&self) -> SurfaceSize { self.size }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+    fn size(&self) -> SurfaceSize {
+        self.size
+    }
 }
 
 #[inline]

--- a/crates/gosub_render_pipeline/src/render/backends/skia_gpu.rs
+++ b/crates/gosub_render_pipeline/src/render/backends/skia_gpu.rs
@@ -7,6 +7,205 @@ use skia_safe::Color4f;
 use std::any::Any;
 use std::sync::Arc;
 
+thread_local! {
+    static FONT_MGR: FontMgr = FontMgr::new();
+}
+
+/// Trait for providing an OpenGL context to `SkiaGpuBackend`.
+pub trait GlContextProvider: Send + Sync {
+    /// Make the GL context current on the calling thread.
+    fn make_current(&self);
+    /// Return the address of an OpenGL function, or null if not available.
+    fn get_proc_address(&self, name: &str) -> *const std::ffi::c_void;
+}
+
+/// Wraps `DirectContext` to allow crossing thread boundaries.
+///
+/// SAFETY: `GlContextProvider::make_current()` is called before every GPU operation,
+/// ensuring the GL context is current on whichever thread the engine uses.
+struct SendDirectContext(DirectContext);
+unsafe impl Send for SendDirectContext {}
+unsafe impl Sync for SendDirectContext {}
+
+pub struct SkiaGpuBackend<C: GlContextProvider> {
+    context: Arc<C>,
+    direct_context: Mutex<SendDirectContext>,
+}
+
+impl<C: GlContextProvider> SkiaGpuBackend<C> {
+    pub fn new(context: Arc<C>) -> Result<Self> {
+        context.make_current();
+
+        let interface = skia_safe::gpu::gl::Interface::new_load_with(|name| {
+            context.get_proc_address(name)
+        })
+        .ok_or_else(|| anyhow!("Failed to create Skia GL interface — no GL functions found"))?;
+
+        let direct_context = DirectContext::new_gl(interface, None)
+            .ok_or_else(|| anyhow!("Failed to create Skia GL DirectContext — GL context must be current"))?;
+
+        Ok(Self {
+            context,
+            direct_context: Mutex::new(SendDirectContext(direct_context)),
+        })
+    }
+}
+
+impl<C: GlContextProvider + Send + Sync + 'static> RenderBackend for SkiaGpuBackend<C> {
+    fn name(&self) -> &'static str {
+        "skia-gpu"
+    }
+
+    fn create_surface(&self, size: SurfaceSize, present: PresentMode) -> Result<Box<dyn ErasedSurface + Send>> {
+        Ok(Box::new(SkiaGpuSurface::new(size, present)))
+    }
+
+    fn render(&self, ctx: &mut dyn RenderContext, surface: &mut dyn ErasedSurface) -> Result<()> {
+        let s = surface
+            .as_any_mut()
+            .downcast_mut::<SkiaGpuSurface>()
+            .ok_or_else(|| anyhow!("SkiaGpuBackend used with non-SkiaGpu surface"))?;
+
+        if s.size.width == 0 || s.size.height == 0 {
+            return Ok(());
+        }
+
+        let vp = ctx.viewport();
+        let offset_x = vp.x as f32;
+        let offset_y = vp.y as f32;
+        let clip = Rect::new(0.0, 0.0, s.size.width as f32, s.size.height as f32);
+        let items: Vec<DisplayItem> = ctx.render_list().items.to_vec();
+
+        // Tile data from SkiaRasterizer is already on CPU; composite into a CPU raster
+        // surface to avoid GL-context thread-affinity issues with the GPU path.
+        let Some(mut cpu_surface) = skia_safe::surfaces::raster_n32_premul(
+            skia_safe::ISize::new(s.size.width as i32, s.size.height as i32),
+        ) else {
+            return Err(anyhow!("SkiaGpuBackend: failed to create CPU raster surface"));
+        };
+
+        {
+            let canvas = cpu_surface.canvas();
+            canvas.clip_rect(clip, None, None);
+            canvas.save();
+            canvas.translate((-offset_x, -offset_y));
+
+            for item in &items {
+                match item {
+                    DisplayItem::Clear { color } => {
+                        canvas.clear(to_color4f(color));
+                    }
+                    DisplayItem::Rect { x, y, w, h, color } => {
+                        let mut paint = Paint::new(to_color4f(color), None);
+                        paint.set_anti_alias(true);
+                        canvas.draw_rect(Rect::new(*x, *y, x + w, y + h), &paint);
+                    }
+                    DisplayItem::TextRun { x, y, text, size, color, .. } => {
+                        let typeface = FONT_MGR.with(|fm| {
+                            fm.legacy_make_typeface(None, FontStyle::normal())
+                                .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("no typeface"))
+                        });
+                        let font = Font::new(typeface, *size);
+                        let mut paint = Paint::new(to_color4f(color), None);
+                        paint.set_anti_alias(true);
+                        canvas.draw_str(text.as_str(), (*x, *y), &font, &paint);
+                    }
+                    DisplayItem::Blit { x, y, w, h, data } => {
+                        let stride = (*w * 4) as usize;
+                        if data.len() < *h as usize * stride {
+                            log::warn!("SkiaGpuBackend: Blit data too short");
+                            continue;
+                        }
+                        let info = ImageInfo::new(
+                            (*w as i32, *h as i32),
+                            skia_safe::ColorType::BGRA8888,
+                            skia_safe::AlphaType::Premul,
+                            None,
+                        );
+                        if let Some(image) = skia_safe::images::raster_from_data(
+                            &info,
+                            skia_safe::Data::new_copy(data),
+                            stride,
+                        ) {
+                            canvas.draw_image(&image, (*x, *y), None);
+                        }
+                    }
+                }
+            }
+
+            canvas.restore();
+        }
+
+        if let Some(peek) = cpu_surface.canvas().peek_pixels() {
+            if let Some(bytes) = peek.bytes() {
+                s.pixels = bytes.to_vec();
+            }
+        }
+
+        s.frame_id = s.frame_id.wrapping_add(1);
+        Ok(())
+    }
+
+    fn snapshot(&self, surface: &mut dyn ErasedSurface, _max_dim: u32) -> Result<RgbaImage> {
+        let s = surface
+            .as_any_mut()
+            .downcast_mut::<SkiaGpuSurface>()
+            .ok_or_else(|| anyhow!("SkiaGpuBackend used with non-SkiaGpu surface"))?;
+        Ok(RgbaImage::from_raw(
+            s.pixels.clone(),
+            s.size.width,
+            s.size.height,
+            (s.size.width * 4) as u32,
+            PixelFormat::PreMulArgb32,
+        ))
+    }
+
+    fn external_handle(&self, surface: &mut dyn ErasedSurface) -> Result<ExternalHandle> {
+        let s = surface
+            .as_any_mut()
+            .downcast_mut::<SkiaGpuSurface>()
+            .ok_or_else(|| anyhow!("SkiaGpuBackend used with non-SkiaGpu surface"))?;
+
+        if s.size.width == 0 || s.size.height == 0 || s.pixels.is_empty() {
+            return Ok(ExternalHandle::NullHandle {
+                width: s.size.width,
+                height: s.size.height,
+                frame_id: s.frame_id,
+            });
+        }
+
+        Ok(ExternalHandle::CpuPixelsOwned {
+            width: s.size.width,
+            height: s.size.height,
+            stride: s.size.width * 4,
+            pixels: s.pixels.clone(),
+            format: PixelFormat::PreMulArgb32,
+        })
+    }
+}
+
+// ── Surface ───────────────────────────────────────────────────────────────────
+
+pub struct SkiaGpuSurface {
+    size: SurfaceSize,
+    pixels: Vec<u8>,
+    #[allow(dead_code)]
+    present: PresentMode,
+    frame_id: u64,
+}
+
+impl SkiaGpuSurface {
+    fn new(size: SurfaceSize, present: PresentMode) -> Self {
+        Self { size, pixels: Vec::new(), present, frame_id: 0 }
+    }
+}
+
+impl ErasedSurface for SkiaGpuSurface {
+    fn as_any(&self) -> &dyn Any { self }
+    fn as_any_mut(&mut self) -> &mut dyn Any { self }
+    fn size(&self) -> SurfaceSize { self.size }
+}
+
 #[inline]
 pub fn to_color4f(c: &Color) -> Color4f {
     Color4f::new(c.r, c.g, c.b, c.a)

--- a/crates/gosub_render_pipeline/src/render/render_list.rs
+++ b/crates/gosub_render_pipeline/src/render/render_list.rs
@@ -177,8 +177,8 @@ pub enum DisplayItem {
         w: u32,
         /// Tile height in pixels.
         h: u32,
-        /// Raw ARgb32 pixel data (length = `h * w * 4`).
-        data: Vec<u8>,
+        /// Raw ARgb32 pixel data (length = `h * w * 4`). Arc-shared from the rasterizer output.
+        data: std::sync::Arc<Vec<u8>>,
     },
 }
 

--- a/crates/gosub_renderer_cairo/src/compositor/inner.rs
+++ b/crates/gosub_renderer_cairo/src/compositor/inner.rs
@@ -41,7 +41,7 @@ pub fn compose_layer(cr: &cairo::Context, layer_id: LayerId, state: &BrowserStat
         };
 
         let surface = match ImageSurface::create_for_data(
-            texture.data.clone(),
+            (*texture.data).clone(),
             cairo::Format::ARgb32,
             texture.width as i32,
             texture.height as i32,

--- a/crates/gosub_renderer_skia/src/rasterizer/text.rs
+++ b/crates/gosub_renderer_skia/src/rasterizer/text.rs
@@ -3,12 +3,15 @@ use gosub_render_pipeline::painter::commands::text::Text;
 use gosub_render_pipeline::tiler::Tile;
 use skia_safe::{Canvas, Color4f, Font, FontMgr, FontStyle, Paint};
 
+thread_local! {
+    static FONT_MGR: FontMgr = FontMgr::new();
+}
+
 pub fn do_paint_text(canvas: &Canvas, _tile: &Tile, cmd: &Text, _dpi_scale_factor: f32) -> Result<(), anyhow::Error> {
     let color4f = brush_to_color4f(&cmd.brush);
     let mut paint = Paint::new(color4f, None);
     paint.set_anti_alias(true);
 
-    let font_mgr = FontMgr::new();
     let font_style = FontStyle::new(
         skia_safe::font_style::Weight::from(cmd.font_info.weight),
         skia_safe::font_style::Width::from((cmd.font_info.width / 100).clamp(1, 9)),
@@ -19,11 +22,11 @@ pub fn do_paint_text(canvas: &Canvas, _tile: &Tile, cmd: &Text, _dpi_scale_facto
         },
     );
 
-    let Some(typeface) = font_mgr
-        .match_family_style(&cmd.font_info.family, font_style)
-        .or_else(|| font_mgr.legacy_make_typeface(None, font_style))
-        .or_else(|| font_mgr.legacy_make_typeface(None, FontStyle::normal()))
-    else {
+    let Some(typeface) = FONT_MGR.with(|fm| {
+        fm.match_family_style(&cmd.font_info.family, font_style)
+            .or_else(|| fm.legacy_make_typeface(None, font_style))
+            .or_else(|| fm.legacy_make_typeface(None, FontStyle::normal()))
+    }) else {
         return Ok(());
     };
 
@@ -62,7 +65,6 @@ pub fn do_paint_text(canvas: &Canvas, _tile: &Tile, cmd: &Text, _dpi_scale_facto
             canvas.draw_str(line.as_str(), (x, y), &font, &paint);
         }
         y += line_height;
-        // Stop drawing if we've exceeded the rect's bottom.
         if y > (cmd.rect.y + cmd.rect.height) as f32 + line_height {
             break;
         }

--- a/crates/gosub_renderer_vello/src/compositor/inner.rs
+++ b/crates/gosub_renderer_vello/src/compositor/inner.rs
@@ -48,7 +48,7 @@ pub fn compose_layer(scene: &mut vello::Scene, layer_id: LayerId, state: &Browse
         };
 
         let surface = ImageData {
-            data: Blob::from(texture.data.clone()),
+            data: Blob::from(texture.data.as_ref().clone()),
             format: ImageFormat::Rgba8,
             alpha_type: ImageAlphaType::AlphaPremultiplied,
             width: texture.width as u32,

--- a/examples/gtk4-skia-gpu/main.rs
+++ b/examples/gtk4-skia-gpu/main.rs
@@ -118,11 +118,20 @@ fn render_item(canvas: &skia_safe::Canvas, item: &DisplayItem) {
             paint.set_anti_alias(true);
             canvas.draw_rect(SkRect::new(*x, *y, x + w, y + h), &paint);
         }
-        DisplayItem::TextRun { x, y, text, size, color, .. } => {
+        DisplayItem::TextRun {
+            x,
+            y,
+            text,
+            size,
+            color,
+            ..
+        } => {
             thread_local! { static FONT_MGR: FontMgr = FontMgr::new(); }
             let typeface = FONT_MGR.with(|fm| {
-                fm.legacy_make_typeface(None, FontStyle::normal())
-                    .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("no typeface"))
+                fm.legacy_make_typeface(None, FontStyle::normal()).unwrap_or_else(|| {
+                    fm.legacy_make_typeface("sans-serif", FontStyle::normal())
+                        .expect("no typeface")
+                })
             });
             let font = Font::new(typeface, *size);
             let mut paint = Paint::new(to_color4f(color), None);

--- a/examples/gtk4-skia-gpu/main.rs
+++ b/examples/gtk4-skia-gpu/main.rs
@@ -118,21 +118,12 @@ fn render_item(canvas: &skia_safe::Canvas, item: &DisplayItem) {
             paint.set_anti_alias(true);
             canvas.draw_rect(SkRect::new(*x, *y, x + w, y + h), &paint);
         }
-        DisplayItem::TextRun {
-            x,
-            y,
-            text,
-            size,
-            color,
-            ..
-        } => {
-            let typeface = FontMgr::new()
-                .legacy_make_typeface(None, FontStyle::normal())
-                .unwrap_or_else(|| {
-                    FontMgr::new()
-                        .legacy_make_typeface("sans-serif", FontStyle::normal())
-                        .expect("no typeface")
-                });
+        DisplayItem::TextRun { x, y, text, size, color, .. } => {
+            thread_local! { static FONT_MGR: FontMgr = FontMgr::new(); }
+            let typeface = FONT_MGR.with(|fm| {
+                fm.legacy_make_typeface(None, FontStyle::normal())
+                    .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("no typeface"))
+            });
             let font = Font::new(typeface, *size);
             let mut paint = Paint::new(to_color4f(color), None);
             paint.set_anti_alias(true);

--- a/examples/winit-skia-gpu/main.rs
+++ b/examples/winit-skia-gpu/main.rs
@@ -433,13 +433,11 @@ fn draw_address_bar(canvas: &skia_safe::Canvas, win_w: u32, h: i32, url: &str, f
     paint.set_stroke_width(1.0);
     canvas.draw_round_rect(SkRect::from_xywh(6.5, 5.5, w - 13.0, hf - 11.0), 4.0, 4.0, &paint);
 
-    let typeface = FontMgr::new()
-        .legacy_make_typeface(None, FontStyle::normal())
-        .unwrap_or_else(|| {
-            FontMgr::new()
-                .legacy_make_typeface("sans-serif", FontStyle::normal())
-                .expect("typeface")
-        });
+    thread_local! { static FONT_MGR: FontMgr = FontMgr::new(); }
+    let typeface = FONT_MGR.with(|fm| {
+        fm.legacy_make_typeface(None, FontStyle::normal())
+            .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("typeface"))
+    });
     let font = Font::new(typeface, 14.0);
     paint.set_color4f(Color4f::new(0.0, 0.0, 0.0, 1.0), None);
     paint.set_style(skia_safe::PaintStyle::Fill);

--- a/examples/winit-skia-gpu/main.rs
+++ b/examples/winit-skia-gpu/main.rs
@@ -435,8 +435,10 @@ fn draw_address_bar(canvas: &skia_safe::Canvas, win_w: u32, h: i32, url: &str, f
 
     thread_local! { static FONT_MGR: FontMgr = FontMgr::new(); }
     let typeface = FONT_MGR.with(|fm| {
-        fm.legacy_make_typeface(None, FontStyle::normal())
-            .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("typeface"))
+        fm.legacy_make_typeface(None, FontStyle::normal()).unwrap_or_else(|| {
+            fm.legacy_make_typeface("sans-serif", FontStyle::normal())
+                .expect("typeface")
+        })
     });
     let font = Font::new(typeface, 14.0);
     paint.set_color4f(Color4f::new(0.0, 0.0, 0.0, 1.0), None);

--- a/examples/winit-skia/main.rs
+++ b/examples/winit-skia/main.rs
@@ -411,13 +411,11 @@ fn draw_address_bar(buf: &mut softbuffer::Buffer<Arc<Window>, Arc<Window>>, win_
     border.set_stroke_width(1.0);
     canvas.draw_rect(SkRect::new(4.5, 5.5, (w - 5) as f32, (h - 5) as f32), &border);
 
-    let typeface = FontMgr::new()
-        .legacy_make_typeface(None, FontStyle::normal())
-        .unwrap_or_else(|| {
-            FontMgr::new()
-                .legacy_make_typeface("sans-serif", FontStyle::normal())
-                .expect("no typeface")
-        });
+    thread_local! { static FONT_MGR: FontMgr = FontMgr::new(); }
+    let typeface = FONT_MGR.with(|fm| {
+        fm.legacy_make_typeface(None, FontStyle::normal())
+            .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("no typeface"))
+    });
     let font = Font::new(typeface, 14.0);
     let mut text_paint = Paint::new(Color4f::new(0.0, 0.0, 0.0, 1.0), None);
     text_paint.set_anti_alias(true);

--- a/examples/winit-skia/main.rs
+++ b/examples/winit-skia/main.rs
@@ -413,8 +413,10 @@ fn draw_address_bar(buf: &mut softbuffer::Buffer<Arc<Window>, Arc<Window>>, win_
 
     thread_local! { static FONT_MGR: FontMgr = FontMgr::new(); }
     let typeface = FONT_MGR.with(|fm| {
-        fm.legacy_make_typeface(None, FontStyle::normal())
-            .unwrap_or_else(|| fm.legacy_make_typeface("sans-serif", FontStyle::normal()).expect("no typeface"))
+        fm.legacy_make_typeface(None, FontStyle::normal()).unwrap_or_else(|| {
+            fm.legacy_make_typeface("sans-serif", FontStyle::normal())
+                .expect("no typeface")
+        })
     });
     let font = Font::new(typeface, 14.0);
     let mut text_paint = Paint::new(Color4f::new(0.0, 0.0, 0.0, 1.0), None);


### PR DESCRIPTION
Added caching to tiles so we don't need to rerender them if not changed. Also Added a static font manager so we don't need to construct it over and over again on each text draw.

Tile rasterization is done in parallel with rayon instead of a sequential loop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Skia GPU render backend with custom GL context provider support.

* **Performance**
  * Implemented per-tile content caching for improved rasterization efficiency.
  * Enabled parallel tile rasterization processing.
  * Optimized font manager and texture data handling to reduce memory allocations and improve throughput.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->