### PR TITLE
Added linting checks on all crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gosub_bin"
 version = "0.1.1"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.82"
 authors = ["Gosub Community <info@gosub.io>"]
 description = "Gosub Browser Engine"
 license = "MIT"

--- a/crates/gosub_config/Cargo.toml
+++ b/crates/gosub_config/Cargo.toml
@@ -25,3 +25,5 @@ rusqlite = "0.39.0"
 
 [dev-dependencies]
 testing_logger = "0.1.1"
+[lints]
+workspace = true

--- a/crates/gosub_css3/Cargo.toml
+++ b/crates/gosub_css3/Cargo.toml
@@ -26,3 +26,6 @@ indexmap = { version = "2.13.0", optional = true }
 [features]
 default = []
 unresolved_syntax = ["dep:indexmap"]
+
+[lints]
+workspace = true

--- a/crates/gosub_css3/src/ast.rs
+++ b/crates/gosub_css3/src/ast.rs
@@ -182,10 +182,13 @@ fn collect_rule(node: &CssNode) -> CssResult<Option<CssRule>> {
                 continue;
             }
 
-            let value = if css_values.len() == 1 {
-                css_values.pop().expect("unreachable")
-            } else {
-                CssValue::List(css_values)
+            let value = match css_values.pop() {
+                Some(value) if css_values.is_empty() => value,
+                Some(value) => {
+                    css_values.push(value);
+                    CssValue::List(css_values)
+                }
+                None => CssValue::List(css_values),
             };
 
             rule.declarations.push(CssDeclaration {
@@ -294,7 +297,7 @@ mod tests {
 
     #[test]
     fn convert_font_family() {
-        let stylesheet = Css3::parse_str(
+        let _stylesheet = Css3::parse_str(
             r#"
               body {
                 border: 1px solid black;
@@ -310,8 +313,6 @@ mod tests {
             "test.css",
         )
         .unwrap();
-
-        dbg!(&stylesheet);
     }
 
     #[test]

--- a/crates/gosub_css3/src/colors.rs
+++ b/crates/gosub_css3/src/colors.rs
@@ -62,37 +62,31 @@ impl From<&str> for RgbColor {
         }
         if value.starts_with("rgb(") {
             // Rgb function
-            let rgb = Rgb::from_str(value);
-            if rgb.is_err() {
+            let Ok(rgb) = Rgb::from_str(value) else {
                 return RgbColor::default();
-            }
-            let rgb = rgb.unwrap();
+            };
             return RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), 255.0);
         }
         if value.starts_with("rgba(") {
             // Rgba function — alpha from colors_transform is in 0..1 range; scale to 0..255
-            let rgb = Rgb::from_str(value);
-            if rgb.is_err() {
+            let Ok(rgb) = Rgb::from_str(value) else {
                 return RgbColor::default();
-            }
-            let rgb = rgb.unwrap();
+            };
             return RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), rgb.get_alpha() * 255.0);
         }
         if value.starts_with("hsl(") {
-            let hsl = Hsl::from_str(value);
-            if hsl.is_err() {
+            let Ok(hsl) = Hsl::from_str(value) else {
                 return RgbColor::default();
-            }
-            let rgb: Rgb = hsl.unwrap().to_rgb();
+            };
+            let rgb: Rgb = hsl.to_rgb();
             return RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), 255.0);
         }
         if value.starts_with("hsla(") {
             // hsla() — alpha from colors_transform is in 0..1 range; scale to 0..255
-            let hsl = Hsl::from_str(value);
-            if hsl.is_err() {
+            let Ok(hsl) = Hsl::from_str(value) else {
                 return RgbColor::default();
-            }
-            let rgb: Rgb = hsl.unwrap().to_rgb();
+            };
+            let rgb: Rgb = hsl.to_rgb();
             return RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), rgb.get_alpha() * 255.0);
         }
 
@@ -307,7 +301,6 @@ fn parse_hex(value: &str) -> RgbColor {
 fn convert_from_hex_str_to_vec_of_ints(hex_value: &str, hex_size: usize) -> Vec<i32> {
     const HEX_RADIX: u32 = 16;
     const LINES_TO_SKIP: usize = 1;
-    const EXPECT_MESSAGE: &str = "is_hex has failed us";
     // Get the individual chars from the hex then convert from hex -> decimal
     match hex_size {
         // if each hex char is only 1 char long
@@ -315,7 +308,7 @@ fn convert_from_hex_str_to_vec_of_ints(hex_value: &str, hex_size: usize) -> Vec<
             hex_value
                 .chars()
                 .skip(LINES_TO_SKIP) // Skip the # at the front
-                .map(|char| i32::from_str_radix(char.to_string().as_str(), HEX_RADIX).expect(EXPECT_MESSAGE)) // Can parse with an unwrap because is_hex made sure it's digits
+                .map(|char| i32::from_str_radix(char.to_string().as_str(), HEX_RADIX).unwrap_or(0)) // is_hex() above guarantees digits
                 .collect::<Vec<i32>>()
         }
         // if each hex char is 2 char long
@@ -331,7 +324,7 @@ fn convert_from_hex_str_to_vec_of_ints(hex_value: &str, hex_size: usize) -> Vec<
 
             hex_vec
                 .iter()
-                .map(|str| i32::from_str_radix(str, HEX_RADIX).expect(EXPECT_MESSAGE))
+                .map(|str| i32::from_str_radix(str, HEX_RADIX).unwrap_or(0))
                 .collect::<Vec<i32>>()
         }
         _ => {

--- a/crates/gosub_css3/src/lib.rs
+++ b/crates/gosub_css3/src/lib.rs
@@ -20,6 +20,9 @@ pub mod errors;
 mod functions;
 #[allow(dead_code)]
 pub mod matcher;
+// The as_* accessors panic by contract when called on the wrong node type;
+// callers are expected to check the matching is_* predicate first.
+#[allow(clippy::panic)]
 pub mod node;
 pub mod parser;
 pub mod stylesheet;
@@ -119,6 +122,7 @@ pub fn load_default_useragent_stylesheet() -> CssStylesheet {
     };
 
     let css_data = include_str!("../resources/useragent.css");
+    #[allow(clippy::expect_used)] // PANIC-SAFE: compiled-in stylesheet, exercised by every parser test
     Css3::parse_str(css_data, config, CssOrigin::UserAgent, url).expect("Could not parse useragent stylesheet")
 }
 

--- a/crates/gosub_css3/src/matcher/property_definitions.rs
+++ b/crates/gosub_css3/src/matcher/property_definitions.rs
@@ -249,13 +249,11 @@ impl CssDefinitions {
             return;
         }
 
-        if !self.properties.contains_key(name) {
+        // Resolve the element
+        let Some(mut element) = self.properties.get(name).cloned() else {
             // Property not found to resolve
             return;
-        }
-
-        // Resolve the element
-        let mut element = self.properties.get_mut(name).unwrap().clone();
+        };
         let mut resolved_components = vec![];
         for component in &element.syntax.components {
             let component = self.resolve_component(component, name);
@@ -329,7 +327,11 @@ impl CssDefinitions {
                     };
                 }
 
-                panic!("Unknown datatype encountered: {datatype:?}");
+                #[allow(clippy::panic)]
+                // PANIC-SAFE: datatypes come from the compiled-in definitions; the test suite resolves them all
+                {
+                    panic!("Unknown datatype encountered: {datatype:?}");
+                }
             }
             SyntaxComponent::Group {
                 components,
@@ -379,11 +381,13 @@ pub static CSS_PROPERTIES: LazyLock<indexmap::IndexMap<String, PropertyDefinitio
 pub const DEFINITIONS_VALUES: &str = include_str!("../../resources/definitions/definitions_values.json");
 pub const DEFINITIONS_PROPERTIES: &str = include_str!("../../resources/definitions/definitions_properties.json");
 
+#[allow(clippy::expect_used)] // PANIC-SAFE: compiled-in definitions file, validated by the test suite
 fn get_values<M: Map<String, SyntaxDefinition>>() -> M {
     let json: serde_json::Value = serde_json::from_str(DEFINITIONS_VALUES).expect("JSON was not well-formatted");
     parse_syntax_file(json)
 }
 
+#[allow(clippy::expect_used)] // PANIC-SAFE: compiled-in definitions file, validated by the test suite
 fn get_properties<M: Map<String, PropertyDefinition>>() -> M {
     let json: serde_json::Value = serde_json::from_str(DEFINITIONS_PROPERTIES).expect("JSON was not well-formatted");
     parse_property_file(json)
@@ -455,6 +459,7 @@ impl<K: Eq + Hash, V> Map<K, V> for indexmap::IndexMap<K, V> {
 }
 
 /// Parses a syntax JSON import file
+#[allow(clippy::unwrap_used)] // PANIC-SAFE: parses the compiled-in definitions; validated by the test suite
 fn parse_syntax_file<M: Map<String, SyntaxDefinition>>(json: serde_json::Value) -> M {
     let mut syntaxes = M::new();
 
@@ -517,6 +522,7 @@ fn parse_syntax_file<M: Map<String, SyntaxDefinition>>(json: serde_json::Value) 
 }
 
 /// Parses the JSON input into a CSS property definitions structure
+#[allow(clippy::unwrap_used, clippy::panic)] // PANIC-SAFE: parses the compiled-in definitions; validated by the test suite
 fn parse_property_file<M: Map<String, PropertyDefinition>>(json: serde_json::Value) -> M {
     let mut properties = M::new();
 

--- a/crates/gosub_css3/src/matcher/shorthands.rs
+++ b/crates/gosub_css3/src/matcher/shorthands.rs
@@ -575,9 +575,7 @@ impl CssDefinitions {
             }
         }
 
-        if syntax.components.len() == 1 {
-            let component = syntax.components.first().unwrap();
-
+        if let [component] = syntax.components.as_slice() {
             match component {
                 SyntaxComponent::Definition { datatype, .. } => {
                     if let Some(d) = self.syntax.get(datatype) {
@@ -731,8 +729,6 @@ mod tests {
                 current_info: None
             }
         );
-
-        dbg!(fix_list);
     }
 
     #[test]
@@ -752,11 +748,7 @@ mod tests {
             &mut fix_list,
         ));
 
-        dbg!(&fix_list);
-
         fix_list.resolve_nested(definitions);
-
-        dbg!(&fix_list);
 
         fix_list = FixList::new();
 
@@ -764,8 +756,6 @@ mod tests {
             &[str!("solid"), CssValue::Color(RgbColor::new(0.0, 0.0, 0.0, 0.0))],
             &mut fix_list,
         ));
-
-        dbg!(fix_list);
 
         fix_list = FixList::new();
 
@@ -777,7 +767,5 @@ mod tests {
             ],
             &mut fix_list,
         ));
-
-        dbg!(fix_list);
     }
 }

