### PR TITLE
Implemented CSS background images (and SVG)

### DIFF
--- a/crates/gosub_css3/src/system.rs
+++ b/crates/gosub_css3/src/system.rs
@@ -106,22 +106,44 @@ impl CssSystem for Css3System {
                                 // `margin: 0 auto` expansion (starting at multi=1 instead of 0).
                                 fix_list.reset_multiplier(&declaration.property);
                                 if !definition.matches_and_shorthands(match_value, &mut fix_list) {
-                                    // Special-case: `background: <color>` — the full shorthand
-                                    // syntax requires comma-separated layers and the simple
-                                    // single-color form fails the complex syntax. Treat it as
-                                    // `background-color: <color>` which the consumer expects.
+                                    // Special-case: the full `background` shorthand grammar
+                                    // (comma-separated `<bg-layer>` lists) is stricter than the
+                                    // matcher supports, so common forms like
+                                    // `background: url(x) no-repeat` or `background: #fff` fail
+                                    // validation and would be dropped entirely. Recover the parts
+                                    // the consumer understands — `background-image` (a `url()`)
+                                    // and `background-color` (a color) — and emit them as the
+                                    // corresponding longhands. Position/repeat/size are still
+                                    // ignored.
                                     if declaration.property == "background" {
-                                        if let CssValue::Color(_) = &value {
+                                        let mut recovered = false;
+                                        if let Some(url_value) = find_background_url(&value) {
+                                            add_property_to_map(
+                                                &mut css_map_entry,
+                                                sheet,
+                                                specificity,
+                                                &CssDeclaration {
+                                                    property: "background-image".to_string(),
+                                                    value: url_value,
+                                                    important: declaration.important,
+                                                },
+                                            );
+                                            recovered = true;
+                                        }
+                                        if let Some(color_value) = find_background_color(&value) {
                                             add_property_to_map(
                                                 &mut css_map_entry,
                                                 sheet,
                                                 specificity,
                                                 &CssDeclaration {
                                                     property: "background-color".to_string(),
-                                                    value,
+                                                    value: color_value,
                                                     important: declaration.important,
                                                 },
                                             );
+                                            recovered = true;
+                                        }
+                                        if recovered {
                                             continue;
                                         }
                                     }
@@ -290,6 +312,26 @@ fn collect_custom_props<C: HasDocument<CssSystem = Css3System>>(
         }
     }
     custom_props
+}
+
+/// Recursively find the first `url(...)` function inside a (possibly nested/list) CSS value.
+/// Used to recover `background-image` from a `background` shorthand that fails strict matching.
+fn find_background_url(value: &CssValue) -> Option<CssValue> {
+    match value {
+        CssValue::Function(name, _) if name.eq_ignore_ascii_case("url") => Some(value.clone()),
+        CssValue::List(list) => list.iter().find_map(find_background_url),
+        _ => None,
+    }
+}
+
+/// Recursively find the first color inside a (possibly nested/list) CSS value.
+/// Used to recover `background-color` from a `background` shorthand.
+fn find_background_color(value: &CssValue) -> Option<CssValue> {
+    match value {
+        CssValue::Color(_) => Some(value.clone()),
+        CssValue::List(list) => list.iter().find_map(find_background_color),
+        _ => None,
+    }
 }
 
 pub fn resolve_functions<C: HasDocument>(

--- a/crates/gosub_render_pipeline/Cargo.toml
+++ b/crates/gosub_render_pipeline/Cargo.toml
@@ -8,7 +8,7 @@ autobins = false
 [dependencies]
 taffy = { workspace = true, features = ["std", "taffy_tree", "flexbox", "grid", "block_layout", "content_size", "calc"] }
 log = { workspace = true }
-image = { workspace = true, features = ["png"] }
+image = { workspace = true, features = ["png", "jpeg", "gif"] }
 rand = { workspace = true }
 sha2 = "0.10.8"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/gosub_render_pipeline/src/common/document/inline_style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/inline_style.rs
@@ -20,6 +20,16 @@ pub fn parse_inline_style_attr(style_attr: &str) -> NodeStyle {
     style
 }
 
+/// Extract the target of a `url(...)` token from a CSS value string, stripping surrounding
+/// quotes. Returns `None` when there is no `url()` (e.g. a gradient or plain color).
+fn parse_css_url(value: &str) -> Option<String> {
+    let start = value.find("url(")? + "url(".len();
+    let rest = &value[start..];
+    let end = rest.find(')')?;
+    let inner = rest[..end].trim().trim_matches(['"', '\'']).trim();
+    (!inner.is_empty()).then(|| inner.to_string())
+}
+
 fn parse_background_color_token(value: &str) -> Option<Value> {
     for token in value.split_whitespace() {
         let v = parse_named_color(token);
@@ -262,6 +272,14 @@ fn apply_style_kv(style: &mut NodeStyle, key: &str, value: &str) {
             if let Some(color) = parse_background_color_token(value) {
                 style.set(StyleProperty::BackgroundColor, color);
             }
+            if let Some(url) = parse_css_url(value) {
+                style.set(StyleProperty::BackgroundImage, Value::Keyword(intern(&url)));
+            }
+        }
+        "background-image" => {
+            if let Some(url) = parse_css_url(value) {
+                style.set(StyleProperty::BackgroundImage, Value::Keyword(intern(&url)));
+            }
         }
 
         "font-weight" => style.set(StyleProperty::FontWeight, parse_font_weight(value)),
@@ -468,5 +486,41 @@ pub fn html_presentation_attr(attrs: &HashMap<String, String>, prop: &StylePrope
             }
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_url_from_value() {
+        assert_eq!(parse_css_url("url(grayarrow.gif)").as_deref(), Some("grayarrow.gif"));
+        assert_eq!(parse_css_url("url('a b.png')").as_deref(), Some("a b.png"));
+        assert_eq!(parse_css_url(r#"url("x.gif") no-repeat"#).as_deref(), Some("x.gif"));
+        assert_eq!(parse_css_url("#fff no-repeat"), None);
+        assert_eq!(parse_css_url("url()"), None);
+    }
+
+    #[test]
+    fn background_shorthand_sets_image_and_color() {
+        let style = parse_inline_style_attr("background: #fff url(grayarrow.gif) no-repeat");
+        assert!(matches!(
+            style.get_own(&StyleProperty::BackgroundImage),
+            Some(Value::Keyword(_))
+        ));
+        assert!(matches!(
+            style.get_own(&StyleProperty::BackgroundColor),
+            Some(Value::Color(255, 255, 255, 255))
+        ));
+    }
+
+    #[test]
+    fn background_image_longhand() {
+        let style = parse_inline_style_attr("background-image: url(pic.png)");
+        assert!(matches!(
+            style.get_own(&StyleProperty::BackgroundImage),
+            Some(Value::Keyword(_))
+        ));
     }
 }

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -177,6 +177,39 @@ fn css_property_to_value<S: CssSystem>(p: &S::Property, prop: &StyleProperty) ->
     }
 }
 
+/// Recursively search a CSS value tree for the first `url(...)` token and return its
+/// (unresolved) target, stripping any quotes. Used for `background-image`.
+fn css_value_url<S: CssSystem>(v: &S::Value) -> Option<String> {
+    if let Some((name, args)) = v.as_function() {
+        if name.eq_ignore_ascii_case("url") {
+            if let Some(s) = args.iter().find_map(|a| a.as_string()) {
+                return Some(s.trim_matches(['"', '\'']).to_string());
+            }
+        }
+    }
+    if let Some(list) = v.as_list() {
+        return list.iter().find_map(css_value_url::<S>);
+    }
+    None
+}
+
+/// Extract the first `url(...)` from a property's actual value. Handles both the
+/// `background-image` longhand (a bare `url()` function) and the `background` shorthand,
+/// whose value is a list like `[url(...), no-repeat]`.
+fn css_property_url<S: CssSystem>(p: &S::Property) -> Option<String> {
+    if let Some((name, args)) = p.as_function() {
+        if name.eq_ignore_ascii_case("url") {
+            if let Some(s) = args.iter().find_map(|a| a.as_string()) {
+                return Some(s.trim_matches(['"', '\'']).to_string());
+            }
+        }
+    }
+    if let Some(list) = p.as_list() {
+        return list.iter().find_map(css_value_url::<S>);
+    }
+    None
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum PipelineNodeKind {
     Text,
@@ -414,6 +447,22 @@ where
                     }
                 }
             }
+        }
+
+        // background-image: accept the `background-image` longhand or a `url(...)` inside the
+        // `background` shorthand. Shorthands are stored under their own key (not expanded into
+        // longhands), so the shorthand must be inspected explicitly — same pattern as
+        // `text-decoration` above. The returned keyword is the unresolved URL; the layouter
+        // resolves it against the base URL and loads it into the media store.
+        if matches!(prop, StyleProperty::BackgroundImage) {
+            for key in ["background-image", "background"] {
+                if let Some(p) = <_ as CssPropertyMap<C::CssSystem>>::get(arc.as_ref(), key) {
+                    if let Some(url) = css_property_url::<C::CssSystem>(p) {
+                        return Some(Value::Keyword(intern(&url)));
+                    }
+                }
+            }
+            return None;
         }
 
         if let Some(p) = <_ as CssPropertyMap<C::CssSystem>>::get(arc.as_ref(), css_name) {

--- a/crates/gosub_render_pipeline/src/common/document/style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/style.rs
@@ -305,6 +305,7 @@ pub enum StyleProperty {
     FontStyle,
     WhiteSpace,
     TextDecorationLine,
+    BackgroundImage,
 }
 
 impl StyleProperty {
@@ -382,6 +383,7 @@ impl StyleProperty {
             StyleProperty::FontStyle => 68,
             StyleProperty::WhiteSpace => 69,
             StyleProperty::TextDecorationLine => 70,
+            StyleProperty::BackgroundImage => 71,
         }
     }
 
@@ -875,6 +877,12 @@ static PROPERTIES: &[PropertyMeta] = &[
         inherited: true,
         initial_kind: InitialKind::Keyword("none"),
     },
+    // 71 background-image — not inherited; initial = none
+    PropertyMeta {
+        name: "background-image",
+        inherited: false,
+        initial_kind: InitialKind::Keyword("none"),
+    },
 ];
 
 // ── NodeStyle — replaces StylePropertyList ────────────────────────────────────
@@ -1008,6 +1016,7 @@ fn from_id(id: u8) -> Option<StyleProperty> {
         68 => Some(StyleProperty::FontStyle),
         69 => Some(StyleProperty::WhiteSpace),
         70 => Some(StyleProperty::TextDecorationLine),
+        71 => Some(StyleProperty::BackgroundImage),
         _ => None,
     }
 }

