### PR TITLE
Fixes the hackernews logo display

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,15 @@
 [registries]
 gosub = { index = "sparse+https://registry.gosub.io/" }
+
+# Faster linker for the large binaries (gosub-screenshot, the example browsers).
+# mold is typically several times faster than the default bfd/gold linker on the
+# big link steps. Install it first:  apt install mold   (or  dnf/pacman install mold)
+# then uncomment the block below. Verify with:  mold --version
+#
+# [target.x86_64-unknown-linux-gnu]
+# linker = "clang"
+# rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+#
+# If you don't have clang, use rustc's bundled cc driver instead:
+# [target.x86_64-unknown-linux-gnu]
+# rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,6 +217,15 @@ gosub_render_pipeline = { path = "./crates/gosub_render_pipeline", features = ["
 vello = { git = "https://github.com/linebender/vello", rev = "1b24e77ba4e01d12f5db86a9b1b5f2cf828a6a33" }
 vello_encoding = { git = "https://github.com/linebender/vello", rev = "1b24e77ba4e01d12f5db86a9b1b5f2cf828a6a33" }
 
+[profile.dev]
+# Keep the linker from copying the (very large) DWARF into every binary on each
+# link — debug info stays in the .o files instead. Combined with line-tables-only
+# this cuts re-link time of the big binaries (gosub-screenshot, the example
+# browsers) from tens of seconds to a few, and shrinks them ~5x. Backtraces still
+# have file/line; only local-variable inspection is dropped.
+split-debuginfo = "unpacked"
+debug = "line-tables-only"
+
 [profile.release]
 lto = "fat"
 opt-level = 3

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -77,7 +77,6 @@ impl HoverFingerprints {
     /// Scan all stylesheets in `doc` and collect the hover-subject fingerprints.
     fn build(doc: &EngineDocument) -> Self {
         let mut fp = Self::empty();
-        let sheet_count = doc.stylesheets().len();
 
         for sheet in doc.stylesheets() {
             for rule in &sheet.rules {
@@ -118,10 +117,6 @@ impl HoverFingerprints {
                             if !specific {
                                 // Bare :hover or *:hover — everything is sensitive.
                                 fp.has_universal = true;
-                                log::info!(
-                                    "[hover] fingerprints: universal :hover (from {} stylesheet(s))",
-                                    sheet_count
-                                );
                                 return fp;
                             }
                         }
@@ -130,14 +125,6 @@ impl HoverFingerprints {
             }
         }
 
-        log::info!(
-            "[hover] fingerprints built from {} stylesheet(s): types={:?}  classes={:?}  ids={:?}  universal={}",
-            sheet_count,
-            fp.types.iter().collect::<Vec<_>>(),
-            fp.classes.iter().collect::<Vec<_>>(),
-            fp.ids.iter().collect::<Vec<_>>(),
-            fp.has_universal,
-        );
         fp
     }
 
@@ -281,6 +268,12 @@ pub struct BrowsingContext {
     /// Set by the tab worker when the engine is initialised with a VelloBackend.
     #[cfg(feature = "backend_vello")]
     pub vello_resources: Option<std::sync::Arc<gosub_render_pipeline::render::backends::vello::WgpuResources>>,
+
+    /// Media store shared between the layout and rasterization stages. The layouter loads
+    /// images/SVGs into it by id; the rasterizer resolves the same ids back. It persists
+    /// across renders so paint-only repaints (e.g. hover) still find previously loaded media.
+    #[cfg(feature = "pipeline")]
+    media_store: std::sync::Arc<gosub_render_pipeline::common::media::MediaStore>,
 }
 
 impl BrowsingContext {
@@ -321,6 +314,8 @@ impl BrowsingContext {
             hover_link_url: None,
             #[cfg(feature = "backend_vello")]
             vello_resources: None,
+            #[cfg(feature = "pipeline")]
+            media_store: std::sync::Arc::new(gosub_render_pipeline::common::media::MediaStore::new()),
         }
     }
 
@@ -436,6 +431,7 @@ impl BrowsingContext {
                     #[cfg(feature = "backend_vello")]
                     self.vello_resources.clone(),
                     prev_tile_cache,
+                    self.media_store.clone(),
                 ));
             }
             self.render_dirty = false;
@@ -444,7 +440,6 @@ impl BrowsingContext {
             self.style_dirty = false;
             self.layout_dirty = false;
         } else if self.hover_dirty {
-            log::warn!("[hover] hover_dirty → dispatching paint-only repaint (stages 4–6)");
             // Paint-only repaint: reuse the cached layout tree, skip stages 1–2.
             if let Some(old_cache) = self.pipeline_cache.take() {
                 let PipelineCache {
@@ -465,6 +460,7 @@ impl BrowsingContext {
                     #[cfg(feature = "backend_vello")]
                     self.vello_resources.clone(),
                     prev_tile_cache,
+                    self.media_store.clone(),
                 ));
             } else {
                 // No cached layout yet — fall back to a full rebuild.
@@ -475,6 +471,7 @@ impl BrowsingContext {
                         #[cfg(feature = "backend_vello")]
                         self.vello_resources.clone(),
                         std::collections::HashMap::new(),
+                        self.media_store.clone(),
                     ));
                 }
             }
@@ -506,6 +503,7 @@ impl BrowsingContext {
                         #[cfg(feature = "backend_vello")]
                         self.vello_resources.clone(),
                         prev_tile_cache,
+                        self.media_store.clone(),
                     ));
                 }
                 self.render_dirty = false;
@@ -660,8 +658,6 @@ impl BrowsingContext {
                 .unwrap_or_else(HoverFingerprints::empty)
         });
 