--- a/crates/gosub_css3/src/matcher/syntax.rs
+++ b/crates/gosub_css3/src/matcher/syntax.rs
@@ -284,7 +284,7 @@ fn parse_unit(input: &str) -> IResult<&str, SyntaxComponent> {
     let (input, value) = float(input)?;
     let (input, suffix) = opt(alpha1).parse(input)?;
 
-    if suffix.is_none() {
+    let Some(suffix) = suffix else {
         return if value == 0.0 {
             // 0 is a special case as it doesn't need a unit
             Ok((
@@ -297,12 +297,12 @@ fn parse_unit(input: &str) -> IResult<&str, SyntaxComponent> {
         } else {
             Err(Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Alpha)))
         };
-    }
+    };
 
     Ok((
         input,
         SyntaxComponent::Value {
-            value: CssValue::Unit(value, suffix.unwrap().to_string()),
+            value: CssValue::Unit(value, suffix.to_string()),
             multipliers: vec![SyntaxComponentMultiplier::Once],
         },
     ))
@@ -512,13 +512,11 @@ fn juxtaposition_or_separated_list(input: &str) -> IResult<&str, Vec<SyntaxCompo
         // Check for a separator
         let result = juxtaseparator(next_input);
 
-        // If errored, we return what we've got
-        if result.is_err() {
-            return Ok((next_input, elements));
-        }
-
+        // If errored, we return what we've got.
         // If found, the sep boolean determines if we are done or not.
-        let (next_input, sep) = result.unwrap();
+        let Ok((next_input, sep)) = result else {
+            return Ok((next_input, elements));
+        };
         if !sep {
             return Ok((next_input, elements));
         }
@@ -560,7 +558,7 @@ fn parse_unit_inner(input: &str) -> IResult<&str, SyntaxComponent> {
     let (input, _) = multispace0(input)?;
     let (input, suffixes) = opt(separated_list0(ws(tag("|")), alpha1)).parse(input)?;
 
-    if suffixes.is_none() {
+    let Some(suffixes) = suffixes else {
         // No suffixes, just a range
         return Ok((
             input,
@@ -571,10 +569,10 @@ fn parse_unit_inner(input: &str) -> IResult<&str, SyntaxComponent> {
                 multipliers: vec![SyntaxComponentMultiplier::Once],
             },
         ));
-    }
+    };
 
     // Convert the suffixes to a vector of strings
-    let suffixes: Vec<String> = suffixes.unwrap().iter().map(|s| (*s).to_string()).collect();
+    let suffixes: Vec<String> = suffixes.iter().map(|s| (*s).to_string()).collect();
     Ok((
         input,
         SyntaxComponent::Unit {

--- a/crates/gosub_css3/src/matcher/syntax_matcher.rs
+++ b/crates/gosub_css3/src/matcher/syntax_matcher.rs
@@ -253,7 +253,9 @@ fn match_component_group<'a>(
 /// Matches a single component value
 fn match_component_single<'a>(input: &'a [CssValue], component: &SyntaxComponent) -> MatchResult<'a> {
     // Get the first value from the input which we will use for matching
-    let value = input.first().unwrap();
+    let Some(value) = input.first() else {
+        return no_match(input);
+    };
 
     // println!("\n\n match_component: {:?} against {:?}", value, component);
 
@@ -380,7 +382,11 @@ fn match_component_single<'a>(input: &'a [CssValue], component: &SyntaxComponent
             }
         }
         e => {
-            panic!("Unknown syntax component: {e:?}");
+            #[allow(clippy::panic)]
+            // PANIC-SAFE: components come from the compiled-in definitions, which the test suite matches exhaustively
+            {
+                panic!("Unknown syntax component: {e:?}");
+            }
         }
     }
 
@@ -454,7 +460,7 @@ fn match_group_exactly_one<'a>(
 
     if components_matched.len() > 1 {
         let mut shortest_remainder_idx = 0;
-        let mut shortest_remainder_len = components_matched.first().unwrap().2.len();
+        let mut shortest_remainder_len = usize::MAX;
 
         for (idx, (_, _, remainder)) in components_matched.iter().enumerate() {
             if remainder.len() < shortest_remainder_len {
@@ -731,7 +737,7 @@ enum Fulfillment {
 fn multiplier_fulfilled(component: &SyntaxComponent, cnt: usize) -> Fulfillment {
     // Filter out the multipliers that are not relevant for this check
     let binding = component.get_multipliers();
-    let mut filtered_multipliers: Vec<_> = binding
+    let filtered_multipliers: Vec<_> = binding
         .iter()
         .filter(|m| {
             !matches!(
@@ -742,11 +748,10 @@ fn multiplier_fulfilled(component: &SyntaxComponent, cnt: usize) -> Fulfillment 
         .collect();
 
     // Make sure that whenever we do not find a (primary) multiplier, we use the default "Once".
-    if filtered_multipliers.is_empty() {
-        filtered_multipliers.push(&SyntaxComponentMultiplier::Once);
-    }
-
-    match filtered_multipliers.first().unwrap() {
+    match filtered_multipliers
+        .first()
+        .unwrap_or(&&SyntaxComponentMultiplier::Once)
+    {
         SyntaxComponentMultiplier::Once => match cnt {
             0 => Fulfillment::NotYetFulfilled,
             1 => Fulfillment::Fulfilled,
@@ -785,7 +790,7 @@ fn first_match(input: &[CssValue]) -> MatchResult<'_> {
     MatchResult {
         remainder: input.get(1..).unwrap_or(&[]),
         matched: true,
-        matched_values: vec![input.first().unwrap().clone()],
+        matched_values: input.first().cloned().into_iter().collect(),
     }
 }
 
@@ -806,7 +811,6 @@ mod tests {
         ($e:expr) => {
             println!("\n\n-------- ASSERT MATCH --------");
             let res = $e.clone();
-            dbg!(&res);
             assert_eq!(true, res.matched);
             println!("------------------------------\n\n");
         };
@@ -816,7 +820,6 @@ mod tests {
         ($e:expr) => {
             println!("\n\n------- ASSERT NOT MATCH ------");
             let res = $e;
-            dbg!(&res);
             assert_eq!(false, res.matched);
             println!("------------------------------\n\n");
         };
@@ -1068,7 +1071,6 @@ mod tests {
         assert_false!(tree.clone().matches(&[str!("foo"), str!("baz"),]));
 
         let tree = CssSyntax::new("foo bar?").compile().unwrap();
-        dbg!(&tree);
         assert_true!(tree.clone().matches(&[str!("foo")]));
         assert_true!(tree.clone().matches(&[str!("foo"), str!("bar"),]));
         assert_false!(tree.clone().matches(&[str!("foo"), str!("bar"), str!("bar"),]));

--- a/crates/gosub_css3/src/parser/block.rs
+++ b/crates/gosub_css3/src/parser/block.rs
@@ -26,12 +26,8 @@ impl Css3<'_> {
 
     /// Reads until the end of a declaration or rule (or end of the block), in case there is a syntax error
     pub(crate) fn parse_until_rule_end(&mut self) {
-        loop {
-            let t = self.consume_any();
-            if t.is_err() {
-                break;
-            }
-            match t.unwrap().token_type {
+        while let Ok(t) = self.consume_any() {
+            match t.token_type {
                 TokenType::Semicolon => {
                     break;
                 }

--- a/crates/gosub_css3/src/parser/condition.rs
+++ b/crates/gosub_css3/src/parser/condition.rs
@@ -39,14 +39,14 @@ impl Css3<'_> {
                         }
                     };
 
-                    if term.is_err() {
+                    let Ok(term) = term else {
                         self.consume(TokenType::RParen)?;
                         let res = self.parse_condition(kind.clone())?;
                         self.consume(TokenType::LParen)?;
                         return Ok(res);
-                    }
+                    };
 
-                    list.push(term.unwrap());
+                    list.push(term);
                 }
                 TokenType::Function(_) => {
                     let term = self.parse_feature_function(kind.clone())?;

--- a/crates/gosub_css3/src/parser/declaration.rs
+++ b/crates/gosub_css3/src/parser/declaration.rs
@@ -98,12 +98,8 @@ impl Css3<'_> {
             "parse_until_declaration_end, now at: {:?}",
             self.tokenizer.current_location()
         );
-        loop {
-            let t = self.consume_any();
-            if t.is_err() {
-                break;
-            }
-            match t.unwrap().token_type {
+        while let Ok(t) = self.consume_any() {
+            match t.token_type {
                 TokenType::Semicolon => {
                     self.tokenizer.reconsume();
                     break;

--- a/crates/gosub_css3/src/parser/value.rs
+++ b/crates/gosub_css3/src/parser/value.rs
@@ -25,11 +25,9 @@ impl Css3<'_> {
                 }
             }
 
-            let child = self.parse_value()?;
-            if child.is_none() {
+            let Some(child) = self.parse_value()? else {
                 break;
-            }
-            let child = child.unwrap();
+            };
             children.push(child);
         }
 

--- a/crates/gosub_css3/src/system.rs
+++ b/crates/gosub_css3/src/system.rs
@@ -129,11 +129,14 @@ impl CssSystem for Css3System {
                                     continue;
                                 }
 
-                                let value = if let CssValue::List(mut value) = value {
-                                    if value.len() == 1 {
-                                        value.pop().expect("unreachable")
-                                    } else {
-                                        CssValue::List(value)
+                                let value = if let CssValue::List(mut values) = value {
+                                    match values.pop() {
+                                        Some(single) if values.is_empty() => single,
+                                        Some(last) => {
+                                            values.push(last);
+                                            CssValue::List(values)
+                                        }
+                                        None => CssValue::List(values),
                                     }
                                 } else {
                                     value
@@ -155,11 +158,14 @@ impl CssSystem for Css3System {
                                 // like margin-top, padding-left, font-size etc. (which are valid
                                 // CSS but happen not to have their own PropertyDefinition entry)
                                 // still reach the style consumer.
-                                let value = if let CssValue::List(mut v) = value {
-                                    if v.len() == 1 {
-                                        v.pop().expect("unreachable")
-                                    } else {
-                                        CssValue::List(v)
+                                let value = if let CssValue::List(mut values) = value {
+                                    match values.pop() {
+                                        Some(single) if values.is_empty() => single,
+                                        Some(last) => {
+                                            values.push(last);
+                                            CssValue::List(values)
+                                        }
+                                        None => CssValue::List(values),
                                     }
                                 } else {
                                     value
@@ -232,16 +238,12 @@ pub fn add_property_to_map(
         specificity,
     };
 
-    if let std::collections::hash_map::Entry::Vacant(e) = css_map_entry.properties.entry(property_name.clone()) {
-        // Generate new property in the css map
-        let mut entry = CssProperty::new(property_name.as_str());
-        entry.declared.push(declaration);
-        e.insert(entry);
-    } else {
-        // Just add the declaration to the existing property
-        let entry = css_map_entry.properties.get_mut(&property_name).unwrap();
-        entry.declared.push(declaration);
-    }
+    css_map_entry
+        .properties
+        .entry(property_name.clone())
+        .or_insert_with(|| CssProperty::new(property_name.as_str()))
+        .declared
+        .push(declaration);
 }
 
 pub fn node_is_unrenderable<C: HasDocument>(doc: &C::Document, id: NodeId) -> bool {

--- a/crates/gosub_css3/src/tokenizer.rs
+++ b/crates/gosub_css3/src/tokenizer.rs
@@ -735,7 +735,9 @@ impl<'stream> Tokenizer<'stream> {
             return default_char;
         }
 
-        let as_u32 = u32::from_str_radix(&value, 16).expect("unable to parse hex string as number");
+        let Ok(as_u32) = u32::from_str_radix(&value, 16) else {
+            return default_char;
+        };
 
         // todo: look for better implementation
         if let Some(char) = char::from_u32(as_u32) {

--- a/crates/gosub_css3/src/unicode.rs
+++ b/crates/gosub_css3/src/unicode.rs
@@ -1,8 +1,5 @@
 // note: file should be in a shared lib
 
-use lazy_static::lazy_static;
-use std::collections::HashMap;
-
 // note: should be shared
 #[derive(Debug, Eq, Hash, PartialEq)]
 pub enum UnicodeChar {
@@ -12,25 +9,22 @@ pub enum UnicodeChar {
     ShiftOut,
     Delete,
     InformationSeparatorOne,
+    #[allow(dead_code)] // only constructed by the escape-sequence tests
     LowLine,
     MaxAllowed,
     ReplacementCharacter,
 }
 
-lazy_static! {
-    static ref UNICODE_CHARS: HashMap<UnicodeChar, char> = HashMap::from([
-        (UnicodeChar::Null, '\u{0000}'),
-        (UnicodeChar::Backspace, '\u{0008}'),
-        (UnicodeChar::Tab, '\u{000B}'),
-        (UnicodeChar::ShiftOut, '\u{000E}'),
-        (UnicodeChar::Delete, '\u{007F}'),
-        (UnicodeChar::InformationSeparatorOne, '\u{001F}'),
-        (UnicodeChar::LowLine, '\u{005F}'),
-        (UnicodeChar::MaxAllowed, '\u{10FFFF}'),
-        (UnicodeChar::ReplacementCharacter, '\u{FFFD}')
-    ]);
-}
-
 pub fn get_unicode_char(char: &UnicodeChar) -> char {
-    *UNICODE_CHARS.get(char).expect("Unknown unicode char.")
+    match char {
+        UnicodeChar::Null => '\u{0000}',
+        UnicodeChar::Backspace => '\u{0008}',
+        UnicodeChar::Tab => '\u{000B}',
+        UnicodeChar::ShiftOut => '\u{000E}',
+        UnicodeChar::Delete => '\u{007F}',
+        UnicodeChar::InformationSeparatorOne => '\u{001F}',
+        UnicodeChar::LowLine => '\u{005F}',
+        UnicodeChar::MaxAllowed => '\u{10FFFF}',
+        UnicodeChar::ReplacementCharacter => '\u{FFFD}',
+    }
 }

--- a/crates/gosub_css3/src/walker.rs
+++ b/crates/gosub_css3/src/walker.rs
@@ -43,17 +43,20 @@ fn inner_walk(node: &Node, depth: usize, f: &mut dyn Write) -> Result<(), std::i
         NodeType::Rule { prelude, block } => {
             writeln!(f, "{prefix}[Rule]")?;
             // writeln!(f, "{}  - prelude: ", prefix)?;
-            inner_walk(prelude.as_ref().unwrap(), depth + 1, f)?;
-            // writeln!(f, "{}  - block: ", prefix)?;
-            inner_walk(block.as_ref().unwrap(), depth + 1, f)?;
+            if let Some(prelude) = prelude {
+                inner_walk(prelude, depth + 1, f)?;
+            }
+            if let Some(block) = block {
+                inner_walk(block, depth + 1, f)?;
+            }
         }
         NodeType::AtRule { name, prelude, block } => {
             writeln!(f, "{prefix}[AtRule] name: {name}")?;
-            if prelude.is_some() {
-                inner_walk(prelude.as_ref().unwrap(), depth + 1, f)?;
+            if let Some(prelude) = prelude {
+                inner_walk(prelude, depth + 1, f)?;
             }
-            if block.is_some() {
-                inner_walk(block.as_ref().unwrap(), depth + 1, f)?;
+            if let Some(block) = block {
+                inner_walk(block, depth + 1, f)?;
             }
         }
         NodeType::Declaration {
@@ -105,8 +108,8 @@ fn inner_walk(node: &Node, depth: usize, f: &mut dyn Write) -> Result<(), std::i
                 f,
                 "{prefix}[AttributeSelector] name: {name} value: {value} flags: {flags}"
             )?;
-            if matcher.is_some() {
-                inner_walk(matcher.as_ref().unwrap(), depth + 1, f)?;
+            if let Some(matcher) = matcher {
+                inner_walk(matcher, depth + 1, f)?;
             }
         }
         NodeType::ClassSelector { value } => {
@@ -140,8 +143,8 @@ fn inner_walk(node: &Node, depth: usize, f: &mut dyn Write) -> Result<(), std::i
             condition,
         } => {
             writeln!(f, "{prefix}[MediaQuery] modifier: {modifier} media_type: {media_type}")?;
-            if condition.is_some() {
-                inner_walk(condition.as_ref().unwrap(), depth + 1, f)?;
+            if let Some(condition) = condition {
+                inner_walk(condition, depth + 1, f)?;
             }
         }
         NodeType::MediaQueryList { media_queries } => {
@@ -158,8 +161,8 @@ fn inner_walk(node: &Node, depth: usize, f: &mut dyn Write) -> Result<(), std::i
         }
         NodeType::Feature { kind, name, value } => {
             writeln!(f, "{prefix}[Feature] kind: {kind:?} name: {name}")?;
-            if value.is_some() {
-                inner_walk(value.as_ref().unwrap(), depth + 1, f)?;
+            if let Some(value) = value {
+                inner_walk(value, depth + 1, f)?;
             }
         }
         NodeType::Hash { value } => {
@@ -192,8 +195,8 @@ fn inner_walk(node: &Node, depth: usize, f: &mut dyn Write) -> Result<(), std::i
         NodeType::Nth { nth, selector } => {
             writeln!(f, "{prefix}[Nth]")?;
             inner_walk(nth, depth + 1, f)?;
-            if selector.is_some() {
-                inner_walk(selector.as_ref().unwrap(), depth + 1, f)?;
+            if let Some(selector) = selector {
+                inner_walk(selector, depth + 1, f)?;
             }
         }
         NodeType::AnPlusB { a, b } => {
@@ -223,11 +226,11 @@ fn inner_walk(node: &Node, depth: usize, f: &mut dyn Write) -> Result<(), std::i
         }
         NodeType::Scope { root, limit } => {
             writeln!(f, "{prefix}[Scope]")?;
-            if root.is_some() {
-                inner_walk(root.as_ref().unwrap(), depth + 1, f)?;
+            if let Some(root) = root {
+                inner_walk(root, depth + 1, f)?;
             }
-            if limit.is_some() {
-                inner_walk(limit.as_ref().unwrap(), depth + 1, f)?;
+            if let Some(limit) = limit {
+                inner_walk(limit, depth + 1, f)?;
             }
         }
         NodeType::LayerList { layers } => {
@@ -261,11 +264,11 @@ fn inner_walk(node: &Node, depth: usize, f: &mut dyn Write) -> Result<(), std::i
             inner_walk(left, depth + 1, f)?;
             inner_walk(left_comparison, depth + 1, f)?;
             inner_walk(middle, depth + 1, f)?;
-            if right_comparison.is_some() {
-                inner_walk(right_comparison.as_ref().unwrap(), depth + 1, f)?;
+            if let Some(right_comparison) = right_comparison {
+                inner_walk(right_comparison, depth + 1, f)?;
             }
-            if right.is_some() {
-                inner_walk(right.as_ref().unwrap(), depth + 1, f)?;
+            if let Some(right) = right {
+                inner_walk(right, depth + 1, f)?;
             }
         }
     }

--- a/crates/gosub_fontmanager/Cargo.toml
+++ b/crates/gosub_fontmanager/Cargo.toml
@@ -56,3 +56,16 @@ pangocairo = { workspace = true, optional = true }
 
 [features]
 gtk = ["dep:gtk4", "dep:cairo-rs", "dep:cairo-sys-rs", "dep:pangocairo"]
+
+# Mirrors the workspace lints, except unsafe_code is "deny" instead of "forbid":
+# this crate has justified unsafe (allowed per-site with a SAFETY comment).
+[lints.rust]
+unsafe_code = "deny"
+
+[lints.clippy]
+todo = "deny"
+unimplemented = "deny"
+dbg_macro = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"

--- a/crates/gosub_fontmanager/src/bin/display-fonts.rs
+++ b/crates/gosub_fontmanager/src/bin/display-fonts.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 use cow_utils::CowUtils;
 use gosub_fontmanager::FontManager;
 use prettytable::{Attr, Cell, Row, Table};

--- a/crates/gosub_fontmanager/src/bin/generate-svg.rs
+++ b/crates/gosub_fontmanager/src/bin/generate-svg.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 use anyhow::anyhow;
 use freetype::Library;
 use gosub_fontmanager::FontManager;

--- a/crates/gosub_fontmanager/src/bin/gtk-test.rs
+++ b/crates/gosub_fontmanager/src/bin/gtk-test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 use gosub_interface::font::{FontInfo, FontManager, FontStyle};
 use gtk4::pango::FontDescription;
 use gtk4::prelude::{

--- a/crates/gosub_fontmanager/src/bin/gtk2-test.rs
+++ b/crates/gosub_fontmanager/src/bin/gtk2-test.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#![allow(unsafe_code)]
 use freetype::Library;
 use gosub_fontmanager::{FontInfo, FontManager};
 use gosub_interface::font::{FontInfo as _, FontManager as _, FontStyle};

--- a/crates/gosub_fontmanager/src/bin/parley.rs
+++ b/crates/gosub_fontmanager/src/bin/parley.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 use gosub_fontmanager::FontManager;
 use gosub_interface::font::FontStyle;
 use image::codecs::png::PngEncoder;
@@ -256,7 +257,7 @@ fn render_glyph(
                 }
             }
         }
-        Content::SubpixelMask => unimplemented!(),
+        Content::SubpixelMask => panic!("SubpixelMask rendering not implemented"),
         Content::Color => {
             let row_size = glyph_width as usize * 4;
             for (pixel_y, row) in rendered_glyph.data.chunks_exact(row_size).enumerate() {

--- a/crates/gosub_fontmanager/src/bin/vello-test.rs
+++ b/crates/gosub_fontmanager/src/bin/vello-test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 use gosub_interface::font::FontStyle;
 use std::sync::Arc;
 use vello::kurbo::{Affine, Circle, Ellipse, Line, RoundedRect, Stroke};

--- a/crates/gosub_fontmanager/src/font_manager/manager.rs
+++ b/crates/gosub_fontmanager/src/font_manager/manager.rs
@@ -31,7 +31,13 @@ impl FontManager {
     #[must_use]
     pub fn new() -> Self {
         let source = font_kit::source::SystemSource::new();
-        let handles = source.all_fonts().unwrap();
+        let handles = match source.all_fonts() {
+            Ok(handles) => handles,
+            Err(e) => {
+                log::error!("Failed to enumerate system fonts: {e}");
+                Vec::new()
+            }
+        };
 
         let mut seen_paths: HashSet<PathBuf> = HashSet::new();
 
@@ -89,7 +95,7 @@ impl TFontManager for FontManager {
 }
 
 fn handle_to_info(seen_paths: &mut HashSet<PathBuf>, handle: &Handle) -> Result<FontInfo, anyhow::Error> {
-    let font = handle.load().unwrap();
+    let font = handle.load()?;
 
     let family = font.family_name();
     let props = font.properties();

--- a/crates/gosub_html5/Cargo.toml
+++ b/crates/gosub_html5/Cargo.toml
@@ -43,3 +43,6 @@ harness = false
 [[bench]]
 name = "tree_construction"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/gosub_html5/benches/tree_construction.rs
+++ b/crates/gosub_html5/benches/tree_construction.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 use criterion::{criterion_group, criterion_main, Criterion};
 use gosub_css3::system::Css3System;
 use gosub_html5::document::document_impl::DocumentImpl;

--- a/crates/gosub_html5/src/document/document_impl.rs
+++ b/crates/gosub_html5/src/document/document_impl.rs
@@ -378,10 +378,9 @@ impl<C: HasDocument<Document = Self>> DocumentImpl<C> {
     }
 
     fn on_document_node_mutation_update_named_id(&mut self, node: &NodeImpl) {
-        if !node.is_element_node() {
+        let Some(element_data) = node.get_element_data() else {
             return;
-        }
-        let element_data = node.get_element_data().unwrap();
+        };
         if let Some(id_value) = element_data.attributes.get("id") {
             if is_valid_id_attribute_value(id_value) {
                 if let Entry::Vacant(e) = self.named_id_elements.entry(id_value.clone()) {
@@ -410,6 +409,7 @@ impl<C: HasDocument<Document = Self>> DocumentImpl<C> {
 
     /// Returns the root node reference
     pub fn get_root(&self) -> &NodeImpl {
+        #[allow(clippy::expect_used)] // PANIC-SAFE: the root node is created in Document::new()
         self.arena.node_ref(NodeId::root()).expect("Root node not found")
     }
 
@@ -417,8 +417,7 @@ impl<C: HasDocument<Document = Self>> DocumentImpl<C> {
     pub fn register_node(&mut self, mut node: NodeImpl) -> NodeId {
         let node_id = self.arena.get_next_id();
         node.set_id(node_id);
-        if node.is_element_node() {
-            let element_data = node.get_element_data_mut().unwrap();
+        if let Some(element_data) = node.get_element_data_mut() {
             element_data.node_id = Some(node_id);
         }
         self.on_document_node_mutation(&node);
@@ -454,21 +453,30 @@ impl<C: HasDocument<Document = Self>> DocumentImpl<C> {
             }
             self.update_node(parent_node);
         }
-        let mut node = self.arena.node(node_id).unwrap();
+        let Some(mut node) = self.arena.node(node_id) else {
+            log::warn!("attach_node: node {node_id} not found in arena");
+            return;
+        };
         node.parent = Some(parent_id);
         self.update_node(node);
     }
 
     pub fn detach_node(&mut self, node_id: NodeId) {
-        let parent = self.node_by_id(node_id).expect("node not found").parent_id();
+        let Some(parent) = self.node_by_id(node_id).map(NodeImpl::parent_id) else {
+            return;
+        };
         if let Some(parent_id) = parent {
-            let mut parent_node = self.node_by_id(parent_id).expect("parent node not found").clone();
-            parent_node.remove(node_id);
-            self.update_node(parent_node);
+            if let Some(parent_node) = self.node_by_id(parent_id) {
+                let mut parent_node = parent_node.clone();
+                parent_node.remove(node_id);
+                self.update_node(parent_node);
+            }
 
-            let mut node = self.node_by_id(node_id).expect("node not found").clone();
-            node.set_parent(None);
-            self.update_node(node);
+            if let Some(node) = self.node_by_id(node_id) {
+                let mut node = node.clone();
+                node.set_parent(None);
+                self.update_node(node);
+            }
         }
     }
 
@@ -479,7 +487,7 @@ impl<C: HasDocument<Document = Self>> DocumentImpl<C> {
         if !node.registered {
             return;
         }
-        if node.parent.is_some() && node.parent.unwrap() == parent_id {
+        if node.parent == Some(parent_id) {
             return;
         }
         self.detach_node(node_id);
@@ -505,12 +513,15 @@ impl<C: HasDocument<Document = Self>> DocumentImpl<C> {
     }
 
     pub fn delete_node_by_id(&mut self, node_id: NodeId) {
-        let node = self.arena.node(node_id).unwrap();
-        let parent_id = node.parent_id();
-        if let Some(parent_id) = parent_id {
-            let mut parent = self.node_by_id(parent_id).unwrap().clone();
-            parent.remove(node_id);
-            self.update_node(parent);
+        let Some(node) = self.arena.node(node_id) else {
+            return;
+        };
+        if let Some(parent_id) = node.parent_id() {
+            if let Some(parent) = self.node_by_id(parent_id) {
+                let mut parent = parent.clone();
+                parent.remove(node_id);
+                self.update_node(parent);
+            }
         }
         self.arena.delete_node(node_id);
     }
@@ -637,7 +648,9 @@ impl<C: HasDocument<Document = Self>> DocumentImpl<C> {
 
         let len = node.children.len();
         for (i, child_id) in node.children.iter().enumerate() {
-            let child_node = self.node_by_id(*child_id).expect("Child not found");
+            let Some(child_node) = self.node_by_id(*child_id) else {
+                continue;
+            };
             self.print_tree(child_node, buffer.clone(), i == len - 1, f);
         }
     }
@@ -705,7 +718,9 @@ fn internal_visit<C: HasDocument<Document = DocumentImpl<C>>>(
 ) {
     visitor.document_enter(node);
     for &child_id in node.children() {
-        let child = doc.node_by_id(child_id).unwrap();
+        let Some(child) = doc.node_by_id(child_id) else {
+            continue;
+        };
         internal_visit(doc, child, visitor);
     }
     visitor.document_leave(node);

--- a/crates/gosub_html5/src/lib.rs
+++ b/crates/gosub_html5/src/lib.rs
@@ -10,6 +10,9 @@ pub mod dom;
 pub mod errors;
 pub mod node;
 pub mod parser;
+// Test-fixture harness for the WHATWG html5lib test suites; panicking on a
+// malformed fixture is the desired behavior there, as in any test code.
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 pub mod testing;
 pub mod tokenizer;
 #[allow(dead_code)]

--- a/crates/gosub_html5/src/parser.rs
+++ b/crates/gosub_html5/src/parser.rs
@@ -714,9 +714,9 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
                         force_quirks,
                         ..
                     } => {
-                        if name.is_some() && name.as_ref().unwrap() != "html"
+                        if name.as_deref().is_some_and(|name| name != "html")
                             || pub_identifier.is_some()
-                            || (sys_identifier.is_some() && sys_identifier.as_ref().unwrap() != "about:legacy-compat")
+                            || sys_identifier.as_deref().is_some_and(|id| id != "about:legacy-compat")
                         {
                             self.parse_error("doctype not allowed in initial insertion mode");
                         }
@@ -1041,6 +1041,7 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
                             return;
                         }
 
+                        #[allow(clippy::unwrap_used)] // PANIC-SAFE: the is_empty() guard above returned
                         let style_text_node_id = *self.document.children(style_node_id).first().unwrap();
 
                         // Load stylesheet from text node
@@ -1775,11 +1776,10 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
     /// Pops the last element from the open elements until we reach any of the elements in $arr
     fn pop_until_any(&mut self, arr: &[&str]) {
         while !self.open_elements.is_empty() {
-            let node_id = self.open_elements.pop();
-            if node_id.is_none() {
+            let Some(node_id) = self.open_elements.pop() else {
                 break;
-            }
-            let tag = self.document.tag_name(node_id.unwrap()).unwrap_or_default();
+            };
+            let tag = self.document.tag_name(node_id).unwrap_or_default();
             if arr.contains(&tag) {
                 break;
             }
@@ -1934,7 +1934,9 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
 
                 // fragment case: use context node
                 if self.is_fragment_case {
-                    node_id = self.context_node_id.expect("context_node_id not set in fragment case");
+                    #[allow(clippy::expect_used)] // PANIC-SAFE: fragment parsing always sets a context node (13.2.4)
+                    let context_node_id = self.context_node_id.expect("context_node_id not set in fragment case");
+                    node_id = context_node_id;
                 }
             }
             match self.document.tag_name(node_id).unwrap_or_default() {
@@ -2526,12 +2528,12 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
                     let node_id = self.form_element;
                     self.form_element = None;
 
-                    if node_id.is_none() || !self.is_in_scope(name, HTML_NAMESPACE, Scope::Regular) {
+                    let Some(node_id) = node_id.filter(|_| self.is_in_scope(name, HTML_NAMESPACE, Scope::Regular))
+                    else {
                         self.parse_error("end tag not in scope");
                         // ignore token
                         return;
-                    }
-                    let node_id = node_id.expect("node_id");
+                    };
 
                     self.generate_implied_end_tags(None, false);
 
@@ -2764,7 +2766,7 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
 
                 self.acknowledge_closing_tag(*is_self_closing);
 
-                if !attributes.contains_key("type") || attributes.get("type").unwrap().cow_to_lowercase() != *"hidden" {
+                if attributes.get("type").is_none_or(|t| t.cow_to_lowercase() != *"hidden") {
                     self.frameset_ok = false;
                 }
             }
@@ -3320,7 +3322,7 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
                 attributes,
                 ..
             } if name == "input" => {
-                if !attributes.contains_key("type") || attributes.get("type").unwrap().cow_to_lowercase() != *"hidden" {
+                if attributes.get("type").is_none_or(|t| t.cow_to_lowercase() != *"hidden") {
                     anything_else = true;
                 } else {
                     self.parse_error("input tag not allowed in in table insertion mode");
@@ -3586,10 +3588,7 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
             return;
         }
 
-        if self
-            .open_elements
-            .contains(&entry.node_id().expect("node id not found"))
-        {
+        if entry.node_id().is_some_and(|id| self.open_elements.contains(&id)) {
             return;
         }
 
@@ -3601,10 +3600,7 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
                 break;
             }
 
-            if self
-                .open_elements
-                .contains(&entry.node_id().expect("node id not found"))
-            {
+            if entry.node_id().is_some_and(|id| self.open_elements.contains(&id)) {
                 entry_index += 1;
                 break;
             }
@@ -3618,11 +3614,10 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
 
         loop {
             let entry = self.active_formatting_elements[entry_index];
-            if let ActiveElement::Marker = entry {
+            let Some(node_id) = entry.node_id() else {
                 // Marker found. This should not happen!
                 break;
-            }
-            let node_id = entry.node_id().expect("node id not found");
+            };
 
             let new_node_id = self.insert_element_from_node(node_id, None);
 
@@ -3656,8 +3651,7 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
         if let Token::StartTag { attributes, .. } = token {
             let mut new_attributes = HashMap::new();
             for (name, value) in attributes.iter() {
-                if SVG_ADJUSTMENTS_ATTRIBUTES.contains_key(name) {
-                    let &new_name = SVG_ADJUSTMENTS_ATTRIBUTES.get(name).expect("svg adjustments");
+                if let Some(&new_name) = SVG_ADJUSTMENTS_ATTRIBUTES.get(name) {
                     new_attributes.insert(new_name.to_owned(), value.clone());
                 } else {
                     new_attributes.insert(name.clone(), value.clone());
@@ -3670,8 +3664,8 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
     /// Adjusts tag name in the given token for SVG
     fn adjust_svg_tag_names(&self, token: &mut Token) {
         if let Token::StartTag { name, .. } = token {
-            if SVG_ADJUSTMENTS_TAGS.contains_key(name) {
-                (*SVG_ADJUSTMENTS_TAGS.get(name).expect("svg tagname")).clone_into(name);
+            if let Some(new_name) = SVG_ADJUSTMENTS_TAGS.get(name) {
+                (*new_name).clone_into(name);
             }
         }
     }
@@ -3681,8 +3675,7 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
         if let Token::StartTag { attributes, .. } = token {
             let mut new_attributes = HashMap::new();
             for (name, value) in attributes.iter() {
-                if MATHML_ADJUSTMENTS.contains_key(name) {
-                    let &new_name = MATHML_ADJUSTMENTS.get(name).expect("svg adjustments");
+                if let Some(&new_name) = MATHML_ADJUSTMENTS.get(name) {
                     new_attributes.insert(new_name.to_owned(), value.clone());
                 } else {
                     new_attributes.insert(name.clone(), value.clone());
@@ -3696,8 +3689,7 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
         if let Token::StartTag { attributes, .. } = token {
             let mut new_attributes = HashMap::new();
             for (name, value) in attributes.iter() {
-                if XML_ADJUSTMENTS.contains_key(name) {
-                    let (prefix, local_name, _namespace) = XML_ADJUSTMENTS.get(name).expect("cml adjustments");
+                if let Some((prefix, local_name, _namespace)) = XML_ADJUSTMENTS.get(name) {
                     new_attributes.insert(format!("{prefix} {local_name}"), value.clone());
                 } else {
                     new_attributes.insert(name.clone(), value.clone());
@@ -3848,16 +3840,20 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
             }
         }
 
-        let token = self.token_queue.first().cloned();
-        self.token_queue.remove(0);
-
-        token.expect("no token found")
+        if self.token_queue.is_empty() {
+            // Cannot happen: the branch above either queued a token or returned early.
+            return Token::Eof {
+                location: Location::default(),
+            };
+        }
+        self.token_queue.remove(0)
     }
 
     /// Returns the NodeId of the adjusted current node.
     fn get_adjusted_current_node_id(&self) -> NodeId {
         if self.is_fragment_case && self.open_elements.len() == 1 {
             // fragment case: return context node
+            #[allow(clippy::expect_used)] // PANIC-SAFE: fragment parsing always sets a context node (13.2.4)
             return self.context_node_id.expect("context_node_id not set in fragment case");
         }
         current_node_id!(self)
@@ -4177,12 +4173,10 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
             return;
         }
 
-        if !attributes.contains_key("rel") {
+        let Some(rel) = attributes.get("rel").cloned() else {
             self.parse_error("link element without 'rel' attribute not supported yet");
             return;
-        }
-
-        let rel = attributes.get("rel").expect("rel").clone();
+        };
 
         // @todo: We need to check if the link rel is body-ok
         let parser_in_body = true;
@@ -4212,19 +4206,16 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
                     Ok(url) => url,
                     Err(_err) => {
                         // Relative URL
-                        if self.document.url().is_some() {
-                            let url = self.document.url();
-                            let base_url = url.as_ref().unwrap();
-                            match base_url.join(href) {
-                                Ok(url) => url,
-                                Err(_) => {
-                                    self.parse_error("link element with invalid href url");
-                                    return;
-                                }
-                            }
-                        } else {
+                        let Some(base_url) = self.document.url() else {
                             self.parse_error("link element without base url not supported yet");
                             return;
+                        };
+                        match base_url.join(href) {
+                            Ok(url) => url,
+                            Err(_) => {
+                                self.parse_error("link element with invalid href url");
+                                return;
+                            }
                         }
                     }
                 };

--- a/crates/gosub_html5/src/parser/tree_builder.rs
+++ b/crates/gosub_html5/src/parser/tree_builder.rs
@@ -115,7 +115,6 @@ mod tests {
     #[test_case("webkit01.dat")]
     #[test_case("webkit02.dat")]
     fn tree_construction(filename: &str) {
-        dbg!(fixture_root_path().join(filename));
         let fixture_file = read_fixture_from_path(fixture_root_path().join(filename)).expect("fixture");
         let mut harness = Harness::new();
 

--- a/crates/gosub_html5/src/tokenizer.rs
+++ b/crates/gosub_html5/src/tokenizer.rs
@@ -2021,7 +2021,9 @@ impl<'stream> Tokenizer<'stream> {
                     }
                 }
                 State::CharacterReferenceInAttributeValue => {
-                    panic!("state {:?} not implemented", self.state);
+                    // Character references in attribute values are handled inline by the
+                    // attribute-value states; nothing ever transitions into this state.
+                    unreachable!("state {:?} is never entered", self.state);
                 }
             }
         }
@@ -2193,7 +2195,10 @@ impl<'stream> Tokenizer<'stream> {
 
     /// Set `is_closing_tag` in current token
     fn set_is_closing_in_current_token(&mut self, is_closing: bool) {
-        match &mut self.current_token.as_mut().unwrap() {
+        let Some(token) = self.current_token.as_mut() else {
+            return;
+        };
+        match token {
             Token::EndTag { .. } => {
                 self.stream_prev();
                 self.parse_error(ParserError::EndTagWithTrailingSolidus, self.get_location());
@@ -2208,7 +2213,7 @@ impl<'stream> Tokenizer<'stream> {
 
     /// Set `force_quirk` mode in current token
     fn set_quirks_mode(&mut self, quirky: bool) {
-        if let Token::DocType { force_quirks, .. } = &mut self.current_token.as_mut().unwrap() {
+        if let Some(Token::DocType { force_quirks, .. }) = self.current_token.as_mut() {
             *force_quirks = quirky;
         }
     }
@@ -2216,7 +2221,7 @@ impl<'stream> Tokenizer<'stream> {
     /// Adds a new attribute to the current token
     #[allow(dead_code)]
     fn set_add_attribute_to_current_token(&mut self, name: &str, value: &str) {
-        if let Token::StartTag { attributes, .. } = &mut self.current_token.as_mut().unwrap() {
+        if let Some(Token::StartTag { attributes, .. }) = self.current_token.as_mut() {
             attributes.insert(name.into(), value.into());
         }
 
@@ -2226,7 +2231,10 @@ impl<'stream> Tokenizer<'stream> {
     /// Sets the given name into the current token
     #[allow(dead_code)]
     fn set_name_in_current_token(&mut self, new_name: String) -> Result<()> {
-        match &mut self.current_token.as_mut().expect("current token") {
+        let Some(token) = self.current_token.as_mut() else {
+            return Err(Error::Parse("trying to set the name without a current token".into()).into());
+        };
+        match token {
             Token::StartTag { name, .. } | Token::EndTag { name, .. } => {
                 *name = new_name;
             }
@@ -2254,14 +2262,14 @@ impl<'stream> Tokenizer<'stream> {
 
     /// This method will add current generated attributes to the current (start) token if needed.
     fn add_stored_attributes_to_current_token(&mut self) {
-        if self.current_token.is_none() {
-            return;
-        }
         if self.current_attrs.is_empty() {
             return;
         }
+        let Some(token) = self.current_token.as_mut() else {
+            return;
+        };
 
-        match self.current_token.as_mut().expect("current token") {
+        match token {
             Token::EndTag { .. } => {
                 // Error is one char before this one. Unread, fetch location and read again
                 self.stream_prev();

--- a/crates/gosub_html5/src/tokenizer/character_reference.rs
+++ b/crates/gosub_html5/src/tokenizer/character_reference.rs
@@ -75,7 +75,8 @@ impl Tokenizer<'_> {
                             return;
                         }
 
-                        let entity_chars = *TOKEN_NAMED_CHARS.get(entity.as_str()).unwrap();
+                        // find_entity() only returns keys of TOKEN_NAMED_CHARS, so the lookup cannot miss
+                        let entity_chars = TOKEN_NAMED_CHARS.get(entity.as_str()).copied().unwrap_or_default();
 
                         // Flush codepoints consumed as character reference
                         for c in entity_chars.chars() {
@@ -277,8 +278,8 @@ impl Tokenizer<'_> {
                     if self.is_control_char(char_ref_code) || char_ref_code == 0x0D {
                         self.parse_error(ParserError::ControlCharacterReference, self.get_location());
 
-                        if TOKEN_REPLACEMENTS.contains_key(&char_ref_code) {
-                            char_ref_code = *TOKEN_REPLACEMENTS.get(&char_ref_code).unwrap() as u32;
+                        if let Some(&replacement) = TOKEN_REPLACEMENTS.get(&char_ref_code) {
+                            char_ref_code = replacement as u32;
                         }
                     }
 

--- a/crates/gosub_jsapi/Cargo.toml
+++ b/crates/gosub_jsapi/Cargo.toml
@@ -11,3 +11,6 @@ gosub_shared = { version = "0.1.1", registry = "gosub", path = "../gosub_shared"
 uuid = { workspace = true, features = ["v4"] }
 regex = { workspace = true }
 cow-utils = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/gosub_jsapi/src/console.rs
+++ b/crates/gosub_jsapi/src/console.rs
@@ -156,17 +156,14 @@ impl Console {
         self.printer.print(LogLevel::Dir, &[&item], options);
     }
 
-    pub fn dirxml(&self, _data: &[&dyn fmt::Display]) {
-        todo!()
+    /// Displays the data at "dir" level. An interactive XML/HTML tree view is not supported.
+    pub fn dirxml(&mut self, data: &[&dyn fmt::Display]) {
+        self.printer.print(LogLevel::Dir, data, &[]);
     }
 
     /// Create a counter named "label"
     pub fn count(&mut self, label: &str) {
-        let mut cnt = 1;
-        if self.count_map.contains_key(label) {
-            cnt = self.count_map.get(label).unwrap() + 1;
-        }
-
+        let cnt = self.count_map.get(label).map_or(1, |c| c + 1);
         self.count_map.insert(label.to_owned(), cnt);
 
         let concat = format!("{}: {}", label.to_owned(), cnt);
@@ -260,12 +257,13 @@ impl Console {
             Err(_) => 0,
         };
 
-        let concat = format!(
-            "{}: {}ms{}",
-            label.to_owned(),
-            cur - self.timer_map.get(label).unwrap().start,
-            message
-        );
+        let Some(timer) = self.timer_map.get(label) else {
+            self.printer
+                .print(LogLevel::Warn, &[&format!("Timer '{label}' does not exist")], &[]);
+            return;
+        };
+
+        let concat = format!("{}: {}ms{}", label.to_owned(), cur - timer.start, message);
         self.printer.print(LogLevel::TimeLog, &[&concat], &[]);
     }
 
@@ -276,11 +274,13 @@ impl Console {
             Err(_) => 0,
         };
 
-        let concat = format!(
-            "{}: {}ms",
-            label.to_owned(),
-            end - self.timer_map.get(label).unwrap().start
-        );
+        let Some(timer) = self.timer_map.get(label) else {
+            self.printer
+                .print(LogLevel::Warn, &[&format!("Timer '{label}' does not exist")], &[]);
+            return;
+        };
+
+        let concat = format!("{}: {}ms", label.to_owned(), end - timer.start);
         self.printer.print(LogLevel::TimeEnd, &[&concat], &[]);
     }
 

--- a/crates/gosub_shared/Cargo.toml
+++ b/crates/gosub_shared/Cargo.toml
@@ -32,3 +32,15 @@ futures = { workspace = true }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.64"
+# Mirrors the workspace lints, except unsafe_code is "deny" instead of "forbid":
+# this crate has justified unsafe (allowed per-site with a SAFETY comment).
+[lints.rust]
+unsafe_code = "deny"
+
+[lints.clippy]
+todo = "deny"
+unimplemented = "deny"
+dbg_macro = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"

--- a/crates/gosub_shared/src/byte_stream.rs
+++ b/crates/gosub_shared/src/byte_stream.rs
@@ -576,13 +576,16 @@ impl Debug for Location {
 /// Returns `(StreamEnd, 0)` for an incomplete sequence at the end of an open stream (signals loop stop).
 fn decode_one_utf8(buf: &[u8], closed: bool) -> (Character, usize) {
     match std::str::from_utf8(buf) {
-        Ok(s) => {
-            let ch = s.chars().next().expect("non-empty buf");
-            (Ch(ch), ch.len_utf8())
-        }
+        Ok(s) => match s.chars().next() {
+            Some(ch) => (Ch(ch), ch.len_utf8()),
+            None => (StreamEnd, 0), // empty buffer
+        },
         Err(e) => {
             if e.valid_up_to() > 0 {
+                // SAFETY: from_utf8 validated bytes up to `valid_up_to()`.
+                #[allow(unsafe_code)]
                 let s = unsafe { std::str::from_utf8_unchecked(&buf[..e.valid_up_to()]) };
+                #[allow(clippy::expect_used)] // PANIC-SAFE: valid_up_to() > 0 guarantees at least one char
                 let ch = s.chars().next().expect("valid_up_to > 0");
                 (Ch(ch), ch.len_utf8())
             } else {

--- a/crates/gosub_shared/src/worker.rs
+++ b/crates/gosub_shared/src/worker.rs
@@ -254,7 +254,10 @@ impl WasmWorker {
 
 
 #[wasm_bindgen]
+#[allow(unsafe_code)]
 pub fn wasm_execute_work(ptr: usize) {
+    // SAFETY: `ptr` is the Box::into_raw pointer passed to the spawned wasm worker;
+    // it is consumed exactly once here.
     let work = unsafe { Box::from_raw(ptr as *mut Work) };
     (work.f)();
 }

--- a/crates/gosub_taffy/Cargo.toml
+++ b/crates/gosub_taffy/Cargo.toml
@@ -17,3 +17,16 @@ anyhow = { workspace = true }
 regex = { workspace = true }
 log = { workspace = true }
 parley = { workspace = true, features = ["std"] }
+
+# Mirrors the workspace lints, except unsafe_code is "deny" instead of "forbid":
+# the calc() expression cache hands raw pointers to taffy (allowed per-site with a SAFETY comment).
+[lints.rust]
+unsafe_code = "deny"
+
+[lints.clippy]
+todo = "deny"
+unimplemented = "deny"
+dbg_macro = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"

--- a/crates/gosub_taffy/src/lib.rs
+++ b/crates/gosub_taffy/src/lib.rs
@@ -136,6 +136,9 @@ pub struct Cache {
     calc_storage: Vec<Box<CalcExpr>>,
 }
 
+// SAFETY: the raw pointers in `style` only ever point into `calc_storage`, which is
+// owned by (and moves with) this same struct.
+#[allow(unsafe_code)]
 unsafe impl Send for Cache {}
 
 impl Deref for Cache {
@@ -279,58 +282,49 @@ impl<C: HasLayouter<Layouter = TaffyLayouter>> LayoutDocument<'_, C> {
             self.update_style(node_id);
         }
 
+        #[allow(clippy::expect_used)]
+        // PANIC-SAFE: update_style() above created the cache entry for this node
         let cache = self
             .tree
             .get_cache(node_id)
-            .expect("Cache not found, why again does taffy don't use optionals?");
+            .expect("cache entry created by update_style");
 
         &cache.style
     }
 
     /// Force the taffy style from the cache. Do not care about dirty styles
     fn get_taffy_style_no_update(&self, node_id: <C::LayoutTree as LayoutTree<C>>::NodeId) -> &Style {
-        if let Some(cache) = self.tree.get_cache(node_id) {
-            return &cache.style;
-        }
-        panic!(
-            "Cache not found, why again does taffy don't use optionals? (node: {})",
-            node_id.into()
-        );
+        #[allow(clippy::expect_used)]
+        // PANIC-SAFE: every node in the layout tree gets a cache entry when its style is computed
+        let cache = self.tree.get_cache(node_id).expect("node has a computed style cache");
+
+        &cache.style
     }
 }
 
 impl<C: HasLayouter<Layouter = TaffyLayouter>> CacheTree for LayoutDocument<'_, C> {
     fn cache_get(&self, node_id: TaffyId, input: &LayoutInput) -> Option<LayoutOutput> {
         let node_id = <C::LayoutTree as LayoutTree<C>>::NodeId::from(node_id.into());
-        let cache = &self
-            .tree
-            .get_cache(node_id)
-            .expect("Cache not found, why again does taffy don't use optionals?")
-            .taffy;
-
-        cache.get(input)
+        self.tree.get_cache(node_id)?.taffy.get(input)
     }
 
     fn cache_store(&mut self, node_id: TaffyId, input: &LayoutInput, layout_output: LayoutOutput) {
         let node_id = <C::LayoutTree as LayoutTree<C>>::NodeId::from(node_id.into());
-        let cache = &mut self
-            .tree
-            .get_cache_mut(node_id)
-            .expect("Cache not found, why again does taffy don't use optionals?")
-            .taffy;
+        let Some(cache) = self.tree.get_cache_mut(node_id) else {
+            log::warn!("Layout cache missing for node {}; dropping cache store", node_id.into());
+            return;
+        };
 
-        cache.store(input, layout_output);
+        cache.taffy.store(input, layout_output);
     }
 
     fn cache_clear(&mut self, node_id: TaffyId) {
         let node_id = <C::LayoutTree as LayoutTree<C>>::NodeId::from(node_id.into());
-        let cache = &mut self
-            .tree
-            .get_cache_mut(node_id)
-            .expect("Cache not found, why again does taffy don't use optionals?")
-            .taffy;
+        let Some(cache) = self.tree.get_cache_mut(node_id) else {
+            return;
+        };
 
-        cache.clear();
+        cache.taffy.clear();
     }
 }
 

--- a/crates/gosub_taffy/src/style/parse.rs
+++ b/crates/gosub_taffy/src/style/parse.rs
@@ -161,14 +161,6 @@ pub fn parse_tracking_sizing_function<C: HasLayouter>(
     Vec::new() //TODO: Implement this
 }
 
-#[allow(dead_code)]
-pub fn parse_non_repeated_tracking_sizing_function<C: HasLayouter>(
-    _node: &mut impl LayoutNode<C>,
-    _name: &str,
-) -> TrackSizingFunction {
-    todo!("implement parse_non_repeated_tracking_sizing_function")
-}
-
 pub fn parse_grid_auto<C: HasLayouter>(node: &mut impl LayoutNode<C>, name: &str) -> Vec<TrackSizingFunction> {
     let Some(display) = node.get_property(name) else {
         return Vec::new();

--- a/crates/gosub_v8/Cargo.toml
+++ b/crates/gosub_v8/Cargo.toml
@@ -19,3 +19,15 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 gosub_webinterop = { version = "0.1.1", registry = "gosub", path = "../gosub_webinterop" }
+# Mirrors the workspace lints, except unsafe_code: this is an FFI binding crate
+# around the V8 C++ API, where unsafe is inherent to nearly every operation.
+[lints.rust]
+unsafe_code = "allow"
+
+[lints.clippy]
+todo = "deny"
+unimplemented = "deny"
+dbg_macro = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"

--- a/crates/gosub_v8/src/v8.rs
+++ b/crates/gosub_v8/src/v8.rs
@@ -41,6 +41,7 @@ impl Default for V8Engine {
 const MAX_V8_INIT_SECONDS: u64 = 10;
 
 impl V8Engine {
+    #[allow(clippy::panic)] // deliberate fail-fast: a hung V8 initialization cannot be recovered from
     pub fn initialize() {
         let mut wait_time = MAX_V8_INIT_SECONDS * 1000;
 

--- a/crates/gosub_v8/src/v8/array.rs
+++ b/crates/gosub_v8/src/v8/array.rs
@@ -178,7 +178,10 @@ impl WebArray for V8Array {
     fn as_vec(&self) -> Vec<<Self::RT as WebRuntime>::Value> {
         let mut vec = Vec::with_capacity(self.len());
         for i in 0..self.len() {
-            vec.push(self.get(i).unwrap());
+            match self.get(i) {
+                Ok(value) => vec.push(value),
+                Err(e) => log::warn!("Failed to get array element {i}: {e}"),
+            }
         }
         vec
     }

--- a/crates/gosub_v8/src/v8/context.rs
+++ b/crates/gosub_v8/src/v8/context.rs
@@ -145,7 +145,9 @@ impl WebContext for V8Context {
 
         let try_catch = &mut TryCatch::new(s);
 
-        let code = v8::String::new(try_catch, code).unwrap();
+        let Some(code) = v8::String::new(try_catch, code) else {
+            return Err(anyhow::anyhow!("Failed to allocate V8 string for script source"));
+        };
 
         let script = v8::Script::compile(try_catch, code, None);
 

--- a/crates/gosub_v8/src/v8/function.rs
+++ b/crates/gosub_v8/src/v8/function.rs
@@ -352,14 +352,23 @@ impl VariadicArgs for V8VariadicArgs {
     where
         <Self::RT as WebRuntime>::Value: IntoRustValue<T>,
     {
-        self.args.iter().map(|x| x.to_rust_value().unwrap()).collect()
+        self.args
+            .iter()
+            .filter_map(|x| match x.to_rust_value() {
+                Ok(value) => Some(value),
+                Err(e) => {
+                    log::warn!("Failed to convert JS argument to Rust value: {e}");
+                    None
+                }
+            })
+            .collect()
     }
 
     fn get_as<T>(&self, index: usize) -> Option<T>
     where
         <Self::RT as WebRuntime>::Value: IntoRustValue<T>,
     {
-        self.args.get(index).map(|x| x.to_rust_value().unwrap())
+        self.args.get(index).and_then(|x| x.to_rust_value().ok())
     }
 }
 

--- a/crates/gosub_webinterop/Cargo.toml
+++ b/crates/gosub_webinterop/Cargo.toml
@@ -17,3 +17,13 @@ cow-utils = { workspace = true }
 
 [lib]
 proc-macro = true
+
+# Proc-macro crate: panicking IS the conventional error path (it surfaces as a
+# compile error at the macro call site), so the panic-family lints stay off.
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+todo = "deny"
+unimplemented = "deny"
+dbg_macro = "deny"


### PR DESCRIPTION
- **Enabled workspace lints on gosub_shared, config and fontmanager**
- **enabled workspace lints on taffy, v8, jsapi and webinterop**
- **workspace linting: gosub_html5**
- **workspace linting: gosub_css3**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability across CSS, HTML, font, JavaScript, and V8 processing by reducing crash-prone edge cases and handling missing or invalid data more safely.
  * Fixed several cases where parsing or rendering could fail unexpectedly, including token handling, color parsing, and document/tree updates.

* **Chores**
  * Raised the minimum supported Rust version to 1.82.
  * Updated crate lint settings for stricter code quality checks across the workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->