--- a/crates/gosub_render_pipeline/src/common/media/media_store.rs
+++ b/crates/gosub_render_pipeline/src/common/media/media_store.rs
@@ -305,7 +305,19 @@ impl MediaStore {
 
 fn detect_file_type(data: &Bytes) -> Option<MediaType> {
     let ft = FileType::from_bytes(data);
-    ft_detect(ft)
+    if let Some(media_type) = ft_detect(ft) {
+        return Some(media_type);
+    }
+
+    // The `file_type` crate misses some raster magic numbers — notably GIF, which it reports
+    // as `application/octet-stream`. Fall back to the `image` crate's own format sniffing,
+    // which reliably recognises GIF/PNG/JPEG/WebP/etc. SVG is handled above (it's XML text,
+    // not something `image` decodes), so this only ever adds raster formats.
+    if image::guess_format(data).is_ok() {
+        return Some(MediaType::Image);
+    }
+
+    None
 }
 
 fn detect_content_type(content_type: &str) -> Option<MediaType> {
@@ -314,6 +326,77 @@ fn detect_content_type(content_type: &str) -> Option<MediaType> {
         return None;
     }
     ft_detect(ft[0])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
+    use std::io::Cursor;
+
+    /// Encode a small solid image into `format`, returning the raw bytes.
+    fn encode(format: ImageFormat) -> Vec<u8> {
+        let rgba = DynamicImage::ImageRgba8(RgbaImage::from_pixel(8, 4, Rgba([200, 100, 50, 255])));
+        let mut buf = Cursor::new(Vec::new());
+        match format {
+            // JPEG has no alpha channel, so encode from an RGB view.
+            ImageFormat::Jpeg => DynamicImage::ImageRgb8(rgba.to_rgb8())
+                .write_to(&mut buf, format)
+                .expect("encode jpeg"),
+            _ => rgba.write_to(&mut buf, format).expect("encode image"),
+        }
+        buf.into_inner()
+    }
+
+    /// The byte-sniffing detector must classify PNG/JPEG/GIF as raster images. If this
+    /// returns `None`, `fetch_resource` would bail and the image silently becomes the
+    /// broken-image placeholder.
+    #[test]
+    fn detects_raster_formats_from_bytes() {
+        for format in [ImageFormat::Png, ImageFormat::Jpeg, ImageFormat::Gif] {
+            let bytes = Bytes::from(encode(format));
+            assert_eq!(
+                detect_file_type(&bytes),
+                Some(MediaType::Image),
+                "{format:?} bytes were not detected as a raster image"
+            );
+        }
+    }
+
+    /// Content-type header detection must also recognise the common raster mime types.
+    #[test]
+    fn detects_raster_formats_from_content_type() {
+        for ct in ["image/gif", "image/png", "image/jpeg"] {
+            assert_eq!(
+                detect_content_type(ct),
+                Some(MediaType::Image),
+                "content-type {ct} was not detected as a raster image"
+            );
+        }
+    }
+
+    /// Each of PNG/JPEG/GIF must decode through `load_media_from_data` and land in the
+    /// store with its real dimensions — not collapse to the fallback placeholder.
+    #[test]
+    fn decodes_png_jpeg_gif() {
+        for format in [ImageFormat::Png, ImageFormat::Jpeg, ImageFormat::Gif] {
+            let store = MediaStore::new();
+            let bytes = encode(format);
+
+            let media_id = store
+                .load_media_from_data(MediaType::Image, &bytes)
+                .unwrap_or_else(|e| panic!("{format:?} failed to load: {e}"));
+
+            assert!(
+                !store.is_placeholder(media_id),
+                "{format:?} fell back to the placeholder instead of decoding"
+            );
+
+            let img = store.get_image(media_id);
+            assert_eq!(img.image.width(), 8, "{format:?} width");
+            assert_eq!(img.image.height(), 4, "{format:?} height");
+        }
+    }
 }
 
 fn ft_detect(ft: &FileType) -> Option<MediaType> {

--- a/crates/gosub_render_pipeline/src/common/media/media_store.rs
+++ b/crates/gosub_render_pipeline/src/common/media/media_store.rs
@@ -328,6 +328,25 @@ fn detect_content_type(content_type: &str) -> Option<MediaType> {
     ft_detect(ft[0])
 }
 
+fn ft_detect(ft: &FileType) -> Option<MediaType> {
+    // Scan *all* media types before deciding. The `file_type` crate lists several aliases
+    // for SVG (e.g. `["image/SVG", "image/svg+xml"]`); a naive first-match-wins loop trips
+    // the generic `image/` branch on the non-standard `image/SVG` alias and misclassifies
+    // SVG as a raster image. So look for any SVG marker first, and only fall back to a
+    // generic raster image if none is found. Comparisons are case-insensitive.
+    let mut is_raster_image = false;
+    for &mt in ft.media_types().iter() {
+        if mt.eq_ignore_ascii_case("image/svg+xml") || mt.eq_ignore_ascii_case("image/svg") {
+            return Some(MediaType::Svg);
+        }
+        if mt.len() >= 6 && mt[..6].eq_ignore_ascii_case("image/") {
+            is_raster_image = true;
+        }
+    }
+
+    is_raster_image.then_some(MediaType::Image)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -397,23 +416,4 @@ mod tests {
             assert_eq!(img.image.height(), 4, "{format:?} height");
         }
     }
-}
-
-fn ft_detect(ft: &FileType) -> Option<MediaType> {
-    // Scan *all* media types before deciding. The `file_type` crate lists several aliases
-    // for SVG (e.g. `["image/SVG", "image/svg+xml"]`); a naive first-match-wins loop trips
-    // the generic `image/` branch on the non-standard `image/SVG` alias and misclassifies
-    // SVG as a raster image. So look for any SVG marker first, and only fall back to a
-    // generic raster image if none is found. Comparisons are case-insensitive.
-    let mut is_raster_image = false;
-    for &mt in ft.media_types().iter() {
-        if mt.eq_ignore_ascii_case("image/svg+xml") || mt.eq_ignore_ascii_case("image/svg") {
-            return Some(MediaType::Svg);
-        }
-        if mt.len() >= 6 && mt[..6].eq_ignore_ascii_case("image/") {
-            is_raster_image = true;
-        }
-    }
-
-    is_raster_image.then_some(MediaType::Image)
 }

--- a/crates/gosub_render_pipeline/src/layouter.rs
+++ b/crates/gosub_render_pipeline/src/layouter.rs
@@ -141,6 +141,17 @@ pub struct LayoutElementNode {
     pub box_model: BoxModel,
     /// Element context. Used by different parts of the render engine
     pub context: ElementContext,
+    /// The element's CSS `background-image`, resolved and loaded into the media store during
+    /// layout. `None` when the element has no background image. Carries the media kind so the
+    /// painter can pick raster (`Brush::image`) vs SVG (`PaintCommand::svg`) rendering.
+    pub background_media: Option<BackgroundMedia>,
+}
+
+/// A resolved CSS `background-image` together with its media kind.
+#[derive(Debug, Clone, Copy)]
+pub enum BackgroundMedia {
+    Image(MediaId),
+    Svg(MediaId),
 }
 
 #[derive(Clone)]

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -10,8 +10,8 @@ use crate::layouter::css_taffy_converter::CssTaffyConverter;
 use crate::layouter::table::post_process_tables;
 use crate::layouter::text::get_text_layout;
 use crate::layouter::{
-    box_model, CanLayout, ElementContext, ElementContextImage, ElementContextSvg, ElementContextText, LayoutElementId,
-    LayoutElementNode, LayoutTree,
+    box_model, BackgroundMedia, CanLayout, ElementContext, ElementContextImage, ElementContextSvg, ElementContextText,
+    LayoutElementId, LayoutElementNode, LayoutTree,
 };
 use crate::rendertree_builder::{RenderNodeId, RenderTree};
 use gosub_fontmanager::ParleyFontSystem;
@@ -514,6 +514,8 @@ impl TaffyLayouter {
             return None;
         };
 
+        let background_media = self.resolve_background_media(layout_tree, dom_node.node_id);
+
         let mut element_node = LayoutElementNode {
             id: layout_tree.next_node_id(),
             dom_node_id: dom_node.node_id,
@@ -521,6 +523,7 @@ impl TaffyLayouter {
             box_model: box_model::BoxModel::ZERO,
             children: vec![],
             context: element_context,
+            background_media,
         };
 
         // Children are tracked in both the taffy tree and the element_node's children vec.
@@ -619,6 +622,36 @@ impl TaffyLayouter {
         self.dom_to_layout_mapping.insert(dom_node.node_id, layout_element_id);
 
         Some((layout_element_id, leaf_id))
+    }
+
+    /// Resolves the element's CSS `background-image` (if any) to a media id: reads the computed
+    /// value, resolves the URL against the document base URL, and loads it into the media store.
+    /// Returns `None` when there is no background image or it fails to load.
+    fn resolve_background_media(&self, layout_tree: &LayoutTree, dom_node_id: DomNodeId) -> Option<BackgroundMedia> {
+        let doc = &layout_tree.render_tree.doc;
+        let url = match doc.get_style(dom_node_id, &StyleProperty::BackgroundImage) {
+            Value::Keyword(id) => lookup(id),
+            _ => return None,
+        };
+        if url.is_empty() || url.eq_ignore_ascii_case("none") {
+            return None;
+        }
+
+        let abs = to_absolute_url(&url, &doc.base_url());
+        let media_id = match self.media_store.load_media(&abs) {
+            Ok(media_id) => media_id,
+            Err(e) => {
+                log::warn!("Could not load background-image '{}': {}", abs, e);
+                return None;
+            }
+        };
+
+        // Pick the renderer based on what was actually stored: an SVG (e.g. HN's
+        // `triangle.svg` votearrow) must go through the SVG paint path, not a raster blit.
+        match &*self.media_store.get(media_id, MediaType::Image) {
+            Media::Svg(_) => Some(BackgroundMedia::Svg(media_id)),
+            Media::Image(_) => Some(BackgroundMedia::Image(media_id)),
+        }
     }
 
     /// Extracts taffy variables based the DOM node. It will generate the taffy style based on the node CSS properties,

--- a/crates/gosub_render_pipeline/src/painter.rs
+++ b/crates/gosub_render_pipeline/src/painter.rs
@@ -4,7 +4,7 @@ use crate::common::browser_state::{BrowserState, WireframeState};
 use crate::common::document::node::NodeId;
 use crate::common::document::style::{BorderStyle as CssBorderStyle, Display, StyleProperty, Value};
 use crate::layering::layer::LayerList;
-use crate::layouter::{ElementContext, LayoutElementNode};
+use crate::layouter::{BackgroundMedia, ElementContext, LayoutElementNode};
 use crate::painter::commands::border::{Border, BorderStyle};
 use crate::painter::commands::brush::Brush;
 use crate::painter::commands::color::Color;
@@ -146,9 +146,40 @@ impl Painter {
         vec![PaintCommand::rectangle(r)]
     }
 
+    /// Paint commands for an element's CSS `background-image`, filling the border box.
+    /// Raster images are blitted via `Brush::image`; SVGs go through the SVG paint path
+    /// (e.g. HN's `triangle.svg` votearrow), which `Brush::image` cannot render.
+    fn background_media_commands(
+        &self,
+        bg: BackgroundMedia,
+        layout_element: &LayoutElementNode,
+        dom_node_id: NodeId,
+    ) -> Vec<PaintCommand> {
+        let border_box = layout_element.box_model.border_box;
+        match bg {
+            BackgroundMedia::Image(media_id) => {
+                let brush = Brush::image(media_id);
+                let r = Rectangle::new(border_box).with_background(brush);
+                let r = self.decorate_with_border_and_radius(dom_node_id, r);
+                vec![PaintCommand::rectangle(r)]
+            }
+            BackgroundMedia::Svg(media_id) => vec![PaintCommand::svg(media_id, Rectangle::new(border_box))],
+        }
+    }
+
     /// Generates the paint commands for the given layout element
     fn generate_element_commands(&self, layout_element: &LayoutElementNode, dom_node_id: NodeId) -> Vec<PaintCommand> {
         let mut commands = Vec::new();
+
+        // CSS background-image. For plain block elements (`None` context) it is painted just
+        // after the background-color in that branch below (correct CSS layering). For
+        // replaced/text content we paint it first so the element's own content stays on top.
+        let bg_media = layout_element.background_media;
+        if let Some(bg) = bg_media {
+            if !matches!(layout_element.context, ElementContext::None) {
+                commands.extend(self.background_media_commands(bg, layout_element, dom_node_id));
+            }
+        }
 
         match &layout_element.context {
             ElementContext::Text(ctx) => {
@@ -189,6 +220,11 @@ impl Painter {
                 let r = Rectangle::new(layout_element.box_model.border_box).with_background(brush);
                 let r = self.decorate_with_border_and_radius(dom_node_id, r);
                 commands.push(PaintCommand::rectangle(r));
+
+                // background-image paints on top of the background-color.
+                if let Some(bg) = bg_media {
+                    commands.extend(self.background_media_commands(bg, layout_element, dom_node_id));
+                }
             }
         }
 

--- a/crates/gosub_render_pipeline/src/tests.rs
+++ b/crates/gosub_render_pipeline/src/tests.rs
@@ -204,6 +204,55 @@ mod rendertree_from_engine {
         None
     }
 
+    // background-image must be readable from a stylesheet `background` shorthand (the HN
+    // `.votearrow` case), from the `background-image` longhand, and from an inline style.
+    #[test]
+    fn background_image_is_read_from_css() {
+        use crate::common::document::pipeline_doc::PipelineDocument;
+        use crate::common::document::style::{lookup, StyleProperty, Value};
+
+        let html = r#"
+            <html>
+            <head>
+                <style>
+                    .votearrow { background: url(grayarrow.gif) no-repeat; }
+                    #longhand  { background-image: url("pic.png"); }
+                </style>
+            </head>
+            <body>
+                <div class="votearrow">up</div>
+                <div id="longhand">x</div>
+                <div id="inline" style="background-image: url(inline.gif)">y</div>
+                <div id="plain">z</div>
+            </body>
+            </html>
+        "#;
+
+        let mut doc = html_compile::<Config>(html);
+        let ua = Css3System::load_default_useragent_stylesheet();
+        doc.add_stylesheet(ua);
+        let adapter = GosubDocumentAdapter::<Config>::new(Arc::new(doc));
+        let root = adapter.doc.root();
+
+        let url_of = |id| match adapter.get_style(id, &StyleProperty::BackgroundImage) {
+            Value::Keyword(k) => lookup(k),
+            other => panic!("expected keyword url, got {other:?}"),
+        };
+
+        let longhand = find_node_by_id_attr(&adapter.doc, root, "longhand").expect("find #longhand");
+        assert_eq!(url_of(longhand), "pic.png", "longhand url not read");
+
+        let votearrow = find_node_by_class_dfs(&adapter.doc, root, "votearrow").expect("find .votearrow");
+        assert_eq!(url_of(votearrow), "grayarrow.gif", "shorthand url not read");
+
+        let inline = find_node_by_id_attr(&adapter.doc, root, "inline").expect("find #inline");
+        assert_eq!(url_of(inline), "inline.gif", "inline url not read");
+
+        // An element without a background-image gets the initial value `none`.
+        let plain = find_node_by_id_attr(&adapter.doc, root, "plain").expect("find #plain");
+        assert_eq!(url_of(plain), "none", "plain element should be `none`");
+    }
+
     // Helper: DFS to find the first element whose `id` attribute matches.
     fn find_node_by_id_attr(
         doc: &DocumentImpl<Config>,

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,10 @@ ignore = [
     # `paste` is unmaintained but only pulled in transitively; no maintained
     # drop-in replacement is wired through our dependencies yet.
     "RUSTSEC-2024-0436", # paste unmaintained
+    # `ttf-parser` is unmaintained but pulled in transitively by SVG rendering
+    # (resvg -> usvg -> fontdb) and font shaping (ab_glyph -> owned_ttf_parser).
+    # Nothing we control depends on it directly.
+    "RUSTSEC-2026-0192", # ttf-parser unmaintained
 ]
 
 [licenses]


### PR DESCRIPTION
- **Implemented CSS background images (and SVG)**
- **cargo fmt + clippy**
- **Added ttf-parser advisory to deny-list**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `background-image` across styling, layout, and rendering, including inline styles and shorthand backgrounds.
  * Improved image handling so more raster formats, including GIF, can be detected and displayed correctly.

* **Bug Fixes**
  * Better recovery from complex `background` values so images and colors are retained more often instead of being dropped.
  * Background images now render more reliably on elements, with improved layering over background colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->