### PR TITLE
CSS rendering fixes and Skia text/pixel format corrections

### DIFF
--- a/crates/gosub_css3/src/colors.rs
+++ b/crates/gosub_css3/src/colors.rs
@@ -96,8 +96,121 @@ impl From<&str> for RgbColor {
             return RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), rgb.get_alpha() * 255.0);
         }
 
+        // Modern CSS Color Level 4 functions stored as unparsed strings.
+        if value.starts_with("oklch(") {
+            if let Some(c) = parse_oklch_str(value) {
+                return c;
+            }
+        }
+        if value.starts_with("oklab(") {
+            if let Some(c) = parse_oklab_str(value) {
+                return c;
+            }
+        }
+
         get_hex_color_from_name(value).map_or(RgbColor::default(), parse_hex)
     }
+}
+
+/// Parse `oklch(L C H [/ alpha])` from a raw CSS string into an `RgbColor`.
+fn parse_oklch_str(s: &str) -> Option<RgbColor> {
+    let inner = s.strip_prefix("oklch(")?.strip_suffix(')')?;
+    let nums = parse_space_nums(inner);
+    if nums.len() < 3 {
+        return None;
+    }
+    let (r, g, b) = oklch_to_srgb(nums[0], nums[1], nums[2]);
+    let a = nums.get(3).copied().unwrap_or(1.0) * 255.0;
+    Some(RgbColor::new(r, g, b, a))
+}
+
+/// Parse `oklab(L a b [/ alpha])` from a raw CSS string into an `RgbColor`.
+fn parse_oklab_str(s: &str) -> Option<RgbColor> {
+    let inner = s.strip_prefix("oklab(")?.strip_suffix(')')?;
+    let nums = parse_space_nums(inner);
+    if nums.len() < 3 {
+        return None;
+    }
+    let (r, g, b) = oklab_to_srgb(nums[0], nums[1], nums[2]);
+    let a = nums.get(3).copied().unwrap_or(1.0) * 255.0;
+    Some(RgbColor::new(r, g, b, a))
+}
+
+/// Extract whitespace-/slash-separated floats from a CSS function argument string.
+/// Strips trailing `%` and skips non-numeric tokens (like the `/` slash).
+fn parse_space_nums(s: &str) -> Vec<f32> {
+    s.split(|c: char| c.is_ascii_whitespace() || c == '/')
+        .filter_map(|tok| {
+            let tok = tok.trim().trim_end_matches('%');
+            tok.parse::<f32>().ok()
+        })
+        .collect()
+}
+
+/// Convert an oklch(L C H) triplet to an sRGB [r,g,b] triplet in the 0.0–255.0 range.
+/// L: 0.0–1.0 lightness, C: 0.0–0.37+ chroma, H: hue in degrees.
+pub fn oklch_to_srgb(l: f32, c: f32, h_deg: f32) -> (f32, f32, f32) {
+    // oklch → oklab
+    let h = h_deg * std::f32::consts::PI / 180.0;
+    let a = c * h.cos();
+    let b = c * h.sin();
+
+    // oklab → linear sRGB (M2 and M1 matrices from the Oklab specification)
+    let l_ = l + 0.396_337_78 * a + 0.215_803_76 * b;
+    let m_ = l - 0.105_561_35 * a - 0.063_854_17 * b;
+    let s_ = l - 0.089_484_18 * a - 1.291_485_55 * b;
+
+    let l_c = l_ * l_ * l_;
+    let m_c = m_ * m_ * m_;
+    let s_c = s_ * s_ * s_;
+
+    let r_lin = 4.076_741_7 * l_c - 3.307_711_6 * m_c + 0.230_970_0 * s_c;
+    let g_lin = -1.268_438_0 * l_c + 2.609_757_4 * m_c - 0.341_319_4 * s_c;
+    let b_lin = -0.004_196_1 * l_c - 0.703_418_6 * m_c + 1.707_614_7 * s_c;
+
+    // linear sRGB → gamma-corrected sRGB
+    let gamma = |x: f32| -> f32 {
+        if x <= 0.003_130_8 {
+            12.92 * x
+        } else {
+            1.055 * x.powf(1.0 / 2.4) - 0.055
+        }
+    };
+
+    (
+        gamma(r_lin).clamp(0.0, 1.0) * 255.0,
+        gamma(g_lin).clamp(0.0, 1.0) * 255.0,
+        gamma(b_lin).clamp(0.0, 1.0) * 255.0,
+    )
+}
+
+/// Convert an oklab(L a b) triplet to an sRGB [r,g,b] triplet in the 0.0–255.0 range.
+pub fn oklab_to_srgb(l: f32, a: f32, b: f32) -> (f32, f32, f32) {
+    let l_ = l + 0.396_337_78 * a + 0.215_803_76 * b;
+    let m_ = l - 0.105_561_35 * a - 0.063_854_17 * b;
+    let s_ = l - 0.089_484_18 * a - 1.291_485_55 * b;
+
+    let l_c = l_ * l_ * l_;
+    let m_c = m_ * m_ * m_;
+    let s_c = s_ * s_ * s_;
+
+    let r_lin = 4.076_741_7 * l_c - 3.307_711_6 * m_c + 0.230_970_0 * s_c;
+    let g_lin = -1.268_438_0 * l_c + 2.609_757_4 * m_c - 0.341_319_4 * s_c;
+    let b_lin = -0.004_196_1 * l_c - 0.703_418_6 * m_c + 1.707_614_7 * s_c;
+
+    let gamma = |x: f32| -> f32 {
+        if x <= 0.003_130_8 {
+            12.92 * x
+        } else {
+            1.055 * x.powf(1.0 / 2.4) - 0.055
+        }
+    };
+
+    (
+        gamma(r_lin).clamp(0.0, 1.0) * 255.0,
+        gamma(g_lin).clamp(0.0, 1.0) * 255.0,
+        gamma(b_lin).clamp(0.0, 1.0) * 255.0,
+    )
 }
 
 fn get_hex_color_from_name(color_name: &str) -> Option<&str> {

--- a/crates/gosub_css3/src/colors.rs
+++ b/crates/gosub_css3/src/colors.rs
@@ -158,14 +158,14 @@ pub fn oklch_to_srgb(l: f32, c: f32, h_deg: f32) -> (f32, f32, f32) {
     // oklab → linear sRGB (M2 and M1 matrices from the Oklab specification)
     let l_ = l + 0.396_337_78 * a + 0.215_803_76 * b;
     let m_ = l - 0.105_561_35 * a - 0.063_854_17 * b;
-    let s_ = l - 0.089_484_18 * a - 1.291_485_55 * b;
+    let s_ = l - 0.089_484_18 * a - 1.291_485_5 * b;
 
     let l_c = l_ * l_ * l_;
     let m_c = m_ * m_ * m_;
     let s_c = s_ * s_ * s_;
 
-    let r_lin = 4.076_741_7 * l_c - 3.307_711_6 * m_c + 0.230_970_0 * s_c;
-    let g_lin = -1.268_438_0 * l_c + 2.609_757_4 * m_c - 0.341_319_4 * s_c;
+    let r_lin = 4.076_741_7 * l_c - 3.307_711_6 * m_c + 0.230_97 * s_c;
+    let g_lin = -1.268_438 * l_c + 2.609_757_4 * m_c - 0.341_319_4 * s_c;
     let b_lin = -0.004_196_1 * l_c - 0.703_418_6 * m_c + 1.707_614_7 * s_c;
 
     // linear sRGB → gamma-corrected sRGB
@@ -188,14 +188,14 @@ pub fn oklch_to_srgb(l: f32, c: f32, h_deg: f32) -> (f32, f32, f32) {
 pub fn oklab_to_srgb(l: f32, a: f32, b: f32) -> (f32, f32, f32) {
     let l_ = l + 0.396_337_78 * a + 0.215_803_76 * b;
     let m_ = l - 0.105_561_35 * a - 0.063_854_17 * b;
-    let s_ = l - 0.089_484_18 * a - 1.291_485_55 * b;
+    let s_ = l - 0.089_484_18 * a - 1.291_485_5 * b;
 
     let l_c = l_ * l_ * l_;
     let m_c = m_ * m_ * m_;
     let s_c = s_ * s_ * s_;
 
-    let r_lin = 4.076_741_7 * l_c - 3.307_711_6 * m_c + 0.230_970_0 * s_c;
-    let g_lin = -1.268_438_0 * l_c + 2.609_757_4 * m_c - 0.341_319_4 * s_c;
+    let r_lin = 4.076_741_7 * l_c - 3.307_711_6 * m_c + 0.230_97 * s_c;
+    let g_lin = -1.268_438 * l_c + 2.609_757_4 * m_c - 0.341_319_4 * s_c;
     let b_lin = -0.004_196_1 * l_c - 0.703_418_6 * m_c + 1.707_614_7 * s_c;
 
     let gamma = |x: f32| -> f32 {

--- a/crates/gosub_css3/src/matcher/shorthands.rs
+++ b/crates/gosub_css3/src/matcher/shorthands.rs
@@ -232,7 +232,7 @@ impl<'a> ShorthandResolver<'a> {
                 let idx = self.fix_list.multipliers.iter_mut().find(|m| m.0 == self.name);
 
                 if let Some(idx) = idx {
-                    let Some(items) = self.multiplier.get_names(complete, idx.1) else {
+                    let Some(items) = self.multiplier.get_names(complete.clone(), idx.1) else {
                         return Ok(None);
                     };
 
@@ -246,7 +246,7 @@ impl<'a> ShorthandResolver<'a> {
                     });
                 }
 
-                let Some(items) = self.multiplier.get_names(complete, 0) else {
+                let Some(items) = self.multiplier.get_names(complete.clone(), 0) else {
                     return Ok(None);
                 };
 
@@ -339,6 +339,14 @@ impl FixList {
 
     pub fn set_info(&mut self, info: FixListInfo) {
         self.current_info = Some(info);
+    }
+
+    /// Reset the {1,4}-multiplier counter for a specific shorthand name.
+    /// Must be called before each CSS declaration is expanded so that the counter
+    /// from a prior rule (e.g. `* { margin: 0 }`) does not bleed into the current
+    /// rule (e.g. `.container { margin: 0 auto }`), causing wrong TRBL assignment.
+    pub fn reset_multiplier(&mut self, name: &str) {
+        self.multipliers.retain(|m| m.0 != name);
     }
 
     fn get_declaration(&self, value: CssValue) -> DeclarationProperty {

--- a/crates/gosub_css3/src/stylesheet.rs
+++ b/crates/gosub_css3/src/stylesheet.rs
@@ -704,10 +704,11 @@ impl gosub_interface::css3::CssValue for CssValue {
     }
 
     fn as_number(&self) -> Option<f32> {
-        if let CssValue::Number(num) = &self {
-            Some(*num)
-        } else {
-            None
+        match self {
+            CssValue::Number(num) => Some(*num),
+            // Bare `0` (no unit) is a valid zero value for any numeric property.
+            CssValue::Zero => Some(0.0),
+            _ => None,
         }
     }
 

--- a/crates/gosub_css3/src/stylesheet.rs
+++ b/crates/gosub_css3/src/stylesheet.rs
@@ -7,7 +7,7 @@ use gosub_shared::errors::CssResult;
 use std::cmp::Ordering;
 use std::fmt::Display;
 
-use crate::colors::RgbColor;
+use crate::colors::{oklab_to_srgb, oklch_to_srgb, RgbColor};
 
 /// Severity of a CSS error
 #[derive(Debug, PartialEq)]
@@ -418,6 +418,7 @@ impl CssValue {
         match self {
             CssValue::Color(col) => Some(*col),
             CssValue::String(s) => Some(RgbColor::from(s.as_str())),
+            CssValue::Function(name, args) => parse_css_color_function(name, args),
             _ => None,
         }
     }
@@ -569,6 +570,75 @@ impl CssValue {
         }
 
         Ok(CssValue::String(value.to_string()))
+    }
+}
+
+/// Parse a CSS color function like `oklch()`, `oklab()`, or `color()` into an RgbColor.
+///
+/// Handles the CSS Color Level 4 space-separated syntax, including an optional alpha
+/// separated by `/` (represented as `CssValue::None` after the CSS parser processes it).
+fn parse_css_color_function(name: &str, args: &[CssValue]) -> Option<RgbColor> {
+    // Collect numeric/percentage/none arguments, skipping the `/` delimiter (stored as None)
+    // and any string tokens (like the color-space name in `color(srgb ...)`).
+    // CSS `none` keyword means "missing value" = 0.
+    let nums: Vec<f32> = args
+        .iter()
+        .filter_map(|v| match v {
+            CssValue::Number(n) => Some(*n),
+            CssValue::Percentage(p) => Some(*p),
+            CssValue::Zero => Some(0.0),
+            CssValue::String(s) if s.eq_ignore_ascii_case("none") => Some(0.0),
+            _ => None,
+        })
+        .collect();
+
+    // Helper to resolve an L (lightness) argument: percentage 0-100 → 0.0-1.0, decimal as-is.
+    let resolve_l = |raw: f32, is_pct: bool| -> f32 {
+        if is_pct { raw / 100.0 } else { raw }
+    };
+
+    // Detect whether each positional arg was given as a percentage.
+    let is_pct: Vec<bool> = args
+        .iter()
+        .filter_map(|v| match v {
+            CssValue::Number(_) | CssValue::Zero => Some(false),
+            CssValue::Percentage(_) => Some(true),
+            CssValue::String(s) if s.eq_ignore_ascii_case("none") => Some(false),
+            _ => None,
+        })
+        .collect();
+
+    match name.to_ascii_lowercase().as_str() {
+        "oklch" if nums.len() >= 3 => {
+            let l = resolve_l(nums[0], *is_pct.first().unwrap_or(&false));
+            // Chroma: percentage 0-100 maps to ~0-0.4 max chroma.
+            let c = if *is_pct.get(1).unwrap_or(&false) { nums[1] / 100.0 * 0.4 } else { nums[1] };
+            let h = nums[2];
+            let alpha = nums.get(3).copied().map(|a| {
+                if *is_pct.get(3).unwrap_or(&false) { a / 100.0 * 255.0 } else { a * 255.0 }
+            }).unwrap_or(255.0);
+            let (r, g, b) = oklch_to_srgb(l, c, h);
+            Some(RgbColor::new(r, g, b, alpha))
+        }
+        "oklab" if nums.len() >= 3 => {
+            let l = resolve_l(nums[0], *is_pct.first().unwrap_or(&false));
+            let a_ok = if *is_pct.get(1).unwrap_or(&false) { nums[1] / 100.0 * 0.4 } else { nums[1] };
+            let b_ok = if *is_pct.get(2).unwrap_or(&false) { nums[2] / 100.0 * 0.4 } else { nums[2] };
+            let alpha = nums.get(3).copied().map(|a| {
+                if *is_pct.get(3).unwrap_or(&false) { a / 100.0 * 255.0 } else { a * 255.0 }
+            }).unwrap_or(255.0);
+            let (r, g, b) = oklab_to_srgb(l, a_ok, b_ok);
+            Some(RgbColor::new(r, g, b, alpha))
+        }
+        // color(srgb R G B) or color(display-p3 R G B) — treat as linear/sRGB for now.
+        "color" if nums.len() >= 3 => {
+            // First element of args is the color space name (a String), skip it.
+            let alpha = nums.get(3).copied().map(|a| {
+                if *is_pct.get(3).unwrap_or(&false) { a / 100.0 * 255.0 } else { a * 255.0 }
+            }).unwrap_or(255.0);
+            Some(RgbColor::new(nums[0] * 255.0, nums[1] * 255.0, nums[2] * 255.0, alpha))
+        }
+        _ => None,
     }
 }
 

--- a/crates/gosub_css3/src/stylesheet.rs
+++ b/crates/gosub_css3/src/stylesheet.rs
@@ -1,5 +1,6 @@
 use core::fmt::Debug;
 use core::slice;
+use cow_utils::CowUtils;
 use gosub_interface::css3::CssOrigin;
 use gosub_shared::byte_stream::Location;
 use gosub_shared::errors::CssError;
@@ -594,7 +595,11 @@ fn parse_css_color_function(name: &str, args: &[CssValue]) -> Option<RgbColor> {
 
     // Helper to resolve an L (lightness) argument: percentage 0-100 → 0.0-1.0, decimal as-is.
     let resolve_l = |raw: f32, is_pct: bool| -> f32 {
-        if is_pct { raw / 100.0 } else { raw }
+        if is_pct {
+            raw / 100.0
+        } else {
+            raw
+        }
     };
 
     // Detect whether each positional arg was given as a percentage.
@@ -608,34 +613,70 @@ fn parse_css_color_function(name: &str, args: &[CssValue]) -> Option<RgbColor> {
         })
         .collect();
 
-    match name.to_ascii_lowercase().as_str() {
+    match name.cow_to_ascii_lowercase().as_ref() {
         "oklch" if nums.len() >= 3 => {
             let l = resolve_l(nums[0], *is_pct.first().unwrap_or(&false));
             // Chroma: percentage 0-100 maps to ~0-0.4 max chroma.
-            let c = if *is_pct.get(1).unwrap_or(&false) { nums[1] / 100.0 * 0.4 } else { nums[1] };
+            let c = if *is_pct.get(1).unwrap_or(&false) {
+                nums[1] / 100.0 * 0.4
+            } else {
+                nums[1]
+            };
             let h = nums[2];
-            let alpha = nums.get(3).copied().map(|a| {
-                if *is_pct.get(3).unwrap_or(&false) { a / 100.0 * 255.0 } else { a * 255.0 }
-            }).unwrap_or(255.0);
+            let alpha = nums
+                .get(3)
+                .copied()
+                .map(|a| {
+                    if *is_pct.get(3).unwrap_or(&false) {
+                        a / 100.0 * 255.0
+                    } else {
+                        a * 255.0
+                    }
+                })
+                .unwrap_or(255.0);
             let (r, g, b) = oklch_to_srgb(l, c, h);
             Some(RgbColor::new(r, g, b, alpha))
         }
         "oklab" if nums.len() >= 3 => {
             let l = resolve_l(nums[0], *is_pct.first().unwrap_or(&false));
-            let a_ok = if *is_pct.get(1).unwrap_or(&false) { nums[1] / 100.0 * 0.4 } else { nums[1] };
-            let b_ok = if *is_pct.get(2).unwrap_or(&false) { nums[2] / 100.0 * 0.4 } else { nums[2] };
-            let alpha = nums.get(3).copied().map(|a| {
-                if *is_pct.get(3).unwrap_or(&false) { a / 100.0 * 255.0 } else { a * 255.0 }
-            }).unwrap_or(255.0);
+            let a_ok = if *is_pct.get(1).unwrap_or(&false) {
+                nums[1] / 100.0 * 0.4
+            } else {
+                nums[1]
+            };
+            let b_ok = if *is_pct.get(2).unwrap_or(&false) {
+                nums[2] / 100.0 * 0.4
+            } else {
+                nums[2]
+            };
+            let alpha = nums
+                .get(3)
+                .copied()
+                .map(|a| {
+                    if *is_pct.get(3).unwrap_or(&false) {
+                        a / 100.0 * 255.0
+                    } else {
+                        a * 255.0
+                    }
+                })
+                .unwrap_or(255.0);
             let (r, g, b) = oklab_to_srgb(l, a_ok, b_ok);
             Some(RgbColor::new(r, g, b, alpha))
         }
         // color(srgb R G B) or color(display-p3 R G B) — treat as linear/sRGB for now.
         "color" if nums.len() >= 3 => {
             // First element of args is the color space name (a String), skip it.
-            let alpha = nums.get(3).copied().map(|a| {
-                if *is_pct.get(3).unwrap_or(&false) { a / 100.0 * 255.0 } else { a * 255.0 }
-            }).unwrap_or(255.0);
+            let alpha = nums
+                .get(3)
+                .copied()
+                .map(|a| {
+                    if *is_pct.get(3).unwrap_or(&false) {
+                        a / 100.0 * 255.0
+                    } else {
+                        a * 255.0
+                    }
+                })
+                .unwrap_or(255.0);
             Some(RgbColor::new(nums[0] * 255.0, nums[1] * 255.0, nums[2] * 255.0, alpha))
         }
         _ => None,

--- a/crates/gosub_css3/src/system.rs
+++ b/crates/gosub_css3/src/system.rs
@@ -100,6 +100,11 @@ impl CssSystem for Css3System {
                                     slice::from_ref(&value)
                                 };
 
+                                // Each CSS declaration starts with a fresh TRBL multiplier
+                                // counter for this shorthand name. Without this reset, a prior
+                                // rule's `margin: 0` (count→1) would corrupt a later rule's
+                                // `margin: 0 auto` expansion (starting at multi=1 instead of 0).
+                                fix_list.reset_multiplier(&declaration.property);
                                 if !definition.matches_and_shorthands(match_value, &mut fix_list) {
                                     // Special-case: `background: <color>` — the full shorthand
                                     // syntax requires comma-separated layers and the simple

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -443,7 +443,13 @@ impl BrowsingContext {
             log::warn!("[hover] hover_dirty → dispatching paint-only repaint (stages 4–6)");
             // Paint-only repaint: reuse the cached layout tree, skip stages 1–2.
             if let Some(old_cache) = self.pipeline_cache.take() {
-                let PipelineCache { layer_list, page_height, tile_pixel_cache: prev_tile_cache, tiles: prev_baked_tiles, .. } = old_cache;
+                let PipelineCache {
+                    layer_list,
+                    page_height,
+                    tile_pixel_cache: prev_tile_cache,
+                    tiles: prev_baked_tiles,
+                    ..
+                } = old_cache;
                 self.pipeline_cache = Some(pipeline_hover_repaint(
                     layer_list,
                     page_height,
@@ -1309,6 +1315,7 @@ fn pipeline_build_cache(
 /// All other tiles are carried over from `prev_baked_tiles` unchanged — no CSS
 /// re-evaluation, no re-rasterization.
 #[cfg(feature = "pipeline")]
+#[allow(clippy::too_many_arguments)]
 fn pipeline_hover_repaint(
     layer_list: Arc<gosub_render_pipeline::layering::layer::LayerList>,
     page_height: f64,
@@ -1350,7 +1357,7 @@ fn pipeline_hover_repaint(
     // Key: (page_x bits, page_y bits) — deterministic since tile positions don't change.
     let mut prev_by_pos: std::collections::HashMap<(u64, u64), BakedTile> = prev_baked_tiles
         .into_iter()
-        .map(|t| ((t.page_x.to_bits() as u64, t.page_y.to_bits() as u64), t))
+        .map(|t| ((t.page_x.to_bits(), t.page_y.to_bits()), t))
         .collect();
 
     // Compute the union bounding box of old and new hovered elements.  Tiles that
@@ -1390,7 +1397,7 @@ fn pipeline_hover_repaint(
                 && tile_rect.y + tile_rect.height > hover_rect.y;
             if !overlaps {
                 tile.state = TileState::Clean;
-                let key = (tile_rect.x.to_bits() as u64, tile_rect.y.to_bits() as u64);
+                let key = (tile_rect.x.to_bits(), tile_rect.y.to_bits());
                 if let Some(baked) = prev_by_pos.remove(&key) {
                     clean_baked.push(baked);
                 }
@@ -1405,13 +1412,24 @@ fn pipeline_hover_repaint(
         // No hover element visible — reuse all previous baked tiles unchanged.
         let all_tiles: Vec<BakedTile> = prev_by_pos.into_values().collect();
         let cached_tiles = Arc::new(
-            all_tiles.iter().map(|t| CachedTile {
-                page_x: t.page_x as f32, page_y: t.page_y as f32,
-                width: t.width, height: t.height,
-                data: Arc::clone(&t.data),
-            }).collect::<Vec<_>>(),
+            all_tiles
+                .iter()
+                .map(|t| CachedTile {
+                    page_x: t.page_x as f32,
+                    page_y: t.page_y as f32,
+                    width: t.width,
+                    height: t.height,
+                    data: Arc::clone(&t.data),
+                })
+                .collect::<Vec<_>>(),
         );
-        return PipelineCache { tiles: all_tiles, page_height, cached_tiles, layer_list, tile_pixel_cache: prev_tile_cache };
+        return PipelineCache {
+            tiles: all_tiles,
+            page_height,
+            cached_tiles,
+            layer_list,
+            tile_pixel_cache: prev_tile_cache,
+        };
     }
 
     // Stage 5: paint ONLY dirty (hover-affected) tiles.
@@ -1446,8 +1464,14 @@ fn pipeline_hover_repaint(
                         cmds += c.len();
                         tiled_element.paint_commands = c;
                     }
-                    log::info!("[pipeline] hover s5 tile ({:.0},{:.0}) elems={} cmds={} in {:.1}ms",
-                        tile.rect.x, tile.rect.y, elem_count, cmds, t_tile.elapsed().as_secs_f64()*1000.0);
+                    log::info!(
+                        "[pipeline] hover s5 tile ({:.0},{:.0}) elems={} cmds={} in {:.1}ms",
+                        tile.rect.x,
+                        tile.rect.y,
+                        elem_count,
+                        cmds,
+                        t_tile.elapsed().as_secs_f64() * 1000.0
+                    );
                     painted_tiles += 1;
                     total_elements_painted += elem_count;
                     let _ = cmds;
@@ -1484,7 +1508,12 @@ fn pipeline_hover_repaint(
                 .flat_map(|&layer_id| tile_list.get_intersecting_tiles(layer_id, full_page_rect))
                 .filter(|&id| tile_list.arena.get(&id).map_or(false, |t| t.state == TileState::Dirty))
                 .collect();
-            log::info!("[pipeline] hover s6 dirty_ids: {:.1}ms ({} dirty, {} layers)", t_dirty.elapsed().as_secs_f64()*1000.0, dirty_ids.len(), layer_ids.len());
+            log::info!(
+                "[pipeline] hover s6 dirty_ids: {:.1}ms ({} dirty, {} layers)",
+                t_dirty.elapsed().as_secs_f64() * 1000.0,
+                dirty_ids.len(),
+                layer_ids.len()
+            );
 
             type CacheEntry = (TileCacheKey, (u32, u32, Arc<Vec<u8>>));
             let results: Vec<(TileId, Option<BakedTile>, Option<CacheEntry>)> = dirty_ids
@@ -1549,8 +1578,14 @@ fn pipeline_hover_repaint(
             }
             timing_stop!(ts6);
             log::warn!(
-                concat!("[pipeline] hover stage 6 rasterize ", $label, " {:>6.1}ms  ({} rasterized, {} hits)"),
-                t.elapsed().as_secs_f64() * 1000.0, rasterized, cache_hits
+                concat!(
+                    "[pipeline] hover stage 6 rasterize ",
+                    $label,
+                    " {:>6.1}ms  ({} rasterized, {} hits)"
+                ),
+                t.elapsed().as_secs_f64() * 1000.0,
+                rasterized,
+                cache_hits
             );
             (tiles, new_tile_cache)
         }};
@@ -1651,7 +1686,13 @@ fn pipeline_hover_repaint(
             .collect::<Vec<_>>(),
     );
 
-    PipelineCache { tiles: all_baked_tiles, page_height, cached_tiles, layer_list, tile_pixel_cache: new_tile_cache }
+    PipelineCache {
+        tiles: all_baked_tiles,
+        page_height,
+        cached_tiles,
+        layer_list,
+        tile_pixel_cache: new_tile_cache,
+    }
 }
 
 /// Stage 7: composite visible tiles from the cache into `rl`.

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -255,6 +255,12 @@ pub struct BrowsingContext {
     /// The DOM node currently under the pointer (for :hover matching).
     #[cfg(feature = "pipeline")]
     hover_leaf: Option<NodeId>,
+    /// Layout element ID from the PREVIOUS hover update (needed to find which tile to repaint).
+    hover_old_lei: Option<LayoutElementId>,
+    /// DOM nodes whose hover state changed in the last update (old chain ∪ new chain).
+    /// Only these nodes need their cached CSS invalidated; everything else in the tile stays cached.
+    #[cfg(feature = "pipeline")]
+    hover_dirty_nodes: Vec<NodeId>,
     /// The layout element currently under the pointer, used for bounding-box pre-check.
     #[cfg(feature = "pipeline")]
     hover_layout_element: Option<LayoutElementId>,
@@ -298,6 +304,9 @@ impl BrowsingContext {
             hover_dirty: false,
             #[cfg(feature = "pipeline")]
             hover_leaf: None,
+            hover_old_lei: None,
+            #[cfg(feature = "pipeline")]
+            hover_dirty_nodes: Vec::new(),
             #[cfg(feature = "pipeline")]
             hover_layout_element: None,
             #[cfg(feature = "pipeline")]
@@ -434,15 +443,14 @@ impl BrowsingContext {
             log::warn!("[hover] hover_dirty → dispatching paint-only repaint (stages 4–6)");
             // Paint-only repaint: reuse the cached layout tree, skip stages 1–2.
             if let Some(old_cache) = self.pipeline_cache.take() {
-                let PipelineCache {
-                    layer_list,
-                    page_height,
-                    tile_pixel_cache: prev_tile_cache,
-                    ..
-                } = old_cache;
+                let PipelineCache { layer_list, page_height, tile_pixel_cache: prev_tile_cache, tiles: prev_baked_tiles, .. } = old_cache;
                 self.pipeline_cache = Some(pipeline_hover_repaint(
                     layer_list,
                     page_height,
+                    prev_baked_tiles,
+                    self.hover_old_lei,
+                    self.hover_layout_element,
+                    &self.hover_dirty_nodes,
                     &self.viewport,
                     #[cfg(feature = "backend_vello")]
                     self.vello_resources.clone(),
@@ -609,6 +617,26 @@ impl BrowsingContext {
         // Common case: same element — skip the ancestor walk entirely.
         if new_leaf == self.hover_leaf {
             return (false, false, self.hover_link_url.clone());
+        }
+
+        self.hover_old_lei = self.hover_layout_element;
+
+        // Collect old and new ancestor chains — only these nodes need CSS cache invalidation.
+        self.hover_dirty_nodes.clear();
+        if let Some(doc) = &self.document {
+            let mut seen = std::collections::HashSet::new();
+            for start in [self.hover_leaf, new_leaf].into_iter().flatten() {
+                let mut id = start;
+                loop {
+                    if seen.insert(id) {
+                        self.hover_dirty_nodes.push(id);
+                    }
+                    match doc.parent(id) {
+                        Some(p) => id = p,
+                        None => break,
+                    }
+                }
+            }
         }
 
         self.hover_leaf = new_leaf;
@@ -980,13 +1008,12 @@ fn pipeline_build_cache(
         total_tiles
     );
 
-    // Stage 5: paint tiles in the renderable window.
-    // We only rasterize tiles that fall within [0, render_height], where render_height is
-    // capped to the viewport height. This bounds memory usage on tall pages: at 256×256×4B
-    // per tile, rendering all tiles for a 117K-px page across hundreds of layers would
-    // exhaust RAM. The viewport is already set to MAX_PAGE_HEIGHT by the screenshot tool
-    // (and to the actual window height by the browser), so capping here is always correct.
-    let render_height = page_height.min(viewport.height as f64);
+    // Stage 5: paint all tiles for the full page so that scrolling reveals pre-rendered
+    // content. We use the full page_height rather than capping to viewport.height; the
+    // compositor only ships the visible subset to the screen anyway, so no extra pixels
+    // are transferred. Memory is bounded by tile count: at 256×256×4B per tile, a 6 000 px
+    // page × 1 280 px wide = ~120 tiles × 256 KB each ≈ 30 MB, which is acceptable.
+    let render_height = page_height;
     let t = Instant::now();
     let ts5 = timing_start!("pipeline.painting");
     let full_page_rect = PipelineRect::new(0.0, 0.0, viewport.width as f64, render_height.max(1.0));
@@ -1278,13 +1305,17 @@ fn pipeline_build_cache(
 }
 
 /// Hover-only repaint: skip stages 1–2 (render-tree + layout), reuse the cached
-/// `LayerList`, then run stages 4–6 (tile, paint, rasterize) with a fresh style cache.
-/// This makes `:hover` visual changes (background, color, box-shadow, …) cheap —
-/// only the tiles that changed content get re-rasterized.
+/// `LayerList`, and only repaint tiles that intersect the old or new hovered element.
+/// All other tiles are carried over from `prev_baked_tiles` unchanged — no CSS
+/// re-evaluation, no re-rasterization.
 #[cfg(feature = "pipeline")]
 fn pipeline_hover_repaint(
     layer_list: Arc<gosub_render_pipeline::layering::layer::LayerList>,
     page_height: f64,
+    prev_baked_tiles: Vec<BakedTile>,
+    old_hover_lei: Option<LayoutElementId>,
+    new_hover_lei: Option<LayoutElementId>,
+    hover_dirty_nodes: &[NodeId],
     viewport: &gosub_render_pipeline::render::Viewport,
     #[cfg(feature = "backend_vello")] _vello_resources: Option<
         std::sync::Arc<gosub_render_pipeline::render::backends::vello::WgpuResources>,
@@ -1301,9 +1332,6 @@ fn pipeline_hover_repaint(
     log::info!("[pipeline] hover repaint (skipping stages 1–2)");
     let t_total = Instant::now();
 
-    // Invalidate the per-node style cache so the painter re-evaluates :hover rules.
-    layer_list.layout_tree.render_tree.doc.clear_style_cache();
-
     // Stage 4: tiling — reuse existing LayerList, no layout work.
     let t = Instant::now();
     let ts4 = timing_start!("pipeline.hover.tiling");
@@ -1311,14 +1339,83 @@ fn pipeline_hover_repaint(
     tile_list.generate();
     let total_tiles = tile_list.arena.len();
     timing_stop!(ts4);
-    log::info!(
+    log::warn!(
         "[pipeline] hover stage 4 tiling: {:>6.1}ms  ({} tiles)",
         t.elapsed().as_secs_f64() * 1000.0,
         total_tiles
     );
 
-    // Stage 5: paint — reads live styles from doc (now with cleared cache).
-    let render_height = page_height.min(viewport.height as f64);
+    // Build a position-keyed lookup of previous baked tiles so non-hover tiles can be
+    // carried over without any CSS re-evaluation or rasterization.
+    // Key: (page_x bits, page_y bits) — deterministic since tile positions don't change.
+    let mut prev_by_pos: std::collections::HashMap<(u64, u64), BakedTile> = prev_baked_tiles
+        .into_iter()
+        .map(|t| ((t.page_x.to_bits() as u64, t.page_y.to_bits() as u64), t))
+        .collect();
+
+    // Compute the union bounding box of old and new hovered elements.  Tiles that
+    // don't intersect this region cannot have changed visually, so we skip them.
+    let hover_rect: Option<PipelineRect> = {
+        let mut union: Option<PipelineRect> = None;
+        for lei in [old_hover_lei, new_hover_lei].into_iter().flatten() {
+            if let Some(el) = layer_list.layout_tree.get_node_by_id(lei) {
+                let m = el.box_model.margin_box;
+                let r = PipelineRect::new(m.x, m.y, m.width, m.height);
+                union = Some(match union {
+                    None => r,
+                    Some(u) => {
+                        let x0 = u.x.min(r.x);
+                        let y0 = u.y.min(r.y);
+                        let x1 = (u.x + u.width).max(r.x + r.width);
+                        let y1 = (u.y + u.height).max(r.y + r.height);
+                        PipelineRect::new(x0, y0, x1 - x0, y1 - y0)
+                    }
+                });
+            }
+        }
+        union
+    };
+
+    // Mark tiles that DON'T intersect the hover region as Clean.  For Clean tiles we
+    // carry the previous BakedTile forward; for Dirty tiles we re-evaluate CSS only
+    // for the elements they contain (targeted invalidation).
+    let mut clean_baked: Vec<BakedTile> = Vec::with_capacity(total_tiles);
+    if let Some(hover_rect) = hover_rect {
+        let doc = &layer_list.layout_tree.render_tree.doc;
+        for tile in tile_list.arena.values_mut() {
+            let tile_rect = tile.rect;
+            let overlaps = tile_rect.x < hover_rect.x + hover_rect.width
+                && tile_rect.x + tile_rect.width > hover_rect.x
+                && tile_rect.y < hover_rect.y + hover_rect.height
+                && tile_rect.y + tile_rect.height > hover_rect.y;
+            if !overlaps {
+                tile.state = TileState::Clean;
+                let key = (tile_rect.x.to_bits() as u64, tile_rect.y.to_bits() as u64);
+                if let Some(baked) = prev_by_pos.remove(&key) {
+                    clean_baked.push(baked);
+                }
+            } else {
+                // Invalidate cached styles only for the hover-chain nodes (old + new ancestors).
+                // Non-hover elements in this tile keep their cached CSS — only the nodes that
+                // actually gained or lost :hover need re-evaluation.
+                doc.invalidate_style_for_nodes(hover_dirty_nodes);
+            }
+        }
+    } else {
+        // No hover element visible — reuse all previous baked tiles unchanged.
+        let all_tiles: Vec<BakedTile> = prev_by_pos.into_values().collect();
+        let cached_tiles = Arc::new(
+            all_tiles.iter().map(|t| CachedTile {
+                page_x: t.page_x as f32, page_y: t.page_y as f32,
+                width: t.width, height: t.height,
+                data: Arc::clone(&t.data),
+            }).collect::<Vec<_>>(),
+        );
+        return PipelineCache { tiles: all_tiles, page_height, cached_tiles, layer_list, tile_pixel_cache: prev_tile_cache };
+    }
+
+    // Stage 5: paint ONLY dirty (hover-affected) tiles.
+    let render_height = page_height;
     let t = Instant::now();
     let ts5 = timing_start!("pipeline.hover.painting");
     let full_page_rect = PipelineRect::new(0.0, 0.0, viewport.width as f64, render_height.max(1.0));
@@ -1335,28 +1432,36 @@ fn pipeline_hover_repaint(
     };
     let painter = Painter::new(tile_list.layer_list.clone());
     let mut painted_tiles = 0usize;
+    let mut total_elements_painted = 0usize;
     for &layer_id in &layer_ids {
         let tile_ids = tile_list.get_intersecting_tiles(layer_id, full_page_rect);
         for tile_id in tile_ids {
             if let Some(tile) = tile_list.get_tile_mut(tile_id) {
                 if tile.state == TileState::Dirty {
+                    let elem_count = tile.elements.len();
+                    let t_tile = Instant::now();
                     let mut cmds = 0usize;
                     for tiled_element in &mut tile.elements {
                         let c = painter.paint(tiled_element, &paint_state);
                         cmds += c.len();
                         tiled_element.paint_commands = c;
                     }
+                    log::info!("[pipeline] hover s5 tile ({:.0},{:.0}) elems={} cmds={} in {:.1}ms",
+                        tile.rect.x, tile.rect.y, elem_count, cmds, t_tile.elapsed().as_secs_f64()*1000.0);
                     painted_tiles += 1;
+                    total_elements_painted += elem_count;
                     let _ = cmds;
                 }
             }
         }
     }
     timing_stop!(ts5);
-    log::info!(
-        "[pipeline] hover stage 5 painting: {:>6.1}ms  ({} tiles painted)",
+    log::warn!(
+        "[pipeline] hover stage 5 painting: {:>6.1}ms  ({} dirty tiles / {} elems painted, {} clean reused)",
         t.elapsed().as_secs_f64() * 1000.0,
-        painted_tiles
+        painted_tiles,
+        total_elements_painted,
+        clean_baked.len()
     );
 
     // Stage 6: rasterize (parallel for Cairo/Skia, using the tile-pixel cache).
@@ -1373,11 +1478,13 @@ fn pipeline_hover_repaint(
             let media_store = MediaStore::new();
             let rasterizer = $rasterizer;
 
+            let t_dirty = Instant::now();
             let dirty_ids: Vec<TileId> = layer_ids
                 .iter()
                 .flat_map(|&layer_id| tile_list.get_intersecting_tiles(layer_id, full_page_rect))
                 .filter(|&id| tile_list.arena.get(&id).map_or(false, |t| t.state == TileState::Dirty))
                 .collect();
+            log::info!("[pipeline] hover s6 dirty_ids: {:.1}ms ({} dirty, {} layers)", t_dirty.elapsed().as_secs_f64()*1000.0, dirty_ids.len(), layer_ids.len());
 
             type CacheEntry = (TileCacheKey, (u32, u32, Arc<Vec<u8>>));
             let results: Vec<(TileId, Option<BakedTile>, Option<CacheEntry>)> = dirty_ids
@@ -1441,15 +1548,9 @@ fn pipeline_hover_repaint(
                 }
             }
             timing_stop!(ts6);
-            log::info!(
-                concat!(
-                    "[pipeline] hover stage 6 rasterize ",
-                    $label,
-                    " {:>6.1}ms  ({} rasterized, {} hits)"
-                ),
-                t.elapsed().as_secs_f64() * 1000.0,
-                rasterized,
-                cache_hits
+            log::warn!(
+                concat!("[pipeline] hover stage 6 rasterize ", $label, " {:>6.1}ms  ({} rasterized, {} hits)"),
+                t.elapsed().as_secs_f64() * 1000.0, rasterized, cache_hits
             );
             (tiles, new_tile_cache)
         }};
@@ -1527,14 +1628,18 @@ fn pipeline_hover_repaint(
         std::collections::HashMap<TileCacheKey, (u32, u32, Arc<Vec<u8>>)>,
     ) = (Vec::new(), std::collections::HashMap::new());
 
-    log::info!(
-        "[pipeline] hover repaint total: {:.1}ms  ({} baked tiles)",
+    // Merge: newly rasterized hover tiles + clean tiles carried from previous render.
+    let all_baked_tiles: Vec<BakedTile> = baked_tiles.into_iter().chain(clean_baked).collect();
+
+    log::warn!(
+        "[pipeline] hover repaint total: {:.1}ms  ({} total tiles, {} dirty+rasterized)",
         t_total.elapsed().as_secs_f64() * 1000.0,
-        baked_tiles.len()
+        all_baked_tiles.len(),
+        painted_tiles,
     );
 
     let cached_tiles = Arc::new(
-        baked_tiles
+        all_baked_tiles
             .iter()
             .map(|t| gosub_render_pipeline::render::backend::CachedTile {
                 page_x: t.page_x as f32,
@@ -1546,13 +1651,7 @@ fn pipeline_hover_repaint(
             .collect::<Vec<_>>(),
     );
 
-    PipelineCache {
-        tiles: baked_tiles,
-        page_height,
-        cached_tiles,
-        layer_list,
-        tile_pixel_cache: new_tile_cache,
-    }
+    PipelineCache { tiles: all_baked_tiles, page_height, cached_tiles, layer_list, tile_pixel_cache: new_tile_cache }
 }
 
 /// Stage 7: composite visible tiles from the cache into `rl`.

--- a/crates/gosub_engine/src/engine/tab/state.rs
+++ b/crates/gosub_engine/src/engine/tab/state.rs
@@ -14,6 +14,8 @@ pub(crate) struct TabRuntime {
     // pub viewport: Viewport,
     /// Has something changed that requires a redraw
     pub dirty: bool,
+    /// When true, the command handler wants an immediate render without waiting for the tick.
+    pub render_now: bool,
     // When the last tick draw was done
     pub last_tick_draw: std::time::Instant,
     /// Scene epoch of the last submitted frame; skip re-render when it matches the context's epoch.
@@ -29,6 +31,7 @@ impl Default for TabRuntime {
             fps,
             interval: tokio::time::interval(Duration::from_secs_f64(1.0 / fps as f64)),
             dirty: false,
+            render_now: false,
             last_tick_draw: std::time::Instant::now(),
             committed_scene_epoch: u64::MAX,
         }

--- a/crates/gosub_engine/src/engine/tab/worker.rs
+++ b/crates/gosub_engine/src/engine/tab/worker.rs
@@ -750,7 +750,6 @@ impl TabWorker {
     /// Do a draw tick. This will be called based on the FPS that is requested
     #[allow(unreachable_code)] // cfg-conditional tile-cache returns make the display-list path unreachable for some feature combos
     async fn tick_draw(&mut self) -> anyhow::Result<()> {
-
         // Skip rendering when nothing has changed to avoid burning CPU at the tick rate.
         if !self.runtime.dirty {
             return Ok(());

--- a/crates/gosub_engine/src/engine/tab/worker.rs
+++ b/crates/gosub_engine/src/engine/tab/worker.rs
@@ -116,8 +116,6 @@ pub struct TabWorker {
     desired_viewport: Viewport,
     /// Set when a resize arrives while rendering. Causes an immediate re-render after finishing the current rendering.
     dirty_after_inflight: bool,
-    /// Latest unprocessed mouse position; coalesced into one hit-test per frame tick.
-    pending_mouse_pos: Option<(f64, f64)>,
     /// Current scroll offset in CSS pixels (updated by MouseScroll).
     scroll_x: i32,
     scroll_y: i32,
@@ -170,7 +168,6 @@ impl TabWorker {
             committed_viewport: Default::default(),
             desired_viewport: Default::default(),
             dirty_after_inflight: false,
-            pending_mouse_pos: None,
             scroll_x: 0,
             scroll_y: 0,
             runtime: TabRuntime::default(),
@@ -253,6 +250,14 @@ impl TabWorker {
                     let Some(cmd) = msg else { break; };
                     if self.handle_tab_command(cmd).is_break() {
                         break;
+                    }
+                    // If the command (e.g. hover change) requested an immediate render,
+                    // call tick_draw now instead of waiting up to 1/fps seconds for the tick.
+                    if std::mem::replace(&mut self.runtime.render_now, false) {
+                        if let Err(e) = self.tick_draw().await {
+                            self.state = TabState::Failed(format!("Tab {:?} immediate render error: {}", self.tab_id, e));
+                            self.runtime.dirty = true;
+                        }
                     }
                 }
             }
@@ -388,8 +393,21 @@ impl TabWorker {
                 ControlFlow::Continue
             }
             TabCommand::MouseMove { x: _x, y: _y } => {
-                // Coalesce: store the latest position and let tick_draw do one hit-test per frame.
-                self.pending_mouse_pos = Some((_x as f64, _y as f64));
+                #[cfg(feature = "pipeline")]
+                {
+                    // Process the hit-test immediately so hover doesn't wait for the next tick.
+                    let (visual_dirty, url_changed, link_url) = self.context.update_hover(_x as f64, _y as f64);
+                    if url_changed {
+                        self.send_event(EngineEvent::HoverUrl {
+                            tab_id: self.tab_id,
+                            url: link_url,
+                        });
+                    }
+                    if visual_dirty {
+                        self.runtime.dirty = true;
+                        self.runtime.render_now = true;
+                    }
+                }
                 #[cfg(not(feature = "pipeline"))]
                 {
                     self.runtime.dirty = true;
@@ -732,20 +750,6 @@ impl TabWorker {
     /// Do a draw tick. This will be called based on the FPS that is requested
     #[allow(unreachable_code)] // cfg-conditional tile-cache returns make the display-list path unreachable for some feature combos
     async fn tick_draw(&mut self) -> anyhow::Result<()> {
-        // Drain the coalesced mouse position — at most one hit-test per frame tick.
-        #[cfg(feature = "pipeline")]
-        if let Some((mx, my)) = self.pending_mouse_pos.take() {
-            let (visual_dirty, url_changed, link_url) = self.context.update_hover(mx, my);
-            if visual_dirty {
-                self.runtime.dirty = true;
-            }
-            if url_changed {
-                self.send_event(EngineEvent::HoverUrl {
-                    tab_id: self.tab_id,
-                    url: link_url,
-                });
-            }
-        }
 
         // Skip rendering when nothing has changed to avoid burning CPU at the tick rate.
         if !self.runtime.dirty {

--- a/crates/gosub_render_pipeline/src/common/document/node.rs
+++ b/crates/gosub_render_pipeline/src/common/document/node.rs
@@ -153,9 +153,12 @@ impl Node {
     pub fn is_inline_element(&self) -> bool {
         match &self.node_type {
             NodeType::Element(data) => match data.get_style(&StyleProperty::Display) {
-                // The CSS initial value for display is inline; treat unset as inline.
-                None => true,
                 Some(Value::Display(Display::Inline)) => true,
+                // When no display is explicitly set, use the HTML element's intrinsic type.
+                // CSS initial value is `inline`, but UA stylesheets set `block` for most
+                // HTML structural elements.  Defaulting unknown elements to inline here
+                // would incorrectly group <li>, <h2>, <div> etc. into inline flows.
+                None => is_intrinsically_inline(&data.tag_name),
                 _ => false,
             },
             _ => false,
@@ -212,4 +215,19 @@ impl Node {
             node_type: NodeType::Element(ElementData::new(tag_name, attributes, self_closing, style)),
         }
     }
+}
+
+/// Returns true if `tag` is an HTML element that is inline by spec when no CSS is applied.
+/// Block-level elements (`div`, `p`, `h1`–`h6`, `li`, `section`, etc.) return false so that
+/// missing `display` in NodeStyle (e.g. from a UA-stylesheet gap) does not accidentally put
+/// them into an inline formatting context.
+fn is_intrinsically_inline(tag: &str) -> bool {
+    matches!(
+        tag.to_ascii_lowercase().as_str(),
+        "a" | "abbr" | "acronym" | "b" | "bdo" | "big" | "br" | "button" | "cite"
+            | "code" | "dfn" | "em" | "i" | "img" | "input" | "kbd" | "label"
+            | "map" | "object" | "output" | "q" | "samp" | "select" | "small"
+            | "span" | "strong" | "sub" | "sup" | "textarea" | "time" | "tt"
+            | "u" | "var"
+    )
 }

--- a/crates/gosub_render_pipeline/src/common/document/node.rs
+++ b/crates/gosub_render_pipeline/src/common/document/node.rs
@@ -1,5 +1,6 @@
 use crate::common::document::document::Document;
 use crate::common::document::style::{Display, NodeStyle, StyleProperty, Value};
+use cow_utils::CowUtils;
 use std::collections::HashMap;
 
 pub use gosub_shared::node::NodeId;
@@ -223,11 +224,38 @@ impl Node {
 /// them into an inline formatting context.
 fn is_intrinsically_inline(tag: &str) -> bool {
     matches!(
-        tag.to_ascii_lowercase().as_str(),
-        "a" | "abbr" | "acronym" | "b" | "bdo" | "big" | "br" | "button" | "cite"
-            | "code" | "dfn" | "em" | "i" | "img" | "input" | "kbd" | "label"
-            | "map" | "object" | "output" | "q" | "samp" | "select" | "small"
-            | "span" | "strong" | "sub" | "sup" | "textarea" | "time" | "tt"
-            | "u" | "var"
+        tag.cow_to_ascii_lowercase().as_ref(),
+        "a" | "abbr"
+            | "acronym"
+            | "b"
+            | "bdo"
+            | "big"
+            | "br"
+            | "button"
+            | "cite"
+            | "code"
+            | "dfn"
+            | "em"
+            | "i"
+            | "img"
+            | "input"
+            | "kbd"
+            | "label"
+            | "map"
+            | "object"
+            | "output"
+            | "q"
+            | "samp"
+            | "select"
+            | "small"
+            | "span"
+            | "strong"
+            | "sub"
+            | "sup"
+            | "textarea"
+            | "time"
+            | "tt"
+            | "u"
+            | "var"
     )
 }

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -45,6 +45,10 @@ pub trait PipelineDocument: Send + Sync {
     /// not cache styles.
     fn clear_style_cache(&self) {}
 
+    /// Discard cached computed styles for specific nodes only. More efficient than
+    /// `clear_style_cache` for hover repaints where only a few elements changed.
+    fn invalidate_style_for_nodes(&self, _ids: &[NodeId]) {}
+
     /// Returns the computed value for `prop` on node `id`:
     ///  1. own value if set,
     ///  2. parent's computed value if the property is inherited,
@@ -286,6 +290,13 @@ where
 
     fn clear_style_cache(&self) {
         self.style_cache.lock().clear();
+    }
+
+    fn invalidate_style_for_nodes(&self, ids: &[NodeId]) {
+        let mut cache = self.style_cache.lock();
+        for id in ids {
+            cache.remove(id);
+        }
     }
 
     fn html_node_id(&self) -> Option<NodeId> {

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -461,12 +461,32 @@ fn build_node_style<S: CssSystem>(prop_map: &S::PropertyMap) -> NodeStyle {
         ("inset-inline-start", StyleProperty::InsetInlineStart),
         ("inset-inline-end", StyleProperty::InsetInlineEnd),
     ];
+    // Pre-compute the element's font-size so ch/ex units can use it below.
+    // unit_to_px() resolves em/rem with 16px base, giving a close enough value.
+    let font_size_for_ch = prop_map
+        .get("font-size")
+        .filter(|fp| fp.as_unit().is_some())
+        .map(|fp| fp.unit_to_px())
+        .unwrap_or(16.0_f32);
+
     for (css_name, prop) in unit_props {
         if let Some(p) = prop_map.get(css_name) {
             if p.as_unit().is_some() {
                 // Convert em/rem to px now so downstream code (get_style_f32) can
                 // treat all Unit values as pixels without knowing the unit.
-                style.set(prop.clone(), Value::Unit(p.unit_to_px(), Unit::Px));
+                // Also handle font-relative units that unit_to_px() ignores:
+                //   ch  ≈ 0.45 × font-size  (width of "0" in the current font)
+                //   ex  ≈ 0.50 × font-size  (x-height)
+                //   ic  ≈ 1.00 × font-size  (CJK ideograph width)
+                //   lh  ≈ 1.40 × font-size  (line-height)
+                let px = match p.as_unit() {
+                    Some((v, "ch")) => v * font_size_for_ch * 0.45,
+                    Some((v, "ex")) => v * font_size_for_ch * 0.50,
+                    Some((v, "ic")) => v * font_size_for_ch,
+                    Some((v, "lh")) => v * font_size_for_ch * 1.40,
+                    _ => p.unit_to_px(),
+                };
+                style.set(prop.clone(), Value::Unit(px, Unit::Px));
             } else if let Some(pct) = p.as_percentage() {
                 style.set(prop.clone(), Value::Unit(pct, Unit::Percent));
             } else if let Some(val) = p.as_number() {

--- a/crates/gosub_render_pipeline/src/layouter.rs
+++ b/crates/gosub_render_pipeline/src/layouter.rs
@@ -50,6 +50,10 @@ pub struct ElementContextText {
     pub text_offset: Coordinate,
     /// When true (white-space: nowrap), the text is measured at unlimited width and must not wrap.
     pub no_wrap: bool,
+    /// The definite container width (CSS px) that Parley received as its max_width during layout.
+    /// Renderers must use this — not content_box.width — as the word-wrap limit to avoid metric
+    /// mismatches between Parley (layout) and the rendering backend (e.g. Skia).
+    pub available_width: f64,
 }
 
 #[derive(Debug, Clone)]
@@ -100,6 +104,7 @@ impl ElementContext {
             node_id,
             text_offset,
             no_wrap,
+            available_width: 0.0,
         })
     }
 

--- a/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
+++ b/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
@@ -80,7 +80,12 @@ impl CssTaffyConverter {
         ts.gap = self.get_size_lp(StyleProperty::Gap, ts.gap);
         ts.align_items = self.get_align_items(StyleProperty::AlignItems, ts.align_items);
         ts.align_self = self.get_align_self(StyleProperty::AlignSelf, ts.align_self);
-        ts.align_content = self.get_align_content(StyleProperty::AlignContent, ts.align_content);
+        // Default align-content to FlexStart rather than Taffy's None (= Stretch).
+        // With None, Taffy's flex-wrap height calculation only counts the first row when
+        // the container has height:auto — subsequent wrapped rows overflow without expanding
+        // the container.  FlexStart packs all rows tightly and always produces a correct
+        // intrinsic height.  CSS override via align-content still takes full effect.
+        ts.align_content = self.get_align_content(StyleProperty::AlignContent, Some(AlignContent::FlexStart));
         ts.justify_items = self.get_align_items(StyleProperty::JustifyItems, ts.justify_items);
         ts.justify_self = self.get_align_self(StyleProperty::JustifySelf, ts.justify_self);
         ts.justify_content = self.get_align_content(StyleProperty::JustifyContent, ts.justify_content);

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -309,9 +309,9 @@ impl TaffyLayouter {
             return;
         };
         el.box_model = taffy_layout_to_boxmodel(&layout, offset);
-        // The parent's content width is the true word-wrap limit for text children.
-        // Using the text node's own measured width (rect_w) causes premature wrapping
-        // because Skia's font metrics differ slightly from Parley's.
+        // For text nodes, available_width is the wrap limit passed to the renderer.
+        // Use the parent element's content width (supplied by our caller), which is the
+        // most accurate available constraint for text that lives directly in a block box.
         if let ElementContext::Text(ref mut text_ctx) = el.context {
             text_ctx.available_width = parent_content_width;
         }

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -318,6 +318,18 @@ impl TaffyLayouter {
         let my_content_width = el.box_model.content_box.width;
         let child_ids = el.children.clone();
 
+        // Inline elements (those placed in an anonymous flex container by their parent) do not
+        // establish a new containing block. Their children should inherit the enclosing block's
+        // content width so that Skia uses the same wrap boundary that Parley used during layout.
+        // Without this, Skia receives the inline element's shrunk natural width and wraps text
+        // that Parley measured as a single line, causing height mismatches and overlapping content.
+        let is_inline_node = self.anon_container_map.contains_key(&layout_node_id);
+        let content_width_for_children = if is_inline_node {
+            parent_content_width
+        } else {
+            my_content_width
+        };
+
         // Absolute position of this node's content area — used as the base offset for direct children.
         let children_offset = Coordinate::new(offset.x + layout.location.x as f64, offset.y + layout.location.y as f64);
 
@@ -339,7 +351,7 @@ impl TaffyLayouter {
                 layout_tree,
                 child_id,
                 Coordinate::new(children_offset.x + anon_offset.x, children_offset.y + anon_offset.y),
-                my_content_width,
+                content_width_for_children,
             );
         }
     }
@@ -402,6 +414,10 @@ impl TaffyLayouter {
             flex_direction: FlexDirection::Row,
             flex_wrap: FlexWrap::Wrap,
             align_self: Some(AlignSelf::FlexStart),
+            // FlexStart ensures multi-row intrinsic height = sum of all row heights.
+            // Taffy's default (None = Stretch) fails to include wrapped rows in the
+            // container's auto height, causing rows beyond the first to overflow.
+            align_content: Some(AlignContent::FlexStart),
             gap: Size {
                 width: LengthPercentage::length(0.0),
                 height: LengthPercentage::length(0.0),

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -76,6 +76,7 @@ impl TaffyContext {
             text: text.to_string(),
             text_offset,
             no_wrap,
+            available_width: 0.0,
         })
     }
 
@@ -270,7 +271,8 @@ impl CanLayout for TaffyLayouter {
         // the taffy layout to a box model layout tree. This makes the rest of the pipeline
         // layout-engine agnostic.
         let root_id = layout_tree.root_id;
-        self.populate_boxmodel(&mut layout_tree, root_id, Coordinate::ZERO);
+        let root_width = layout_tree.root_dimension.width;
+        self.populate_boxmodel(&mut layout_tree, root_id, Coordinate::ZERO, root_width);
 
         // get dimension of the root node
         if let Some(root) = layout_tree.get_node_by_id(root_id) {
@@ -285,7 +287,13 @@ impl CanLayout for TaffyLayouter {
 
 impl TaffyLayouter {
     // Populate the layout tree with the box models that we now can generate
-    fn populate_boxmodel(&self, layout_tree: &mut LayoutTree, layout_node_id: LayoutElementId, offset: Coordinate) {
+    fn populate_boxmodel(
+        &self,
+        layout_tree: &mut LayoutTree,
+        layout_node_id: LayoutElementId,
+        offset: Coordinate,
+        parent_content_width: f64,
+    ) {
         let Some(taffy_node_id) = self.layout_taffy_mapping.get(&layout_node_id) else {
             log::warn!("No taffy mapping for layout node {:?}", layout_node_id);
             return;
@@ -301,6 +309,13 @@ impl TaffyLayouter {
             return;
         };
         el.box_model = taffy_layout_to_boxmodel(&layout, offset);
+        // The parent's content width is the true word-wrap limit for text children.
+        // Using the text node's own measured width (rect_w) causes premature wrapping
+        // because Skia's font metrics differ slightly from Parley's.
+        if let ElementContext::Text(ref mut text_ctx) = el.context {
+            text_ctx.available_width = parent_content_width;
+        }
+        let my_content_width = el.box_model.content_box.width;
         let child_ids = el.children.clone();
 
         // Absolute position of this node's content area — used as the base offset for direct children.
@@ -324,6 +339,7 @@ impl TaffyLayouter {
                 layout_tree,
                 child_id,
                 Coordinate::new(children_offset.x + anon_offset.x, children_offset.y + anon_offset.y),
+                my_content_width,
             );
         }
     }

--- a/crates/gosub_render_pipeline/src/painter.rs
+++ b/crates/gosub_render_pipeline/src/painter.rs
@@ -125,7 +125,8 @@ impl Painter {
                 let brush = self.get_parent_brush(dom_node_id, &StyleProperty::Color, Brush::solid(Color::BLACK));
 
                 let r = layout_element.box_model.content_box;
-                let t = Text::new(r, &ctx.text, &ctx.font_info, brush);
+                let avail_w = if ctx.available_width > 0.0 { ctx.available_width } else { 1_000_000_000.0 };
+                let t = Text::new(r, &ctx.text, &ctx.font_info, brush, avail_w);
                 commands.push(PaintCommand::text(t));
             }
             ElementContext::Svg(svg_ctx) => {

--- a/crates/gosub_render_pipeline/src/painter.rs
+++ b/crates/gosub_render_pipeline/src/painter.rs
@@ -125,7 +125,11 @@ impl Painter {
                 let brush = self.get_parent_brush(dom_node_id, &StyleProperty::Color, Brush::solid(Color::BLACK));
 
                 let r = layout_element.box_model.content_box;
-                let avail_w = if ctx.available_width > 0.0 { ctx.available_width } else { 1_000_000_000.0 };
+                let avail_w = if ctx.available_width > 0.0 {
+                    ctx.available_width
+                } else {
+                    1_000_000_000.0
+                };
                 let t = Text::new(r, &ctx.text, &ctx.font_info, brush, avail_w);
                 commands.push(PaintCommand::text(t));
             }

--- a/crates/gosub_render_pipeline/src/painter/commands/text.rs
+++ b/crates/gosub_render_pipeline/src/painter/commands/text.rs
@@ -11,15 +11,19 @@ pub struct Text {
     pub text: String,
     /// Brush to paint the text with
     pub brush: Brush,
+    /// The container width (CSS px) that the layout engine used as the word-wrap limit.
+    /// Renderers should use this instead of `rect.width` to avoid metric-mismatch wrapping.
+    pub available_width: f64,
 }
 
 impl Text {
-    pub fn new(rect: Rect, text: &str, font_info: &FontInfo, brush: Brush) -> Self {
+    pub fn new(rect: Rect, text: &str, font_info: &FontInfo, brush: Brush, available_width: f64) -> Self {
         Text {
             rect,
             text: text.to_string(),
             font_info: font_info.clone(),
             brush,
+            available_width,
         }
     }
 }

--- a/crates/gosub_render_pipeline/src/render/backends/skia.rs
+++ b/crates/gosub_render_pipeline/src/render/backends/skia.rs
@@ -163,10 +163,13 @@ impl SkiaSurface {
     }
 
     fn with_canvas(&mut self, f: impl FnOnce(&skia_safe::Canvas)) {
-        let Some(mut surface) = skia_safe::surfaces::raster_n32_premul(skia_safe::ISize::new(
-            self.size.width as i32,
-            self.size.height as i32,
-        )) else {
+        let info = skia_safe::ImageInfo::new(
+            skia_safe::ISize::new(self.size.width as i32, self.size.height as i32),
+            skia_safe::ColorType::BGRA8888,
+            skia_safe::AlphaType::Premul,
+            None,
+        );
+        let Some(mut surface) = skia_safe::surfaces::raster(&info, None, None) else {
             log::error!(
                 "SkiaBackend: failed to create raster surface {}x{}",
                 self.size.width,

--- a/crates/gosub_renderer_skia/src/rasterizer.rs
+++ b/crates/gosub_renderer_skia/src/rasterizer.rs
@@ -31,9 +31,13 @@ impl Rasterable for SkiaRasterizer {
             return None;
         }
 
-        let Some(mut surface) =
-            skia_safe::surfaces::raster_n32_premul(skia_safe::ISize::new(width as i32, height as i32))
-        else {
+        let info = skia_safe::ImageInfo::new(
+            skia_safe::ISize::new(width as i32, height as i32),
+            skia_safe::ColorType::BGRA8888,
+            skia_safe::AlphaType::Premul,
+            None,
+        );
+        let Some(mut surface) = skia_safe::surfaces::raster(&info, None, None) else {
             log::error!("Failed to create Skia surface for tile rasterization");
             return None;
         };

--- a/crates/gosub_renderer_skia/src/rasterizer/text.rs
+++ b/crates/gosub_renderer_skia/src/rasterizer/text.rs
@@ -32,11 +32,27 @@ pub fn do_paint_text(canvas: &Canvas, _tile: &Tile, cmd: &Text, _dpi_scale_facto
 
     let font_size = cmd.font_info.size as f32;
     let font = Font::new(typeface, font_size);
-    // Determine how many lines Parley allocated for this text node.
-    // If it's a single line, use a huge max_width so Skia never wraps due to
-    // font-metric differences. Only multi-line nodes need a real width constraint.
-    let parley_line_count = (cmd.rect.height as f32 / cmd.font_info.line_height as f32 + 0.1).floor() as u32;
-    let max_width = if parley_line_count <= 1 { 1_000_000_000.0_f32 } else { cmd.available_width as f32 };
+
+    // Determine the effective wrap width using the same approach as the Cairo/Pango backend:
+    //
+    // 1. Measure the text unconstrained (single line) to find its natural width.
+    // 2. Base width = max(taffy rect width, available_width). The rect is the text node's
+    //    own taffy allocation; available_width is the parent block's content width and acts
+    //    as a floor when the flex algorithm squeezes a text node to near-zero.
+    // 3. If natural ≤ base + 20px tolerance the text was measured as a single line by
+    //    Parley — use the natural width so Skia's slightly-different font metrics don't
+    //    introduce a spurious extra line break.
+    // 4. Otherwise Parley intentionally wrapped the text; use the base width so Skia
+    //    reproduces the same line-break points.
+    let text_single_line: String = cmd.text.lines().collect::<Vec<_>>().join(" ");
+    let (natural_width, _) = font.measure_str(&text_single_line, Some(&paint));
+    let base_width = (cmd.rect.width as f32).max(cmd.available_width as f32);
+    let metric_slack = 20.0_f32;
+    let max_width = if natural_width <= base_width + metric_slack {
+        natural_width.max(base_width)
+    } else {
+        base_width
+    };
 
     // Word-wrap: greedily pack words into lines that fit within max_width.
     let mut lines: Vec<String> = Vec::new();

--- a/crates/gosub_renderer_skia/src/rasterizer/text.rs
+++ b/crates/gosub_renderer_skia/src/rasterizer/text.rs
@@ -32,7 +32,11 @@ pub fn do_paint_text(canvas: &Canvas, _tile: &Tile, cmd: &Text, _dpi_scale_facto
 
     let font_size = cmd.font_info.size as f32;
     let font = Font::new(typeface, font_size);
-    let max_width = cmd.rect.width as f32;
+    // Determine how many lines Parley allocated for this text node.
+    // If it's a single line, use a huge max_width so Skia never wraps due to
+    // font-metric differences. Only multi-line nodes need a real width constraint.
+    let parley_line_count = (cmd.rect.height as f32 / cmd.font_info.line_height as f32 + 0.1).floor() as u32;
+    let max_width = if parley_line_count <= 1 { 1_000_000_000.0_f32 } else { cmd.available_width as f32 };
 
     // Word-wrap: greedily pack words into lines that fit within max_width.
     let mut lines: Vec<String> = Vec::new();

--- a/crates/gosub_renderer_skia/src/rasterizer/text.rs
+++ b/crates/gosub_renderer_skia/src/rasterizer/text.rs
@@ -1,10 +1,45 @@
 use gosub_render_pipeline::painter::commands::brush::Brush;
 use gosub_render_pipeline::painter::commands::text::Text;
 use gosub_render_pipeline::tiler::Tile;
-use skia_safe::{Canvas, Color4f, Font, FontMgr, FontStyle, Paint};
+use skia_safe::{Canvas, Color4f, Font, FontMgr, FontStyle, Paint, Typeface};
+use std::cell::RefCell;
+use std::collections::HashMap;
 
+// FontMgr is the font resolver; the typeface cache avoids repeated family-style lookups.
+// Key: (family, weight, width, slant_nonzero, size_bits) — size is baked into the Font object.
 thread_local! {
     static FONT_MGR: FontMgr = FontMgr::new();
+    static TYPEFACE_CACHE: RefCell<HashMap<(String, i32, i32, bool), Typeface>> =
+        RefCell::new(HashMap::new());
+}
+
+fn get_font(family: &str, weight: i32, width: i32, slant: i32, size: f32) -> Option<Font> {
+    let font_style = FontStyle::new(
+        skia_safe::font_style::Weight::from(weight),
+        skia_safe::font_style::Width::from(width.clamp(1, 9)),
+        if slant > 0 {
+            skia_safe::font_style::Slant::Italic
+        } else {
+            skia_safe::font_style::Slant::Upright
+        },
+    );
+
+    let cache_key = (family.to_string(), weight, width, slant > 0);
+
+    // Try to reuse a cached typeface — match_family_style is non-trivial work.
+    TYPEFACE_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if let Some(tf) = cache.get(&cache_key) {
+            return Some(Font::new(tf.clone(), size));
+        }
+        let tf = FONT_MGR.with(|fm| {
+            fm.match_family_style(family, font_style)
+                .or_else(|| fm.legacy_make_typeface(None, font_style))
+                .or_else(|| fm.legacy_make_typeface(None, FontStyle::normal()))
+        })?;
+        cache.insert(cache_key, tf.clone());
+        Some(Font::new(tf, size))
+    })
 }
 
 pub fn do_paint_text(canvas: &Canvas, _tile: &Tile, cmd: &Text, _dpi_scale_factor: f32) -> Result<(), anyhow::Error> {
@@ -12,64 +47,53 @@ pub fn do_paint_text(canvas: &Canvas, _tile: &Tile, cmd: &Text, _dpi_scale_facto
     let mut paint = Paint::new(color4f, None);
     paint.set_anti_alias(true);
 
-    let font_style = FontStyle::new(
-        skia_safe::font_style::Weight::from(cmd.font_info.weight),
-        skia_safe::font_style::Width::from((cmd.font_info.width / 100).clamp(1, 9)),
-        if cmd.font_info.slant > 0 {
-            skia_safe::font_style::Slant::Italic
-        } else {
-            skia_safe::font_style::Slant::Upright
-        },
-    );
-
-    let Some(typeface) = FONT_MGR.with(|fm| {
-        fm.match_family_style(&cmd.font_info.family, font_style)
-            .or_else(|| fm.legacy_make_typeface(None, font_style))
-            .or_else(|| fm.legacy_make_typeface(None, FontStyle::normal()))
-    }) else {
+    let font_size = cmd.font_info.size as f32;
+    let Some(font) = get_font(
+        &cmd.font_info.family,
+        cmd.font_info.weight,
+        cmd.font_info.width / 100,
+        cmd.font_info.slant,
+        font_size,
+    ) else {
         return Ok(());
     };
 
-    let font_size = cmd.font_info.size as f32;
-    let font = Font::new(typeface, font_size);
-
-    // Determine the effective wrap width using the same approach as the Cairo/Pango backend:
-    //
-    // 1. Measure the text unconstrained (single line) to find its natural width.
-    // 2. Base width = max(taffy rect width, available_width). The rect is the text node's
-    //    own taffy allocation; available_width is the parent block's content width and acts
-    //    as a floor when the flex algorithm squeezes a text node to near-zero.
-    // 3. If natural ≤ base + 20px tolerance the text was measured as a single line by
-    //    Parley — use the natural width so Skia's slightly-different font metrics don't
-    //    introduce a spurious extra line break.
-    // 4. Otherwise Parley intentionally wrapped the text; use the base width so Skia
-    //    reproduces the same line-break points.
+    // Measure the full text as a single line to determine the natural (unconstrained) width.
+    // This matches Parley's measuring step so we use the same wrap decision Parley made.
     let text_single_line: String = cmd.text.lines().collect::<Vec<_>>().join(" ");
     let (natural_width, _) = font.measure_str(&text_single_line, Some(&paint));
     let base_width = (cmd.rect.width as f32).max(cmd.available_width as f32);
-    let metric_slack = 20.0_f32;
-    let max_width = if natural_width <= base_width + metric_slack {
+    let max_width = if natural_width <= base_width + 20.0 {
         natural_width.max(base_width)
     } else {
         base_width
     };
 
-    // Word-wrap: greedily pack words into lines that fit within max_width.
+    // O(N) word-wrap: measure each word once, accumulate widths with a precomputed space
+    // advance.  The previous O(N²) approach measured the whole accumulated string on every
+    // word, multiplying font-shaping work by the average line length.
+    let space_width = font.measure_str(" ", Some(&paint)).0;
     let mut lines: Vec<String> = Vec::new();
     for paragraph in cmd.text.lines() {
         let mut current = String::new();
+        let mut current_width = 0.0f32;
         for word in paragraph.split_whitespace() {
-            let candidate = if current.is_empty() {
-                word.to_string()
+            let (word_width, _) = font.measure_str(word, Some(&paint));
+            let candidate_width = if current.is_empty() {
+                word_width
             } else {
-                format!("{current} {word}")
+                current_width + space_width + word_width
             };
-            let (measured, _) = font.measure_str(&candidate, Some(&paint));
-            if measured <= max_width || current.is_empty() {
-                current = candidate;
+            if candidate_width <= max_width || current.is_empty() {
+                if !current.is_empty() {
+                    current.push(' ');
+                }
+                current.push_str(word);
+                current_width = candidate_width;
             } else {
                 lines.push(std::mem::take(&mut current));
                 current = word.to_string();
+                current_width = word_width;
             }
         }
         lines.push(current);
@@ -77,7 +101,6 @@ pub fn do_paint_text(canvas: &Canvas, _tile: &Tile, cmd: &Text, _dpi_scale_facto
 
     let line_height = cmd.font_info.line_height as f32;
     let x = cmd.rect.x as f32;
-    // y is the text baseline; offset by font_size from the top of the rect.
     let mut y = cmd.rect.y as f32 + font_size;
 
     for line in &lines {

--- a/crates/gosub_renderer_vello/src/rasterizer/text/skia.rs
+++ b/crates/gosub_renderer_vello/src/rasterizer/text/skia.rs
@@ -9,7 +9,13 @@ use vello::Scene;
 pub fn do_paint_text(scene: &mut Scene, cmd: &Text, tile_size: Dimension, affine: Affine) -> Result<(), anyhow::Error> {
     let paragraph = get_skia_paragraph(cmd.text.as_str(), &cmd.font_info, cmd.rect.width, None, 1.00);
 
-    let mut surface = skia_safe::surfaces::raster_n32_premul((tile_size.width as i32, tile_size.height as i32))
+    let info = skia_safe::ImageInfo::new(
+        skia_safe::ISize::new(tile_size.width as i32, tile_size.height as i32),
+        skia_safe::ColorType::RGBA8888,
+        skia_safe::AlphaType::Premul,
+        None,
+    );
+    let mut surface = skia_safe::surfaces::raster(&info, None, None)
         .ok_or_else(|| anyhow::anyhow!("Failed to create Skia surface for text rendering"))?;
     let canvas = surface.canvas();
 

--- a/examples/winit-skia/main.rs
+++ b/examples/winit-skia/main.rs
@@ -20,6 +20,7 @@ use softbuffer::Surface;
 use std::num::NonZeroU32;
 use std::sync::Arc;
 use tokio::runtime::{Builder, Runtime};
+use tokio::sync::watch;
 use url::Url;
 use uuid::uuid;
 use winit::application::ApplicationHandler;
@@ -52,6 +53,7 @@ struct BrowserApp {
     compositor: Arc<RwLock<DefaultCompositor>>,
     #[allow(dead_code)]
     proxy: EventLoopProxy<()>,
+    mouse_tx: watch::Sender<Option<(f32, f32)>>,
 
     window: Option<Arc<Window>>,
     surface: Option<Surface<Arc<Window>, Arc<Window>>>,
@@ -109,6 +111,7 @@ impl BrowserApp {
                     content_h,
                     handle,
                     &mut self.page_height,
+                    self.scroll,
                 );
             }
         }
@@ -122,11 +125,11 @@ impl BrowserApp {
     }
 
     fn to_css_x(&self, x: f64) -> f32 {
-        (x + self.scroll.0 as f64) as f32
+        x as f32
     }
 
     fn to_css_y(&self, y: f64) -> f32 {
-        (y - ADDRESS_BAR_HEIGHT as f64 + self.scroll.1 as f64) as f32
+        (y - ADDRESS_BAR_HEIGHT as f64) as f32
     }
 }
 
@@ -205,10 +208,7 @@ impl ApplicationHandler<()> for BrowserApp {
                 self.cursor = position;
                 if !self.is_in_address_bar(position.y) {
                     let (x, y) = (self.to_css_x(position.x), self.to_css_y(position.y));
-                    let tab = self.tab.clone();
-                    TOKIO_RT.spawn(async move {
-                        let _ = tab.send(TabCommand::MouseMove { x, y }).await;
-                    });
+                    let _ = self.mouse_tx.send(Some((x, y)));
                 }
             }
 
@@ -305,6 +305,7 @@ fn blit_to_buffer(
     content_h: u32,
     handle: ExternalHandle,
     page_height: &mut f32,
+    scroll: (f32, f32),
 ) {
     match handle {
         ExternalHandle::CpuPixelsOwned {
@@ -315,56 +316,72 @@ fn blit_to_buffer(
             ..
         } => {
             let copy_rows = height.min(content_h) as usize;
+            let cols = (width as usize).min(win_w as usize);
             for row in 0..copy_rows {
-                for col in 0..(width as usize).min(win_w as usize) {
+                let dst_base = (addr_h as usize + row) * win_w as usize;
+                for col in 0..cols {
                     let off = row * stride as usize + col * 4;
                     let b = pixels[off] as u32;
                     let g = pixels[off + 1] as u32;
                     let r = pixels[off + 2] as u32;
-                    let idx = (addr_h as usize + row) * win_w as usize + col;
-                    if idx < buf.len() {
-                        buf[idx] = (r << 16) | (g << 8) | b;
-                    }
+                    buf[dst_base + col] = (r << 16) | (g << 8) | b;
                 }
             }
         }
         ExternalHandle::TileCache {
             tiles,
             page_height: ph,
-            scroll_x,
-            scroll_y,
             dpr,
             ..
         } => {
             *page_height = ph;
             let d = dpr as usize;
-            let sx = scroll_x as usize * d;
-            let sy = scroll_y as usize * d;
+            // Use the locally-tracked scroll position so scrolling feels instant without
+            // waiting for the engine to acknowledge the scroll command.
+            let sx = scroll.0 as usize * d;
+            let sy = scroll.1 as usize * d;
             for tile in tiles.iter() {
-                let screen_x = (tile.page_x as usize * d).saturating_sub(sx);
-                let screen_y = (tile.page_y as usize * d).saturating_sub(sy);
+                let tile_px = tile.page_x as usize * d;
+                let tile_py = tile.page_y as usize * d;
                 let tw = tile.width as usize;
                 let th = tile.height as usize;
+
+                // Skip tiles entirely outside the viewport.
+                if tile_px + tw <= sx || tile_py + th <= sy {
+                    continue;
+                }
+
+                // First visible row/col within the tile (> 0 when tile is partially above/left).
+                let row_start = if tile_py < sy { sy - tile_py } else { 0 };
+                let col_start = if tile_px < sx { sx - tile_px } else { 0 };
+
+                // Screen position of the first visible pixel.
+                let screen_x = if tile_px >= sx { tile_px - sx } else { 0 };
+                let screen_y = if tile_py >= sy { tile_py - sy } else { 0 };
+
                 let tile_u32 =
                     unsafe { std::slice::from_raw_parts(tile.data.as_ptr() as *const u32, tile.data.len() / 4) };
-                for row in 0..th {
-                    let dst_y = addr_h as usize + screen_y + row;
+
+                for row in row_start..th {
+                    let dst_y = addr_h as usize + screen_y + (row - row_start);
                     if dst_y >= (addr_h + content_h) as usize {
                         break;
                     }
-                    let cw = tw.min(win_w as usize - screen_x.min(win_w as usize));
+                    let visible_cols = tw - col_start;
+                    let avail_x = win_w as usize - screen_x.min(win_w as usize);
+                    let cw = visible_cols.min(avail_x);
                     if cw == 0 {
                         break;
                     }
-                    for col in 0..cw {
-                        let px = tile_u32[row * tw + col];
-                        let b = px & 0xFF;
-                        let g = (px >> 8) & 0xFF;
-                        let r = (px >> 16) & 0xFF;
-                        let idx = dst_y * win_w as usize + screen_x + col;
-                        if idx < buf.len() {
-                            buf[idx] = (r << 16) | (g << 8) | b;
-                        }
+                    // Skia tiles are BGRA8888; softbuffer wants 0x00RRGGBB.
+                    // BGRA as little-endian u32 = B|(G<<8)|(R<<16)|(A<<24).
+                    // 0x00RRGGBB                = B|(G<<8)|(R<<16) = px & 0x00FFFFFF.
+                    let row_off = row * tw + col_start;
+                    let src = &tile_u32[row_off..row_off + cw];
+                    let dst_base = dst_y * win_w as usize + screen_x;
+                    let dst = &mut buf[dst_base..dst_base + cw];
+                    for (d, &s) in dst.iter_mut().zip(src.iter()) {
+                        *d = s & 0x00_FF_FF_FF;
                     }
                 }
             }
@@ -524,6 +541,18 @@ fn main() {
         let _ = nav_tab.send(TabCommand::Navigate { url: nav_url }).await;
     });
 
+    let (mouse_tx, mut mouse_rx) = watch::channel::<Option<(f32, f32)>>(None);
+    let hover_tab = tab.clone();
+    TOKIO_RT.spawn(async move {
+        while mouse_rx.changed().await.is_ok() {
+            // Copy the value out before awaiting so the Ref guard is dropped.
+            let pos = *mouse_rx.borrow_and_update();
+            if let Some((x, y)) = pos {
+                let _ = hover_tab.send(TabCommand::MouseMove { x, y }).await;
+            }
+        }
+    });
+
     let mut app = BrowserApp {
         engine,
         zone,
@@ -531,6 +560,7 @@ fn main() {
         tab_id,
         compositor,
         proxy,
+        mouse_tx,
         window: None,
         surface: None,
         surface_size: (0, 0),

--- a/examples/winit-skia/main.rs
+++ b/examples/winit-skia/main.rs
@@ -352,12 +352,12 @@ fn blit_to_buffer(
                 }
 
                 // First visible row/col within the tile (> 0 when tile is partially above/left).
-                let row_start = if tile_py < sy { sy - tile_py } else { 0 };
-                let col_start = if tile_px < sx { sx - tile_px } else { 0 };
+                let row_start = sy.saturating_sub(tile_py);
+                let col_start = sx.saturating_sub(tile_px);
 
                 // Screen position of the first visible pixel.
-                let screen_x = if tile_px >= sx { tile_px - sx } else { 0 };
-                let screen_y = if tile_py >= sy { tile_py - sy } else { 0 };
+                let screen_x = tile_px.saturating_sub(sx);
+                let screen_y = tile_py.saturating_sub(sy);
 
                 let tile_u32 =
                     unsafe { std::slice::from_raw_parts(tile.data.as_ptr() as *const u32, tile.data.len() / 4) };


### PR DESCRIPTION
A batch of rendering correctness fixes spanning CSS colour parsing, text wrapping, Skia pixel format, and hover repaint precision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CSS Color Level 4 oklch() and oklab() color functions in stylesheets.

* **Bug Fixes**
  * Fixed text wrapping to correctly account for container width constraints.
  * Fixed CSS shorthand property expansion state bleeding across declarations.

* **Refactor**
  * Optimized hover state rendering with tile-level repainting.
  * Improved mouse movement event handling for better responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->