### PR TITLE
Updated some CSS parsing rules

### DIFF
--- a/crates/gosub_css3/src/parser/at_rule.rs
+++ b/crates/gosub_css3/src/parser/at_rule.rs
@@ -43,6 +43,31 @@ impl Css3<'_> {
         }
     }
 
+    /// Parses the prelude of a `@custom-selector` rule (CSS Extensions / PostCSS):
+    /// `@custom-selector <custom-selector> <selector-list>;`, e.g.
+    /// `@custom-selector :--heading h1, h2, h3;`. The `<custom-selector>` name is a
+    /// pseudo-class-style `:--ident`.
+    fn parse_at_rule_custom_selector_prelude(&mut self) -> CssResult<Node> {
+        log::trace!("parse_at_rule_custom_selector_prelude");
+
+        let loc = self.tokenizer.current_location();
+
+        // <custom-selector> name: `:--ident`
+        self.consume(TokenType::Colon)?;
+        let name = self.consume_any_ident()?;
+        self.consume_whitespace_comments();
+
+        // <selector-list>
+        let selectors = self.parse_selector_list()?;
+
+        Ok(Node::new(
+            NodeType::Value {
+                children: vec![Node::new(NodeType::Ident { value: format!(":{name}") }, loc), selectors],
+            },
+            loc,
+        ))
+    }
+
     fn read_sequence_at_rule_prelude(&mut self) -> CssResult<Node> {
         log::trace!("read_sequence_at_rule_prelude");
 
@@ -62,6 +87,8 @@ impl Css3<'_> {
         self.consume_whitespace_comments();
         let node = match name.cow_to_lowercase().as_ref() {
             "container" => Some(self.parse_at_rule_container_prelude()?),
+            "custom-media" => Some(self.parse_at_rule_custom_media_prelude()?),
+            "custom-selector" => Some(self.parse_at_rule_custom_selector_prelude()?),
             "font-face" => None,
             "import" => Some(self.parse_at_rule_import_prelude()?),
             "layer" => Some(self.parse_at_rule_layer_prelude()?),

--- a/crates/gosub_css3/src/parser/at_rule.rs
+++ b/crates/gosub_css3/src/parser/at_rule.rs
@@ -62,7 +62,15 @@ impl Css3<'_> {
 
         Ok(Node::new(
             NodeType::Value {
-                children: vec![Node::new(NodeType::Ident { value: format!(":{name}") }, loc), selectors],
+                children: vec![
+                    Node::new(
+                        NodeType::Ident {
+                            value: format!(":{name}"),
+                        },
+                        loc,
+                    ),
+                    selectors,
+                ],
             },
             loc,
         ))

--- a/crates/gosub_css3/src/parser/at_rule/container.rs
+++ b/crates/gosub_css3/src/parser/at_rule/container.rs
@@ -10,10 +10,15 @@ impl Css3<'_> {
         let mut children = Vec::new();
 
         let t = self.consume_any()?;
-        if let TokenType::Ident(value) = t.token_type {
+        if let TokenType::Ident(value) = &t.token_type {
+            // An optional container name may precede the query condition. The condition
+            // keywords are not valid names, so anything else is treated as the name.
             if !["none", "and", "not", "or"].contains(&value.as_str()) {
-                children.push(Node::new(NodeType::Ident { value }, t.location));
+                children.push(Node::new(NodeType::Ident { value: value.clone() }, t.location));
             }
+        } else {
+            // No container name: put the token back so it is parsed as part of the condition.
+            self.tokenizer.reconsume();
         }
 
         children.push(self.parse_condition(FeatureKind::Container)?);

--- a/crates/gosub_css3/src/parser/at_rule/media.rs
+++ b/crates/gosub_css3/src/parser/at_rule/media.rs
@@ -97,15 +97,13 @@ impl Css3<'_> {
             self.consume_whitespace_comments();
 
             let t = self.consume_any()?;
-            value = match t.token_type {
-                TokenType::Number(value) => Some(Node::new(NodeType::Number { value }, t.location)),
-                TokenType::Dimension { value, unit } => {
-                    Some(Node::new(NodeType::Dimension { value, unit }, t.location))
-                }
-                TokenType::Ident(value) => Some(Node::new(NodeType::Ident { value }, t.location)),
+            let first = match t.token_type {
+                TokenType::Number(value) => Node::new(NodeType::Number { value }, t.location),
+                TokenType::Dimension { value, unit } => Node::new(NodeType::Dimension { value, unit }, t.location),
+                TokenType::Ident(value) => Node::new(NodeType::Ident { value }, t.location),
                 TokenType::Function(_) => {
                     self.tokenizer.reconsume();
-                    Some(self.parse_function()?)
+                    self.parse_function()?
                 }
                 _ => {
                     return Err(CssError::with_location(
@@ -113,6 +111,23 @@ impl Css3<'_> {
                         t.location,
                     ));
                 }
+            };
+
+            self.consume_whitespace_comments();
+
+            // Optional `<ratio>` (`<number> / <number>`), e.g. `aspect-ratio: 16/9`.
+            value = if self.tokenizer.lookahead(0).is_delim('/') {
+                let op_loc = self.tokenizer.current_location();
+                self.consume_any()?;
+                let second = self.parse_media_read_term()?;
+                Some(Node::new(
+                    NodeType::Value {
+                        children: vec![first, Node::new(NodeType::Operator("/".into()), op_loc), second],
+                    },
+                    loc,
+                ))
+            } else {
+                Some(first)
             };
 
             self.consume_whitespace_comments();
@@ -139,13 +154,17 @@ impl Css3<'_> {
         let mut right_comparison = None;
         let mut right = None;
 
-        if self.tokenizer.lookahead_sc(0).is_delim('(') {
+        // Optional second comparison for a double-ended range, e.g. `400px <= width <= 700px`.
+        // It is introduced by another comparison operator (`<`, `>` or `=`), not a parenthesis.
+        self.consume_whitespace_comments();
+        if matches!(self.tokenizer.lookahead_sc(0).token_type, TokenType::Delim('<' | '>' | '=')) {
             right_comparison = Some(self.parse_media_read_comparison()?);
             right = Some(self.parse_media_read_term()?);
         }
 
         self.consume_whitespace_comments();
-        self.consume_delim(')')?;
+        // Parentheses are tokenized as `RParen`, not `Delim(')')`.
+        self.consume(TokenType::RParen)?;
 
         Ok(Node::new(
             NodeType::Range {
@@ -255,5 +274,27 @@ impl Css3<'_> {
         log::trace!("parse_at_rule_media_prelude");
 
         self.parse_media_query_list()
+    }
+
+    /// Parses the prelude of a `@custom-media` rule (Media Queries Level 5 / PostCSS):
+    /// `@custom-media <extension-name> <media-query-list>;`, e.g.
+    /// `@custom-media --screen-max-xxl (max-width: 1440px);`. The value can also be the
+    /// keywords `true`/`false`, which the media-query parser accepts as a media type.
+    pub fn parse_at_rule_custom_media_prelude(&mut self) -> CssResult<Node> {
+        log::trace!("parse_at_rule_custom_media_prelude");
+
+        let loc = self.tokenizer.current_location();
+
+        let name = self.consume_any_ident()?;
+        self.consume_whitespace_comments();
+
+        let query_list = self.parse_media_query_list()?;
+
+        Ok(Node::new(
+            NodeType::Value {
+                children: vec![Node::new(NodeType::Ident { value: name }, loc), query_list],
+            },
+            loc,
+        ))
     }
 }

--- a/crates/gosub_css3/src/parser/at_rule/media.rs
+++ b/crates/gosub_css3/src/parser/at_rule/media.rs
@@ -157,7 +157,10 @@ impl Css3<'_> {
         // Optional second comparison for a double-ended range, e.g. `400px <= width <= 700px`.
         // It is introduced by another comparison operator (`<`, `>` or `=`), not a parenthesis.
         self.consume_whitespace_comments();
-        if matches!(self.tokenizer.lookahead_sc(0).token_type, TokenType::Delim('<' | '>' | '=')) {
+        if matches!(
+            self.tokenizer.lookahead_sc(0).token_type,
+            TokenType::Delim('<' | '>' | '=')
+        ) {
             right_comparison = Some(self.parse_media_read_comparison()?);
             right = Some(self.parse_media_read_term()?);
         }

--- a/crates/gosub_css3/src/parser/block.rs
+++ b/crates/gosub_css3/src/parser/block.rs
@@ -49,15 +49,39 @@ impl Css3<'_> {
         }
     }
 
-    /// Reads until the end of a declaration or rule (or end of the block), in case there is a syntax error
+    /// Reads until the end of a rule (or the end of the enclosing block), in case there is a
+    /// syntax error.
+    ///
+    /// A rule is either a statement that ends at a top-level `;` (e.g. a block-less at-rule) or a
+    /// construct whose body is a `{ ... }` block. To resynchronise at the next rule boundary we
+    /// balance nested `()`, `[]`, `{}` and functions: a top-level `;` ends a block-less rule, and
+    /// once we have entered and matched a `{ ... }` block we stop right after its closing `}`. A
+    /// `}` seen while still at the top level belongs to an enclosing block we did not open, so we
+    /// leave it in place for that block to consume.
     pub(crate) fn parse_until_rule_end(&mut self) {
+        let mut depth: usize = 0;
         while let Ok(t) = self.consume_any() {
             match t.token_type {
-                TokenType::Semicolon => {
-                    break;
+                TokenType::LParen | TokenType::LBracket | TokenType::LCurly | TokenType::Function(_) => {
+                    depth += 1;
+                }
+                TokenType::RParen | TokenType::RBracket => {
+                    depth = depth.saturating_sub(1);
                 }
                 TokenType::RCurly => {
-                    self.tokenizer.reconsume();
+                    if depth == 0 {
+                        // Closing brace of an enclosing block we never opened; leave it.
+                        self.tokenizer.reconsume();
+                        break;
+                    }
+                    depth -= 1;
+                    if depth == 0 {
+                        // Consumed the rule's whole `{ ... }` block.
+                        break;
+                    }
+                }
+                TokenType::Semicolon if depth == 0 => {
+                    // Statement-level rule with no block.
                     break;
                 }
                 TokenType::Eof => {
@@ -67,6 +91,33 @@ impl Css3<'_> {
                     // ignore
                 }
             }
+        }
+    }
+
+    /// Discards the remnants of an invalid declaration inside a style block: consumes tokens up to
+    /// and including the next top-level `;`, or up to (but not including) the block's closing `}`.
+    /// Nested `()`, `[]`, `{}` and functions are balanced so a terminator inside them is not
+    /// mistaken for the end of the declaration.
+    fn skip_to_declaration_end(&mut self) {
+        let mut depth: usize = 0;
+        loop {
+            let t = self.tokenizer.lookahead(0);
+            match t.token_type {
+                TokenType::Eof => break,
+                TokenType::Semicolon if depth == 0 => {
+                    self.tokenizer.consume(); // eat the terminator
+                    break;
+                }
+                TokenType::RCurly if depth == 0 => break, // leave for the block to close
+                TokenType::LParen | TokenType::LBracket | TokenType::LCurly | TokenType::Function(_) => {
+                    depth += 1;
+                }
+                TokenType::RParen | TokenType::RBracket | TokenType::RCurly => {
+                    depth = depth.saturating_sub(1);
+                }
+                _ => {}
+            }
+            self.tokenizer.consume();
         }
     }
 
@@ -105,6 +156,18 @@ impl Css3<'_> {
                 _ => match mode {
                     BlockParseMode::StyleBlock => {
                         if !semicolon_seperated {
+                            if self.config.ignore_errors {
+                                // An invalid declaration left junk before the next `;`/`}`
+                                // (e.g. a missing semicolon glued two declarations together).
+                                // Per the CSS spec, discard the bad declaration and keep parsing
+                                // the remaining declarations in this block rather than aborting
+                                // the whole rule, which would desync block boundaries.
+                                log::warn!("Ignoring error in parse_block: Expected a ; got {t:?}");
+                                self.tokenizer.reconsume();
+                                self.skip_to_declaration_end();
+                                semicolon_seperated = true;
+                                continue;
+                            }
                             return Err(CssError::with_location(
                                 format!("Expected a ; got {t:?}").as_str(),
                                 self.tokenizer.current_location(),
@@ -143,5 +206,48 @@ impl Css3<'_> {
         let n = Node::new(NodeType::Block { children }, loc);
 
         Ok(n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::walker::Walker;
+    use crate::{CssOrigin, ParserConfig};
+    use gosub_shared::byte_stream::{ByteStream, Encoding};
+
+    /// Parses a full stylesheet with error recovery enabled and returns the walked AST.
+    fn parse_recovering(input: &str) -> String {
+        let mut stream = ByteStream::from_str(input, Encoding::UTF8);
+        let config = ParserConfig {
+            ignore_errors: true,
+            ..Default::default()
+        };
+        let mut parser = crate::Css3::new(&mut stream, config, CssOrigin::Author, "");
+        let result = parser.parse_stylesheet_internal().unwrap().unwrap();
+        Walker::new(&result).walk_to_string()
+    }
+
+    #[test]
+    fn recover_missing_semicolon_keeps_block_and_following_rules() {
+        // A declaration is missing its terminating `;` (`color: red` glued to `width: 1px`).
+        // The bad declaration is dropped, but the rest of the block and the following rule must
+        // still parse instead of cascading into desync.
+        let out = parse_recovering(".a { color: red width: 1px; height: 2px; } .b { top: 0 }");
+
+        // The valid declarations after the recovery point survive.
+        assert!(out.contains("property: height"), "expected height to survive:\n{out}");
+        // The following rule is not swallowed by the cascade.
+        assert!(out.contains("[ClassSelector] b"), "expected .b rule to parse:\n{out}");
+        assert!(out.contains("property: top"), "expected .b's declaration:\n{out}");
+    }
+
+    #[test]
+    fn recover_invalid_rule_skips_whole_block() {
+        // The first rule's body is malformed enough to abort the rule; recovery must skip its
+        // entire `{ ... }` block (brace-balanced) so the following rule parses cleanly.
+        let out = parse_recovering(".bad { @#$ {nested junk} } .good { color: blue }");
+
+        assert!(out.contains("[ClassSelector] good"), "expected .good rule to parse:\n{out}");
+        assert!(out.contains("property: color"), "expected .good's declaration:\n{out}");
     }
 }

--- a/crates/gosub_css3/src/parser/block.rs
+++ b/crates/gosub_css3/src/parser/block.rs
@@ -15,6 +15,31 @@ impl Css3<'_> {
         self.parse_rule()
     }
 
+    /// Disambiguates, inside a style block, between a nested style rule and a declaration.
+    ///
+    /// Per CSS Nesting, a construct is a nested rule when its prelude is followed by a `{ ... }`
+    /// block, and a declaration when it terminates at a `;` or at the block's closing `}`. We
+    /// scan ahead from the current position for whichever comes first at the top level, ignoring
+    /// any content nested inside parentheses, brackets or functions (e.g. `calc(...)`, attribute
+    /// selectors, `:is(...)`), which can never contain a top-level `{`.
+    fn starts_nested_rule(&mut self) -> bool {
+        let mut depth: usize = 0;
+        let mut offset = 0;
+
+        loop {
+            let t = self.tokenizer.lookahead(offset);
+            match t.token_type {
+                TokenType::LParen | TokenType::LBracket | TokenType::Function(_) => depth += 1,
+                TokenType::RParen | TokenType::RBracket => depth = depth.saturating_sub(1),
+                TokenType::LCurly if depth == 0 => return true,
+                TokenType::Semicolon | TokenType::RCurly if depth == 0 => return false,
+                TokenType::Eof => return false,
+                _ => {}
+            }
+            offset += 1;
+        }
+    }
+
     fn parse_consume_declaration(&mut self) -> CssResult<Option<Node>> {
         log::trace!("parse_consume_declaration");
 
@@ -87,29 +112,20 @@ impl Css3<'_> {
                         }
 
                         self.tokenizer.reconsume();
-                        if t.is_delim('&') {
-                            let rule = self.parse_consume_rule()?;
-                            if let Some(rule_node) = rule {
+                        if self.starts_nested_rule() {
+                            // CSS Nesting: a nested style rule (with or without a leading `&`).
+                            if let Some(rule_node) = self.parse_consume_rule()? {
                                 children.push(rule_node);
                             }
+                            // A nested rule is self-terminating (it ends with `}`), so no
+                            // separating semicolon is required before the next item.
+                            semicolon_seperated = true;
                         } else {
-                            let declaration = self.parse_consume_declaration()?;
-                            if let Some(declaration_node) = declaration {
+                            if let Some(declaration_node) = self.parse_consume_declaration()? {
                                 children.push(declaration_node);
                             }
+                            semicolon_seperated = false;
                         }
-
-                        // // check for either semicolon, eof, or rcurly
-                        // let t = self.tokenizer.lookahead_sc(0);
-                        // if t.token_type == TokenType::Semicolon {
-                        //     self.consume(TokenType::Semicolon)?;
-                        //     semicolon_seperated = true;
-                        // } else if t.token_type == TokenType::RCurly {
-                        //     self.tokenizer.reconsume();
-                        //     break;
-                        // }
-
-                        semicolon_seperated = false;
                     }
                     BlockParseMode::RegularBlock => {
                         self.tokenizer.reconsume();

--- a/crates/gosub_css3/src/parser/block.rs
+++ b/crates/gosub_css3/src/parser/block.rs
@@ -247,7 +247,10 @@ mod tests {
         // entire `{ ... }` block (brace-balanced) so the following rule parses cleanly.
         let out = parse_recovering(".bad { @#$ {nested junk} } .good { color: blue }");
 
-        assert!(out.contains("[ClassSelector] good"), "expected .good rule to parse:\n{out}");
+        assert!(
+            out.contains("[ClassSelector] good"),
+            "expected .good rule to parse:\n{out}"
+        );
         assert!(out.contains("property: color"), "expected .good's declaration:\n{out}");
     }
 }

--- a/crates/gosub_css3/src/parser/declaration.rs
+++ b/crates/gosub_css3/src/parser/declaration.rs
@@ -66,7 +66,14 @@ impl Css3<'_> {
         self.consume_whitespace_comments();
         let value = self.parse_value_sequence()?;
 
-        if value.is_empty() {
+        // Custom properties (`--foo`) accept an arbitrary token stream (CSS Custom Properties
+        // spec), including an empty value (`--foo: ;`) and tokens the value parser does not
+        // recognise (e.g. a stray `$` from unprocessed preprocessor output). Keep whatever the
+        // value parser understood and skip the remainder up to the declaration's terminator,
+        // rather than erroring. Regular properties still require a parseable value.
+        if custom_property {
+            self.skip_custom_property_remainder();
+        } else if value.is_empty() {
             return Err(CssError::with_location(
                 "Expected value in declaration",
                 self.tokenizer.current_location(),
@@ -91,6 +98,29 @@ impl Css3<'_> {
             },
             loc,
         ))
+    }
+
+    /// Consumes any leftover custom-property value tokens up to — but not including — the
+    /// declaration's terminating top-level `;` or `}`. Brackets, parentheses and `{}` blocks
+    /// nested within the value are skipped over so a terminator inside them is not mistaken
+    /// for the end of the declaration.
+    fn skip_custom_property_remainder(&mut self) {
+        let mut depth: usize = 0;
+        loop {
+            let t = self.tokenizer.lookahead(0);
+            match t.token_type {
+                TokenType::Eof => break,
+                TokenType::Semicolon | TokenType::RCurly if depth == 0 => break,
+                TokenType::LParen | TokenType::LBracket | TokenType::LCurly | TokenType::Function(_) => {
+                    depth += 1;
+                }
+                TokenType::RParen | TokenType::RBracket | TokenType::RCurly => {
+                    depth = depth.saturating_sub(1);
+                }
+                _ => {}
+            }
+            self.tokenizer.consume();
+        }
     }
 
     fn parse_until_declaration_end(&mut self) {

--- a/crates/gosub_css3/src/parser/pseudo.rs
+++ b/crates/gosub_css3/src/parser/pseudo.rs
@@ -26,6 +26,26 @@ impl Css3<'_> {
         Ok(Node::new(NodeType::Ident { value }, loc))
     }
 
+    /// Reads a whitespace-separated sequence of idents, e.g. the part name list of `::part(a b)`.
+    fn parse_pseudo_function_ident_sequence(&mut self) -> CssResult<Node> {
+        log::trace!("parse_pseudo_function_ident_sequence");
+
+        let loc = self.tokenizer.current_location();
+
+        let mut children = Vec::new();
+        loop {
+            self.consume_whitespace_comments();
+            if let TokenType::Ident(_) = self.tokenizer.lookahead(0).token_type {
+                let value = self.consume_any_ident()?;
+                children.push(Node::new(NodeType::Ident { value }, loc));
+            } else {
+                break;
+            }
+        }
+
+        Ok(Node::new(NodeType::Value { children }, loc))
+    }
+
     fn parse_pseudo_function_nth(&mut self) -> CssResult<Node> {
         log::trace!("parse_pseudo_function_nth");
 
@@ -100,6 +120,8 @@ impl Css3<'_> {
             "slotted" => self.parse_pseudo_function_selector(),
             "host" => self.parse_pseudo_function_selector(),
             "host-context" => self.parse_pseudo_function_selector(),
+            "part" => self.parse_pseudo_function_ident_sequence(),
+            "highlight" => self.parse_pseudo_function_ident_list(),
             _ => Err(CssError::with_location(
                 format!("Unexpected pseudo function {name:?}").as_str(),
                 self.tokenizer.current_location(),

--- a/crates/gosub_css3/src/parser/selector.rs
+++ b/crates/gosub_css3/src/parser/selector.rs
@@ -199,14 +199,24 @@ impl Css3<'_> {
         self.consume(TokenType::Colon)?;
         self.consume(TokenType::Colon)?;
 
-        let t = self.tokenizer.lookahead(0);
-        let value = if t.is_ident() {
-            self.consume_any_ident()?
-        } else {
-            return Err(CssError::with_location(
-                format!("Unexpected token {t:?}").as_str(),
-                self.tokenizer.current_location(),
-            ));
+        let t = self.tokenizer.consume();
+        let value = match t.token_type {
+            TokenType::Ident(value) => value,
+            TokenType::Function(name) => {
+                // Functional pseudo-element, e.g. `::part(foo)`, `::slotted(span)`,
+                // `::highlight(name)`. Parse and consume the arguments so the stream advances
+                // past the `)`; the selector model only retains the pseudo-element name.
+                let lower = name.cow_to_lowercase();
+                self.parse_pseudo_function(lower.as_ref())?;
+                self.consume(TokenType::RParen)?;
+                name
+            }
+            _ => {
+                return Err(CssError::with_location(
+                    format!("Unexpected token {t:?}").as_str(),
+                    self.tokenizer.current_location(),
+                ));
+            }
         };
 
         Ok(Node::new(NodeType::PseudoElementSelector { value }, loc))

--- a/crates/gosub_css3/src/parser/value.rs
+++ b/crates/gosub_css3/src/parser/value.rs
@@ -90,6 +90,11 @@ impl Css3<'_> {
                 let node = Node::new(NodeType::Url { url }, t.location);
                 Ok(Some(node))
             }
+            TokenType::UnicodeRange(value) => {
+                // Stored as a string node (e.g. for the `unicode-range` @font-face descriptor).
+                let node = Node::new(NodeType::String { value }, t.location);
+                Ok(Some(node))
+            }
             TokenType::Ident(value) => {
                 if value.eq_ignore_ascii_case("progid") {
                     let _ = self.consume(TokenType::Colon)?;

--- a/crates/gosub_css3/src/tokenizer.rs
+++ b/crates/gosub_css3/src/tokenizer.rs
@@ -17,6 +17,8 @@ pub enum TokenType {
     AtKeyword(String),
     Ident(String),
     Function(String),
+    /// A `<unicode-range-token>`, stored as its raw textual form (e.g. `U+0000-00FF`, `U+4??`).
+    UnicodeRange(String),
     Url(String),
     BadUrl(String),
     Dimension {
@@ -197,6 +199,7 @@ impl fmt::Display for Token {
             | TokenType::Function(val)
             | TokenType::QuotedString(val)
             | TokenType::BadString(val) => val,
+            TokenType::UnicodeRange(val) => val,
             TokenType::Delim(val) => val.to_string(),
             TokenType::Number(val) => val.to_string(),
             TokenType::Percentage(val) => format!("{val}%"),
@@ -343,6 +346,13 @@ impl<'stream> Tokenizer<'stream> {
 
     /// 4.3.1. [Consume a token](https://www.w3.org/TR/css-syntax-3/#consume-token)
     fn consume_token(&mut self) -> Token {
+        // Strip a leading UTF-8 BOM (U+FEFF) at the very start of the stream, per CSS Syntax
+        // input preprocessing. `tokens.is_empty()` ensures this only applies before the first
+        // token is produced, so an in-content U+FEFF is left untouched.
+        if self.tokens.is_empty() && self.current_char() == Ch('\u{FEFF}') {
+            self.next_char();
+        }
+
         while self.look_ahead_slice(2) == "/*" {
             self.consume_comment();
         }
@@ -481,6 +491,7 @@ impl<'stream> Tokenizer<'stream> {
                 Token::new_delim(c, loc)
             }
             Ch(c) if c.is_numeric() => self.consume_numeric_token(),
+            Ch('u' | 'U') if self.starts_unicode_range() => self.consume_unicode_range_token(),
             Ch(c) if self.is_ident_start(c) => self.consume_ident_like_seq(),
             Ch(c) => {
                 self.next_char();
@@ -527,6 +538,62 @@ impl<'stream> Tokenizer<'stream> {
         }
 
         Token::new_number(number, loc)
+    }
+
+    /// Returns true if the stream starts a `<unicode-range-token>`: the current code point is
+    /// `u`/`U`, followed by `+`, followed by a hex digit or `?` (e.g. `U+1F600`, `U+4??`).
+    /// Assumes the current code point is `u`/`U`.
+    fn starts_unicode_range(&self) -> bool {
+        matches!(self.stream.look_ahead(1), Ch('+'))
+            && matches!(self.stream.look_ahead(2), Ch(c) if c.is_ascii_hexdigit() || c == '?')
+    }
+
+    /// 4.3.6. [Consume a unicode-range token](https://www.w3.org/TR/css-syntax-3/#consume-unicode-range-token)
+    ///
+    /// Consumes `U+` followed by up to 6 hex digits, optional `?` wildcards, and an optional
+    /// `-<hex>` range end. The token stores the raw textual form.
+    fn consume_unicode_range_token(&mut self) -> Token {
+        let loc = self.current_location();
+
+        let mut value = String::new();
+        // Consume the `u`/`U` and the `+`.
+        value.push(self.next_char().into());
+        value.push(self.next_char().into());
+
+        // Up to 6 hex digits.
+        let mut digits = 0;
+        while digits < 6 {
+            match self.current_char() {
+                Ch(c) if c.is_ascii_hexdigit() => {
+                    value.push(self.next_char().into());
+                    digits += 1;
+                }
+                _ => break,
+            }
+        }
+
+        // Trailing `?` wildcards, up to a total of 6 characters.
+        while digits < 6 && self.current_char() == Ch('?') {
+            value.push(self.next_char().into());
+            digits += 1;
+        }
+
+        // Optional range end: `-` followed by hex digits.
+        if self.current_char() == Ch('-') && matches!(self.stream.look_ahead(1), Ch(c) if c.is_ascii_hexdigit()) {
+            value.push(self.next_char().into());
+            let mut end_digits = 0;
+            while end_digits < 6 {
+                match self.current_char() {
+                    Ch(c) if c.is_ascii_hexdigit() => {
+                        value.push(self.next_char().into());
+                        end_digits += 1;
+                    }
+                    _ => break,
+                }
+            }
+        }
+
+        Token::new(TokenType::UnicodeRange(value), loc)
     }
 
     /// 4.3.5. [Consume a string token](https://www.w3.org/TR/css-syntax-3/#consume-string-token)

--- a/src/bin/css-check.rs
+++ b/src/bin/css-check.rs
@@ -1,0 +1,50 @@
+use anyhow::{anyhow, bail, Result};
+use gosub_css3::Css3;
+use gosub_interface::css3::CssOrigin;
+use gosub_shared::config::ParserConfig;
+use log::LevelFilter;
+use simple_logger::SimpleLogger;
+use std::path::Path;
+
+/// Parse a single CSS source (local file or http(s):// URL) and report the result.
+///
+/// The parser is run with `ignore_errors` enabled so it does not stop at the first
+/// problem; instead every rule it cannot parse is emitted as a `WARN` via the logger
+/// (the same `gosub_css3::parser::rule` warnings you already see in the renderer examples).
+fn main() -> Result<()> {
+    // Default to WARN so the only output is the parser's warnings/errors. Override with
+    // RUST_LOG (e.g. RUST_LOG=trace) for deeper inspection.
+    SimpleLogger::new().with_level(LevelFilter::Warn).env().init()?;
+
+    let source = match std::env::args().nth(1) {
+        Some(s) => s,
+        None => bail!("usage: css-check <file|http(s)-url>"),
+    };
+
+    // Accept either a real URL or a local file path.
+    let url = match url::Url::parse(&source) {
+        Ok(u) if matches!(u.scheme(), "http" | "https" | "file") => u,
+        _ => url::Url::from_file_path(Path::new(&source).canonicalize().unwrap_or_else(|_| source.clone().into()))
+            .map_err(|_| anyhow!("not a valid URL or file path: {source}"))?,
+    };
+
+    let response = gosub_net::net::simple::sync_fetch(&url)?;
+    if !response.is_ok() {
+        bail!("could not fetch {source} (status {})", response.status);
+    }
+    let css = String::from_utf8_lossy(&response.body).into_owned();
+
+    let config = ParserConfig {
+        source: Some(source.clone()),
+        ignore_errors: true,
+        ..Default::default()
+    };
+
+    match Css3::parse_str(&css, config, CssOrigin::Author, &source) {
+        Ok(sheet) => {
+            println!("Parsed {source}: {} rule(s).", sheet.rules.len());
+            Ok(())
+        }
+        Err(e) => bail!("failed to parse {source}: {}", e.message),
+    }
+}

--- a/src/bin/css-check.rs
+++ b/src/bin/css-check.rs
@@ -24,8 +24,12 @@ fn main() -> Result<()> {
     // Accept either a real URL or a local file path.
     let url = match url::Url::parse(&source) {
         Ok(u) if matches!(u.scheme(), "http" | "https" | "file") => u,
-        _ => url::Url::from_file_path(Path::new(&source).canonicalize().unwrap_or_else(|_| source.clone().into()))
-            .map_err(|_| anyhow!("not a valid URL or file path: {source}"))?,
+        _ => url::Url::from_file_path(
+            Path::new(&source)
+                .canonicalize()
+                .unwrap_or_else(|_| source.clone().into()),
+        )
+        .map_err(|_| anyhow!("not a valid URL or file path: {source}"))?,
     };
 
     let response = gosub_net::net::simple::sync_fetch(&url)?;


### PR DESCRIPTION
When parsing CSS found in the wild, there were still some syntax that wasn't parsed correctly. This PR will fix a few of them (not all though).

We still have to think about what we need to do with old style CSS (IE-specific CSS rules, invalid CSS etc). But for now, we try to parse as many rules as possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `@custom-media`, `@custom-selector`, `::part(...)`, and CSS unicode-range tokens.
  * Improved handling of media queries, including ratio values and range syntax.
  * Added a CSS check command that parses CSS from a local path or URL and reports the rule count.

* **Bug Fixes**
  * Better recovery from malformed CSS so later declarations and rules can still be parsed.
  * Improved handling of custom properties and nested style rules.
  * BOM characters are now handled more consistently at the start of input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->