-        log::debug!("[hover] leaf → {:?}  lei={:?}", new_leaf, new_lei);
-
         // Walk the ancestor chain once for both link detection and fingerprint matching.
         // Terminate early once both are found.
         let (link_url, new_sensitive) = {
@@ -699,10 +695,6 @@ impl BrowsingContext {
         // the hover chain. If neither the old nor new chain touches a :hover rule, skip it.
         let visual_dirty = self.hover_chain_sensitive || new_sensitive;
         self.hover_chain_sensitive = new_sensitive;
-
-        log::debug!(
-            "[hover] visual_dirty={visual_dirty}  url_changed={url_changed}  new_sensitive={new_sensitive}  url={link_url:?}"
-        );
 
         if visual_dirty {
             if let Some(doc) = &self.document {
@@ -935,6 +927,7 @@ fn pipeline_build_cache(
         std::sync::Arc<gosub_render_pipeline::render::backends::vello::WgpuResources>,
     >,
     prev_tile_cache: std::collections::HashMap<TileCacheKey, (u32, u32, bytes::Bytes)>,
+    media_store: Arc<gosub_render_pipeline::common::media::MediaStore>,
 ) -> PipelineCache {
     use gosub_render_pipeline::common::browser_state::{BrowserState, WireframeState};
     use gosub_render_pipeline::common::document::pipeline_doc::GosubDocumentAdapter;
@@ -946,18 +939,10 @@ fn pipeline_build_cache(
     use gosub_render_pipeline::rendertree_builder::RenderTree;
     use gosub_render_pipeline::tiler::{TileList, TileState};
     use gosub_shared::{timing_start, timing_stop};
-    use std::time::Instant;
 
-    log::info!(
-        "[pipeline] build cache (viewport {}x{})",
-        viewport.width,
-        viewport.height
-    );
-    let t_total = Instant::now();
     let ts_total = timing_start!("pipeline.total");
 
     // Stage 1: render tree
-    let t = Instant::now();
     let ts1 = timing_start!("pipeline.render_tree");
     let adapter = GosubDocumentAdapter::<HtmlEngineConfig>::new(doc);
     let mut render_tree = RenderTree::new(Arc::new(adapter));
@@ -966,11 +951,6 @@ fn pipeline_build_cache(
         log::error!("Failed to build render tree: {e}");
     }
     timing_stop!(ts1);
-    log::info!(
-        "[pipeline] stage 1 render-tree:  {:>6.1}ms  ({} nodes)",
-        t.elapsed().as_secs_f64() * 1000.0,
-        render_tree.arena.len()
-    );
 
     let vp_dim = if viewport.width > 0 && viewport.height > 0 {
         Some(PipelineDimension::new(viewport.width as f64, viewport.height as f64))
@@ -979,44 +959,26 @@ fn pipeline_build_cache(
     };
 
     // Stage 2: layout
-    let t = Instant::now();
     let ts2 = timing_start!("pipeline.layout");
     let mut layouter = TaffyLayouter::new();
+    // Share the persistent media store so resources loaded during layout are visible to the
+    // rasterizer (which resolves them by id). Otherwise every image renders as a placeholder.
+    layouter.set_media_store(Arc::clone(&media_store));
     let layout_tree = layouter.layout(render_tree, vp_dim, 1.0);
     timing_stop!(ts2);
     let page_height = layout_tree.root_dimension.height;
-    log::info!(
-        "[pipeline] stage 2 layout:        {:>6.1}ms  (root {}x{:.0})",
-        t.elapsed().as_secs_f64() * 1000.0,
-        layout_tree.root_dimension.width,
-        page_height
-    );
 
     // Stage 3: layering
-    let t = Instant::now();
     let ts3 = timing_start!("pipeline.layering");
     let layer_list = LayerList::new(layout_tree);
-    let layer_count = layer_list.layer_ids.read().len();
     timing_stop!(ts3);
-    log::info!(
-        "[pipeline] stage 3 layering:      {:>6.1}ms  ({} layers)",
-        t.elapsed().as_secs_f64() * 1000.0,
-        layer_count
-    );
 
     // Stage 4: tiling
-    let t = Instant::now();
     let ts4 = timing_start!("pipeline.tiling");
     let mut tile_list = TileList::new(layer_list, PipelineDimension::new(256.0, 256.0));
     let saved_layer_list = Arc::clone(&tile_list.layer_list);
     tile_list.generate();
-    let total_tiles = tile_list.arena.len();
     timing_stop!(ts4);
-    log::info!(
-        "[pipeline] stage 4 tiling:        {:>6.1}ms  ({} tiles total)",
-        t.elapsed().as_secs_f64() * 1000.0,
-        total_tiles
-    );
 
     // Stage 5: paint all tiles for the full page so that scrolling reveals pre-rendered
     // content. We use the full page_height rather than capping to viewport.height; the
@@ -1024,7 +986,6 @@ fn pipeline_build_cache(
     // are transferred. Memory is bounded by tile count: at 256×256×4B per tile, a 6 000 px
     // page × 1 280 px wide = ~120 tiles × 256 KB each ≈ 30 MB, which is acceptable.
     let render_height = page_height;
-    let t = Instant::now();
     let ts5 = timing_start!("pipeline.painting");
     let full_page_rect = PipelineRect::new(0.0, 0.0, viewport.width as f64, render_height.max(1.0));
     let layer_ids = tile_list.layer_list.layer_ids.read().clone();
@@ -1040,32 +1001,19 @@ fn pipeline_build_cache(
         dpi_scale_factor: 1.0,
     };
     let painter = Painter::new(tile_list.layer_list.clone());
-    let mut painted_tiles = 0usize;
-    let mut painted_commands = 0usize;
     for &layer_id in &layer_ids {
         let tile_ids = tile_list.get_intersecting_tiles(layer_id, full_page_rect);
         for tile_id in tile_ids {
             if let Some(tile) = tile_list.get_tile_mut(tile_id) {
                 if tile.state == TileState::Dirty {
-                    let mut cmd_count = 0usize;
                     for tiled_element in &mut tile.elements {
-                        let cmds = painter.paint(tiled_element, &paint_state);
-                        cmd_count += cmds.len();
-                        tiled_element.paint_commands = cmds;
+                        tiled_element.paint_commands = painter.paint(tiled_element, &paint_state);
                     }
-                    painted_tiles += 1;
-                    painted_commands += cmd_count;
                 }
             }
         }
     }
     timing_stop!(ts5);
-    log::info!(
-        "[pipeline] stage 5 painting:      {:>6.1}ms  ({} tiles painted, {} commands total)",
-        t.elapsed().as_secs_f64() * 1000.0,
-        painted_tiles,
-        painted_commands
-    );
 
     // Stage 6: rasterize ALL tiles → collect into BakedTile vec.
     //
@@ -1083,7 +1031,6 @@ fn pipeline_build_cache(
     #[cfg(any(feature = "backend_cairo", feature = "backend_skia"))]
     macro_rules! rasterize_parallel {
         ($rasterizer:expr, $label:literal) => {{
-            use gosub_render_pipeline::common::media::MediaStore;
             use gosub_render_pipeline::common::texture_store::TextureStore;
             use gosub_render_pipeline::rasterizer::Rasterable;
             use gosub_render_pipeline::render::backend::PixelFormat;
@@ -1093,9 +1040,9 @@ fn pipeline_build_cache(
             // Cairo and Skia both emit premultiplied ARGB32 (BGRA byte order).
             let tile_format = PixelFormat::PreMulArgb32;
 
-            let t = Instant::now();
             let ts6 = timing_start!("pipeline.rasterize");
-            let media_store = MediaStore::new();
+            // `media_store` (the shared store populated during layout) comes from the enclosing
+            // function; rasterize() resolves image/SVG ids against it. &Arc derefs to &MediaStore.
             let rasterizer = $rasterizer;
 
             // Phase 1: collect IDs of dirty tiles across all layers.
@@ -1152,9 +1099,6 @@ fn pipeline_build_cache(
                 .collect();
 
             // Phase 3: update tile states, gather BakedTiles, and build the new tile cache.
-            let mut rasterized = 0usize;
-            let mut cache_hits = 0usize;
-            let mut empty = 0usize;
             let mut tiles: Vec<BakedTile> = Vec::with_capacity(results.len());
             let mut new_tile_cache: std::collections::HashMap<TileCacheKey, (u32, u32, bytes::Bytes)> =
                 std::collections::HashMap::with_capacity(results.len());
@@ -1166,32 +1110,17 @@ fn pipeline_build_cache(
                             tile.state = TileState::Clean;
                             if let Some(entry) = cache_entry {
                                 new_tile_cache.insert(entry.0, entry.1);
-                                rasterized += 1;
-                            } else {
-                                cache_hits += 1;
                             }
                             tiles.push(b);
                         }
                         None => {
                             tile.state = TileState::Empty;
-                            empty += 1;
                         }
                     }
                 }
             }
 
             timing_stop!(ts6);
-            log::info!(
-                concat!(
-                    "[pipeline] stage 6 rasterize ",
-                    $label,
-                    " {:>6.1}ms  ({} rasterized, {} hits, {} empty)"
-                ),
-                t.elapsed().as_secs_f64() * 1000.0,
-                rasterized,
-                cache_hits,
-                empty
-            );
             (tiles, new_tile_cache)
         }};
     }
@@ -1217,16 +1146,13 @@ fn pipeline_build_cache(
         // prev_tile_cache is used by the cairo/skia parallel rasterizer; vello doesn't
         // implement the dirty-tile cache yet, so acknowledge the parameter here.
         let _ = &prev_tile_cache;
-        use gosub_render_pipeline::common::media::MediaStore;
         use gosub_render_pipeline::common::texture_store::TextureStore;
         use gosub_render_pipeline::rasterizer::Rasterable;
         use gosub_renderer_vello::VelloRasterizer;
 
-        let t = Instant::now();
         let ts6 = timing_start!("pipeline.rasterize");
-        let media_store = MediaStore::new();
+        // Shared store populated during layout (see pipeline_build_cache `media_store` param).
         let mut texture_store = TextureStore::new();
-        let mut rasterized = 0usize;
         let mut empty = 0usize;
 
         let tiles = if let Some(ref resources) = _vello_resources {
@@ -1240,7 +1166,6 @@ fn pipeline_build_cache(
                                 Some(texture_id) => {
                                     tile.texture_id = Some(texture_id);
                                     tile.state = TileState::Clean;
-                                    rasterized += 1;
                                 }
                                 None => {
                                     tile.state = TileState::Empty;
@@ -1273,12 +1198,6 @@ fn pipeline_build_cache(
         };
 
         timing_stop!(ts6);
-        log::info!(
-            "[pipeline] stage 6 rasterize (vello): {:>6.1}ms  ({} clean, {} empty)",
-            t.elapsed().as_secs_f64() * 1000.0,
-            rasterized,
-            empty
-        );
         tiles
     };
     // Vello uses sequential rasterization; dirty-tile cache not yet implemented.
@@ -1297,11 +1216,6 @@ fn pipeline_build_cache(
         std::collections::HashMap::new();
 
     timing_stop!(ts_total);
-    log::info!(
-        "[pipeline] total (build cache): {:.1}ms  ({} baked tiles)",
-        t_total.elapsed().as_secs_f64() * 1000.0,
-        baked_tiles.len()
-    );
 
     // Pre-build the CachedTile list for zero-copy scroll handles.
     let cached_tiles = Arc::new(
@@ -1345,29 +1259,20 @@ fn pipeline_hover_repaint(
         std::sync::Arc<gosub_render_pipeline::render::backends::vello::WgpuResources>,
     >,
     prev_tile_cache: std::collections::HashMap<TileCacheKey, (u32, u32, bytes::Bytes)>,
+    media_store: Arc<gosub_render_pipeline::common::media::MediaStore>,
 ) -> PipelineCache {
     use gosub_render_pipeline::common::browser_state::{BrowserState, WireframeState};
     use gosub_render_pipeline::common::geo::{Dimension as PipelineDimension, Rect as PipelineRect};
     use gosub_render_pipeline::painter::Painter;
     use gosub_render_pipeline::tiler::{TileList, TileState};
     use gosub_shared::{timing_start, timing_stop};
-    use std::time::Instant;
-
-    log::info!("[pipeline] hover repaint (skipping stages 1–2)");
-    let t_total = Instant::now();
 
     // Stage 4: tiling — reuse existing LayerList, no layout work.
-    let t = Instant::now();
     let ts4 = timing_start!("pipeline.hover.tiling");
     let mut tile_list = TileList::from_arc(Arc::clone(&layer_list), PipelineDimension::new(256.0, 256.0));
     tile_list.generate();
     let total_tiles = tile_list.arena.len();
     timing_stop!(ts4);
-    log::warn!(
-        "[pipeline] hover stage 4 tiling: {:>6.1}ms  ({} tiles)",
-        t.elapsed().as_secs_f64() * 1000.0,
-        total_tiles
-    );
 
     // Build a position-keyed lookup of previous baked tiles so non-hover tiles can be
     // carried over without any CSS re-evaluation or rasterization.
@@ -1452,7 +1357,6 @@ fn pipeline_hover_repaint(
 
     // Stage 5: paint ONLY dirty (hover-affected) tiles.
     let render_height = page_height;
-    let t = Instant::now();
     let ts5 = timing_start!("pipeline.hover.painting");
     let full_page_rect = PipelineRect::new(0.0, 0.0, viewport.width as f64, render_height.max(1.0));
     let layer_ids = tile_list.layer_list.layer_ids.read().clone();
@@ -1468,50 +1372,24 @@ fn pipeline_hover_repaint(
         dpi_scale_factor: 1.0,
     };
     let painter = Painter::new(tile_list.layer_list.clone());
-    let mut painted_tiles = 0usize;
-    let mut total_elements_painted = 0usize;
     for &layer_id in &layer_ids {
         let tile_ids = tile_list.get_intersecting_tiles(layer_id, full_page_rect);
         for tile_id in tile_ids {
             if let Some(tile) = tile_list.get_tile_mut(tile_id) {
                 if tile.state == TileState::Dirty {
-                    let elem_count = tile.elements.len();
-                    let t_tile = Instant::now();
-                    let mut cmds = 0usize;
                     for tiled_element in &mut tile.elements {
-                        let c = painter.paint(tiled_element, &paint_state);
-                        cmds += c.len();
-                        tiled_element.paint_commands = c;
+                        tiled_element.paint_commands = painter.paint(tiled_element, &paint_state);
                     }
-                    log::info!(
-                        "[pipeline] hover s5 tile ({:.0},{:.0}) elems={} cmds={} in {:.1}ms",
-                        tile.rect.x,
-                        tile.rect.y,
-                        elem_count,
-                        cmds,
-                        t_tile.elapsed().as_secs_f64() * 1000.0
-                    );
-                    painted_tiles += 1;
-                    total_elements_painted += elem_count;
-                    let _ = cmds;
                 }
             }
         }
     }
     timing_stop!(ts5);
-    log::warn!(
-        "[pipeline] hover stage 5 painting: {:>6.1}ms  ({} dirty tiles / {} elems painted, {} clean reused)",
-        t.elapsed().as_secs_f64() * 1000.0,
-        painted_tiles,
-        total_elements_painted,
-        clean_baked.len()
-    );
 
     // Stage 6: rasterize (parallel for Cairo/Skia, using the tile-pixel cache).
     #[cfg(any(feature = "backend_cairo", feature = "backend_skia"))]
     macro_rules! rasterize_parallel {
         ($rasterizer:expr, $label:literal) => {{
-            use gosub_render_pipeline::common::media::MediaStore;
             use gosub_render_pipeline::common::texture_store::TextureStore;
             use gosub_render_pipeline::rasterizer::Rasterable;
             use gosub_render_pipeline::render::backend::PixelFormat;
@@ -1521,23 +1399,16 @@ fn pipeline_hover_repaint(
             // Cairo and Skia both emit premultiplied ARGB32 (BGRA byte order).
             let tile_format = PixelFormat::PreMulArgb32;
 
-            let t = Instant::now();
             let ts6 = timing_start!("pipeline.hover.rasterize");
-            let media_store = MediaStore::new();
+            // `media_store` is the shared store passed into pipeline_hover_repaint. It still
+            // holds media loaded by the last full layout. &Arc derefs to &MediaStore.
             let rasterizer = $rasterizer;
 
-            let t_dirty = Instant::now();
             let dirty_ids: Vec<TileId> = layer_ids
                 .iter()
                 .flat_map(|&layer_id| tile_list.get_intersecting_tiles(layer_id, full_page_rect))
                 .filter(|&id| tile_list.arena.get(&id).map_or(false, |t| t.state == TileState::Dirty))
                 .collect();
-            log::info!(
-                "[pipeline] hover s6 dirty_ids: {:.1}ms ({} dirty, {} layers)",
-                t_dirty.elapsed().as_secs_f64() * 1000.0,
-                dirty_ids.len(),
-                layer_ids.len()
-            );
 
             type CacheEntry = (TileCacheKey, (u32, u32, bytes::Bytes));
             let results: Vec<(TileId, Option<BakedTile>, Option<CacheEntry>)> = dirty_ids
@@ -1578,8 +1449,6 @@ fn pipeline_hover_repaint(
                 })
                 .collect();
 
-            let mut rasterized = 0usize;
-            let mut cache_hits = 0usize;
             let mut tiles: Vec<BakedTile> = Vec::with_capacity(results.len());
             let mut new_tile_cache: std::collections::HashMap<TileCacheKey, (u32, u32, bytes::Bytes)> =
                 std::collections::HashMap::with_capacity(results.len());
@@ -1590,9 +1459,6 @@ fn pipeline_hover_repaint(
                             tile.state = TileState::Clean;
                             if let Some(e) = cache_entry {
                                 new_tile_cache.insert(e.0, e.1);
-                                rasterized += 1;
-                            } else {
-                                cache_hits += 1;
                             }
                             tiles.push(b);
                         }
@@ -1603,16 +1469,6 @@ fn pipeline_hover_repaint(
                 }
             }
             timing_stop!(ts6);
-            log::warn!(
-                concat!(
-                    "[pipeline] hover stage 6 rasterize ",
-                    $label,
-                    " {:>6.1}ms  ({} rasterized, {} hits)"
-                ),
-                t.elapsed().as_secs_f64() * 1000.0,
-                rasterized,
-                cache_hits
-            );
             (tiles, new_tile_cache)
         }};
     }
@@ -1636,13 +1492,11 @@ fn pipeline_hover_repaint(
     ))]
     let (baked_tiles, new_tile_cache) = {
         // Vello: sequential rasterization, no tile-pixel cache yet.
-        use gosub_render_pipeline::common::media::MediaStore;
         use gosub_render_pipeline::common::texture_store::TextureStore;
         use gosub_render_pipeline::rasterizer::Rasterable;
         use gosub_renderer_vello::VelloRasterizer;
-        let t = Instant::now();
         let ts6 = timing_start!("pipeline.hover.rasterize");
-        let media_store = MediaStore::new();
+        // Shared store from pipeline_hover_repaint param (still holds last-layout media).
         let mut texture_store = TextureStore::new();
         let mut tiles: Vec<BakedTile> = Vec::new();
         if let Some(ref resources) = _vello_resources {
@@ -1677,10 +1531,6 @@ fn pipeline_hover_repaint(
             }
         }
         timing_stop!(ts6);
-        log::info!(
-            "[pipeline] hover stage 6 rasterize (vello): {:>6.1}ms",
-            t.elapsed().as_secs_f64() * 1000.0
-        );
         (tiles, std::collections::HashMap::new())
     };
 
@@ -1692,13 +1542,6 @@ fn pipeline_hover_repaint(
 
     // Merge: newly rasterized hover tiles + clean tiles carried from previous render.
     let all_baked_tiles: Vec<BakedTile> = baked_tiles.into_iter().chain(clean_baked).collect();
-
-    log::warn!(
-        "[pipeline] hover repaint total: {:.1}ms  ({} total tiles, {} dirty+rasterized)",
-        t_total.elapsed().as_secs_f64() * 1000.0,
-        all_baked_tiles.len(),
-        painted_tiles,
-    );
 
     let cached_tiles = Arc::new(
         all_baked_tiles
@@ -1731,7 +1574,6 @@ fn pipeline_hover_repaint(
 fn pipeline_composite(cache: &PipelineCache, scroll_x: f64, scroll_y: f64, vp_w: f64, vp_h: f64, rl: &mut RenderList) {
     use gosub_shared::{timing_start, timing_stop};
     let ts7 = timing_start!("pipeline.composite");
-    let mut blits = 0usize;
 
     for tile in &cache.tiles {
         // Cull tiles fully outside the viewport.
@@ -1756,9 +1598,7 @@ fn pipeline_composite(cache: &PipelineCache, scroll_x: f64, scroll_y: f64, vp_w:
             data: tile.data.clone(),
             format: tile.format,
         });
-        blits += 1;
     }
 
     timing_stop!(ts7);
-    log::debug!("[pipeline] stage 7 composite: {} blit items", blits);
 }

--- a/crates/gosub_lattice/src/sizing/columns.rs
+++ b/crates/gosub_lattice/src/sizing/columns.rs
@@ -40,14 +40,17 @@ pub fn compute_column_widths<T: TableTree>(
             for cell in grid.cells_in_row(row_idx) {
                 found_any = true;
                 if cell.colspan == 1 {
+                    let cw = tree.cell_content_width(cell.node);
                     if explicit[cell.col].is_none() {
+                        // A specified width cannot shrink a cell below its content's min-width
+                        // (CSS: used width = max(specified, min-content)). Without this, e.g. a
+                        // `width:18px` cell holding a 20px image clips it and eats the padding.
                         match tree.css_length(cell.node, CssProp::Width) {
-                            CssLength::Px(px) => explicit[cell.col] = Some(px),
-                            CssLength::Percent(p) => explicit[cell.col] = Some(p / 100.0 * table_width),
+                            CssLength::Px(px) => explicit[cell.col] = Some(px.max(cw)),
+                            CssLength::Percent(p) => explicit[cell.col] = Some((p / 100.0 * table_width).max(cw)),
                             _ => {}
                         }
                     }
-                    let cw = tree.cell_content_width(cell.node);
                     if cw > natural[cell.col] {
                         natural[cell.col] = cw;
                     }

--- a/crates/gosub_render_pipeline/src/common/media/media_store.rs
+++ b/crates/gosub_render_pipeline/src/common/media/media_store.rs
@@ -324,11 +324,10 @@ fn ft_detect(ft: &FileType) -> Option<MediaType> {
     // generic raster image if none is found. Comparisons are case-insensitive.
     let mut is_raster_image = false;
     for &mt in ft.media_types().iter() {
-        let mt = mt.to_ascii_lowercase();
-        if mt == "image/svg+xml" || mt == "image/svg" {
+        if mt.eq_ignore_ascii_case("image/svg+xml") || mt.eq_ignore_ascii_case("image/svg") {
             return Some(MediaType::Svg);
         }
-        if mt.starts_with("image/") {
+        if mt.len() >= 6 && mt[..6].eq_ignore_ascii_case("image/") {
             is_raster_image = true;
         }
     }

--- a/crates/gosub_render_pipeline/src/common/media/media_store.rs
+++ b/crates/gosub_render_pipeline/src/common/media/media_store.rs
@@ -317,14 +317,21 @@ fn detect_content_type(content_type: &str) -> Option<MediaType> {
 }
 
 fn ft_detect(ft: &FileType) -> Option<MediaType> {
+    // Scan *all* media types before deciding. The `file_type` crate lists several aliases
+    // for SVG (e.g. `["image/SVG", "image/svg+xml"]`); a naive first-match-wins loop trips
+    // the generic `image/` branch on the non-standard `image/SVG` alias and misclassifies
+    // SVG as a raster image. So look for any SVG marker first, and only fall back to a
+    // generic raster image if none is found. Comparisons are case-insensitive.
+    let mut is_raster_image = false;
     for &mt in ft.media_types().iter() {
-        if mt == "image/svg+xml" {
+        let mt = mt.to_ascii_lowercase();
+        if mt == "image/svg+xml" || mt == "image/svg" {
             return Some(MediaType::Svg);
         }
         if mt.starts_with("image/") {
-            return Some(MediaType::Image);
+            is_raster_image = true;
         }
     }
 
-    None
+    is_raster_image.then_some(MediaType::Image)
 }

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -35,6 +35,33 @@ impl<'a> PipelineTableTree<'a> {
         }
     }
 
+    /// Sum of the border-box heights of the nested tables directly contained in a cell (not
+    /// counting tables nested deeper inside those). Zero if the cell holds no table. This lets
+    /// a table cell grow to contain a nested table whose height lattice computes in a later pass.
+    fn nested_table_height(&self, cell_layout_id: LayoutElementId) -> f32 {
+        let Some(el) = self.layout_tree.arena.get(&cell_layout_id) else {
+            return 0.0;
+        };
+        let mut total = 0.0;
+        for &child_id in &el.children {
+            let Some(child) = self.layout_tree.arena.get(&child_id) else {
+                continue;
+            };
+            let is_table = matches!(
+                self.doc.get_own_style(child.dom_node_id, &StyleProperty::Display),
+                Some(Value::Display(Display::Table))
+            );
+            if is_table {
+                // Self-contained nested table — stop here, don't double-count its inner tables.
+                total += child.box_model.border_box.height as f32;
+            } else {
+                // The table may be wrapped (e.g. in an anonymous box); keep descending.
+                total += self.nested_table_height(child_id);
+            }
+        }
+        total
+    }
+
     /// Convert pending relative positions to absolute `BoxModel`s in the arena.
     /// Must be called after `compute_table_layout` returns.
     pub fn apply_positions(&mut self, table_dom_id: DomNodeId) {
@@ -153,8 +180,10 @@ fn cell_layout_to_box_model(layout: &CellLayout, abs: Coordinate) -> BoxModel {
 fn intrinsic_content_width(el: &LayoutElementNode, arena: &HashMap<LayoutElementId, LayoutElementNode>) -> f32 {
     match &el.context {
         ElementContext::Text(_) => el.box_model.content_box.width as f32,
-        ElementContext::Image(ctx) => ctx.dimension.width as f32,
-        ElementContext::Svg(ctx) => ctx.dimension.width as f32,
+        // Replaced elements: use the laid-out border-box width so the column is wide enough for
+        // the image *including its own CSS border* (the bare `dimension` omits it). Images are
+        // never stretched to the cell width, so the border box is the true intrinsic width.
+        ElementContext::Image(_) | ElementContext::Svg(_) => el.box_model.border_box.width as f32,
         ElementContext::None => el
             .children
             .iter()
@@ -239,7 +268,11 @@ impl TableTree for PipelineTableTree<'_> {
         // than 0 and covers the most common case (single column of text).
         if let Some(&layout_id) = self.dom_to_layout.get(&id) {
             if let Some(element) = self.layout_tree.arena.get(&layout_id) {
-                return element.box_model.content_box.height as f32;
+                let taffy_h = element.box_model.content_box.height as f32;
+                // A cell containing a nested table must be at least as tall as that table.
+                // The nested table's real height is only known after lattice lays it out, so
+                // the second (bottom-up) pass in `post_process_tables` propagates it up here.
+                return taffy_h.max(self.nested_table_height(layout_id));
             }
         }
         0.0
@@ -248,7 +281,10 @@ impl TableTree for PipelineTableTree<'_> {
     fn cell_content_width(&self, id: DomNodeId) -> f32 {
         if let Some(&layout_id) = self.dom_to_layout.get(&id) {
             if let Some(element) = self.layout_tree.arena.get(&layout_id) {
-                return intrinsic_content_width(element, &self.layout_tree.arena);
+                // Include the cell's own horizontal padding so the column is wide enough to hold
+                // the content *and* its padding (e.g. HN's logo cell: 20px image + 4px padding-right).
+                let pad = (element.box_model.padding.left + element.box_model.padding.right) as f32;
+                return intrinsic_content_width(element, &self.layout_tree.arena) + pad;
             }
         }
         0.0
@@ -273,58 +309,68 @@ pub fn post_process_tables(layout_tree: &mut LayoutTree, dom_to_layout: &HashMap
 
     log::info!("lattice: post_process_tables found {} table node(s)", table_nodes.len());
 
-    for (table_dom_id, table_layout_id) in table_nodes {
-        // Use the parent element's content width as available_width. For nested
-        // tables the parent is a table cell whose box model was already updated
-        // by the outer table's apply_positions call, giving us the correct width.
-        // Fall back to the table's own Taffy-computed width for root-level tables.
-        let available_width = doc
-            .parent(table_dom_id)
-            .and_then(|p| dom_to_layout.get(&p))
-            .and_then(|&pid| layout_tree.arena.get(&pid))
-            .map(|el| el.box_model.content_box.width as f32)
-            .unwrap_or_else(|| {
-                layout_tree
-                    .arena
-                    .get(&table_layout_id)
-                    .map(|e| e.box_model.content_box.width as f32)
-                    .unwrap_or(0.0)
-            });
+    // Two passes. Pass 1 is pre-order (outer→inner): it establishes column widths, which flow
+    // top-down (a nested table reads its width from its already-sized parent cell). Pass 2 is
+    // post-order (inner→outer): each table is re-laid-out *after* the tables nested inside its
+    // cells, so an outer cell's height now reflects its nested table's true height — height
+    // flows bottom-up. A single reverse pass propagates through any table-nesting depth.
+    for pass in 0..2 {
+        let order: Vec<(DomNodeId, LayoutElementId)> = if pass == 0 {
+            table_nodes.clone()
+        } else {
+            table_nodes.iter().rev().copied().collect()
+        };
+        for (table_dom_id, table_layout_id) in order {
+            lay_out_one_table(&*doc, layout_tree, dom_to_layout, table_dom_id, table_layout_id);
+        }
+    }
+}
 
-        log::info!(
-            "lattice: computing layout for table node {:?}, available_width={}",
-            table_dom_id,
-            available_width
-        );
+/// Run lattice for a single table node and write the computed cell positions and the table's
+/// own size back into the layout tree.
+fn lay_out_one_table(
+    doc: &dyn PipelineDocument,
+    layout_tree: &mut LayoutTree,
+    dom_to_layout: &HashMap<DomNodeId, LayoutElementId>,
+    table_dom_id: DomNodeId,
+    table_layout_id: LayoutElementId,
+) {
+    // Use the parent element's content width as available_width. For nested
+    // tables the parent is a table cell whose box model was already updated
+    // by the outer table's apply_positions call, giving us the correct width.
+    // Fall back to the table's own Taffy-computed width for root-level tables.
+    let available_width = doc
+        .parent(table_dom_id)
+        .and_then(|p| dom_to_layout.get(&p))
+        .and_then(|&pid| layout_tree.arena.get(&pid))
+        .map(|el| el.box_model.content_box.width as f32)
+        .unwrap_or_else(|| {
+            layout_tree
+                .arena
+                .get(&table_layout_id)
+                .map(|e| e.box_model.content_box.width as f32)
+                .unwrap_or(0.0)
+        });
 
-        // &*doc borrows from our local Arc, not from layout_tree — no conflict.
-        let mut tree = PipelineTableTree::new(&*doc, layout_tree, dom_to_layout);
+    let mut tree = PipelineTableTree::new(doc, layout_tree, dom_to_layout);
 
-        match gosub_lattice::compute_table_layout(&mut tree, table_dom_id, available_width, None) {
-            Ok((table_width, table_height)) => {
-                log::info!(
-                    "lattice: table node {:?} → {}×{}px, pending={}",
-                    table_dom_id,
-                    table_width,
-                    table_height,
-                    tree.pending.len()
+    match gosub_lattice::compute_table_layout(&mut tree, table_dom_id, available_width, None) {
+        Ok((table_width, table_height)) => {
+            tree.apply_positions(table_dom_id);
+            // Write back both dimensions so deeply-nested tables can read the
+            // correct width from this table's box model via their parent lookup.
+            if let Some(el) = layout_tree.arena.get_mut(&table_layout_id) {
+                let bb = el.box_model.border_box;
+                el.box_model = BoxModel::new(
+                    Rect::new(bb.x, bb.y, table_width as f64, table_height as f64),
+                    el.box_model.padding,
+                    el.box_model.border,
+                    el.box_model.margin,
                 );
-                tree.apply_positions(table_dom_id);
-                // Write back both dimensions so deeply-nested tables can read the
-                // correct width from this table's box model via their parent lookup.
-                if let Some(el) = layout_tree.arena.get_mut(&table_layout_id) {
-                    let bb = el.box_model.border_box;
-                    el.box_model = BoxModel::new(
-                        Rect::new(bb.x, bb.y, table_width as f64, table_height as f64),
-                        el.box_model.padding,
-                        el.box_model.border,
-                        el.box_model.margin,
-                    );
-                }
             }
-            Err(e) => {
-                log::warn!("lattice: table layout failed for node {:?}: {:?}", table_dom_id, e);
-            }
+        }
+        Err(e) => {
+            log::warn!("lattice: table layout failed for node {:?}: {:?}", table_dom_id, e);
         }
     }
 }

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -43,8 +43,9 @@ pub struct TaffyLayouter {
     /// populate_boxmodel uses this to add the container's taffy-computed offset to the offset
     /// it passes down to the child, which would otherwise be missing from the calculation.
     anon_container_map: HashMap<LayoutElementId, TaffyNodeId>,
-    /// Media store for loading images/SVGs during layout
-    media_store: MediaStore,
+    /// Media store for loading images/SVGs during layout. Shared (Arc) so the media loaded
+    /// here is visible to the rasterization stage, which looks resources up by the same id.
+    media_store: Arc<MediaStore>,
     /// Shared font system used for text measurement. Locking once per measurement
     /// call avoids keeping the guard alive across the full layout pass, which lets
     /// other threads (e.g. the rasterizer) access the font collection between calls.
@@ -93,12 +94,12 @@ impl TaffyContext {
         })
     }
 
-    fn svg(src: &str, media_id: MediaId, node_id: DomNodeId) -> TaffyContext {
+    fn svg(src: &str, media_id: MediaId, dimension: geo::Dimension, node_id: DomNodeId) -> TaffyContext {
         TaffyContext::Svg(ElementContextSvg {
             node_id,
             src: src.to_string(),
             media_id,
-            dimension: geo::Dimension::ZERO,
+            dimension,
         })
     }
 }
@@ -125,7 +126,7 @@ impl TaffyLayouter {
             root_id: TaffyNodeId::new(0),
             layout_taffy_mapping: HashMap::new(),
             anon_container_map: HashMap::new(),
-            media_store: MediaStore::new(),
+            media_store: Arc::new(MediaStore::new()),
             font_system,
             measure_cache: HashMap::new(),
             dom_to_layout_mapping: HashMap::new(),
@@ -135,6 +136,18 @@ impl TaffyLayouter {
     /// Expose the font system so callers can share it with other components.
     pub fn font_system(&self) -> Arc<Mutex<ParleyFontSystem>> {
         Arc::clone(&self.font_system)
+    }
+
+    /// Share an external media store with this layouter. Resources loaded during layout are
+    /// stored here; passing the same store to the rasterizer lets it resolve those resources
+    /// by id. Without this they live in two separate stores and images render as placeholders.
+    pub fn set_media_store(&mut self, media_store: Arc<MediaStore>) {
+        self.media_store = media_store;
+    }
+
+    /// The media store shared by this layouter (see [`set_media_store`](Self::set_media_store)).
+    pub fn media_store(&self) -> Arc<MediaStore> {
+        Arc::clone(&self.media_store)
     }
 
     pub fn print_tree(&mut self) {
@@ -261,6 +274,12 @@ impl CanLayout for TaffyLayouter {
                     Some(TaffyContext::Image(image_ctx)) => Size {
                         width: image_ctx.dimension.width as f32,
                         height: image_ctx.dimension.height as f32,
+                    },
+                    // SVG-backed <img> elements carry their intrinsic size the same way.
+                    // Without this arm they measured as 0×0 and collapsed (e.g. the HN logo).
+                    Some(TaffyContext::Svg(svg_ctx)) => Size {
+                        width: svg_ctx.dimension.width as f32,
+                        height: svg_ctx.dimension.height as f32,
                     },
                     _ => Size::ZERO,
                 }
@@ -637,7 +656,17 @@ impl TaffyLayouter {
                     // occupies, so display quality is unaffected.
                     let is_placeholder = self.media_store.is_placeholder(media_id);
                     taffy_context = match media.borrow() {
-                        Media::Svg(_) => Some(TaffyContext::svg(src.as_str(), media_id, dom_node.node_id)),
+                        Media::Svg(media_svg) => {
+                            // Use the SVG's intrinsic size so the element gets a non-zero box.
+                            // A failed/placeholder load uses the same small fixed size as images.
+                            let dimension = if is_placeholder {
+                                geo::Dimension::new(32.0, 32.0)
+                            } else {
+                                let size = media_svg.svg.tree.size();
+                                geo::Dimension::new(size.width() as f64, size.height() as f64)
+                            };
+                            Some(TaffyContext::svg(src.as_str(), media_id, dimension, dom_node.node_id))
+                        }
                         Media::Image(media_image) => {
                             let dimension = if is_placeholder {
                                 geo::Dimension::new(32.0, 32.0)
@@ -656,7 +685,16 @@ impl TaffyLayouter {
                         .load_media_from_data(MediaType::Svg, inner_html.into_bytes().as_slice())
                     {
                         Ok(media_id) => {
-                            taffy_context = Some(TaffyContext::svg("gosub://internal", media_id, dom_node.node_id));
+                            let media = self.media_store.get(media_id, MediaType::Svg);
+                            let dimension = match media.borrow() {
+                                Media::Svg(media_svg) => {
+                                    let size = media_svg.svg.tree.size();
+                                    geo::Dimension::new(size.width() as f64, size.height() as f64)
+                                }
+                                _ => geo::Dimension::ZERO,
+                            };
+                            taffy_context =
+                                Some(TaffyContext::svg("gosub://internal", media_id, dimension, dom_node.node_id));
                         }
                         Err(e) => {
                             log::warn!("Could not load SVG media: {:?}", e);

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -693,8 +693,12 @@ impl TaffyLayouter {
                                 }
                                 _ => geo::Dimension::ZERO,
                             };
-                            taffy_context =
-                                Some(TaffyContext::svg("gosub://internal", media_id, dimension, dom_node.node_id));
+                            taffy_context = Some(TaffyContext::svg(
+                                "gosub://internal",
+                                media_id,
+                                dimension,
+                                dom_node.node_id,
+                            ));
                         }
                         Err(e) => {
                             log::warn!("Could not load SVG media: {:?}", e);

--- a/crates/gosub_render_pipeline/src/painter.rs
+++ b/crates/gosub_render_pipeline/src/painter.rs
@@ -164,91 +164,112 @@ impl Painter {
                 commands.push(PaintCommand::text(t));
             }
             ElementContext::Svg(svg_ctx) => {
-                let brush = Brush::solid(Color::from_rgb8(130, 130, 130));
-                let r = Rectangle::new(layout_element.box_model.border_box).with_background(brush);
-                commands.push(PaintCommand::svg(svg_ctx.media_id, r));
+                let border_box = layout_element.box_model.border_box;
+                commands.push(PaintCommand::svg(svg_ctx.media_id, Rectangle::new(border_box)));
+                // The SVG painter doesn't draw the element's CSS border/radius, so emit it as a
+                // separate border-only rectangle painted on top of the icon (e.g. the HN logo's
+                // `border:1px white solid`).
+                if self.has_border(dom_node_id) {
+                    let r = self.decorate_with_border_and_radius(dom_node_id, Rectangle::new(border_box));
+                    commands.push(PaintCommand::rectangle(r));
+                }
             }
             ElementContext::Image(image_ctx) => {
                 let brush = Brush::image(image_ctx.media_id);
                 let r = Rectangle::new(layout_element.box_model.border_box).with_background(brush);
+                let r = self.decorate_with_border_and_radius(dom_node_id, r);
                 commands.push(PaintCommand::rectangle(r));
             }
             ElementContext::None => {
-                let doc = &self.layer_list.layout_tree.render_tree.doc;
                 let brush = self.get_brush(
                     dom_node_id,
                     &StyleProperty::BackgroundColor,
                     Brush::solid(Color::TRANSPARENT),
                 );
-                let mut r = Rectangle::new(layout_element.box_model.border_box).with_background(brush);
-
-                // Get border
-                let border_top_width = doc.get_style_f32(dom_node_id, &StyleProperty::BorderTopWidth);
-                let border_right_width = doc.get_style_f32(dom_node_id, &StyleProperty::BorderRightWidth);
-                let border_bottom_width = doc.get_style_f32(dom_node_id, &StyleProperty::BorderBottomWidth);
-                let border_left_width = doc.get_style_f32(dom_node_id, &StyleProperty::BorderLeftWidth);
-
-                if border_top_width != 0.0
-                    || border_right_width != 0.0
-                    || border_bottom_width != 0.0
-                    || border_left_width != 0.0
-                {
-                    let border_top_color =
-                        self.get_brush(dom_node_id, &StyleProperty::BorderTopColor, Brush::solid(Color::BLACK));
-                    let border_right_color = self.get_brush(
-                        dom_node_id,
-                        &StyleProperty::BorderRightColor,
-                        Brush::solid(Color::BLACK),
-                    );
-                    let border_bottom_color = self.get_brush(
-                        dom_node_id,
-                        &StyleProperty::BorderBottomColor,
-                        Brush::solid(Color::BLACK),
-                    );
-                    let border_left_color =
-                        self.get_brush(dom_node_id, &StyleProperty::BorderLeftColor, Brush::solid(Color::BLACK));
-
-                    let border_style = match doc.get_style(dom_node_id, &StyleProperty::BorderTopStyle) {
-                        Value::BorderStyle(s) => css_border_style_to_paint(&s),
-                        _ => BorderStyle::Solid,
-                    };
-                    let border = Border::new(
-                        border_top_width,
-                        border_style,
-                        [
-                            border_top_color,
-                            border_right_color,
-                            border_bottom_color,
-                            border_left_color,
-                        ],
-                    );
-                    r = r.with_border(border);
-                }
-
-                // Get radius
-                let radius_bottom_left = doc.get_style_f32(dom_node_id, &StyleProperty::BorderBottomLeftRadius);
-                let radius_bottom_right = doc.get_style_f32(dom_node_id, &StyleProperty::BorderBottomRightRadius);
-                let radius_top_left = doc.get_style_f32(dom_node_id, &StyleProperty::BorderTopLeftRadius);
-                let radius_top_right = doc.get_style_f32(dom_node_id, &StyleProperty::BorderTopRightRadius);
-
-                if radius_bottom_left != 0.0
-                    || radius_bottom_right != 0.0
-                    || radius_top_left != 0.0
-                    || radius_top_right != 0.0
-                {
-                    r = r.with_radius_tlrb(
-                        Radius::new(radius_top_left as f64),
-                        Radius::new(radius_top_right as f64),
-                        Radius::new(radius_bottom_right as f64),
-                        Radius::new(radius_bottom_left as f64),
-                    );
-                }
-
+                let r = Rectangle::new(layout_element.box_model.border_box).with_background(brush);
+                let r = self.decorate_with_border_and_radius(dom_node_id, r);
                 commands.push(PaintCommand::rectangle(r));
             }
         }
 
         commands
+    }
+
+    /// Returns true when the element has a non-zero border on any edge.
+    fn has_border(&self, dom_node_id: NodeId) -> bool {
+        let doc = &self.layer_list.layout_tree.render_tree.doc;
+        doc.get_style_f32(dom_node_id, &StyleProperty::BorderTopWidth) != 0.0
+            || doc.get_style_f32(dom_node_id, &StyleProperty::BorderRightWidth) != 0.0
+            || doc.get_style_f32(dom_node_id, &StyleProperty::BorderBottomWidth) != 0.0
+            || doc.get_style_f32(dom_node_id, &StyleProperty::BorderLeftWidth) != 0.0
+    }
+
+    /// Apply the element's computed CSS border and border-radius to `r`. Shared by block,
+    /// image and SVG elements so replaced elements (`<img>`) get their borders too.
+    fn decorate_with_border_and_radius(&self, dom_node_id: NodeId, mut r: Rectangle) -> Rectangle {
+        let doc = &self.layer_list.layout_tree.render_tree.doc;
+
+        let border_top_width = doc.get_style_f32(dom_node_id, &StyleProperty::BorderTopWidth);
+        let border_right_width = doc.get_style_f32(dom_node_id, &StyleProperty::BorderRightWidth);
+        let border_bottom_width = doc.get_style_f32(dom_node_id, &StyleProperty::BorderBottomWidth);
+        let border_left_width = doc.get_style_f32(dom_node_id, &StyleProperty::BorderLeftWidth);
+
+        if border_top_width != 0.0
+            || border_right_width != 0.0
+            || border_bottom_width != 0.0
+            || border_left_width != 0.0
+        {
+            let border_top_color =
+                self.get_brush(dom_node_id, &StyleProperty::BorderTopColor, Brush::solid(Color::BLACK));
+            let border_right_color = self.get_brush(
+                dom_node_id,
+                &StyleProperty::BorderRightColor,
+                Brush::solid(Color::BLACK),
+            );
+            let border_bottom_color = self.get_brush(
+                dom_node_id,
+                &StyleProperty::BorderBottomColor,
+                Brush::solid(Color::BLACK),
+            );
+            let border_left_color =
+                self.get_brush(dom_node_id, &StyleProperty::BorderLeftColor, Brush::solid(Color::BLACK));
+
+            let border_style = match doc.get_style(dom_node_id, &StyleProperty::BorderTopStyle) {
+                Value::BorderStyle(s) => css_border_style_to_paint(&s),
+                _ => BorderStyle::Solid,
+            };
+            let border = Border::new(
+                border_top_width,
+                border_style,
+                [
+                    border_top_color,
+                    border_right_color,
+                    border_bottom_color,
+                    border_left_color,
+                ],
+            );
+            r = r.with_border(border);
+        }
+
+        let radius_bottom_left = doc.get_style_f32(dom_node_id, &StyleProperty::BorderBottomLeftRadius);
+        let radius_bottom_right = doc.get_style_f32(dom_node_id, &StyleProperty::BorderBottomRightRadius);
+        let radius_top_left = doc.get_style_f32(dom_node_id, &StyleProperty::BorderTopLeftRadius);
+        let radius_top_right = doc.get_style_f32(dom_node_id, &StyleProperty::BorderTopRightRadius);
+
+        if radius_bottom_left != 0.0
+            || radius_bottom_right != 0.0
+            || radius_top_left != 0.0
+            || radius_top_right != 0.0
+        {
+            r = r.with_radius_tlrb(
+                Radius::new(radius_top_left as f64),
+                Radius::new(radius_top_right as f64),
+                Radius::new(radius_bottom_right as f64),
+                Radius::new(radius_bottom_left as f64),
+            );
+        }
+
+        r
     }
 }
 

--- a/crates/gosub_render_pipeline/src/painter.rs
+++ b/crates/gosub_render_pipeline/src/painter.rs
@@ -256,10 +256,7 @@ impl Painter {
         let radius_top_left = doc.get_style_f32(dom_node_id, &StyleProperty::BorderTopLeftRadius);
         let radius_top_right = doc.get_style_f32(dom_node_id, &StyleProperty::BorderTopRightRadius);
 
-        if radius_bottom_left != 0.0
-            || radius_bottom_right != 0.0
-            || radius_top_left != 0.0
-            || radius_top_right != 0.0
+        if radius_bottom_left != 0.0 || radius_bottom_right != 0.0 || radius_top_left != 0.0 || radius_top_right != 0.0
         {
             r = r.with_radius_tlrb(
                 Radius::new(radius_top_left as f64),

--- a/crates/gosub_render_pipeline/src/render/backend.rs
+++ b/crates/gosub_render_pipeline/src/render/backend.rs
@@ -95,6 +95,61 @@ fn swap_rb(data: &[u8]) -> Vec<u8> {
     out
 }
 
+impl PixelFormat {
+    /// Reinterpret a little-endian 4-byte pixel (read as a `u32`) into the canonical
+    /// `0xAARRGGBB` packing used for compositing, regardless of source channel order.
+    ///
+    /// On little-endian hosts, `PreMulArgb32` bytes `[B, G, R, A]` already read as
+    /// `0xAARRGGBB`, while `Rgba8` bytes `[R, G, B, A]` read as `0xAABBGGRR` and need
+    /// their red/blue channels swapped.
+    #[inline]
+    pub fn pixel_to_argb_u32(self, px: u32) -> u32 {
+        match self {
+            PixelFormat::PreMulArgb32 => px,
+            PixelFormat::Rgba8 => {
+                let a = px & 0xFF00_0000;
+                let g = px & 0x0000_FF00;
+                let r = px & 0x0000_00FF;
+                let b = (px >> 16) & 0xFF;
+                a | (r << 16) | g | b
+            }
+        }
+    }
+}
+
+/// Alpha-blend a premultiplied source pixel over a premultiplied destination pixel,
+/// both packed as `0xAARRGGBB`. Returns the premultiplied `0xAARRGGBB` result.
+///
+/// This is the "source-over" Porter-Duff operator: `out = src + dst * (1 - src_alpha)`.
+/// Compositing tiles with this (rather than overwriting the destination) lets a
+/// transparent upper-layer tile reveal the content of lower layers beneath it.
+#[inline]
+pub fn blend_over_argb_u32(src: u32, dst: u32) -> u32 {
+    let sa = src >> 24;
+    if sa == 0xFF {
+        return src; // opaque source fully covers the destination
+    }
+    if sa == 0 {
+        return dst; // fully transparent source contributes nothing
+    }
+    let inv = 255 - sa;
+    // Blend the two pixels half a channel-pair at a time to keep it branch-free.
+    // 0x00FF00FF mask isolates R and B; 0xFF00FF00 isolates A and G.
+    let rb = (src & 0x00FF_00FF) + mul_div255_pair(dst & 0x00FF_00FF, inv);
+    let ag = ((src >> 8) & 0x00FF_00FF) + mul_div255_pair((dst >> 8) & 0x00FF_00FF, inv);
+    (rb & 0x00FF_00FF) | ((ag & 0x00FF_00FF) << 8)
+}
+
+/// Multiply each of the two 8-bit channels packed in `pair` (`0x00XX00YY`) by `factor`
+/// (0..=255) and divide by 255 with rounding, returning the packed result.
+#[inline]
+fn mul_div255_pair(pair: u32, factor: u32) -> u32 {
+    // Process both channels at once: add rounding bias, then the classic
+    // `(x + (x >> 8) + 128) >> 8` approximation of `x / 255`.
+    let t = pair * factor + 0x0080_0080;
+    ((t + ((t >> 8) & 0x00FF_00FF)) >> 8) & 0x00FF_00FF
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum GpuPixelFormat {
     Bgra8UnormSrgb,
@@ -303,5 +358,52 @@ impl RenderBackend for RenderBackendRouter {
     #[cfg(feature = "backend_vello")]
     fn wgpu_resources(&self) -> Option<std::sync::Arc<crate::render::backends::vello::WgpuResources>> {
         self.current().wgpu_resources()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const WHITE: u32 = 0xFFFF_FFFF; // opaque white, premultiplied
+    const BLACK: u32 = 0xFF00_0000; // opaque black, premultiplied
+
+    #[test]
+    fn transparent_source_preserves_destination() {
+        // This is the bug the blend fixes: a transparent upper-layer tile must NOT
+        // erase the content drawn beneath it.
+        assert_eq!(blend_over_argb_u32(0x0000_0000, WHITE), WHITE);
+        assert_eq!(blend_over_argb_u32(0x0000_0000, BLACK), BLACK);
+        assert_eq!(blend_over_argb_u32(0x0000_0000, 0xFF12_3456), 0xFF12_3456);
+    }
+
+    #[test]
+    fn opaque_source_replaces_destination() {
+        assert_eq!(blend_over_argb_u32(BLACK, WHITE), BLACK);
+        assert_eq!(blend_over_argb_u32(0xFFAB_CDEF, WHITE), 0xFFAB_CDEF);
+    }
+
+    #[test]
+    fn half_alpha_black_over_white_is_grey() {
+        // Premultiplied 50% black = alpha 0x80, rgb 0. Over opaque white → ~50% grey,
+        // still fully opaque.
+        let out = blend_over_argb_u32(0x8000_0000, WHITE);
+        assert_eq!(out >> 24, 0xFF, "result must be opaque");
+        let r = (out >> 16) & 0xFF;
+        assert!((126..=129).contains(&r), "expected ~half grey, got {r}");
+    }
+
+    #[test]
+    fn rgba8_pixel_normalizes_to_argb() {
+        // Rgba8 little-endian bytes [R,G,B,A] = [0x11,0x22,0x33,0xFF] read as 0xFF332211.
+        let le = u32::from_le_bytes([0x11, 0x22, 0x33, 0xFF]);
+        assert_eq!(PixelFormat::Rgba8.pixel_to_argb_u32(le), 0xFF11_2233);
+    }
+
+    #[test]
+    fn premul_argb32_pixel_is_unchanged() {
+        // PreMulArgb32 little-endian bytes [B,G,R,A] = [0x33,0x22,0x11,0xFF] read as 0xFF112233.
+        let le = u32::from_le_bytes([0x33, 0x22, 0x11, 0xFF]);
+        assert_eq!(PixelFormat::PreMulArgb32.pixel_to_argb_u32(le), 0xFF11_2233);
     }
 }

--- a/crates/gosub_render_pipeline/src/render/mod.rs
+++ b/crates/gosub_render_pipeline/src/render/mod.rs
@@ -7,8 +7,8 @@ pub mod render_list;
 pub mod viewport;
 
 pub use backend::{
-    CompositorSink, ErasedSurface, ExternalHandle, GpuPixelFormat, PixelFormat, PresentMode, RenderBackend,
-    RenderBackendRouter, RgbaImage, SurfaceRect, SurfaceSize, WgpuTextureId,
+    blend_over_argb_u32, CompositorSink, ErasedSurface, ExternalHandle, GpuPixelFormat, PixelFormat, PresentMode,
+    RenderBackend, RenderBackendRouter, RgbaImage, SurfaceRect, SurfaceSize, WgpuTextureId,
 };
 pub use compositor::DefaultCompositor;
 pub use render_context::RenderContext;

--- a/crates/gosub_renderer_cairo/src/rasterizer.rs
+++ b/crates/gosub_renderer_cairo/src/rasterizer.rs
@@ -85,7 +85,7 @@ impl Rasterable for CairoRasterizer {
                 for command in &element.paint_commands {
                     match command {
                         PaintCommand::Svg(command) => {
-                            svg::do_paint_svg(&cr.clone(), tile, &command.rect, command.media_id, media_store);
+                            svg::do_paint_svg(&cr.clone(), tile, &command.rect, command.media_id, media_store, dpr);
                         }
                         PaintCommand::Rectangle(command) => {
                             rectangle::do_paint_rectangle(&cr.clone(), tile, command, media_store);

--- a/crates/gosub_renderer_cairo/src/rasterizer/svg.rs
+++ b/crates/gosub_renderer_cairo/src/rasterizer/svg.rs
@@ -1,49 +1,54 @@
 use cairo::Context;
+use gosub_render_pipeline::common::geo::Dimension;
 use gosub_render_pipeline::common::media::{MediaId, MediaStore};
 use gosub_render_pipeline::painter::commands::rectangle::Rectangle;
 use gosub_render_pipeline::tiler::Tile;
 use resvg::usvg::Transform;
 
-pub(crate) fn do_paint_svg(cr: &Context, tile: &Tile, rect: &Rectangle, media_id: MediaId, media_store: &MediaStore) {
+pub(crate) fn do_paint_svg(
+    cr: &Context,
+    tile: &Tile,
+    rect: &Rectangle,
+    media_id: MediaId,
+    media_store: &MediaStore,
+    dpr: i32,
+) {
     log::debug!("Painting SVG: {:?}", media_id);
     let media = media_store.get_svg(media_id);
 
     let target_dim = rect.rect().dimension();
-    let dest_x = rect.rect().x - tile.rect.x;
-    let dest_y = rect.rect().y - tile.rect.y;
+
+    // Round the placement to integer CSS pixels. The tile context is scaled by `dpr`, so an
+    // integer CSS coordinate maps to an integer device pixel — keeping the glyph/icon on the
+    // device grid. Without this the surface lands on a fractional device pixel (very visible
+    // at dpr ≥ 2) and looks soft and shifted.
+    let dest_x = (rect.rect().x - tile.rect.x).round();
+    let dest_y = (rect.rect().y - tile.rect.y).round();
+
+    // Rasterize at physical resolution (CSS size × dpr) so the icon is crisp instead of being
+    // upscaled from CSS-pixel resolution by the dpr-scaled context. `set_device_scale(dpr)`
+    // then maps the physical surface back to its CSS logical size for placement.
+    let phys_w = (target_dim.width as u32 * dpr.max(1) as u32).max(1);
+    let phys_h = (target_dim.height as u32 * dpr.max(1) as u32).max(1);
+    // The cache stores physical pixels, so key it on the physical dimension (which also
+    // encodes dpr) — a dpr change re-renders rather than reusing a stale-resolution bitmap.
+    let phys_dim = Dimension::new(phys_w as f64, phys_h as f64);
 
     {
         let cached = media.svg.rendered.read();
-        if cached.dimension == target_dim && !cached.data.is_empty() {
-            let surface = match cairo::ImageSurface::create_for_data(
-                cached.data.clone(),
-                cairo::Format::ARgb32,
-                cached.dimension.width as i32,
-                cached.dimension.height as i32,
-                cached.dimension.width as i32 * 4,
-            ) {
-                Ok(s) => s,
-                Err(e) => {
-                    log::warn!("Failed to create image surface for cached SVG {:?}: {:?}", media_id, e);
-                    return;
-                }
-            };
-            _ = cr.set_source_surface(&surface, dest_x, dest_y);
-            _ = cr.paint();
+        if cached.dimension == phys_dim && !cached.data.is_empty() {
+            paint_surface(cr, &cached.data, phys_w, phys_h, dpr, dest_x, dest_y, media_id);
             return;
         }
     }
 
-    let target_w = (target_dim.width as u32).max(1);
-    let target_h = (target_dim.height as u32).max(1);
-
     let pixmap_size = media.svg.tree.size().to_int_size();
     let intrinsic_w = pixmap_size.width().max(1) as f32;
     let intrinsic_h = pixmap_size.height().max(1) as f32;
-    let sx = target_w as f32 / intrinsic_w;
-    let sy = target_h as f32 / intrinsic_h;
+    let sx = phys_w as f32 / intrinsic_w;
+    let sy = phys_h as f32 / intrinsic_h;
 
-    let Some(mut pixmap) = resvg::tiny_skia::Pixmap::new(target_w, target_h) else {
+    let Some(mut pixmap) = resvg::tiny_skia::Pixmap::new(phys_w, phys_h) else {
         log::warn!("SVG has zero or invalid dimensions, skipping render");
         return;
     };
@@ -56,14 +61,30 @@ pub(crate) fn do_paint_svg(cr: &Context, tile: &Tile, rect: &Rectangle, media_id
 
     let mut cached = media.svg.rendered.write();
     cached.data = new_data;
-    cached.dimension = target_dim;
+    cached.dimension = phys_dim;
 
+    paint_surface(cr, &cached.data, phys_w, phys_h, dpr, dest_x, dest_y, media_id);
+}
+
+/// Wrap the physical-pixel ARGB32 buffer in a Cairo surface, scale it back to CSS logical size
+/// via `device_scale`, and paint it at the (grid-aligned) destination.
+#[allow(clippy::too_many_arguments)]
+fn paint_surface(
+    cr: &Context,
+    data: &[u8],
+    phys_w: u32,
+    phys_h: u32,
+    dpr: i32,
+    dest_x: f64,
+    dest_y: f64,
+    media_id: MediaId,
+) {
     let surface = match cairo::ImageSurface::create_for_data(
-        cached.data.clone(),
+        data.to_vec(),
         cairo::Format::ARgb32,
-        cached.dimension.width as i32,
-        cached.dimension.height as i32,
-        cached.dimension.width as i32 * 4,
+        phys_w as i32,
+        phys_h as i32,
+        phys_w as i32 * 4,
     ) {
         Ok(s) => s,
         Err(e) => {
@@ -71,7 +92,11 @@ pub(crate) fn do_paint_svg(cr: &Context, tile: &Tile, rect: &Rectangle, media_id
             return;
         }
     };
+    // device_scale maps the physical surface (phys = CSS × dpr) back to CSS logical units, so it
+    // places 1:1 on the device grid in the dpr-scaled tile context.
+    surface.set_device_scale(dpr.max(1) as f64, dpr.max(1) as f64);
 
     _ = cr.set_source_surface(&surface, dest_x, dest_y);
+    cr.source().set_filter(cairo::Filter::Good);
     _ = cr.paint();
 }

--- a/crates/gosub_renderer_cairo/src/rasterizer/text/pango.rs
+++ b/crates/gosub_renderer_cairo/src/rasterizer/text/pango.rs
@@ -28,7 +28,11 @@ pub(crate) fn do_paint_text(
     let x = cmd.rect.x.round();
     let y = cmd.rect.y.round();
     cr.set_source_surface(&surface, x, y)?;
-    cr.source().set_filter(Filter::Fast);
+    // Use a quality filter rather than nearest-neighbour: when the glyph surface is not
+    // placed on an exact integer-pixel boundary (e.g. fractional display scaling), nearest
+    // sampling resamples the grayscale-AA coverage and shreds the glyph edges. `Good`
+    // collapses to an exact copy when the blit *is* 1:1 aligned, so there is no cost there.
+    cr.source().set_filter(Filter::Good);
     cr.paint()?;
     cr.restore()?;
 
@@ -122,7 +126,10 @@ fn build_pango_layout_inner(
 ) -> pangocairo::pango::Layout {
     if let Ok(mut font_opts) = FontOptions::new() {
         font_opts.set_antialias(Antialias::Gray);
-        font_opts.set_hint_style(HintStyle::Full);
+        // Slight hinting matches browser rendering more closely than Full: it nudges stems
+        // toward the pixel grid for crispness without the heavy snapping that distorts glyph
+        // shapes and produces uneven stroke weights at small sizes.
+        font_opts.set_hint_style(HintStyle::Slight);
         font_opts.set_hint_metrics(HintMetrics::On);
         cr.set_font_options(&font_opts);
     }

--- a/examples/egui-cairo/main.rs
+++ b/examples/egui-cairo/main.rs
@@ -11,7 +11,7 @@ use gosub_engine::storage::{InMemorySessionStore, PartitionPolicy, SqliteLocalSt
 use gosub_engine::tab::{TabDefaults, TabHandle, TabId};
 use gosub_engine::zone::{Zone, ZoneConfig, ZoneId, ZoneServices};
 use gosub_engine::GosubEngine;
-use gosub_render_pipeline::render::backend::ExternalHandle;
+use gosub_render_pipeline::render::backend::{blend_over_argb_u32, ExternalHandle};
 use gosub_render_pipeline::render::backends::cairo::{CairoBackend, DEVICE_PIXEL_RATIO};
 use gosub_render_pipeline::render::DefaultCompositor;
 use once_cell::sync::Lazy;
@@ -218,7 +218,8 @@ impl BrowserApp {
                 // Physical-pixel scroll offset using local state (no async roundtrip).
                 let sx = (self.scroll_x * dpr_f) as i64;
                 let sy = (self.scroll_y * dpr_f) as i64;
-                let mut buf = vec![0x00FF_FFFFu32; w * h];
+                // Opaque white: a valid premultiplied background for source-over blending.
+                let mut buf = vec![0xFFFF_FFFFu32; w * h];
 
                 for tile in tiles.iter() {
                     // Physical-pixel position of this tile on the page.
@@ -256,7 +257,12 @@ impl BrowserApp {
                         }
                         let src_off = tile_row * tw + tile_start_col;
                         let dst_off = dst_y * w + dst_x;
-                        buf[dst_off..dst_off + copy_w].copy_from_slice(&tile_u32[src_off..src_off + copy_w]);
+                        // Source-over blend so transparent upper-layer pixels reveal the
+                        // content beneath, instead of overwriting it.
+                        for col in 0..copy_w {
+                            let src_argb = tile.format.pixel_to_argb_u32(tile_u32[src_off + col]);
+                            buf[dst_off + col] = blend_over_argb_u32(src_argb, buf[dst_off + col]);
+                        }
                     }
                 }
 

--- a/examples/egui-skia/main.rs
+++ b/examples/egui-skia/main.rs
@@ -10,7 +10,7 @@ use gosub_engine::storage::{InMemorySessionStore, PartitionPolicy, SqliteLocalSt
 use gosub_engine::tab::{TabDefaults, TabHandle, TabId};
 use gosub_engine::zone::{Zone, ZoneConfig, ZoneId, ZoneServices};
 use gosub_engine::GosubEngine;
-use gosub_render_pipeline::render::backend::ExternalHandle;
+use gosub_render_pipeline::render::backend::{blend_over_argb_u32, ExternalHandle};
 use gosub_render_pipeline::render::backends::skia::SkiaBackend;
 use gosub_render_pipeline::render::DefaultCompositor;
 use once_cell::sync::Lazy;
@@ -205,7 +205,8 @@ impl BrowserApp {
                 // Physical-pixel scroll offset using local state (no async roundtrip).
                 let sx = (self.scroll_x * dpr_f) as i64;
                 let sy = (self.scroll_y * dpr_f) as i64;
-                let mut buf = vec![0x00FF_FFFFu32; w * h];
+                // Opaque white: a valid premultiplied background for source-over blending.
+                let mut buf = vec![0xFFFF_FFFFu32; w * h];
                 for tile in tiles.iter() {
                     let px = (tile.page_x * dpr_f) as i64;
                     let py = (tile.page_y * dpr_f) as i64;
@@ -238,7 +239,12 @@ impl BrowserApp {
                         }
                         let src_off = tile_row * tw + tile_start_col;
                         let dst_off = dst_y * w + dst_x;
-                        buf[dst_off..dst_off + copy_w].copy_from_slice(&tile_u32[src_off..src_off + copy_w]);
+                        // Source-over blend so transparent upper-layer pixels reveal the
+                        // content beneath, instead of overwriting it.
+                        for col in 0..copy_w {
+                            let src_argb = tile.format.pixel_to_argb_u32(tile_u32[src_off + col]);
+                            buf[dst_off + col] = blend_over_argb_u32(src_argb, buf[dst_off + col]);
+                        }
                     }
                 }
                 let mut rgba = Vec::with_capacity(w * h * 4);

--- a/examples/egui-vello/main.rs
+++ b/examples/egui-vello/main.rs
@@ -10,7 +10,7 @@ use gosub_engine::storage::{InMemorySessionStore, PartitionPolicy, SqliteLocalSt
 use gosub_engine::tab::{TabDefaults, TabHandle, TabId};
 use gosub_engine::zone::{Zone, ZoneConfig, ZoneId, ZoneServices};
 use gosub_engine::GosubEngine;
-use gosub_render_pipeline::render::backend::ExternalHandle;
+use gosub_render_pipeline::render::backend::{blend_over_argb_u32, ExternalHandle};
 use gosub_render_pipeline::render::backends::vello::{VelloBackend, WgpuContextProvider};
 use gosub_render_pipeline::render::{DefaultCompositor, Viewport};
 use once_cell::sync::Lazy;
@@ -288,7 +288,8 @@ impl BrowserApp {
                 }
                 let sx = (self.scroll_x * dpr_f) as i64;
                 let sy = (self.scroll_y * dpr_f) as i64;
-                let mut buf = vec![0x00FF_FFFFu32; w * h];
+                // Opaque white: a valid premultiplied background for source-over blending.
+                let mut buf = vec![0xFFFF_FFFFu32; w * h];
 
                 for tile in tiles.iter() {
                     let px = (tile.page_x * dpr_f) as i64;
@@ -325,7 +326,13 @@ impl BrowserApp {
                         }
                         let src_off = tile_row * tw + tile_start_col;
                         let dst_off = dst_y * w + dst_x;
-                        buf[dst_off..dst_off + copy_w].copy_from_slice(&tile_u32[src_off..src_off + copy_w]);
+                        // Source-over blend so transparent upper-layer pixels reveal the
+                        // content beneath, instead of overwriting it. `buf` and `tile_u32`
+                        // are both [R,G,B,A]; the blend is channel-symmetric, so the
+                        // swapped R/B (vs. ARGB) does not affect the result.
+                        for col in 0..copy_w {
+                            buf[dst_off + col] = blend_over_argb_u32(tile_u32[src_off + col], buf[dst_off + col]);
+                        }
                     }
                 }
 

--- a/examples/gtk4-cairo/Cargo.toml
+++ b/examples/gtk4-cairo/Cargo.toml
@@ -10,7 +10,8 @@ path = "main.rs"
 [dependencies]
 gosub_engine = { path = "../../crates/gosub_engine", features = ["gtk4", "backend_cairo_pango", "sqlite_cookie_store"] }
 gosub_render_pipeline = { path = "../../crates/gosub_render_pipeline", features = ["backend_cairo"] }
-gtk4 = { workspace = true }
+# v4_12 enables GdkSurface::scale() for true fractional display-scale detection.
+gtk4 = { workspace = true, features = ["v4_12"] }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }

--- a/examples/gtk4-cairo/main.rs
+++ b/examples/gtk4-cairo/main.rs
@@ -482,7 +482,7 @@ fn main() {
             let local_tiles = local_tiles.clone();
             let local_scroll = local_scroll.clone();
             move |area, w, h| {
-                let scale = area.scale_factor() as u32;
+                let scale = render_dpr(area);
                 DEVICE_PIXEL_RATIO.store(scale, std::sync::atomic::Ordering::Relaxed);
                 // Clear cached tiles — they were rasterized for the old viewport size.
                 *local_tiles.borrow_mut() = None;
@@ -637,6 +637,25 @@ fn main() {
     app.run_with_args(&argv0);
 }
 
+/// Resolve the device-pixel ratio to render at for `widget`.
+///
+/// `GtkWidget::scale_factor()` only ever reports an integer, so on a fractionally scaled
+/// display (e.g. 1.25× or 1.5×, common on Wayland) it returns 1 and the page is rasterized
+/// at logical resolution — the compositor then upscales the whole surface, blurring text.
+///
+/// `GdkSurface::scale()` exposes the true fractional scale. We round it *up* to the next
+/// integer and render at that resolution; downscaling a slightly-too-large buffer to the
+/// display's fractional size stays sharp, whereas upscaling a too-small one does not.
+fn render_dpr(widget: &impl IsA<gtk4::Widget>) -> u32 {
+    let fractional = widget
+        .native()
+        .and_then(|n| n.surface())
+        .map(|s| s.scale())
+        .filter(|s| *s > 0.0)
+        .unwrap_or_else(|| widget.scale_factor() as f64);
+    fractional.ceil().max(1.0) as u32
+}
+
 /// Composite a TileDrawState at the given scroll position into `cr`.
 fn draw_tile_cache(cr: &gtk4::cairo::Context, w: i32, h: i32, state: &TileDrawState, scroll_x: f32, scroll_y: f32) {
     let dpr_i = state.dpr as i32;
@@ -720,7 +739,11 @@ fn draw_tile_cache(cr: &gtk4::cairo::Context, w: i32, h: i32, state: &TileDrawSt
     dst.set_device_scale(dpr_f, dpr_f);
 
     cr.set_source_surface(&dst, 0.0, 0.0).unwrap_or_default();
-    cr.source().set_filter(gtk4::cairo::Filter::Nearest);
+    // `dst` is rendered at an integer DPR that is the ceil of the display's (possibly
+    // fractional) scale, so the draw context resamples it to the real device resolution.
+    // `Good` keeps that down/up-scale smooth. There are no internal tile seams to worry
+    // about here because all tiles were already CPU-blitted into this single surface.
+    cr.source().set_filter(gtk4::cairo::Filter::Good);
     cr.paint().unwrap_or_default();
 }
 

--- a/examples/gtk4-cairo/main.rs
+++ b/examples/gtk4-cairo/main.rs
@@ -12,7 +12,7 @@ use gosub_engine::storage::{InMemorySessionStore, PartitionPolicy, SqliteLocalSt
 use gosub_engine::tab::{TabDefaults, TabId};
 use gosub_engine::zone::{ZoneConfig, ZoneId, ZoneServices};
 use gosub_engine::GosubEngine;
-use gosub_render_pipeline::render::backend::{CachedTile, ExternalHandle};
+use gosub_render_pipeline::render::backend::{blend_over_argb_u32, CachedTile, ExternalHandle};
 use gosub_render_pipeline::render::backends::cairo::DEVICE_PIXEL_RATIO;
 use gosub_render_pipeline::render::DefaultCompositor;
 use gtk4::glib;
@@ -700,7 +700,18 @@ fn draw_tile_cache(cr: &gtk4::cairo::Context, w: i32, h: i32, state: &TileDrawSt
                 }
                 let src_off = (tile_row * tw_usize + tile_col0) * 4;
                 let dst_off = dst_y * stride + dst_x * 4;
-                data[dst_off..dst_off + copy_w * 4].copy_from_slice(&tile.data[src_off..src_off + copy_w * 4]);
+                // Alpha-blend (source-over) rather than overwrite, so transparent
+                // pixels of an upper-layer tile reveal the content drawn beneath it.
+                for col in 0..copy_w {
+                    let s = src_off + col * 4;
+                    let d = dst_off + col * 4;
+                    let src_px =
+                        u32::from_le_bytes([tile.data[s], tile.data[s + 1], tile.data[s + 2], tile.data[s + 3]]);
+                    let src_argb = tile.format.pixel_to_argb_u32(src_px);
+                    let dst_px = u32::from_le_bytes([data[d], data[d + 1], data[d + 2], data[d + 3]]);
+                    let out = blend_over_argb_u32(src_argb, dst_px);
+                    data[d..d + 4].copy_from_slice(&out.to_le_bytes());
+                }
             }
         }
     }

--- a/examples/gtk4-skia/main.rs
+++ b/examples/gtk4-skia/main.rs
@@ -11,7 +11,7 @@ use gosub_engine::storage::{InMemorySessionStore, PartitionPolicy, SqliteLocalSt
 use gosub_engine::tab::{TabDefaults, TabId};
 use gosub_engine::zone::{ZoneConfig, ZoneId, ZoneServices};
 use gosub_engine::GosubEngine;
-use gosub_render_pipeline::render::backend::{CachedTile, ExternalHandle};
+use gosub_render_pipeline::render::backend::{blend_over_argb_u32, CachedTile, ExternalHandle};
 use gosub_render_pipeline::render::DefaultCompositor;
 use gtk4::glib;
 use gtk4::prelude::*;
@@ -696,7 +696,18 @@ fn draw_tile_cache(cr: &gtk4::cairo::Context, w: i32, h: i32, state: &TileDrawSt
                 }
                 let src_off = (tile_row * tw_usize + tile_col0) * 4;
                 let dst_off = dst_y * stride + dst_x * 4;
-                data[dst_off..dst_off + copy_w * 4].copy_from_slice(&tile.data[src_off..src_off + copy_w * 4]);
+                // Alpha-blend (source-over) rather than overwrite, so transparent
+                // pixels of an upper-layer tile reveal the content drawn beneath it.
+                for col in 0..copy_w {
+                    let s = src_off + col * 4;
+                    let d = dst_off + col * 4;
+                    let src_px =
+                        u32::from_le_bytes([tile.data[s], tile.data[s + 1], tile.data[s + 2], tile.data[s + 3]]);
+                    let src_argb = tile.format.pixel_to_argb_u32(src_px);
+                    let dst_px = u32::from_le_bytes([data[d], data[d + 1], data[d + 2], data[d + 3]]);
+                    let out = blend_over_argb_u32(src_argb, dst_px);
+                    data[d..d + 4].copy_from_slice(&out.to_le_bytes());
+                }
             }
         }
     }

--- a/examples/winit-cairo/main.rs
+++ b/examples/winit-cairo/main.rs
@@ -11,7 +11,7 @@ use gosub_engine::storage::{InMemorySessionStore, PartitionPolicy, SqliteLocalSt
 use gosub_engine::tab::{TabDefaults, TabHandle, TabId};
 use gosub_engine::zone::{Zone, ZoneConfig, ZoneId, ZoneServices};
 use gosub_engine::GosubEngine;
-use gosub_render_pipeline::render::backend::ExternalHandle;
+use gosub_render_pipeline::render::backend::{blend_over_argb_u32, ExternalHandle};
 use gosub_render_pipeline::render::backends::cairo::{CairoBackend, DEVICE_PIXEL_RATIO};
 use gosub_render_pipeline::render::DefaultCompositor;
 use once_cell::sync::Lazy;
@@ -130,8 +130,8 @@ impl BrowserApp {
 
         let Ok(mut buf) = surface.buffer_mut() else { return };
 
-        // Fill white
-        buf.fill(0x00FF_FFFF);
+        // Fill opaque white (valid premultiplied background for source-over blending).
+        buf.fill(0xFFFF_FFFF);
 
         // Composite engine content into the content area (below address bar).
         let content_h = win_h.saturating_sub(ADDRESS_BAR_HEIGHT);
@@ -455,7 +455,10 @@ fn blit_handle_to_buffer(
                     let buf_row = (addr_h as usize + dst_y) * win_w as usize + dst_x;
                     let src_row = tile_row * tw_usize + tile_col0;
                     for col in 0..copy_w {
-                        buf[buf_row + col] = tile_u32[src_row + col] & 0x00FF_FFFF;
+                        // Source-over blend so transparent upper-layer pixels reveal the
+                        // content (or white background) beneath, instead of overwriting it.
+                        let src_argb = tile.format.pixel_to_argb_u32(tile_u32[src_row + col]);
+                        buf[buf_row + col] = blend_over_argb_u32(src_argb, buf[buf_row + col]);
                     }
                 }
             }

--- a/examples/winit-skia/main.rs
+++ b/examples/winit-skia/main.rs
@@ -10,7 +10,7 @@ use gosub_engine::storage::{InMemorySessionStore, PartitionPolicy, SqliteLocalSt
 use gosub_engine::tab::{TabDefaults, TabHandle, TabId};
 use gosub_engine::zone::{Zone, ZoneConfig, ZoneId, ZoneServices};
 use gosub_engine::GosubEngine;
-use gosub_render_pipeline::render::backend::ExternalHandle;
+use gosub_render_pipeline::render::backend::{blend_over_argb_u32, ExternalHandle};
 use gosub_render_pipeline::render::backends::skia::SkiaBackend;
 use gosub_render_pipeline::render::DefaultCompositor;
 use once_cell::sync::Lazy;
@@ -98,7 +98,8 @@ impl BrowserApp {
         }
 
         let Ok(mut buf) = surface.buffer_mut() else { return };
-        buf.fill(0x00FF_FFFF);
+        // Opaque white: a valid premultiplied background for source-over blending.
+        buf.fill(0xFFFF_FFFF);
 
         let content_h = win_h.saturating_sub(ADDRESS_BAR_HEIGHT);
         if content_h > 0 {
@@ -373,15 +374,17 @@ fn blit_to_buffer(
                     if cw == 0 {
                         break;
                     }
-                    // Skia tiles are BGRA8888; softbuffer wants 0x00RRGGBB.
-                    // BGRA as little-endian u32 = B|(G<<8)|(R<<16)|(A<<24).
-                    // 0x00RRGGBB                = B|(G<<8)|(R<<16) = px & 0x00FFFFFF.
+                    // Skia tiles are BGRA8888 (premultiplied); reinterpreted as a
+                    // little-endian u32 they read as 0xAARRGGBB. Source-over blend so
+                    // transparent upper-layer pixels reveal the content beneath instead
+                    // of overwriting it. softbuffer ignores the high (alpha) byte.
                     let row_off = row * tw + col_start;
                     let src = &tile_u32[row_off..row_off + cw];
                     let dst_base = dst_y * win_w as usize + screen_x;
                     let dst = &mut buf[dst_base..dst_base + cw];
                     for (d, &s) in dst.iter_mut().zip(src.iter()) {
-                        *d = s & 0x00_FF_FF_FF;
+                        let src_argb = tile.format.pixel_to_argb_u32(s);
+                        *d = blend_over_argb_u32(src_argb, *d);
                     }
                 }
             }


### PR DESCRIPTION
This is a very specific fix for getting the hackernews logo [Y] rendered properly on the screen. It will fix more issues with other images, svg's and tables, but we focused on one specific image for now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved rendering quality for SVGs, images, text, and tiled content across the app.
  * Added support for smoother alpha blending in rendered surfaces.
* **Bug Fixes**
  * Fixed SVGs appearing at incorrect sizes or with clipped layout.
  * Improved table sizing for nested tables and content-driven column widths.
  * Corrected tile compositing so transparent pixels now blend properly instead of overwriting content.
* **Chores**
  * Updated development and build settings to reduce compile and link overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->