### PR TITLE
Reflowed markdown documentation

### DIFF
--- a/crates/gosub_config/Cargo.toml
+++ b/crates/gosub_config/Cargo.toml
@@ -24,5 +24,6 @@ rusqlite = "0.39.0"
 
 [dev-dependencies]
 testing_logger = "0.1.1"
+
 [lints]
 workspace = true

--- a/crates/gosub_config/src/lib.rs
+++ b/crates/gosub_config/src/lib.rs
@@ -411,6 +411,7 @@ impl ConfigStore {
         };
 
         self.storage.remove(key)?;
+
         // Revert the in-memory value back to the default so subsequent reads return the default.
         let default = info.default.clone();
         let changed = {

--- a/crates/gosub_engine/src/engine/cookies/cookie_jar.rs
+++ b/crates/gosub_engine/src/engine/cookies/cookie_jar.rs
@@ -9,10 +9,10 @@
 //! and parses a subset of RFC 6265 `Set-Cookie` semantics.
 //!
 //! ## Notes & limitations
-//! - Parsing is intentionally **minimal**: attributes like `Expires`, `Path`,
-//!   `Domain`, `Secure`, `HttpOnly`, and `SameSite` are handled; `Max-Age`,
-//!   priorities, size limits, eviction policies, and expiration enforcement are
-//!   not (yet) implemented.
+//! - The attributes `Expires`, `Max-Age`, `Path`, `Domain`, `Secure`,
+//!   `HttpOnly`, and `SameSite` are parsed and enforced; expired cookies are
+//!   filtered on read and can be removed via [`CookieJar::purge_expired`].
+//!   Priorities, size limits, and eviction policies are not (yet) implemented.
 //! - Cookies are bucketed by **origin** (`url.origin().ascii_serialization()`).
 //!   Within a bucket, simple host/subdomain and path prefix checks are applied.
 //! - This module is **not** internally synchronized. Use it via a

--- a/docs/binaries.md
+++ b/docs/binaries.md
@@ -1,11 +1,8 @@
 # Component tool reference
 
-These binaries each exercise a single crate in isolation — the HTML5 parser, CSS3 parser,
-config store, etc. They are useful for development and debugging but are not the primary way to
-drive the engine.
+These binaries each exercise a single crate in isolation --- the HTML5 parser, CSS3 parser, config store, etc. They are useful for development and debugging but are not the primary way to drive the engine.
 
-To see the full `GosubEngine` stack in action (multi-zone/tab model, async networking, event
-bus), run the engine examples instead:
+To see the full `GosubEngine` stack in action (multi-zone/tab model, async networking, event bus), run the engine examples instead:
 
 ```bash
 cargo run --example hello-world    # single tab, headless
@@ -16,7 +13,7 @@ cargo run -p example-egui-vello    # egui/wgpu window
 
 See [`examples/README.md`](../examples/README.md) for details.
 
----
+------------------------------------------------------------------------
 
 ## config-store
 
@@ -39,11 +36,9 @@ useragent.tab.close_button              : m: left
 useragent.tab.max_opened                : i:-1
 ```
 
-
 ## css3-parser
 
-Parse a CSS stylesheet and print the parse tree (or any errors encountered). Does not validate
-property value syntax — `color: 1%` will parse without error.
+Parse a CSS stylesheet and print the parse tree (or any errors encountered). Does not validate property value syntax --- `color: 1%` will parse without error.
 
 ```bash
 $ cargo run -r --bin css3-parser file://tests/data/css3-data/test.css
@@ -62,7 +57,6 @@ Running css3 parser of (54.00 B) took 0 ms.
       [Declaration] border
         List([Unit(1.0, "px"), String("solid"), String("black")])
 ```
-
 
 ## gosub-parser
 
@@ -86,41 +80,33 @@ html5.parse          |        1 |      605ms |      605ms |      605ms |      60
 css3.parse           |        1 |      613µs |      613µs |      613µs |      613µs
 ```
 
-
 ## display-text-tree
 
-Fetch a URL and print a plain-text representation — all text nodes from the parsed document,
-with no layout or styling applied. Useful for a quick sanity check on what the parser sees.
+Fetch a URL and print a plain-text representation --- all text nodes from the parsed document, with no layout or styling applied. Useful for a quick sanity check on what the parser sees.
 
 ```bash
 $ cargo run -r --bin display-text-tree https://gosub.io
 ```
 
-
 ## html5-parser-test
 
-Run the html5lib tree-builder test suite from the command line. The test data files must be
-reachable from the working directory; run from the repo root.
+Run the html5lib tree-builder test suite from the command line. The test data files must be reachable from the working directory; run from the repo root.
 
 ```bash
 $ cargo run -r --bin html5-parser-test
 ```
 
-
 ## parser-test
 
-A focused parser development harness for running specific HTML5 parser tests during development.
-Intended for use while actively working on the parser; not a substitute for the full test suite.
+A focused parser development harness for running specific HTML5 parser tests during development. Intended for use while actively working on the parser; not a substitute for the full test suite.
 
 ```bash
 $ cargo run -r --bin parser-test
 ```
 
-
 ## run-js
 
-Run a JavaScript file through the V8 engine. There is no DOM or Web API binding, so browser
-globals (`console`, `document`, `fetch`, etc.) are not available.
+Run a JavaScript file through the V8 engine. There is no DOM or Web API binding, so browser globals (`console`, `document`, `fetch`, etc.) are not available.
 
 ```javascript
 var a = 1 + 3

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,46 +1,35 @@
 # Configuration: choosing your components
 
-`GosubEngine` is generic over a single *configuration* type that names every pluggable component
-at compile time. There is no runtime registry — naming a component (e.g. `CairoBackend`) is what
-pulls that crate into your build. This page explains how to pick the right config when you embed
-the engine.
+`GosubEngine` is generic over a single *configuration* type that names every pluggable component at compile time. There is no runtime registry --- naming a component (e.g. `CairoBackend`) is what pulls that crate into your build. This page explains how to pick the right config when you embed the engine.
 
 ## The two layers
 
-The configuration is split into two traits so that tools which never paint don't have to compile
-in the renderer crates.
+The configuration is split into two traits so that tools which never paint don't have to compile in the renderer crates.
 
-| Trait | Crate | Names | Used by |
-|---|---|---|---|
-| [`ModuleConfiguration`](../crates/gosub_interface/src/config.rs) | `gosub_interface` | CSS system, DOM document, HTML parser | everyone (parse-only tools implement *only* this) |
-| `RenderConfiguration` | `gosub_engine` (`html` module) | render backend, compositor sink, font system | anything that actually renders |
+| Trait                                                            | Crate                          | Names                                        |
+| ---------------------------------------------------------------- | ------------------------------ | -------------------------------------------- |
+| [`ModuleConfiguration`](../crates/gosub_interface/src/config.rs) | `gosub_interface`              | CSS system, DOM document, HTML parser        |
+| `RenderConfiguration`                                            | `gosub_engine` (`html` module) | render backend, compositor sink, font system |
 
-`RenderConfiguration` extends `ModuleConfiguration`, so a rendering config satisfies both. Parser
-test harnesses and fuzz targets implement just `ModuleConfiguration` and stay renderer-free.
+`RenderConfiguration` extends `ModuleConfiguration`, so a rendering config satisfies both. Parser test harnesses and fuzz targets implement just `ModuleConfiguration` and stay renderer-free.
 
-How the trait machinery works underneath (the auto-derived `Has*` view traits, why subsystems
-bound on those instead of the full config) is covered in [`interface.md`](interface.md).
+How the trait machinery works underneath (the auto-derived `Has*` view traits, why subsystems bound on those instead of the full config) is covered in [`interface.md`](interface.md).
 
 ## The ready-made config
 
-You almost never implement those traits by hand. `DefaultRenderConfig<B, F, S>` is a zero-sized
-marker that wires the standard gosub stack (`gosub_html5` + `gosub_css3`) and lets you choose the
-parts that vary:
+You almost never implement those traits by hand. `DefaultRenderConfig<B, F, S>` is a zero-sized marker that wires the standard gosub stack (`gosub_html5` + `gosub_css3`) and lets you choose the parts that vary:
 
-| Param | Meaning | Default |
-|---|---|---|
-| `B` | render backend | `NullBackend` |
-| `F` | font system | `ParleyFontSystem` |
-| `S` | compositor sink | `DefaultCompositor` |
+| Param | Meaning         | Default             |
+|------:|-----------------|---------------------|
+| `B`   | render backend  | `NullBackend`       |
+| `F`   | font system     | `ParleyFontSystem`  |
+| `S`   | compositor sink | `DefaultCompositor` |
 
-With no parameters, `DefaultRenderConfig` is the headless
-`DefaultRenderConfig<NullBackend, ParleyFontSystem, DefaultCompositor>` — that's why headless
-examples need no backend choice.
+With no parameters, `DefaultRenderConfig` is the headless `DefaultRenderConfig<NullBackend, ParleyFontSystem, DefaultCompositor>` --- that's why headless examples need no backend choice.
 
 ## Starting a browser that renders
 
-Pick a backend and font system, alias them once, and hand the alias to the engine. Reuse the
-alias everywhere the config type is needed (struct fields, function signatures):
+Pick a backend and font system, alias them once, and hand the alias to the engine. Reuse the alias everywhere the config type is needed (struct fields, function signatures):
 
 ```rust
 use std::sync::Arc;
@@ -53,23 +42,19 @@ type AppConfig = DefaultRenderConfig<CairoBackend, PangoFontSystem>;
 let mut engine = GosubEngine::<AppConfig>::new(None, Arc::new(backend), compositor);
 ```
 
-Every GUI example follows this pattern — see `examples/winit-cairo/main.rs`,
-`examples/egui-vello/main.rs`, etc., and [`examples.md`](examples.md) for the full list.
+Every GUI example follows this pattern --- see `examples/winit-cairo/main.rs`, `examples/egui-vello/main.rs`, etc., and [`examples.md`](examples.md) for the full list.
 
 ## Available backends
 
-| Backend | Crate | Notes |
-|---|---|---|
-| `NullBackend` | `gosub_render_pipeline` | headless; no pixels, just geometry + events |
-| `CairoBackend` | `gosub_renderer_cairo` | CPU; pairs with `PangoFontSystem` |
-| `SkiaBackend` | `gosub_renderer_skia` | CPU or GPU; pairs with `SkiaFontSystem` |
-| `VelloBackend` | `gosub_renderer_vello` | GPU via wgpu; generic over a `WgpuContextProvider` |
+| Backend        | Crate                   | Notes                                               |
+|----------------|-------------------------|-----------------------------------------------------|
+| `NullBackend`  | `gosub_render_pipeline` | headless; no pixels, just geometry + events         |
+| `CairoBackend` | `gosub_renderer_cairo`  | CPU; pairs with `PangoFontSystem`                   |
+| `SkiaBackend`  | `gosub_renderer_skia`   | CPU or GPU; pairs with `SkiaFontSystem`             |
+| `VelloBackend` | `gosub_renderer_vello`  | GPU via wgpu; generic over a `WgpuContextProvider`  |
 
 ## Going fully custom
 
-If you need a different CSS/DOM/parser stack (not just a different backend), implement
-`ModuleConfiguration` + `RenderConfiguration` on your own zero-sized marker type instead of using
-`DefaultRenderConfig`. See the trait definitions in `crates/gosub_engine/src/html.rs`.
+If you need a different CSS/DOM/parser stack (not just a different backend), implement `ModuleConfiguration` + `RenderConfiguration` on your own zero-sized marker type instead of using `DefaultRenderConfig`. See the trait definitions in `crates/gosub_engine/src/html.rs`.
 
-> The authoritative API reference lives in the `gosub_engine` crate docs — run
-> `cargo doc -p gosub_engine --open` and read the crate-level "Configuration" section.
+> The authoritative API reference lives in the `gosub_engine` crate docs --- run `cargo doc -p gosub_engine --open` and read the crate-level "Configuration" section.

--- a/docs/cookies.md
+++ b/docs/cookies.md
@@ -1,56 +1,185 @@
 # Architecture: Cookies subsystem
 
-## Scope
-- Runtime cookie management within a zone using a `CookieJar`.
-- Persistence and restoration across runs using a `CookieStore`.
-- Type‑erased handles for safe and concurrent access by the engine.
+## What this subsystem does
 
-Cookies are a **zone service**: the jar/store handles live in `ZoneServices`, so each zone
-is its own cookie universe (the profile/container model). See
+Cookies are how a server asks the browser to remember state: a response carries
+`Set-Cookie` headers, the engine stores the cookies it accepts, and every later
+request to a matching site carries them back in a single `Cookie` header. The
+engine implements this per RFC 6265 / RFC 6265bis with its own parser and
+matching logic — it does not delegate cookie handling to the HTTP client.
+
+The subsystem splits into two layers with distinct jobs:
+
+-   **`CookieJar`** — the runtime working set. One jar per zone; it parses
+    `Set-Cookie` headers on responses and builds the `Cookie` header for
+    requests. Everything security-relevant (domain/path matching, `Secure`,
+    `SameSite`, expiry) happens here.
+-   **`CookieStore`** — the persistence layer. It creates or restores a jar for
+    a zone and writes snapshots back out. Backends: in-memory (ephemeral),
+    JSON file, or SQLite. The jar never talks to the store on the hot path;
+    persistence is bolted on via a decorator (see below).
+
+Cookies are a **zone service**: the jar/store handles live in `ZoneServices`,
+so each zone is its own cookie universe (the profile/container model). Two
+zones never see each other's cookies. See
 [`zones-and-tabs.md`](zones-and-tabs.md) for how services reach tabs.
 
 ## Directory layout
-- `src/engine/cookies/cookies.rs`: type‑erased handles and serializable `Cookie`.
-- `src/engine/cookies/cookie_jar.rs`: `CookieJar` trait and default behaviors.
-- `src/engine/cookies/persistent_cookie_jar.rs`: `DefaultCookieJar` snapshot type.
-- `src/engine/cookies/store.rs`: `CookieStore` trait.
-- `src/engine/cookies/store/in_memory.rs`: in‑memory store.
-- `src/engine/cookies/store/json.rs`: JSON store.
-- `src/engine/cookies/store/sqlite.rs`: SQLite store.
-- `src/engine/zone/zone.rs`: `Zone` and `ZoneId` integration points.
 
-## Key concepts
-- `CookieJar` (runtime)
-    - Per‑zone working set used during request/response handling.
-    - Typical calls: `get_request_cookies(url)`, `store_response_cookies(url, headers)`, `clear()`.
-    - Accessed via `CookieJarHandle = Arc<RwLock<Box<dyn CookieJar + Send + Sync>>>`.
-- `CookieStore` (persistence/factory)
-    - Creates/restores per‑zone jars and persists or removes them.
-    - Typical calls: `jar_for(zone)`, `persist_zone_from_snapshot(zone, snap)`, `remove_zone(zone)`, `persist_all()`.
-    - Exposed as `CookieStoreHandle = Arc<dyn CookieStore + Send + Sync>`.
-- `Cookie` (data model)
-    - Serializable struct for persistence and inspection.
-    - Fields: `name`, `value`, `path`, `domain`, `secure`, `expires`, `same_site`, `http_only`.
+-   `src/engine/cookies/cookies.rs`: type‑erased handles and the serializable `Cookie` struct.
+-   `src/engine/cookies/cookie_jar.rs`: `CookieJar` trait, `DefaultCookieJar`, and all parsing/matching/`SameSite` logic.
+-   `src/engine/cookies/persistent_cookie_jar.rs`: `PersistentCookieJar` decorator that snapshots to a store after mutations.
+-   `src/engine/cookies/store.rs`: `CookieStore` trait.
+-   `src/engine/cookies/store/in_memory.rs`: in‑memory store.
+-   `src/engine/cookies/store/json.rs`: JSON store.
+-   `src/engine/cookies/store/sqlite.rs`: SQLite store (behind the `sqlite_cookie_store` feature; off on WASM).
+-   `src/engine/zone/zone.rs`: `Zone` and `ZoneId` integration points.
+-   `src/engine/tab/worker.rs`: the fetch-pipeline call sites that read and write the jar.
+
+## The cookie lifecycle
+
+### 1. A response arrives: storing cookies
+
+When a navigation fetch completes, the tab worker calls
+`store_response_cookies(final_url, headers, top_level)` on the zone's jar
+(`src/engine/tab/worker.rs`). `DefaultCookieJar` then processes every
+`Set-Cookie` header:
+
+1.  **Parse** the `name=value` pair and attributes (case-insensitively):
+    `Path`, `Domain`, `Expires`, `Max-Age`, `SameSite`, `Secure`, `HttpOnly`.
+    Values are kept raw (no URL-decoding); UTF-8 values survive. Empty names
+    and malformed pairs are rejected per RFC 6265 §5.2.
+2.  **Validate and reject** where the spec requires:
+    -   A `Domain` attribute must cover the request host and must not be a
+        public suffix — validated against the compiled-in Mozilla Public
+        Suffix List (`psl` crate), so a response from `evil.github.io` cannot
+        set a cookie for `github.io`.
+    -   A `Secure` cookie arriving over plain HTTP is dropped.
+    -   The `__Secure-` and `__Host-` name prefixes are enforced
+        (RFC 6265bis §4.1.3): `__Host-` additionally requires `Path=/` and no
+        `Domain`.
+3.  **Resolve expiry**: `Max-Age` wins over `Expires`; both are folded into a
+    single `expires` Unix timestamp on the `Cookie` struct. `Max-Age<=0`
+    deletes the cookie immediately. No expiry means a session cookie.
+4.  **Default the path** from the request URL when no `Path` attribute is given
+    (RFC 6265 §5.1.4).
+5.  **Store**, bucketed by origin, deduplicating on `(name, domain, path)` with
+    last-write-wins while preserving the original creation time (needed for
+    RFC 6265bis §5.5 ordering later).
+
+### 2. A request goes out: attaching cookies
+
+Before a navigation request, the worker asks the jar for the header value:
+
+```rust
+jar.read().get_request_cookies(&url, Some(&top_level_url), SameSiteContext::SameSite)
+```
+
+The jar scans its cookies and applies a filter chain; only cookies that pass
+every filter are sent:
+
+-   **Not expired** — expired cookies are skipped (and can be physically
+    removed via `purge_expired()`, which stores also run on load).
+-   **Domain match** — a cookie with a `Domain` attribute matches that host and
+    its subdomains; a host-only cookie (no `Domain`) matches only the exact
+    origin that set it.
+-   **Path match** — RFC 6265 §5.1.4 prefix rules.
+-   **`Secure`** — secure cookies are only sent over HTTPS.
+-   **`SameSite`** — enforced against the request's `SameSiteContext` (next
+    section).
+-   **Third-party policy** — if the jar is configured with
+    `ThirdPartyCookiePolicy::Block` or `SameSiteNoneOnly`, cross-site requests
+    (registrable domain of the request differs from the top-level page, per
+    the PSL) lose some or all cookies.
+
+Survivors are sorted longest-path-first, ties broken by creation time
+(RFC 6265bis §5.5), and joined into a single `name=value; name=value` string.
+
+One more protection lives in the network layer rather than the jar: on a
+cross-domain redirect, `gosub_net` strips the `Cookie` header from the
+follow-up request so cookies never leak to a different host
+(`crates/gosub_net/src/net/fetch.rs`).
+
+### 3. Persistence
+
+`DefaultCookieJar` is purely in-memory. Durability comes from wrapping it in a
+`PersistentCookieJar`: reads pass through untouched, and after every mutating
+call the decorator snapshots the inner jar and hands it to the store via
+`persist_zone_from_snapshot(zone, snapshot)`. If a zone is configured with a
+`CookieStore` but no explicit jar, the engine builds this wrapper
+automatically, and `jar_for(zone)` restores the previous session's cookies at
+zone bootstrap.
+
+## Security attributes: what is enforced today
+
+| Attribute | Status |
+|---|---|
+| `Secure` | Enforced both ways: not **stored** from HTTP responses, not **sent** on HTTP requests. |
+| `SameSite` (`Strict`/`Lax`/`None`) | Fully enforced on sending via `SameSiteContext`; a missing attribute defaults to `Lax`; `SameSite=None` requires `Secure`. |
+| `HttpOnly` | Parsed and stored, but currently inert — there is no `document.cookie` JS binding yet to hide the cookie from. |
+| `__Secure-` / `__Host-` prefixes | Enforced at storage time. |
+| `Domain` vs. public suffixes | Enforced via the PSL; supercookies on eTLDs are rejected. |
+
+`SameSiteContext` encodes the request's cross-site situation, and the jar
+applies the RFC 6265bis truth table:
+
+| Cookie attribute | `SameSite` | `CrossSiteNavigation` | `CrossSite` |
+|---|:---:|:---:|:---:|
+| `SameSite=Strict` | ✓ | ✗ | ✗ |
+| `SameSite=Lax` | ✓ | ✓ | ✗ |
+| *(no attribute)* | ✓ | ✓ | ✗ |
+| `SameSite=None; Secure` | ✓ | ✓ | ✓ |
+
+`CrossSiteNavigation` is a cross-site top-level navigation with a safe method
+(GET/HEAD); `CrossSite` is a cross-site subrequest or unsafe-method navigation.
+
+## Key types
+
+-   `Cookie` (data model)
+    -   Serializable struct for persistence and inspection.
+    -   Fields: `name`, `value`, `path`, `domain` (`None` = host-only),
+        `secure`, `http_only`, `expires` (Unix seconds; `None` = session
+        cookie; `Max-Age` is folded in at parse time), `same_site`,
+        `created_at`.
+-   `CookieJar` (runtime trait)
+    -   `store_response_cookies(url, headers, top_level)`,
+        `get_request_cookies(url, top_level, samesite)`, `clear()`,
+        `get_all_cookies()` (diagnostics), `remove_cookie(url, name)`,
+        `remove_cookies_for_url(url)`, `purge_expired()`.
+    -   Accessed via `CookieJarHandle = Arc<RwLock<Box<dyn CookieJar + Send + Sync>>>`.
+-   `CookieStore` (persistence/factory trait)
+    -   `jar_for(zone)`, `persist_zone_from_snapshot(zone, snap)`,
+        `remove_zone(zone)`, `persist_all()`.
+    -   Exposed as `CookieStoreHandle = Arc<dyn CookieStore + Send + Sync>`.
+-   `ThirdPartyCookiePolicy`: `Allow` (default) / `Block` / `SameSiteNoneOnly`.
+-   `SameSiteContext`: `SameSite` / `CrossSiteNavigation` / `CrossSite`.
 
 ## Concurrency model
-- `CookieJarHandle`
-    - `RwLock` outside the trait object.
-    - Read lock for queries, write lock for mutations.
-- `CookieStoreHandle`
-    - Only `&self` methods; implementations must be internally synchronized.
-    - Store impls are `Send + Sync` and may use `Mutex`, pools, or transactional back ends.
+
+-   `CookieJarHandle`
+    -   `RwLock` outside the trait object.
+    -   Read lock for queries, write lock for mutations.
+-   `CookieStoreHandle`
+    -   Only `&self` methods; implementations must be internally synchronized.
+    -   Store impls are `Send + Sync` and may use `Mutex`, pools, or transactional back ends.
 
 ## Component view
-```mermaid
+
+``` mermaid
 flowchart TD
   subgraph Zone
     Z["Zone: ZoneId"]
   end
 
+  subgraph Fetch["tab worker (src/engine/tab/worker.rs)"]
+    REQ["outgoing request<br>get_request_cookies()"]
+    RES["incoming response<br>store_response_cookies()"]
+  end
+
   subgraph Cookie_Runtime["engine/cookies runtime"]
     CJH["CookieJarHandle<br>Arc<RwLock<Box<dyn CookieJar + Send + Sync>>>"]
-    CJT["CookieJar (trait)<br>get_request_cookies()<br>store_response_cookies()<br>clear()"]
-    DCJ["DefaultCookieJar<br>(snapshot type)"]
+    PCJ["PersistentCookieJar<br>(decorator, snapshots after writes)"]
+    DCJ["DefaultCookieJar<br>origin → Vec<Cookie>"]
     C["Cookie<br>serde Serialize/Deserialize"]
   end
 
@@ -63,47 +192,69 @@ flowchart TD
   end
 
   Z -->|"cookie_jar()"| CJH
+  REQ -->|"read()"| CJH
+  RES -->|"write()"| CJH
+  CJH --> PCJ
+  PCJ --> DCJ
+  DCJ -->|"holds"| C
+
   CSH --> CST
   CST --> IM
   CST --> JS
   CST --> SQ
 
-  CSH -->|"jar_for(zone)"| CJH
-  CJH -->|"read()/write()"| CJT
-  CJT -->|"holds"| C
-
-  CSH -. "persist_zone_from_snapshot(zone, DefaultCookieJar)" .-> CST
-  CSH -. "remove_zone(zone)" .-> CST
-  CSH -. "persist_all()" .-> CST
-
-  note1["Jar concurrency: external RwLock on handle"]
-  note2["Store concurrency: internal in impls (Send + Sync)"]
-  CJH --- note1
-  CST --- note2
+  CSH -->|"jar_for(zone) at bootstrap"| CJH
+  PCJ -. "persist_zone_from_snapshot(zone, snapshot)" .-> CSH
 ```
 
-
 ## Responsibilities and boundaries
-- Zone owns the `CookieJarHandle` for its lifetime; it does not depend on the store during hot path.
-- Store is used at zone bootstrap for `jar_for` and at persistence points for `persist_zone_from_snapshot` or `persist_all`.
-- All jar read/write coordination happens via the handle `RwLock`; stores do not participate in jar locking.
+
+-   Zone owns the `CookieJarHandle` for its lifetime; it does not depend on the store during hot path.
+-   The tab worker is the single fetch-pipeline touch point: it reads the jar
+    before a navigation request and writes response cookies back afterwards.
+-   Store is used at zone bootstrap for `jar_for` and at persistence points for `persist_zone_from_snapshot` or `persist_all`.
+-   All jar read/write coordination happens via the handle `RwLock`; stores do not participate in jar locking.
+-   Tabs can deviate from their zone via `TabCookieJar` (`Inherit` the zone jar,
+    `Ephemeral` private jar, or `Custom` handle) — resolved in
+    `src/engine/tab/services.rs`.
 
 ## Error handling and durability
-- Store implementations decide durability semantics:
-    - `in_memory`: ephemeral, process‑lifetime only.
-    - `json`: human‑readable file; fs atomicity recommended in impl.
-    - `sqlite`: transactional durability; concurrent access via connection pool.
-- Trait methods on stores take `&self`; impls must guard internal state.
+
+-   Store implementations decide durability semantics:
+    -   `in_memory`: ephemeral, process‑lifetime only; `persist_*` are no-ops.
+    -   `json`: one human‑readable file for all zones; the whole file is
+        rewritten per snapshot and writes are not atomic — fine for
+        development, not for crash safety.
+    -   `sqlite`: transactional durability (DELETE+INSERT per zone snapshot);
+        concurrent access via a connection pool; expired cookies are purged on
+        load.
+-   Trait methods on stores take `&self`; impls must guard internal state.
+
+## Current limitations
+
+Documented so readers don't assume more than the engine does today:
+
+-   **No `document.cookie`.** JavaScript can neither read nor write cookies
+    yet; consequently `HttpOnly` is stored but has nothing to hide cookies
+    from.
+-   **Only top-level navigations carry cookies.** Subresource fetches (images,
+    stylesheets, scripts) do not consult the jar, and the single call site
+    always passes `SameSiteContext::SameSite` — the `CrossSiteNavigation` /
+    `CrossSite` machinery is implemented and tested in the jar but not yet
+    driven by the fetch pipeline.
+-   **`ThirdPartyCookiePolicy` is not wired up.** Jars are created with the
+    default `Allow`; no production code path selects `Block` or
+    `SameSiteNoneOnly` yet.
+-   **`EngineConfig.cookie_jar_partitioning`** (`CookiePartitioning`) is
+    declared in the config but not yet consumed by the cookie subsystem.
 
 ## Extension points
-- New jar implementation
-    - Implement `CookieJar + Send + Sync`.
-    - Wrap with `CookieJarHandle::new(your_impl)`.
-- New store implementation
-    - Implement `CookieStore + Send + Sync` with internal synchronization.
-    - Decide snapshot format; use `DefaultCookieJar` as the interchange.
 
-## Integration touch‑points
-- `Zone` obtains and exposes `CookieJarHandle` \(`src/engine/zone/zone.rs`\).
-- Net pipeline \(`src/net/fetch.rs`\) reads jar before requests and writes back on responses.
-- Persist triggers can be explicit calls \(`persist_zone_from_snapshot`, `persist_all`\) during shutdown or checkpoints.
+-   New jar implementation
+    -   Implement `CookieJar + Send + Sync`.
+    -   Wrap with `CookieJarHandle::new(your_impl)`.
+    -   Note: `PersistentCookieJar` snapshots by downcasting to
+        `DefaultCookieJar`; a custom jar needs its own persistence strategy.
+-   New store implementation
+    -   Implement `CookieStore + Send + Sync` with internal synchronization.
+    -   Decide snapshot format; use `DefaultCookieJar` as the interchange.

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -1,149 +1,132 @@
 # Gosub crates
 
-The engine is a Cargo workspace split into focused crates. Each crate owns one concern; the
-`gosub_engine` crate is the unified entry point that ties them together for downstream users.
+The engine is a Cargo workspace split into focused crates. Each crate owns one concern; the `gosub_engine` crate is the unified entry point that ties them together for downstream users.
 
 ## Entry point
 
 ### gosub_engine
-The primary public API. Exposes `GosubEngine`, the `Zone`/`Tab` model, the async networking
-stack, cookie and storage isolation, and the `EngineEvent` / `TabCommand` event bus. This is
-what you depend on if you are building a user agent or embedding the browser engine.
 
-See [`examples/hello-world.rs`](../examples/hello-world.rs) for a minimal integration example,
-[`configuration.md`](configuration.md) for how to choose a render backend, and
-[`zones-and-tabs.md`](zones-and-tabs.md) for the zone/tab runtime model.
+The primary public API. Exposes `GosubEngine`, the `Zone`/`Tab` model, the async networking stack, cookie and storage isolation, and the `EngineEvent` / `TabCommand` event bus. This is what you depend on if you are building a user agent or embedding the browser engine.
 
----
+See [`examples/hello-world.rs`](../examples/hello-world.rs) for a minimal integration example, [`configuration.md`](configuration.md) for how to choose a render backend, and [`zones-and-tabs.md`](zones-and-tabs.md) for the zone/tab runtime model.
+
+------------------------------------------------------------------------
 
 ## Parsing
 
 ### gosub_html5
-HTML5 tokenizer and parser. Produces a `Document` / DOM tree. Conforms to the HTML5 spec,
-including error recovery. Also holds the `Document`, `Node`, and related DOM types. See
-[`html5.md`](html5.md) for the tokenizer/tree-builder structure and the html5lib test harness.
+
+HTML5 tokenizer and parser. Produces a `Document` / DOM tree. Conforms to the HTML5 spec, including error recovery. Also holds the `Document`, `Node`, and related DOM types. See [`html5.md`](html5.md) for the tokenizer/tree-builder structure and the html5lib test harness.
 
 ### gosub_css3
-CSS3 tokenizer and parser. Parses stylesheets into a `CssStylesheet` (rules, selectors,
-declarations). Includes a property-value syntax checker for validating CSS property values
-against their formal grammar. See [`css.md`](css.md) for the full parse → match → cascade →
-computed-value flow.
 
----
+CSS3 tokenizer and parser. Parses stylesheets into a `CssStylesheet` (rules, selectors, declarations). Includes a property-value syntax checker for validating CSS property values against their formal grammar. See [`css.md`](css.md) for the full parse → match → cascade → computed-value flow.
+
+------------------------------------------------------------------------
 
 ## Layout and rendering
 
 ### gosub_taffy
-Flexbox / grid layout backed by the [Taffy](https://github.com/DioxusLabs/taffy) library.
-Implements the layout traits from `gosub_interface`. Currently dormant: the live rendering
-path uses `gosub_render_pipeline`'s own layouter instead — see
-[`two-worlds.md`](two-worlds.md).
+
+Flexbox / grid layout backed by the [Taffy](https://github.com/DioxusLabs/taffy) library. Implements the layout traits from `gosub_interface`. Currently dormant: the live rendering path uses `gosub_render_pipeline`'s own layouter instead --- see [`two-worlds.md`](two-worlds.md).
 
 ### gosub_lattice
-CSS table layout engine — handles the table layout algorithm that Taffy does not cover.
-See [`lattice.md`](lattice.md) for the algorithm and the `TableTree` adapter contract.
+
+CSS table layout engine --- handles the table layout algorithm that Taffy does not cover. See [`lattice.md`](lattice.md) for the algorithm and the `TableTree` adapter contract.
 
 ### gosub_render_pipeline
-The render pipeline. Converts the DOM + CSSOM into a render tree with resolved styles and
-positions, runs the paint stages, tiles the output, and composites it. Render backends plug in
-here; this is the crate they implement against.
+
+The render pipeline. Converts the DOM + CSSOM into a render tree with resolved styles and positions, runs the paint stages, tiles the output, and composites it. Render backends plug in here; this is the crate they implement against.
 
 ### gosub_fontmanager
-Font loading and management. Provides the font system abstraction used for text shaping /
-measurement by layout and shared with the render backends for drawing. See [fonts.md](fonts.md)
-for the full picture (font systems vs text rasterizers).
+
+Font loading and management. Provides the font system abstraction used for text shaping / measurement by layout and shared with the render backends for drawing. See [fonts.md](fonts.md) for the full picture (font systems vs text rasterizers).
 
 ### gosub_svg
+
 SVG document support backed by `usvg` and optionally `resvg`.
 
----
+------------------------------------------------------------------------
 
 ## Render backends
 
-Each backend implements the `RenderBackend` trait against `gosub_render_pipeline`. You select
-one at compile time via the engine config — see [`configuration.md`](configuration.md).
+Each backend implements the `RenderBackend` trait against `gosub_render_pipeline`. You select one at compile time via the engine config --- see [`configuration.md`](configuration.md).
 
 ### gosub_renderer_cairo
-Cairo render backend (CPU), with Pango text rendering. Used by the `winit-cairo`, `gtk4-cairo`,
-and `egui-cairo` examples.
+
+Cairo render backend (CPU), with Pango text rendering. Used by the `winit-cairo`, `gtk4-cairo`, and `egui-cairo` examples.
 
 ### gosub_renderer_skia
+
 Skia render backend (CPU or GPU). Used by the `*-skia` and `*-skia-gpu` examples.
 
 ### gosub_renderer_vello
-Vello / wgpu render backend (GPU). Generic over a `WgpuContextProvider`. Used by the
-`winit-vello` and `egui-vello` examples.
+
+Vello / wgpu render backend (GPU). Generic over a `WgpuContextProvider`. Used by the `winit-vello` and `egui-vello` examples.
 
 ### gosub_renderer_dynamic
-Runtime-selectable backend that bundles Cairo, Skia, and Vello behind a single `RenderBackend`,
-chosen at runtime via feature flags rather than at the type level.
 
----
+Runtime-selectable backend that bundles Cairo, Skia, and Vello behind a single `RenderBackend`, chosen at runtime via feature flags rather than at the type level.
+
+------------------------------------------------------------------------
 
 ## Networking
 
 ### gosub_net
-The async networking stack: streaming HTTP fetcher with priority queues, inflight coalescing,
-redirect handling, and per-zone cookie isolation, plus lower-level helpers. Consumed by
-`gosub_engine`.
 
-> Note: this crate is moving to its own project, **gosub_sonar**, which carries its own
-> documentation. The [network docs](network/) here describe the in-tree crate until the
-> move completes.
+The async networking stack: streaming HTTP fetcher with priority queues, inflight coalescing, redirect handling, and per-zone cookie isolation, plus lower-level helpers. Consumed by `gosub_engine`.
 
----
+> Note: this crate is moving to its own project, **gosub_sonar**, which carries its own documentation. The [network docs](network/) here describe the in-tree crate until the move completes.
+
+------------------------------------------------------------------------
 
 ## JavaScript
 
-See [`javascript.md`](javascript.md) for how these crates stack together. Note: the whole
-scripting stack is currently **built but not wired** — no page script is executed yet.
+See [`javascript.md`](javascript.md) for how these crates stack together. Note: the whole scripting stack is currently **built but not wired** --- no page script is executed yet.
 
 ### gosub_v8
+
 Rust bindings to the V8 JavaScript engine.
 
 ### gosub_webexecutor
-JavaScript (and future scripting language) execution runtime. Wraps V8 and provides a
-consistent interface for running scripts inside a browsing context.
+
+JavaScript (and future scripting language) execution runtime. Wraps V8 and provides a consistent interface for running scripts inside a browsing context.
 
 ### gosub_webinterop
-Proc-macro crate. Provides macros for easily exposing Rust functions as JavaScript / Wasm / Lua
-APIs without hand-writing the binding glue.
+
+Proc-macro crate. Provides macros for easily exposing Rust functions as JavaScript / Wasm / Lua APIs without hand-writing the binding glue.
 
 ### gosub_jsapi
-Implementations of browser Web APIs (console, fetch, DOM, etc.) that are callable from
-JavaScript inside the engine.
 
----
+Implementations of browser Web APIs (console, fetch, DOM, etc.) that are callable from JavaScript inside the engine.
+
+------------------------------------------------------------------------
 
 ## Infrastructure
 
 ### gosub_shared
-Shared types, error types, byte streams, and geometry primitives used throughout the workspace.
-Nearly every other crate depends on this.
+
+Shared types, error types, byte streams, and geometry primitives used throughout the workspace. Nearly every other crate depends on this.
 
 ### gosub_interface
-Trait definitions for the major engine components (render backend, layout, CSS system, font
-system, document, etc.). Crates implement these traits; `gosub_engine` wires them together. See
-[`interface.md`](interface.md) for the trait families and type-erasure seams, and
-[`configuration.md`](configuration.md) for how `ModuleConfiguration` / `RenderConfiguration` use
-them.
+
+Trait definitions for the major engine components (render backend, layout, CSS system, font system, document, etc.). Crates implement these traits; `gosub_engine` wires them together. See [`interface.md`](interface.md) for the trait families and type-erasure seams, and [`configuration.md`](configuration.md) for how `ModuleConfiguration` / `RenderConfiguration` use them.
 
 ### gosub_config
-Configuration store. Supports multiple backends (SQLite, JSON) and provides a key/value API
-for engine and UA settings.
+
+Configuration store. Supports multiple backends (SQLite, JSON) and provides a key/value API for engine and UA settings.
 
 ### gosub_web_platform
-Web platform event loop implementation. Manages the JS/Lua runtime lifecycle, timers, and
-event listeners for a browsing context.
 
----
+Web platform event loop implementation. Manages the JS/Lua runtime lifecycle, timers, and event listeners for a browsing context.
+
+------------------------------------------------------------------------
 
 ## Dependency overview
 
-Arrows point from a crate to the crates that depend on it (i.e. build/data flows upward).
-`gosub_shared` underlies nearly everything and most of its edges are omitted for clarity.
+Arrows point from a crate to the crates that depend on it (i.e. build/data flows upward). `gosub_shared` underlies nearly everything and most of its edges are omitted for clarity.
 
-```mermaid
+``` mermaid
 flowchart TD
     shared("gosub_shared")
     interface("gosub_interface")

--- a/docs/css.md
+++ b/docs/css.md
@@ -1,12 +1,10 @@
 # CSS internals (`gosub_css3`)
 
-How a stylesheet's text becomes the computed value the render pipeline reads for a node.
-The crate implements the `CssSystem` trait from [`gosub_interface`](interface.md); its parser
-is heavily based on the MIT-licensed [csstree](https://github.com/csstree/csstree) parser.
+How a stylesheet's text becomes the computed value the render pipeline reads for a node. The crate implements the `CssSystem` trait from [`gosub_interface`](interface.md); its parser is heavily based on the MIT-licensed [csstree](https://github.com/csstree/csstree) parser.
 
 The flow has four stages:
 
-```text
+``` text
   text ──► tokenizer/parser ──► AST ──► CssStylesheet          (parse, once per sheet)
                                             │
   node ──► selector matching ──► matched declarations          (per node)
@@ -18,121 +16,57 @@ The flow has four stages:
 
 ## Parsing (`tokenizer.rs`, `parser/`, `ast.rs`, `stylesheet.rs`)
 
-The tokenizer and hand-written recursive-descent parser (one module per construct under
-`parser/`: selectors, declarations, at-rules, `calc`, `an+b`, …) produce a `CssNode` AST;
-`convert_ast_to_stylesheet` flattens that into the `CssStylesheet` the rest of the engine
-uses: a list of `CssRule`s (selectors + declarations), plus extracted `@font-face` entries.
+The tokenizer and hand-written recursive-descent parser (one module per construct under `parser/`: selectors, declarations, at-rules, `calc`, `an+b`, ...) produce a `CssNode` AST; `convert_ast_to_stylesheet` flattens that into the `CssStylesheet` the rest of the engine uses: a list of `CssRule`s (selectors + declarations), plus extracted `@font-face` entries.
 
-Every stylesheet is tagged with a `CssOrigin` — `UserAgent`, `Author` (the page's own
-sheets), or `User` — which drives cascade priority later. The user-agent stylesheet ships
-embedded in the crate (`resources/useragent.css`, loaded by
-`load_default_useragent_stylesheet`).
+Every stylesheet is tagged with a `CssOrigin` --- `UserAgent`, `Author` (the page's own sheets), or `User` --- which drives cascade priority later. The user-agent stylesheet ships embedded in the crate (`resources/useragent.css`, loaded by `load_default_useragent_stylesheet`).
 
 ## Selector matching (`matcher/styling.rs`)
 
-`match_selector` matches one selector against one node, **right-to-left**: the rightmost
-compound must match the node itself, then combinators (`>`, ` `, `+`, `~`) walk the tree
-looking for matches for the remaining compounds. Pseudo-element matching is explicit: when
-computing styles for `::before`/`::after`, only selectors that carry that pseudo-element
-part are considered, and the rest of the compound is matched against the originating
-element; conversely, a selector with a pseudo-element part never matches the element
-itself.
+`match_selector` matches one selector against one node, **right-to-left**: the rightmost compound must match the node itself, then combinators (`>`, ``, `+`, `~`) walk the tree looking for matches for the remaining compounds. Pseudo-element matching is explicit: when computing styles for `::before`/`::after`, only selectors that carry that pseudo-element part are considered, and the rest of the compound is matched against the originating element; conversely, a selector with a pseudo-element part never matches the element itself.
 
-A successful match returns a `Specificity` — the classic `(id, class, element)` triple,
-compared lexicographically.
+A successful match returns a `Specificity` --- the classic `(id, class, element)` triple, compared lexicographically.
 
 ## Style collection (`system.rs::compute_properties`)
 
 This is the orchestrator behind `CssSystem::properties_from_node`. For one node it:
 
-1. **Filters unrenderables** — `head`/`script`/`style`/`svg`/`noscript`/`title` elements
-   and whitespace-only text nodes get no property map at all (`None` = "not renderable").
-2. **Collects custom properties** — a first pass walks the ancestor chain root-first,
-   gathering every `--*` declaration whose selector matches, so descendants override
-   ancestors. This is a simplified custom-property inheritance model (re-matching selectors
-   per ancestor rather than storing computed maps).
-3. **Matches every rule** in every sheet and, for each matching declaration:
-   - resolves functions: `var()` against the collected custom properties, `attr()` against
-     the DOM, and `clamp()`/`min()`/`max()` arithmetic (`functions/`). Resolved tokens are
-     spliced *flat* into multi-token values — a nested list would break shorthand matching
-     (e.g. `border: 1px solid var(--c)` must stay three top-level tokens);
-   - normalizes vendor prefixes (`-webkit-x` → `x`) so values match the standard grammars;
-   - looks up the property's grammar definition and validates the value (next section).
-     A property *without* a definition entry is passed through unvalidated — deliberately,
-     so valid-but-not-yet-defined longhands still reach consumers. `content` is also passed
-     through verbatim: its grammar (strings, `attr()`, counters) isn't matcher-friendly,
-     and the render pipeline resolves it itself.
-4. **Applies the shorthand fix-list** — expansions collected during validation are merged
-   into the map (see below).
+1.  **Filters unrenderables** --- `head`/`script`/`style`/`svg`/`noscript`/`title` elements and whitespace-only text nodes get no property map at all (`None` = "not renderable").
+2.  **Collects custom properties** --- a first pass walks the ancestor chain root-first, gathering every `--*` declaration whose selector matches, so descendants override ancestors. This is a simplified custom-property inheritance model (re-matching selectors per ancestor rather than storing computed maps).
+3.  **Matches every rule** in every sheet and, for each matching declaration:
+    -   resolves functions: `var()` against the collected custom properties, `attr()` against the DOM, and `clamp()`/`min()`/`max()` arithmetic (`functions/`). Resolved tokens are spliced *flat* into multi-token values --- a nested list would break shorthand matching (e.g. `border: 1px solid var(--c)` must stay three top-level tokens);
+    -   normalizes vendor prefixes (`-webkit-x` → `x`) so values match the standard grammars;
+    -   looks up the property's grammar definition and validates the value (next section). A property *without* a definition entry is passed through unvalidated --- deliberately, so valid-but-not-yet-defined longhands still reach consumers. `content` is also passed through verbatim: its grammar (strings, `attr()`, counters) isn't matcher-friendly, and the render pipeline resolves it itself.
+4.  **Applies the shorthand fix-list** --- expansions collected during validation are merged into the map (see below).
 
-The output `CssProperties` map holds, per property name, a `CssProperty` with the full list
-of `DeclarationProperty`s that matched — value, origin, `!important`, source location, and
-specificity. Nothing is decided yet; the cascade runs lazily per property.
+The output `CssProperties` map holds, per property name, a `CssProperty` with the full list of `DeclarationProperty`s that matched --- value, origin, `!important`, source location, and specificity. Nothing is decided yet; the cascade runs lazily per property.
 
 ## Validation and shorthands (`matcher/`)
 
-`resources/definitions/*.json` (embedded at compile time) define each property's grammar in
-the CSS **value definition syntax** — the notation used by the specs themselves, e.g.
-`<length> | <percentage> | auto`. `matcher/syntax.rs` parses that notation with nom into a
-`CssSyntaxTree` of `SyntaxComponent`s: groups with the four spec combinators
-(juxtaposition, `&&` all-any-order, `||` at-least-one, `|` exactly-one), multipliers
-(`?`, `*`, `+`, `{m,n}`, `#` comma-lists), literals, functions, and ~50 built-in data types
-(`<length>`, `<color>`, `<ident>`, …). `matcher/syntax_matcher.rs` then matches a parsed
-`CssValue` slice against that tree — this is the formal grammar validator: a declaration
-whose value doesn't match its property's grammar is dropped (with a debug log), like a real
-browser discards invalid declarations.
+`resources/definitions/*.json` (embedded at compile time) define each property's grammar in the CSS **value definition syntax** --- the notation used by the specs themselves, e.g. `<length> | <percentage> | auto`. `matcher/syntax.rs` parses that notation with nom into a `CssSyntaxTree` of `SyntaxComponent`s: groups with the four spec combinators (juxtaposition, `&&` all-any-order, `||` at-least-one, `|` exactly-one), multipliers (`?`, `*`, `+`, `{m,n}`, `#` comma-lists), literals, functions, and \~50 built-in data types (`<length>`, `<color>`, `<ident>`, ...). `matcher/syntax_matcher.rs` then matches a parsed `CssValue` slice against that tree --- this is the formal grammar validator: a declaration whose value doesn't match its property's grammar is dropped (with a debug log), like a real browser discards invalid declarations.
 
-**Shorthand expansion** rides on the same match. A shorthand's definition lists its longhand
-properties; while matching, a `FixList` records which matched component corresponds to which
-longhand (e.g. `margin: 0 auto` → `margin-block-start: 0`, `margin-inline-start: auto`, …).
-Two details matter:
+**Shorthand expansion** rides on the same match. A shorthand's definition lists its longhand properties; while matching, a `FixList` records which matched component corresponds to which longhand (e.g. `margin: 0 auto` → `margin-block-start: 0`, `margin-inline-start: auto`, ...). Two details matter:
 
-- Each expansion is tagged (`FixListInfo`) with the *declaring* rule's origin, importance,
-  and specificity, so an author `margin: 0` correctly outranks the UA `body { margin: 8px }`
-  instead of losing on processing order.
-- The `background` shorthand's full `<bg-layer>` grammar is stricter than the matcher
-  supports; instead of dropping `background: url(x) no-repeat` wholesale, the system
-  recovers the parts consumers understand (`background-image` from the `url()`/gradient,
-  `background-color` from the color) and emits those longhands.
+-   Each expansion is tagged (`FixListInfo`) with the *declaring* rule's origin, importance, and specificity, so an author `margin: 0` correctly outranks the UA `body { margin: 8px }` instead of losing on processing order.
+-   The `background` shorthand's full `<bg-layer>` grammar is stricter than the matcher supports; instead of dropping `background: url(x) no-repeat` wholesale, the system recovers the parts consumers understand (`background-image` from the `url()`/gradient, `background-color` from the color) and emits those longhands.
 
 ## The cascade and value stages (`matcher/styling.rs`)
 
-`CssProperty::compute_value()` runs lazily (a `dirty` flag) and walks the spec's value
-stages:
+`CssProperty::compute_value()` runs lazily (a `dirty` flag) and walks the spec's value stages:
 
-1. **Cascaded** — the winning declaration is the `max` of the declared list, ordered by
-   origin/importance priority, then specificity. The priority ranking (per the CSS cascade
-   spec): UA `!important` (7) > User `!important` (6) > Author `!important` (5) >
-   Author (3) > User (2) > UA (1). Ties on both keys resolve to the *last* declaration —
-   i.e. source order wins.
-2. **Specified** — the cascaded value, else the inherited value (filled in by the consumer
-   for inherited properties), else…
-3. **Computed** — …the property's initial value from its definition.
-4. **Used → Actual** — absolute units (`px`, `pt`, `in`, `cm`, `mm`, `pc`, `q`) are rounded
-   to whole values; relative units (`em`, `rem`, `%`, `vw`, `vh`) are deliberately *not*
-   (rounding `1.5em` to `2em` would resize headings), and `opacity` keeps its fraction
-   (rounding `0.15` to `0` would make elements vanish).
+1.  **Cascaded** --- the winning declaration is the `max` of the declared list, ordered by origin/importance priority, then specificity. The priority ranking (per the CSS cascade spec): UA `!important` (7) \> User `!important` (6) \> Author `!important` (5) \> Author (3) \> User (2) \> UA (1). Ties on both keys resolve to the *last* declaration --- i.e. source order wins.
+2.  **Specified** --- the cascaded value, else the inherited value (filled in by the consumer for inherited properties), else...
+3.  **Computed** --- ...the property's initial value from its definition.
+4.  **Used → Actual** --- absolute units (`px`, `pt`, `in`, `cm`, `mm`, `pc`, `q`) are rounded to whole values; relative units (`em`, `rem`, `%`, `vw`, `vh`) are deliberately *not* (rounding `1.5em` to `2em` would resize headings), and `opacity` keeps its fraction (rounding `0.15` to `0` would make elements vanish).
 
-Whether a property inherits, and its initial value, come from the same definitions files
-(`prop_is_inherit`, `PropertyDefinition::initial_value`).
+Whether a property inherits, and its initial value, come from the same definitions files (`prop_is_inherit`, `PropertyDefinition::initial_value`).
 
 ## Hover fingerprints (`system.rs`)
 
-`hover_fingerprints` scans all sheets once and records which element types, classes, and
-ids appear in a compound with `:hover` (or whether a bare `*:hover` exists). The engine
-uses this to skip style recalculation entirely for pointer movement that no hover rule
-could affect — and the scan lives in this crate because only the CSS system understands
-its own selector representation. See the trait notes in [interface.md](interface.md).
+`hover_fingerprints` scans all sheets once and records which element types, classes, and ids appear in a compound with `:hover` (or whether a bare `*:hover` exists). The engine uses this to skip style recalculation entirely for pointer movement that no hover rule could affect --- and the scan lives in this crate because only the CSS system understands its own selector representation. See the trait notes in [interface.md](interface.md).
 
 ## Known gaps
 
-- Not every longhand has a grammar definition yet; those skip validation (by design, see
-  above).
-- The `background` shorthand is recovered partially (image + color; position/repeat/size
-  are ignored).
-- Custom-property collection re-matches selectors along the ancestor chain per node, which
-  is correct but not cheap.
-- At-rules are parsed into the AST, but during stylesheet conversion only two survive:
-  `@font-face` (extracted into the sheet's font list) and `@layer` (its rules are flattened
-  in, without layer-order cascade semantics). Everything else — including `@media` blocks
-  and the rules inside them — is currently dropped.
+-   Not every longhand has a grammar definition yet; those skip validation (by design, see above).
+-   The `background` shorthand is recovered partially (image + color; position/repeat/size are ignored).
+-   Custom-property collection re-matches selectors along the ancestor chain per node, which is correct but not cheap.
+-   At-rules are parsed into the AST, but during stylesheet conversion only two survive: `@font-face` (extracted into the sheet's font list) and `@layer` (its rules are flattened in, without layer-order cascade semantics). Everything else --- including `@media` blocks and the rules inside them --- is currently dropped.

--- a/docs/datastores.md
+++ b/docs/datastores.md
@@ -1,57 +1,53 @@
 # Architecture: Storage subsystem (local and session)
 
 ## Scope
-- Web Storage runtime for per\-origin key/value maps: `localStorage` (persistent) and `sessionStorage` (ephemeral).
-- Service layer that routes reads/writes, enforces scoping, and emits storage events.
 
-Storage is a **zone service**: each zone gets its own `StorageService` via `ZoneServices`, which
-is how two zones browsing the same site stay isolated. See
-[`zones-and-tabs.md`](zones-and-tabs.md) for how services reach tabs.
+-   Web Storage runtime for per-origin key/value maps: `localStorage` (persistent) and `sessionStorage` (ephemeral).
+-   Service layer that routes reads/writes, enforces scoping, and emits storage events.
+
+Storage is a **zone service**: each zone gets its own `StorageService` via `ZoneServices`, which is how two zones browsing the same site stay isolated. See [`zones-and-tabs.md`](zones-and-tabs.md) for how services reach tabs.
 
 ## Directory layout
-- `src/engine/storage/area.rs`: storage area abstraction (key/value operations).
-- `src/engine/storage/service.rs`: orchestration, lookup by zone/tab/origin, event wiring.
-- `src/engine/storage/types.rs`: shared types (keys, values, origins, quotas).
-- `src/engine/storage/event.rs`: `StorageEvent` emission.
-- `src/engine/storage/local/in_memory.rs`: in\-memory local storage backend.
-- `src/engine/storage/local/sqlite_store.rs`: SQLite local storage backend.
-- `src/engine/storage/session/in_memory.rs`: in\-memory session storage backend.
+
+-   `src/engine/storage/area.rs`: storage area abstraction (key/value operations).
+-   `src/engine/storage/service.rs`: orchestration, lookup by zone/tab/origin, event wiring.
+-   `src/engine/storage/types.rs`: shared types (keys, values, origins, quotas).
+-   `src/engine/storage/event.rs`: `StorageEvent` emission.
+-   `src/engine/storage/local/in_memory.rs`: in-memory local storage backend.
+-   `src/engine/storage/local/sqlite_store.rs`: SQLite local storage backend.
+-   `src/engine/storage/session/in_memory.rs`: in-memory session storage backend.
 
 ## Key concepts
-- StorageArea (runtime)
-    - Per\-origin key/value map with typical operations: get, set, remove, clear, len, keys.
-    - Session areas are scoped to a tab/session; local areas are per origin and durable.
-- StorageService (orchestration)
-    - Resolves a storage area for a given `Zone`/tab and origin.
-    - Emits `StorageEvent` to other tabs of the same origin on mutations.
-    - Mediates persistence for local storage via the selected backend.
-- Stores and durability
-    - Local: in\-memory (ephemeral) or SQLite (durable across runs).
-    - Session: in\-memory only; discarded when the tab/session ends.
+
+-   StorageArea (runtime)
+    -   Per-origin key/value map with typical operations: get, set, remove, clear, len, keys.
+    -   Session areas are scoped to a tab/session; local areas are per origin and durable.
+-   StorageService (orchestration)
+    -   Resolves a storage area for a given `Zone`/tab and origin.
+    -   Emits `StorageEvent` to other tabs of the same origin on mutations.
+    -   Mediates persistence for local storage via the selected backend.
+-   Stores and durability
+    -   Local: in-memory (ephemeral) or SQLite (durable across runs).
+    -   Session: in-memory only; discarded when the tab/session ends.
 
 ## Partitioning
 
-Storage areas are keyed by **(partition key, origin)**, not origin alone. The zone's
-`PartitionPolicy` (part of `ZoneServices`) controls the partition key:
+Storage areas are keyed by **(partition key, origin)**, not origin alone. The zone's `PartitionPolicy` (part of `ZoneServices`) controls the partition key:
 
-- `PartitionPolicy::None` — no partitioning; one global state per origin.
-- `PartitionPolicy::TopLevelOrigin` (the default) — the key is the top-level origin of the
-  navigated URL, so `site-a.com` and `site-b.com` embedding the same third party see
-  *different* storage for it.
+-   `PartitionPolicy::None` --- no partitioning; one global state per origin.
+-   `PartitionPolicy::TopLevelOrigin` (the default) --- the key is the top-level origin of the navigated URL, so `site-a.com` and `site-b.com` embedding the same third party see *different* storage for it.
 
-The tab worker computes the key on every navigation (`compute_partition_key` in
-`storage/types.rs`, called from `prepare_storage_for`) and resolves its local/session
-handles for that (partition, origin) pair. Cookies do not use this mechanism; their
-isolation is per-zone via the cookie store (see [`cookies.md`](cookies.md)).
+The tab worker computes the key on every navigation (`compute_partition_key` in `storage/types.rs`, called from `prepare_storage_for`) and resolves its local/session handles for that (partition, origin) pair. Cookies do not use this mechanism; their isolation is per-zone via the cookie store (see [`cookies.md`](cookies.md)).
 
 ## Concurrency model
-- Areas and stores are `Send + Sync`; implementations perform internal synchronization.
-- Service exposes cheap handles and never blocks hot read paths longer than necessary.
-- Cross\-tab notifications are delivered via the engine event bus.
+
+-   Areas and stores are `Send + Sync`; implementations perform internal synchronization.
+-   Service exposes cheap handles and never blocks hot read paths longer than necessary.
+-   Cross-tab notifications are delivered via the engine event bus.
 
 ## Component view
 
-```mermaid
+``` mermaid
 flowchart TD
 %% Zones & Tabs
   subgraph Z["Zone"]
@@ -99,10 +95,9 @@ flowchart TD
   LArea -. "mutations" .-> EV
   EV -. "notify same-origin tabs in Zone" .- T1
   EV -. "notify same-origin tabs in Zone" .- T2
-
 ```
 
-```svg
+``` svg
 <svg xmlns="http://www.w3.org/2000/svg" width="980" height="520" viewBox="0 0 980 520">
   <style>
     .box { fill:#fff; stroke:#333; rx:10; ry:10; }
@@ -176,7 +171,7 @@ flowchart TD
 
 ## Sequence diagram
 
-```mermaid
+``` mermaid
 sequenceDiagram
   participant TA as Tab A (origin A)
   participant SS as StorageService
@@ -201,10 +196,12 @@ sequenceDiagram
 ```
 
 ## Responsibilities and boundaries
-- StorageService resolves areas, scopes them by origin (and tab for session), and emits `StorageEvent`.
-- Local storage is persisted by its backend (SQLite or in\-memory ephemeral); session storage lives only in memory.
-- Backends handle their own synchronization and durability semantics.
+
+-   StorageService resolves areas, scopes them by origin (and tab for session), and emits `StorageEvent`.
+-   Local storage is persisted by its backend (SQLite or in-memory ephemeral); session storage lives only in memory.
+-   Backends handle their own synchronization and durability semantics.
 
 ## Extension points
-- Add a new local storage backend by implementing the local store interface and wiring it in `src/engine/storage/service.rs`.
-- Enforce quotas or eviction policies inside `StorageArea` implementations or mediated by `StorageService`.
+
+-   Add a new local storage backend by implementing the local store interface and wiring it in `src/engine/storage/service.rs`.
+-   Enforce quotas or eviction policies inside `StorageArea` implementations or mediated by `StorageService`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,20 +2,20 @@
 
 Run the test suite:
 
-```bash
+``` bash
 make test
 ```
 
 Run the benchmarks (Criterion):
 
-```bash
+``` bash
 cargo bench
 # open target/criterion/report/index.html
 ```
 
 Build everything in the workspace, including all examples and GUI binaries:
 
-```bash
+``` bash
 cargo build --workspace --examples --bins
 ```
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,16 +1,12 @@
 # Running the examples
 
-The repository ships runnable examples in two groups: headless engine examples (no GUI), and GUI
-examples that open a real window. For a narrative description of what each example does, see
-[`examples/README.md`](../examples/README.md). For how the engine is configured per backend, see
-[`configuration.md`](configuration.md).
+The repository ships runnable examples in two groups: headless engine examples (no GUI), and GUI examples that open a real window. For a narrative description of what each example does, see [`examples/README.md`](../examples/README.md). For how the engine is configured per backend, see [`configuration.md`](configuration.md).
 
 ## Installing dependencies
 
-This project uses [cargo](https://doc.rust-lang.org/cargo/) and
-[rustup](https://www.rust-lang.org/tools/install). Install `rustup`, then:
+This project uses [cargo](https://doc.rust-lang.org/cargo/) and [rustup](https://www.rust-lang.org/tools/install). Install `rustup`, then:
 
-```bash
+``` bash
 rustup default stable
 git clone https://github.com/gosub-io/gosub-engine.git
 cd gosub-engine
@@ -19,72 +15,96 @@ cargo build
 
 **OS packages required for GTK4 and Cairo examples** (Ubuntu / Debian):
 
-```
-make gcc g++
-libglib2.0-dev libcairo2-dev libpango1.0-dev
-libgdk-pixbuf-2.0-dev libgraphene-1.0-dev libgtk-4-dev
-libsqlite3-dev
-```
+    make gcc g++
+    libglib2.0-dev libcairo2-dev libpango1.0-dev
+    libgdk-pixbuf-2.0-dev libgraphene-1.0-dev libgtk-4-dev
+    libsqlite3-dev
 
-The winit-vello, egui-vello, and gosub-screenshot binaries have no system-library dependencies and
-build out of the box on Linux, macOS, and Windows.
+The winit-vello, egui-vello, and gosub-screenshot binaries have no system-library dependencies and build out of the box on Linux, macOS, and Windows.
 
 ## Engine examples (no GUI required)
 
-| Command | Description |
-|---|---|
-| `cargo run --example hello-world` | Single tab — navigate a URL, stream events to stdout |
-| `cargo run --example multi-tab` | 25 tabs navigating random sites; live progress bars via `indicatif` |
-| `cargo run --example tutorial -- <url>` | The companion to [`tutorial.md`](tutorial.md) |
+  ---------------------------------------------------------------------------------------------------------------
+  Command                                   Description
+  ----------------------------------------- ---------------------------------------------------------------------
+  `cargo run --example hello-world`         Single tab --- navigate a URL, stream events to stdout
+
+  `cargo run --example multi-tab`           25 tabs navigating random sites; live progress bars via `indicatif`
+
+  `cargo run --example tutorial -- <url>`   The companion to [`tutorial.md`](tutorial.md)
+  ---------------------------------------------------------------------------------------------------------------
 
 ## GUI examples
 
-All GUI examples accept a URL as the first argument, e.g. `-- https://example.com`.
+All GUI examples accept a URL as the first argument, e.g. `-- https://example.com`.
 
 ### winit (cross-platform, no GTK required)
 
-| Command | Renderer | Notes |
-|---|---|---|
-| `cargo run -p example-winit-vello` | Vello / wgpu | Cross-platform — Metal, DX12, Vulkan |
-| `cargo run -p example-winit-skia` | Skia CPU | softbuffer presentation |
-| `cargo run -p example-winit-skia-gpu` | Skia GPU (OpenGL) | OpenGL compositing |
-| `cargo run -p example-winit-cairo` | Cairo CPU | Linux; needs libcairo |
+  --------------------------------------------------------------------------------------------------------
+  Command                                 Renderer                Notes
+  --------------------------------------- ----------------------- ----------------------------------------
+  `cargo run -p example-winit-vello`      Vello / wgpu            Cross-platform --- Metal, DX12, Vulkan
+
+  `cargo run -p example-winit-skia`       Skia CPU                softbuffer presentation
+
+  `cargo run -p example-winit-skia-gpu`   Skia GPU (OpenGL)       OpenGL compositing
+
+  `cargo run -p example-winit-cairo`      Cairo CPU               Linux; needs libcairo
+  --------------------------------------------------------------------------------------------------------
 
 ### GTK4 (Linux, requires GTK4 system packages)
 
-| Command | Renderer | Notes |
-|---|---|---|
-| `cargo run -p example-gtk4-cairo` | Cairo CPU | Pango text rendering |
-| `cargo run -p example-gtk4-skia` | Skia CPU | |
-| `cargo run -p example-gtk4-skia-gpu` | Skia GPU (OpenGL/GLArea) | Hardware-accelerated compositing |
+  ----------------------------------------------------------------------------------------------------
+  Command                                Renderer                   Notes
+  -------------------------------------- -------------------------- ----------------------------------
+  `cargo run -p example-gtk4-cairo`      Cairo CPU                  Pango text rendering
+
+  `cargo run -p example-gtk4-skia`       Skia CPU                   
+
+  `cargo run -p example-gtk4-skia-gpu`   Skia GPU (OpenGL/GLArea)   Hardware-accelerated compositing
+  ----------------------------------------------------------------------------------------------------
 
 ### egui
 
-| Command | Renderer | Notes |
-|---|---|---|
-| `cargo run -p example-egui-vello` | Vello / wgpu | Cross-platform |
-| `cargo run -p example-egui-skia` | Skia CPU | |
-| `cargo run -p example-egui-cairo` | Cairo CPU | Linux; needs libcairo |
+  -----------------------------------------------------------------------------------
+  Command                             Renderer                Notes
+  ----------------------------------- ----------------------- -----------------------
+  `cargo run -p example-egui-vello`   Vello / wgpu            Cross-platform
+
+  `cargo run -p example-egui-skia`    Skia CPU                
+
+  `cargo run -p example-egui-cairo`   Cairo CPU               Linux; needs libcairo
+  -----------------------------------------------------------------------------------
 
 ## Headless tool
 
-| Command | Description |
-|---|---|
-| `cargo run -p gosub-screenshot -- <url> [out.png]` | Render a URL to a full-page PNG without opening a window (CPU Skia, statically linked — no GPU or system libraries) |
+  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  Command                                              Description
+  ---------------------------------------------------- -----------------------------------------------------------------------------------------------------------------------
+  `cargo run -p gosub-screenshot -- <url> [out.png]`   Render a URL to a full-page PNG without opening a window (CPU Skia, statically linked --- no GPU or system libraries)
 
-See [headless.md](headless.md) for how the tool drives the engine and how to build your own
-headless integration.
+  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+See [headless.md](headless.md) for how the tool drives the engine and how to build your own headless integration.
 
 ## Component tools (individual crate testing)
 
-| Command | Description |
-|---|---|
-| `cargo run --bin gosub-parser` | HTML5 parser / tokenizer — prints a document tree |
-| `cargo run --bin css3-parser` | CSS3 parser — prints a CSS tree from a URL |
-| `cargo run --bin display-text-tree` | Text-only render of a page |
-| `cargo run --bin config-store` | Config store smoke test |
-| `cargo run --bin run-js` | Run a JS file (event loop not yet implemented) |
-| `cargo run --bin html5-parser-test` | html5lib tree-builder test suite |
-| `cargo run --bin parser-test` | Parser development test runner |
+  -------------------------------------------------------------------------------------------
+  Command                               Description
+  ------------------------------------- -----------------------------------------------------
+  `cargo run --bin gosub-parser`        HTML5 parser / tokenizer --- prints a document tree
+
+  `cargo run --bin css3-parser`         CSS3 parser --- prints a CSS tree from a URL
+
+  `cargo run --bin display-text-tree`   Text-only render of a page
+
+  `cargo run --bin config-store`        Config store smoke test
+
+  `cargo run --bin run-js`              Run a JS file (event loop not yet implemented)
+
+  `cargo run --bin html5-parser-test`   html5lib tree-builder test suite
+
+  `cargo run --bin parser-test`         Parser development test runner
+  -------------------------------------------------------------------------------------------
 
 For more detail on the component tools see [`binaries.md`](binaries.md).

--- a/docs/fonts.md
+++ b/docs/fonts.md
@@ -1,25 +1,17 @@
 # Fonts: the two backend families
 
-Text handling in Gosub is split across **two independent backend families** that are easy to
-confuse, because both come in `pango`, `parley`, and `skia` flavours:
+Text handling in Gosub is split across **two independent backend families** that are easy to confuse, because both come in `pango`, `parley`, and `skia` flavours:
 
-1. **Font systems** — implement the `FontSystem` trait. They register fonts and *measure*
-   text so the layouter can size boxes. They never draw anything.
-2. **Text rasterizers** — the code that actually *renders glyphs* onto a surface. Selected
-   per render-backend crate at compile time with `text_*` cargo features. They have no
-   shared trait; each exposes a `do_paint_text(...)` function.
+1.  **Font systems** --- implement the `FontSystem` trait. They register fonts and *measure* text so the layouter can size boxes. They never draw anything.
+2.  **Text rasterizers** --- the code that actually *renders glyphs* onto a surface. Selected per render-backend crate at compile time with `text_*` cargo features. They have no shared trait; each exposes a `do_paint_text(...)` function.
 
-You pick a font system at runtime (it's a type parameter on your config); you pick a text
-rasterizer at build time (it's a cargo feature on the renderer crate). The two must agree —
-the whole design exists to guarantee that text is **measured and drawn against the same font
-collection**, so a layout box is never sized with one font and painted with another.
+You pick a font system at runtime (it's a type parameter on your config); you pick a text rasterizer at build time (it's a cargo feature on the renderer crate). The two must agree --- the whole design exists to guarantee that text is **measured and drawn against the same font collection**, so a layout box is never sized with one font and painted with another.
 
 ## Family 1: font systems (`FontSystem`)
 
-The trait lives in [`gosub_interface/src/font_system.rs`](../crates/gosub_interface/src/font_system.rs)
-and is deliberately small:
+The trait lives in [`gosub_interface/src/font_system.rs`](../crates/gosub_interface/src/font_system.rs) and is deliberately small:
 
-```rust
+``` rust
 pub trait FontSystem: Send + Sync + 'static {
     /// Register a font from raw bytes (`@font-face` web fonts, bundled fallbacks).
     fn register_font(&mut self, data: Vec<u8>, family_override: Option<&str>) -> Result<(), FontError>;
@@ -30,92 +22,61 @@ pub trait FontSystem: Send + Sync + 'static {
 }
 ```
 
-Shaping and drawing are intentionally **not** on the trait: the shaped representation and the
-draw target are backend-specific. A render backend that wants more than measurement downcasts
-via `as_any_mut` and calls the concrete type's own inherent methods.
+Shaping and drawing are intentionally **not** on the trait: the shaped representation and the draw target are backend-specific. A render backend that wants more than measurement downcasts via `as_any_mut` and calls the concrete type's own inherent methods.
 
-The trait file also defines the shared value types: `TextStyle` (family, size, weight, style,
-stretch, optional line-height and wrap width, display scale), `FontQuery` / `ResolvedFont`
-(family resolution with raw `FontBlob` bytes), and `ShapedText` / `ShapedRun` / `ShapedGlyph`
-(positioned glyph runs, produced by implementations that shape natively).
+The trait file also defines the shared value types: `TextStyle` (family, size, weight, style, stretch, optional line-height and wrap width, display scale), `FontQuery` / `ResolvedFont` (family resolution with raw `FontBlob` bytes), and `ShapedText` / `ShapedRun` / `ShapedGlyph` (positioned glyph runs, produced by implementations that shape natively).
 
 ### Implementations
 
-| Implementation | Crate / file | Backed by | Notes |
-|---|---|---|---|
-| `ParleyFontSystem` | [`gosub_fontmanager/src/parley_system.rs`](../crates/gosub_fontmanager/src/parley_system.rs) | Parley + Fontique | The default; portable (not tied to a renderer). |
-| `CosmicFontSystem` | [`gosub_fontmanager/src/cosmic_system.rs`](../crates/gosub_fontmanager/src/cosmic_system.rs) | cosmic-text (fontdb + rustybuzz + swash) | A second implementation proving the trait is engine-agnostic; see its module doc for why the trait is still somewhat "Parley-shaped". |
-| `PangoFontSystem` | [`gosub_renderer_cairo/src/font/pango.rs`](../crates/gosub_renderer_cairo/src/font/pango.rs) | Pango / fontconfig | Registers web fonts into process-global fontconfig. Requires one-time init from the GTK main thread (`init_from_gtk_thread`) to resolve `system-ui`; a process-wide singleton exists for this reason. |
-| `SkiaFontSystem` | [`gosub_renderer_skia/src/font/skia.rs`](../crates/gosub_renderer_skia/src/font/skia.rs) | Skia (`skia_safe`) paragraph layout | Measures through the same thread-local `FontCollection` the Skia rasterizer draws with. |
+| Implementation     | Crate / file                                                                                 | Backed by                                  | Notes |
+|--------------------|----------------------------------------------------------------------------------------------|--------------------------------------------|-------|
+| `ParleyFontSystem` | [`gosub_fontmanager/src/parley_system.rs`](../crates/gosub_fontmanager/src/parley_system.rs) | Parley + Fontique                          | The default; portable, not tied to a renderer. |
+| `CosmicFontSystem` | [`gosub_fontmanager/src/cosmic_system.rs`](../crates/gosub_fontmanager/src/cosmic_system.rs) | cosmic-text, fontdb, rustybuzz, swash      | A second implementation proving the trait is engine-agnostic; see its module doc for why the trait is still somewhat “Parley-shaped”. |
+| `PangoFontSystem`  | [`gosub_renderer_cairo/src/font/pango.rs`](../crates/gosub_renderer_cairo/src/font/pango.rs) | Pango / fontconfig                         | Registers web fonts into process-global fontconfig. Requires one-time init from the GTK main thread, `init_from_gtk_thread`, to resolve `system-ui`; a process-wide singleton exists for this reason. |
+| `SkiaFontSystem`   | [`gosub_renderer_skia/src/font/skia.rs`](../crates/gosub_renderer_skia/src/font/skia.rs)     | Skia, `skia_safe`, paragraph layout        | Measures through the same thread-local `FontCollection` the Skia rasterizer draws with. |
 
-`ParleyFontSystem` and `CosmicFontSystem` live in `gosub_fontmanager` because they are
-renderer-independent. `PangoFontSystem` and `SkiaFontSystem` live inside their renderer
-crates because they are inherently coupled to that renderer's text engine.
+`ParleyFontSystem` and `CosmicFontSystem` live in `gosub_fontmanager` because they are renderer-independent. `PangoFontSystem` and `SkiaFontSystem` live inside their renderer crates because they are inherently coupled to that renderer's text engine.
 
 ### How a font system reaches layout and rendering
 
-A single instance is shared as `Arc<Mutex<dyn FontSystem>>` between the layouter and the
-rasterizer:
+A single instance is shared as `Arc<Mutex<dyn FontSystem>>` between the layouter and the rasterizer:
 
-- Your config implements `HasFontSystem` (usually via `DefaultRenderConfig<Backend, FontSystem>`,
-  see [configuration.md](configuration.md)), which hands the `Arc` to both sides.
-- In the render pipeline, `Rasterable::font_system()`
-  ([`gosub_render_pipeline/src/rasterizer.rs`](../crates/gosub_render_pipeline/src/rasterizer.rs))
-  exposes the rasterizer's font system so the layouter can adopt the same instance. It returns
-  `None` for rasterizers that don't shape through a `FontSystem` (e.g. the null rasterizer);
-  the layouter then falls back to its own `ParleyFontSystem`
-  (`TaffyLayouter::new()` in [`gosub_render_pipeline/src/layouter/taffy.rs`](../crates/gosub_render_pipeline/src/layouter/taffy.rs)).
-- `register_font` is how `@font-face` web fonts and bundled fallbacks (Roboto, from
-  `gosub_shared`) enter the collection — once, visible to both measurement and drawing.
+-   Your config implements `HasFontSystem` (usually via `DefaultRenderConfig<Backend, FontSystem>`, see [configuration.md](configuration.md)), which hands the `Arc` to both sides.
+-   In the render pipeline, `Rasterable::font_system()` ([`gosub_render_pipeline/src/rasterizer.rs`](../crates/gosub_render_pipeline/src/rasterizer.rs)) exposes the rasterizer's font system so the layouter can adopt the same instance. It returns `None` for rasterizers that don't shape through a `FontSystem` (e.g. the null rasterizer); the layouter then falls back to its own `ParleyFontSystem` (`TaffyLayouter::new()` in [`gosub_render_pipeline/src/layouter/taffy.rs`](../crates/gosub_render_pipeline/src/layouter/taffy.rs)).
+-   `register_font` is how `@font-face` web fonts and bundled fallbacks (Roboto, from `gosub_shared`) enter the collection --- once, visible to both measurement and drawing.
 
 Measurement happens in **CSS pixels**; DPI scaling is applied later in the pipeline.
 
 ## Family 2: text rasterizers (`text_*` features)
 
-Each renderer crate can draw text through more than one text engine. The choice is a cargo
-feature, resolved at compile time; each variant lives in `src/rasterizer/text/<engine>.rs`
-and exports a `do_paint_text(...)` entry point that paints one `PaintCommand::Text` onto the
-backend's surface.
+Each renderer crate can draw text through more than one text engine. The choice is a cargo feature, resolved at compile time; each variant lives in `src/rasterizer/text/<engine>.rs` and exports a `do_paint_text(...)` entry point that paints one `PaintCommand::Text` onto the backend's surface.
 
-| Renderer crate | Available features | Default |
-|---|---|---|
-| `gosub_renderer_cairo` | `text_pango`, `text_parley`, `text_skia` | `text_pango` |
-| `gosub_renderer_vello` | `text_parley`, `text_skia`, `text_pango` | `text_parley` |
-| `gosub_renderer_skia` | — (always uses Skia paragraph layout) | built in |
+| Renderer crate          | Available features                       | Default       |
+|-------------------------|------------------------------------------|---------------|
+| `gosub_renderer_cairo`  | `text_pango`, `text_parley`, `text_skia` | `text_pango`  |
+| `gosub_renderer_vello`  | `text_parley`, `text_skia`, `text_pango` | `text_parley` |
+| `gosub_renderer_skia`   | — always uses Skia paragraph layout      | built in      |
 
-A `compile_error!` in each crate's `rasterizer/text.rs` guards that at least one `text_*`
-feature is enabled; when several are enabled at once, a fixed precedence chain picks which
-`do_paint_text` is used.
+A `compile_error!` in each crate's `rasterizer/text.rs` guards that at least one `text_*` feature is enabled; when several are enabled at once, a fixed precedence chain picks which `do_paint_text` is used.
 
-Layout-building helpers for the rasterizers live under each crate's `src/font/` directory
-(e.g. `get_parley_layout` in the Vello crate, `get_skia_paragraph` in the Skia crate) —
-distinct from the `FontSystem` implementations that happen to share that directory. Vello
-additionally caches shaped text in `backend/text_renderer.rs` (keyed by `TextKey`).
+Layout-building helpers for the rasterizers live under each crate's `src/font/` directory (e.g. `get_parley_layout` in the Vello crate, `get_skia_paragraph` in the Skia crate) --- distinct from the `FontSystem` implementations that happen to share that directory. Vello additionally caches shaped text in `backend/text_renderer.rs` (keyed by `TextKey`).
 
 ## Which font system pairs with which renderer
 
-Measurement must match drawing, so pick the font system that corresponds to the text
-rasterizer your renderer was built with:
+Measurement must match drawing, so pick the font system that corresponds to the text rasterizer your renderer was built with:
 
-| Renderer (text feature) | Font system | Used by |
-|---|---|---|
-| Cairo (`text_pango`) | `PangoFontSystem` | GTK4/winit/egui cairo examples |
-| Vello (`text_parley`) | `ParleyFontSystem` | winit/egui vello examples |
-| Skia | `SkiaFontSystem` | skia examples, `bin/gosub-screenshot` |
+| Renderer/text feature | Font system        | Used by                         |
+|-----------------------|--------------------|---------------------------------|
+| Cairo, `text_pango`   | `PangoFontSystem`  | GTK4/winit/egui cairo examples  |
+| Vello, `text_parley`  | `ParleyFontSystem` | winit/egui vello examples       |
+| Skia                  | `SkiaFontSystem`   | skia examples, `bin/gosub-screenshot` |
 
 For example, the screenshot tool uses `DefaultRenderConfig<SkiaBackend, SkiaFontSystem>`.
 
-Mixing (say, `ParleyFontSystem` for measurement with Pango drawing) will compile — the trait
-doesn't stop you — but line breaks and box sizes are then computed with different metrics
-than the glyphs painted into them, which shows up as clipped or overflowing text.
+Mixing (say, `ParleyFontSystem` for measurement with Pango drawing) will compile --- the trait doesn't stop you --- but line breaks and box sizes are then computed with different metrics than the glyphs painted into them, which shows up as clipped or overflowing text.
 
 ### Per-implementation quirks worth knowing
 
-- **Pango** uses its own natural line height during measurement, deliberately matching how
-  the Cairo rasterizer draws; `TextStyle::line_height` is not applied there.
-- **Skia** *does* apply the CSS line height during measurement (as a multiple of font size),
-  exactly like its draw path — skipping this used to make measured boxes shorter than the
-  painted text. It also prunes the CSS family list so an unavailable leading family can't
-  capture the platform default.
-- **Pango's `system-ui`** resolution must happen on the GTK main thread before background
-  rendering starts.
+-   **Pango** uses its own natural line height during measurement, deliberately matching how the Cairo rasterizer draws; `TextStyle::line_height` is not applied there.
+-   **Skia** *does* apply the CSS line height during measurement (as a multiple of font size), exactly like its draw path --- skipping this used to make measured boxes shorter than the painted text. It also prunes the CSS family list so an unavailable leading family can't capture the platform default.
+-   **Pango's `system-ui`** resolution must happen on the GTK main thread before background rendering starts.

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -1,83 +1,55 @@
 # Headless usage
 
-How to drive the full engine — navigation, layout, rasterization — without opening a
-window. The reference implementation is the screenshot tool
-([`bin/gosub-screenshot/main.rs`](../bin/gosub-screenshot/main.rs)): URL in, full-page PNG
-out.
+How to drive the full engine --- navigation, layout, rasterization --- without opening a window. The reference implementation is the screenshot tool ([`bin/gosub-screenshot/main.rs`](../bin/gosub-screenshot/main.rs)): URL in, full-page PNG out.
 
-```sh
+``` sh
 cargo run --release -p gosub-screenshot -- news.ycombinator.com out.png 1280
 ```
 
 Two levels of "headless" exist, pick per use case:
 
-- **Engine without rendering** — the single-file examples (`hello-world`, `multi-tab`, …)
-  run on the `NullBackend`: navigation, parsing, and events work, nothing is rasterized.
-  Good for crawling and parser work. See [examples.md](examples.md).
-- **Engine with real rendering, no window** — this page: the screenshot tool renders
-  pages exactly as a GUI browser would, using CPU Skia.
+-   **Engine without rendering** --- the single-file examples (`hello-world`, `multi-tab`, ...) run on the `NullBackend`: navigation, parsing, and events work, nothing is rasterized. Good for crawling and parser work. See [examples.md](examples.md).
+-   **Engine with real rendering, no window** --- this page: the screenshot tool renders pages exactly as a GUI browser would, using CPU Skia.
 
 ## Why CPU Skia
 
 The tool uses `DefaultRenderConfig<SkiaBackend, SkiaFontSystem>`:
 
-- **No GPU, no window system**: no wgpu adapter is requested, and skia-safe is statically
-  linked, so the binary runs on a bare server/CI container with no system libraries.
-- **No size limit**: the page is rasterized into small cached tiles
-  (`ExternalHandle::TileCache`) that the tool composites itself, so — unlike a
-  GPU-texture path — there is no texture-size cap and a page of *any* height can be
-  captured in one image.
+-   **No GPU, no window system**: no wgpu adapter is requested, and skia-safe is statically linked, so the binary runs on a bare server/CI container with no system libraries.
+-   **No size limit**: the page is rasterized into small cached tiles (`ExternalHandle::TileCache`) that the tool composites itself, so --- unlike a GPU-texture path --- there is no texture-size cap and a page of *any* height can be captured in one image.
 
-The font system must match the backend (measurement and drawing share one font
-collection) — see [fonts.md](fonts.md).
+The font system must match the backend (measurement and drawing share one font collection) --- see [fonts.md](fonts.md).
 
 ## Engine setup
 
-The setup is the same as a GUI embedder's, minus the window (compare
-[tutorial.md](tutorial.md)):
+The setup is the same as a GUI embedder's, minus the window (compare [tutorial.md](tutorial.md)):
 
-1. Create the backend and a `DefaultCompositor` whose redraw callback signals a channel —
-   this is the "new frame available" notification a GUI would use to schedule a repaint.
-2. `GosubEngine::<AppConfig>::new(…)`, `start()`, `subscribe_events()`.
-3. Create a zone with throwaway storage (`SqliteLocalStore::new(":memory:")`, in-memory
-   session store, no cookie persistence) and one tab.
-4. Send `TabCommand::SetViewport`, `Navigate`, and `ResumeDrawing { fps }`.
+1.  Create the backend and a `DefaultCompositor` whose redraw callback signals a channel --- this is the "new frame available" notification a GUI would use to schedule a repaint.
+2.  `GosubEngine::<AppConfig>::new(…)`, `start()`, `subscribe_events()`.
+3.  Create a zone with throwaway storage (`SqliteLocalStore::new(":memory:")`, in-memory session store, no cookie persistence) and one tab.
+4.  Send `TabCommand::SetViewport`, `Navigate`, and `ResumeDrawing { fps }`.
 
-One trick worth stealing: the tool sets the initial viewport to `width × 16384` CSS px.
-The tall viewport makes below-the-fold and lazily-sized content lay out immediately; the
-final image uses the page's *true* laid-out height, not this value.
+One trick worth stealing: the tool sets the initial viewport to `width × 16384` CSS px. The tall viewport makes below-the-fold and lazily-sized content lay out immediately; the final image uses the page's *true* laid-out height, not this value.
 
 ## Capturing a frame
 
 The tool runs three phases:
 
-1. **Wait for content** — spin on the event stream until `NavigationEvent::Finished`, then
-   wait for the first redraw signal after that (the first frame that actually contains the
-   page). Both waits have timeouts (`--nav-timeout`, `--render-timeout`).
-2. **Obtain the tile cache** — ask the compositor for the tab's latest frame
-   (`compositor.frame_for(tab_id)`) and expect an `ExternalHandle::TileCache`, which
-   carries the tiles and the laid-out `page_height`. A 1-px synthetic scroll
-   (`TabCommand::MouseScroll`) nudges the engine into publishing a fresh tile-cache frame
-   if needed.
-3. **Composite** — allocate an opaque-white RGBA buffer at `viewport_width × page_height`
-   and blend every tile into it. This is a miniature version of what every host compositor
-   does (see [layering-and-compositing.md](render-pipeline/layering-and-compositing.md)):
-   - normalize the tile's pixel format to RGBA via `PixelFormat::to_rgba` (tiles are
-     self-describing; Skia produces premultiplied `[B,G,R,A]`);
-   - scale by the tile's layer **group opacity** (a translucent navbar fades as a unit);
-   - **source-over blend** into the buffer rather than overwrite — a promoted
-     `position: fixed` layer's transparent tile regions must reveal the rows already
-     composited beneath, not erase them.
+1.  **Wait for content** --- spin on the event stream until `NavigationEvent::Finished`, then wait for the first redraw signal after that (the first frame that actually contains the page). Both waits have timeouts (`--nav-timeout`, `--render-timeout`).
+2.  **Obtain the tile cache** --- ask the compositor for the tab's latest frame (`compositor.frame_for(tab_id)`) and expect an `ExternalHandle::TileCache`, which carries the tiles and the laid-out `page_height`. A 1-px synthetic scroll (`TabCommand::MouseScroll`) nudges the engine into publishing a fresh tile-cache frame if needed.
+3.  **Composite** --- allocate an opaque-white RGBA buffer at `viewport_width × page_height` and blend every tile into it. This is a miniature version of what every host compositor does (see [layering-and-compositing.md](render-pipeline/layering-and-compositing.md)):
+    -   normalize the tile's pixel format to RGBA via `PixelFormat::to_rgba` (tiles are self-describing; Skia produces premultiplied `[B,G,R,A]`);
+    -   scale by the tile's layer **group opacity** (a translucent navbar fades as a unit);
+    -   **source-over blend** into the buffer rather than overwrite --- a promoted `position: fixed` layer's transparent tile regions must reveal the rows already composited beneath, not erase them.
 
 Scroll anchors are irrelevant here because the capture is the full page at scroll 0.
 
 ## CLI reference
 
-```text
+``` text
 gosub-screenshot <url> [output.png] [width]
     --nav-timeout <s>      wait for navigation (default 30)
     --render-timeout <s>   wait for first render after navigation (default 120)
 ```
 
-`https://` is prepended when the URL has no scheme. The build embeds the git SHA and date
-via `build.rs` (`gosub-screenshot --version`).
+`https://` is prepended when the URL has no scheme. The build embeds the git SHA and date via `build.rs` (`gosub-screenshot --version`).

--- a/docs/html5.md
+++ b/docs/html5.md
@@ -1,12 +1,8 @@
 # HTML5 parsing (`gosub_html5`)
 
-The HTML5 tokenizer, tree builder, and DOM implementation. The crate implements the
-`Html5Parser` and `Document` traits from [`gosub_interface`](interface.md) and follows the
-WHATWG HTML parsing specification, including its error-recovery rules — invalid HTML never
-fails; it produces the same tree a browser would, plus a list of recoverable
-`ParseError`s.
+The HTML5 tokenizer, tree builder, and DOM implementation. The crate implements the `Html5Parser` and `Document` traits from [`gosub_interface`](interface.md) and follows the WHATWG HTML parsing specification, including its error-recovery rules --- invalid HTML never fails; it produces the same tree a browser would, plus a list of recoverable `ParseError`s.
 
-```text
+``` text
   bytes ──► ByteStream ──► Tokenizer (state machine) ──► Tokens ──► Html5Parser
                                                                     (insertion modes)
                                                                         │
@@ -16,78 +12,42 @@ fails; it produces the same tree a browser would, plus a list of recoverable
 
 ## Tokenizer (`tokenizer/`)
 
-A direct implementation of the spec's tokenizer state machine: `state.rs` defines one enum
-variant per spec state (74 of them, each doc-commented with its spec section number, e.g.
-"8.2.4.36 After attribute name state"). Supporting tables live beside it:
+A direct implementation of the spec's tokenizer state machine: `state.rs` defines one enum variant per spec state (74 of them, each doc-commented with its spec section number, e.g. "8.2.4.36 After attribute name state"). Supporting tables live beside it:
 
-- `character_reference.rs` — named character references (`&amp;`, `&nbsp;`, …) with the
-  spec's longest-match semantics;
-- `replacement_tables.rs` — control-character and Windows-1252 code-point replacements.
+-   `character_reference.rs` --- named character references (`&amp;`, `&nbsp;`, ...) with the spec's longest-match semantics;
+-   `replacement_tables.rs` --- control-character and Windows-1252 code-point replacements.
 
-The tokenizer produces `Token`s (`token.rs`: start/end tags with attributes, text, comment,
-doctype, EOF) and reports errors into an `ErrorLogger` shared with the parser, so tokenizer
-and tree-construction errors end up in one list with source locations.
+The tokenizer produces `Token`s (`token.rs`: start/end tags with attributes, text, comment, doctype, EOF) and reports errors into an `ErrorLogger` shared with the parser, so tokenizer and tree-construction errors end up in one list with source locations.
 
 ## Tree construction (`parser.rs`)
 
-`Html5Parser` is the spec's tree-construction stage: a loop that dispatches each token on
-the current **insertion mode** (all 23 spec modes, from `Initial` through `InBody`,
-the table modes, `InTemplate`, to `AfterAfterFrameset`). The spec's machinery is all here:
+`Html5Parser` is the spec's tree-construction stage: a loop that dispatches each token on the current **insertion mode** (all 23 spec modes, from `Initial` through `InBody`, the table modes, `InTemplate`, to `AfterAfterFrameset`). The spec's machinery is all here:
 
-- the **stack of open elements** and the **list of active formatting elements** (with
-  markers), including the **adoption agency algorithm** for misnested formatting tags
-  (`<b><i></b></i>`);
-- **foster parenting** for content that appears illegally inside tables;
-- `Text` and `InTableText` buffering, pending table character tokens;
-- the **template insertion mode stack** for `<template>` (whose contents parse into a
-  separate fragment, exposed via `Document::template_contents`);
-- **quirks-mode detection** (`quirks.rs`) from the doctype, stored on the document;
-- **foreign content**: SVG and MathML get their namespaces, and `attr_replacements.rs`
-  applies the spec's attribute/tag case adjustments (e.g. `viewbox` → `viewBox`);
-- **fragment parsing** (`parse_fragment`, used for `innerHTML`-style parsing) with a
-  context element;
-- a `scripting_enabled` option (`Html5ParserOptions`) that changes how `<noscript>`
-  parses, matching the spec's scripting flag.
+-   the **stack of open elements** and the **list of active formatting elements** (with markers), including the **adoption agency algorithm** for misnested formatting tags (`<b><i></b></i>`);
+-   **foster parenting** for content that appears illegally inside tables;
+-   `Text` and `InTableText` buffering, pending table character tokens;
+-   the **template insertion mode stack** for `<template>` (whose contents parse into a separate fragment, exposed via `Document::template_contents`);
+-   **quirks-mode detection** (`quirks.rs`) from the doctype, stored on the document;
+-   **foreign content**: SVG and MathML get their namespaces, and `attr_replacements.rs` applies the spec's attribute/tag case adjustments (e.g. `viewbox` → `viewBox`);
+-   **fragment parsing** (`parse_fragment`, used for `innerHTML`-style parsing) with a context element;
+-   a `scripting_enabled` option (`Html5ParserOptions`) that changes how `<noscript>` parses, matching the spec's scripting flag.
 
-The parser writes into the document through the small `TreeBuilder` trait
-(`parser/tree_builder.rs`: create element/text/comment, insert attribute). Two
-implementations exist: direct document mutation, and `DocumentTaskQueue`
-(`document/task_queue.rs`), which batches mutations as `DocumentTask`s to be committed at
-once — groundwork for decoupling parsing from DOM commits.
+The parser writes into the document through the small `TreeBuilder` trait (`parser/tree_builder.rs`: create element/text/comment, insert attribute). Two implementations exist: direct document mutation, and `DocumentTaskQueue` (`document/task_queue.rs`), which batches mutations as `DocumentTask`s to be committed at once --- groundwork for decoupling parsing from DOM commits.
 
 ## The DOM (`document/`, `node/`)
 
-`DocumentImpl` is the `Document` trait implementation: a `NodeArena` (a `Vec<Option<NodeImpl>>`
-indexed by `NodeId`) plus document metadata (URL, doctype, quirks mode, attached
-stylesheets) and a two-way index for `id="…"` lookups (`node_by_named_id` without scanning).
-Node payloads live under `node/data/` (element with attributes and class list, text,
-comment, doctype). As required by the `Document` trait, no `&Node` ever escapes — callers
-query by `NodeId`. `writer.rs` serializes a document back to HTML (used by `Document::write`
-and `inner_html`).
+`DocumentImpl` is the `Document` trait implementation: a `NodeArena` (a `Vec<Option<NodeImpl>>` indexed by `NodeId`) plus document metadata (URL, doctype, quirks mode, attached stylesheets) and a two-way index for `id="…"` lookups (`node_by_named_id` without scanning). Node payloads live under `node/data/` (element with attributes and class list, text, comment, doctype). As required by the `Document` trait, no `&Node` ever escapes --- callers query by `NodeId`. `writer.rs` serializes a document back to HTML (used by `Document::write` and `inner_html`).
 
 ## Testing: the html5lib harness (`testing/`)
 
-The crate vendors the WHATWG **html5lib-tests** suite (`tests/data/html5lib-tests/`) and
-runs two of its suites:
+The crate vendors the WHATWG **html5lib-tests** suite (`tests/data/html5lib-tests/`) and runs two of its suites:
 
-- **tree-construction**: `testing/tree_construction/` parses the `.dat` fixture format
-  (input / expected errors / expected tree), runs the full parser, serializes the resulting
-  DOM with `TreeOutputGenerator`, and diffs it line-by-line against the expected tree.
-  Script-on/script-off variants are honoured; a small `DISABLED_CASES` list tracks known
-  failures.
-- **tokenizer**: `testing/tokenizer.rs` drives the tokenizer against the JSON token
-  fixtures, including tests that must start in a specific tokenizer state.
+-   **tree-construction**: `testing/tree_construction/` parses the `.dat` fixture format (input / expected errors / expected tree), runs the full parser, serializes the resulting DOM with `TreeOutputGenerator`, and diffs it line-by-line against the expected tree. Script-on/script-off variants are honoured; a small `DISABLED_CASES` list tracks known failures.
+-   **tokenizer**: `testing/tokenizer.rs` drives the tokenizer against the JSON token fixtures, including tests that must start in a specific tokenizer state.
 
-The `testing` module is explicitly allowed to panic/unwrap (see `lib.rs`) — it is test
-infrastructure, where failing loudly on a malformed fixture is the right behaviour.
+The `testing` module is explicitly allowed to panic/unwrap (see `lib.rs`) --- it is test infrastructure, where failing loudly on a malformed fixture is the right behaviour.
 
 ## Known limitations
 
-- **Parsing is not incremental.** The whole document must be in memory before parsing
-  starts (`html_compile` takes a `&str`). The TODO in `lib.rs` spells out the plan: a
-  push-driven parser that accepts network chunks, so the engine can start building the DOM
-  and dispatching sub-resource fetches (images, stylesheets) while the HTML response is
-  still downloading.
-- **No script execution during parse.** The parser tracks script nesting and pause state
-  per the spec, but `document.write`-style reentrancy isn't wired to a JS engine — scripts
-  are handled after parsing, not during.
+-   **Parsing is not incremental.** The whole document must be in memory before parsing starts (`html_compile` takes a `&str`). The TODO in `lib.rs` spells out the plan: a push-driven parser that accepts network chunks, so the engine can start building the DOM and dispatching sub-resource fetches (images, stylesheets) while the HTML response is still downloading.
+-   **No script execution during parse.** The parser tracks script nesting and pause state per the spec, but `document.write`-style reentrancy isn't wired to a JS engine --- scripts are handled after parsing, not during.

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -1,19 +1,14 @@
 # `gosub_interface`: the trait families
 
-`gosub_interface` is the dependency-inversion heart of the workspace. It defines the trait
-contracts for every major engine component; component crates (`gosub_html5`, `gosub_css3`,
-the renderer crates, …) depend on the interface and implement its traits, and never on each
-other. Generic engine code names components only through a config type.
+`gosub_interface` is the dependency-inversion heart of the workspace. It defines the trait contracts for every major engine component; component crates (`gosub_html5`, `gosub_css3`, the renderer crates, ...) depend on the interface and implement its traits, and never on each other. Generic engine code names components only through a config type.
 
-This page is the crate-side architecture view. For the *user's* view — how to pick
-components when embedding the engine — see [configuration.md](configuration.md).
+This page is the crate-side architecture view. For the *user's* view --- how to pick components when embedding the engine --- see [configuration.md](configuration.md).
 
 ## The configuration model
 
-`ModuleConfiguration` (`config.rs`) is a compile-time description of a component set: a
-client defines one zero-sized marker type and names each component as an associated type.
+`ModuleConfiguration` (`config.rs`) is a compile-time description of a component set: a client defines one zero-sized marker type and names each component as an associated type.
 
-```rust
+``` rust
 pub trait ModuleConfiguration: /* … */ {
     type CssSystem: CssSystem;
     type Document: Document<Self>;
@@ -23,113 +18,61 @@ pub trait ModuleConfiguration: /* … */ {
 
 Three properties define the model:
 
-- **Compile-time resolution.** The engine is generic over `C: ModuleConfiguration`; there
-  is no runtime registry. Naming a component implies a Cargo dependency on the crate that
-  provides it — you cannot name `CairoBackend` without compiling Cairo in.
-- **Narrow `Has*` view traits.** Subsystem code doesn't bound on the full config; it asks
-  for exactly what it needs (`HasCssSystem`, `HasDocument`, `HasHtmlParser`, `HasLayouter`,
-  `HasFontSystem`). These are **derived automatically** from a `ModuleConfiguration` via
-  blanket impls — never implemented by hand. A function bounded on `C: HasDocument`
-  therefore accepts any config, but can only touch the document and CSS system.
-- **Parse-only by design.** `ModuleConfiguration` deliberately contains no render types.
-  The rendering extension, `RenderConfiguration` (adding `RenderBackend`,
-  `CompositorSink`, `FontSystem`), lives in **`gosub_engine`** (`src/html.rs`), not here —
-  so parse-only configs (parser test harnesses, fuzz targets) never pull in renderer
-  crates. `DefaultRenderConfig<Backend, FontSystem, Compositor>` is the ready-made
-  implementation.
+-   **Compile-time resolution.** The engine is generic over `C: ModuleConfiguration`; there is no runtime registry. Naming a component implies a Cargo dependency on the crate that provides it --- you cannot name `CairoBackend` without compiling Cairo in.
+-   **Narrow `Has*` view traits.** Subsystem code doesn't bound on the full config; it asks for exactly what it needs (`HasCssSystem`, `HasDocument`, `HasHtmlParser`, `HasLayouter`, `HasFontSystem`). These are **derived automatically** from a `ModuleConfiguration` via blanket impls --- never implemented by hand. A function bounded on `C: HasDocument` therefore accepts any config, but can only touch the document and CSS system.
+-   **Parse-only by design.** `ModuleConfiguration` deliberately contains no render types. The rendering extension, `RenderConfiguration` (adding `RenderBackend`, `CompositorSink`, `FontSystem`), lives in **`gosub_engine`** (`src/html.rs`), not here --- so parse-only configs (parser test harnesses, fuzz targets) never pull in renderer crates. `DefaultRenderConfig<Backend, FontSystem, Compositor>` is the ready-made implementation.
 
 ## The trait families
 
 ### Document (`document.rs`, `node.rs`)
 
-`Document<C>` is a storage-agnostic DOM: all access goes through `NodeId` handles and the
-document answers questions about nodes — no `&Node` is ever handed out, so the concrete
-storage (arena, column store, …) stays hidden. It covers node creation, tree surgery
-(`attach`/`detach`/`relocate_node`), element data (attributes, classes, `<template>`
-contents), quirks mode, and serialisation. Stylesheets attach to the document
-(`add_stylesheet`/`stylesheets`), typed via the config's CSS system. Implemented by
-`gosub_html5::DocumentImpl`.
+`Document<C>` is a storage-agnostic DOM: all access goes through `NodeId` handles and the document answers questions about nodes --- no `&Node` is ever handed out, so the concrete storage (arena, column store, ...) stays hidden. It covers node creation, tree surgery (`attach`/`detach`/`relocate_node`), element data (attributes, classes, `<template>` contents), quirks mode, and serialisation. Stylesheets attach to the document (`add_stylesheet`/`stylesheets`), typed via the config's CSS system. Implemented by `gosub_html5::DocumentImpl`.
 
 ### HTML parsing (`html5.rs`)
 
-`Html5Parser<C>` is two functions — `parse` and `parse_fragment` — from a `ByteStream`
-into a `C::Document`, returning recoverable parse errors. Implemented by `gosub_html5`.
+`Html5Parser<C>` is two functions --- `parse` and `parse_fragment` --- from a `ByteStream` into a `C::Document`, returning recoverable parse errors. Implemented by `gosub_html5`.
 
 ### CSS (`css3.rs`)
 
-`CssSystem` bundles four associated types (`Stylesheet`, `PropertyMap`, `Property`,
-`Value`) and the operations other crates need without understanding CSS internals:
+`CssSystem` bundles four associated types (`Stylesheet`, `PropertyMap`, `Property`, `Value`) and the operations other crates need without understanding CSS internals:
 
-- `parse_str` — text → stylesheet, tagged with a `CssOrigin` (UserAgent / Author / User);
-- `properties_from_node` — selector matching + cascade for one node (`None` = not
-  renderable), and `pseudo_properties_from_node` for `::before`/`::after`;
-- `load_default_useragent_stylesheet`;
-- `hover_fingerprints` — scans stylesheets for the element types/classes/ids targeted by
-  `:hover` rules, so the engine can skip style recalculation for pointer moves that no
-  hover rule could affect. It lives on this trait because only the CSS implementation
-  understands its own selector representation.
+-   `parse_str` --- text → stylesheet, tagged with a `CssOrigin` (UserAgent / Author / User);
+-   `properties_from_node` --- selector matching + cascade for one node (`None` = not renderable), and `pseudo_properties_from_node` for `::before`/`::after`;
+-   `load_default_useragent_stylesheet`;
+-   `hover_fingerprints` --- scans stylesheets for the element types/classes/ids targeted by `:hover` rules, so the engine can skip style recalculation for pointer moves that no hover rule could affect. It lives on this trait because only the CSS implementation understands its own selector representation.
 
-`CssProperty`/`CssValue` are deliberately lowest-common-denominator accessor traits
-(`as_string`, `as_unit`, `as_color`, `as_list`, …) — consumers like the pipeline's
-[document adapter](two-worlds.md) probe values through these and convert into their own
-representation. Implemented by `gosub_css3::Css3`.
+`CssProperty`/`CssValue` are deliberately lowest-common-denominator accessor traits (`as_string`, `as_unit`, `as_color`, `as_list`, ...) --- consumers like the pipeline's [document adapter](two-worlds.md) probe values through these and convert into their own representation. Implemented by `gosub_css3::Css3`.
 
 ### Layout (`layout.rs`)
 
-The interface-world layout family: `Layouter<C>`, `LayoutTree<C>` (with its own node-id
-space), `LayoutNode`, `LayoutCache`, `Layout` (the per-node geometry), and
-`TextLayout`/`HasTextLayout` for shaped text. Implemented by `gosub_taffy` — which is
-currently **dormant**: the live rendering path uses the pipeline's own layouter instead.
-See [The two worlds](two-worlds.md) before spending time here.
+The interface-world layout family: `Layouter<C>`, `LayoutTree<C>` (with its own node-id space), `LayoutNode`, `LayoutCache`, `Layout` (the per-node geometry), and `TextLayout`/`HasTextLayout` for shaped text. Implemented by `gosub_taffy` --- which is currently **dormant**: the live rendering path uses the pipeline's own layouter instead. See [The two worlds](two-worlds.md) before spending time here.
 
 ### Fonts (`font.rs`, `font_system.rs`)
 
-`FontSystem` (register + measure, never draw) with its value types (`FontBlob`,
-`FontStyle`, `TextStyle`, `ShapedText`, …) and the `HasFontSystem` view. Covered in depth
-in [fonts.md](fonts.md).
+`FontSystem` (register + measure, never draw) with its value types (`FontBlob`, `FontStyle`, `TextStyle`, `ShapedText`, ...) and the `HasFontSystem` view. Covered in depth in [fonts.md](fonts.md).
 
 ### Render (`render/`)
 
-The contract between the render pipeline and the concrete backends. It lives *here* — not
-in `gosub_render_pipeline` — so a config can name a `RenderBackend` without inverting the
-dependency direction; the pipeline re-exports these types for downstream code.
+The contract between the render pipeline and the concrete backends. It lives *here* --- not in `gosub_render_pipeline` --- so a config can name a `RenderBackend` without inverting the dependency direction; the pipeline re-exports these types for downstream code.
 
-- `RenderBackend` — surface creation, `render`, `snapshot`, `external_handle`, plus the
-  capability flags the engine uses to pick a flow without knowing which backend is active:
-  `raster_strategy()` (ParallelCached / Sequential / None), `renders_to_gpu_texture()`,
-  `gpu_tile_compositing()`, `device_pixel_ratio()`, and `composite_tiles()` for GPU tile
-  blitting. See [render-pipeline/backends.md](render-pipeline/backends.md) and
-  [gpu-render-flow.md](render-pipeline/gpu-render-flow.md) for how these drive the flows.
-- `ErasedSurface`, `RenderContext` (per-tab state a backend needs: viewport, `RenderList`,
-  scroll offset, type-erased paint scene), `CompositorSink` (receives finished frames per
-  tab), `ExternalHandle` (the many ways a frame can travel: CPU pixels, tile cache, GL/wgpu
-  texture ids, …).
-- Value types shared by every compositor: `PixelFormat` (self-describing byte order) with
-  the hot blend helpers (`blend_over_argb_u32`, `scale_premul_argb_u32`), `TileAnchor` /
-  `StickyConstraint`, `CachedTile` / `PlacedGpuTile`, `Viewport` / `DevicePixelRatio`, and
-  `RenderList` / `DisplayItem`. The compositing semantics are documented in
-  [layering-and-compositing.md](render-pipeline/layering-and-compositing.md).
+-   `RenderBackend` --- surface creation, `render`, `snapshot`, `external_handle`, plus the capability flags the engine uses to pick a flow without knowing which backend is active: `raster_strategy()` (ParallelCached / Sequential / None), `renders_to_gpu_texture()`, `gpu_tile_compositing()`, `device_pixel_ratio()`, and `composite_tiles()` for GPU tile blitting. See [render-pipeline/backends.md](render-pipeline/backends.md) and [gpu-render-flow.md](render-pipeline/gpu-render-flow.md) for how these drive the flows.
+-   `ErasedSurface`, `RenderContext` (per-tab state a backend needs: viewport, `RenderList`, scroll offset, type-erased paint scene), `CompositorSink` (receives finished frames per tab), `ExternalHandle` (the many ways a frame can travel: CPU pixels, tile cache, GL/wgpu texture ids, ...).
+-   Value types shared by every compositor: `PixelFormat` (self-describing byte order) with the hot blend helpers (`blend_over_argb_u32`, `scale_premul_argb_u32`), `TileAnchor` / `StickyConstraint`, `CachedTile` / `PlacedGpuTile`, `Viewport` / `DevicePixelRatio`, and `RenderList` / `DisplayItem`. The compositing semantics are documented in [layering-and-compositing.md](render-pipeline/layering-and-compositing.md).
 
 ### Input (`input.rs`)
 
-`InputEvent` / `MouseButton` — the small event vocabulary UAs feed into the engine
-(consumed by `gosub_web_platform` and tab input handling).
+`InputEvent` / `MouseButton` --- the small event vocabulary UAs feed into the engine (consumed by `gosub_web_platform` and tab input handling).
 
 ## The type-erasure escape hatches
 
-The interface crate sits at the bottom of the dependency graph, so it can never name types
-from the crates above it. Where a contract genuinely needs to carry such a type, the crate
-uses a deliberate, documented `Any` seam — the owning crate downcasts on the other side:
+The interface crate sits at the bottom of the dependency graph, so it can never name types from the crates above it. Where a contract genuinely needs to carry such a type, the crate uses a deliberate, documented `Any` seam --- the owning crate downcasts on the other side:
 
 | Seam | Carries | Downcast by |
-|---|---|---|
-| `RenderBackend::create_rasterizer → Box<dyn Any>` | a `Box<dyn Rasterable>` (pipeline tile/texture types) | `gosub_render_pipeline::rasterizer::downcast_rasterizer` |
-| `RenderBackend::wgpu_resources → Arc<dyn Any>` | a backend's shared GPU device/queue/renderer | the code that shares the wgpu context |
-| `RenderContext::paint_scene → &dyn Any` | the pipeline's `PaintScene` for GPU scene backends | the GPU backend's `render` |
-| `FontSystem::as_any_mut → &mut dyn Any` | the concrete font system | a render backend's native shape/draw path |
-| `ErasedSurface::as_any(_mut)` | a backend's concrete surface | the backend itself |
+|------|---------|-------------|
+| `RenderBackend::create_rasterizer → Box<dyn Any>` | a `Box<dyn Rasterable>`; pipeline tile/texture types | `gosub_render_pipeline::rasterizer::downcast_rasterizer` |
+| `RenderBackend::wgpu_resources → Arc<dyn Any>` | a backend’s shared GPU device/queue/renderer | the code that shares the wgpu context |
+| `RenderContext::paint_scene → &dyn Any` | the pipeline’s `PaintScene` for GPU scene backends | the GPU backend’s `render` |
+| `FontSystem::as_any_mut → &mut dyn Any` | the concrete font system | a render backend’s native shape/draw path |
+| `ErasedSurface::as_any(_mut)` | a backend’s concrete surface | the backend itself |
 
-The pattern is consistent: *traits define behaviour the engine drives; `Any` carries state
-that only one crate on each side understands.* If you find yourself wanting to add a
-pipeline or backend type to a trait in this crate, one of these seams (or a new one) is
-the intended alternative.
+The pattern is consistent: *traits define behaviour the engine drives; `Any` carries state that only one crate on each side understands.* If you find yourself wanting to add a pipeline or backend type to a trait in this crate, one of these seams (or a new one) is the intended alternative.

--- a/docs/lattice.md
+++ b/docs/lattice.md
@@ -1,88 +1,45 @@
-# Lattice: the table layout engine (`gosub_lattice`)
+    # Lattice: the table layout engine (`gosub_lattice`)
 
-Taffy covers flexbox, grid, and block layout — but not CSS tables. `gosub_lattice` fills
-that gap: a standalone implementation of the CSS table layout algorithm that works *in
-conjunction with* a general layout engine rather than replacing it. Taffy (or any host)
-lays out everything, tables included, as ordinary boxes; lattice then recomputes the table
-grid geometry — column widths, row heights, cell positions — and writes it back, while
-delegating the layout *inside* each cell right back to the host engine.
+Taffy covers flexbox, grid, and block layout --- but not CSS tables. `gosub_lattice` fills that gap: a standalone implementation of the CSS table layout algorithm that works *in conjunction with* a general layout engine rather than replacing it. Taffy (or any host) lays out everything, tables included, as ordinary boxes; lattice then recomputes the table grid geometry --- column widths, row heights, cell positions --- and writes it back, while delegating the layout *inside* each cell right back to the host engine.
 
 ## The `TableTree` adapter
 
-Lattice knows nothing about DOM types, style storage, or which layout engine hosts it. All
-I/O goes through the `TableTree` trait (`lib.rs`), generic over the host's node-id type:
+Lattice knows nothing about DOM types, style storage, or which layout engine hosts it. All I/O goes through the `TableTree` trait (`lib.rs`), generic over the host's node-id type:
 
 | Method | Direction | Purpose |
-|---|---|---|
+|--------|-----------|---------|
 | `children`, `table_role`, `css_length`, `attr_usize` | read | tree structure, `display: table-*` roles, widths/heights/borders/padding, `colspan`/`rowspan` |
 | `set_layout(id, CellLayout)` | write | computed position/size for groups, rows, and cells |
-| `layout_cell(id, available_width) → height` | **callback into the host** | lay out the cell's children with the host engine and report their content height |
-| `cell_content_width(id) → width` | read | the cell's natural width from a prior host layout pass |
+| `layout_cell(id, available_width) → height` | **callback into the host** | lay out the cell’s children with the host engine and report their content height |
+| `cell_content_width(id) → width` | read | the cell’s natural width from a prior host layout pass |
 
-`layout_cell` and `cell_content_width` are the cooperation points with Taffy: lattice does
-grid geometry, the host engine does everything inside the cells.
+`layout_cell` and `cell_content_width` are the cooperation points with Taffy: lattice does grid geometry, the host engine does everything inside the cells.
 
-Two adapters exist — one per [world](two-worlds.md):
+Two adapters exist --- one per [world](two-worlds.md):
 
-- **`PipelineTableTree`** (`gosub_render_pipeline/src/layouter/table.rs`) — the live one.
-  Tables are first laid out by Taffy as ordinary blocks (wrong positions, but cell text is
-  measured correctly), then `post_process_tables` runs lattice over every `display: table`
-  node in two passes — pre-order so column widths flow top-down into nested tables,
-  reverse post-order so heights flow bottom-up out of them. See
-  [render-pipeline/layout.md](render-pipeline/layout.md#tables-the-lattice-write-back).
-- **`gosub_taffy`'s adapter** — the interface-world counterpart (currently dormant along
-  with the rest of that crate).
+-   **`PipelineTableTree`** (`gosub_render_pipeline/src/layouter/table.rs`) --- the live one. Tables are first laid out by Taffy as ordinary blocks (wrong positions, but cell text is measured correctly), then `post_process_tables` runs lattice over every `display: table` node in two passes --- pre-order so column widths flow top-down into nested tables, reverse post-order so heights flow bottom-up out of them. See [render-pipeline/layout.md](render-pipeline/layout.md#tables-the-lattice-write-back).
+-   **`gosub_taffy`'s adapter** --- the interface-world counterpart (currently dormant along with the rest of that crate).
 
 ## The algorithm (`compute_table_layout`)
 
-One call per table; returns the table's `(width, height)` border-box size (the caller
-positions the table itself in the surrounding flow).
+One call per table; returns the table's `(width, height)` border-box size (the caller positions the table itself in the surrounding flow).
 
-1. **Model building** (`model.rs`) — walk the subtree into a typed `TableModel`: caption,
-   column groups, and header/body/footer row groups, classified by `display` role. The CSS
-   2.1 §17.2.1 anonymous-box fixups are applied here: a bare row directly under the table
-   gets an anonymous body group, a bare cell under a group gets an anonymous row.
-   `border-spacing`, `border-collapse`, and `table-layout` are parsed into the model.
-2. **Grid placement** (`grid.rs`) — per section, resolve each source cell to a concrete
-   `(row, col)` slot with effective `colspan`/`rowspan` (rowspan clamped to its section, so
-   nothing spans out of a `<thead>`). The result is a `SectionGrid` that can answer
-   "which cells are in row *i*" and "which columns are spanned across a row boundary".
-3. **Column widths** (`sizing/columns.rs`) — available space is the table width minus all
-   border-spacing gutters. The first non-empty row is scanned: single-column cells with an
-   explicit CSS width get it (clamped to at least their content's natural width — a
-   `width: 18px` cell holding a 20 px image must not clip it). Remaining space goes to the
-   auto columns **proportionally to their natural content width** (from
-   `cell_content_width`), with a threshold heuristic: narrow columns (< 50 px intrinsic —
-   rank numbers, vote buttons) keep their natural width with a 14 px floor, wide content
-   columns share what's left. Equal distribution is the fallback when no content-width
-   data exists (mock trees).
-4. **Row heights** (`sizing/rows.rs`) — per non-spanning cell: `layout_cell(inner_width)`
-   asks the host to lay out the cell's children at the now-final column width; the row
-   height is the max over its cells of `max(content height, explicit CSS height) + border
-   + padding`. Explicit height is a *minimum* — content can grow past it.
-5. **Placement** (`compute.rs`) — sections render header → body → footer regardless of
-   source order, per CSS. Groups are positioned relative to the table, rows relative to
-   their group, cells relative to their row; spanning cells sum the widths/heights of the
-   columns/rows they cover. Everything is written back through `set_layout` as *relative*
-   positions — the adapter converts to absolute coordinates (the pipeline's does so in
-   `apply_positions`).
+1.  **Model building** (`model.rs`) --- walk the subtree into a typed `TableModel`: caption, column groups, and header/body/footer row groups, classified by `display` role. The CSS 2.1 §17.2.1 anonymous-box fixups are applied here: a bare row directly under the table gets an anonymous body group, a bare cell under a group gets an anonymous row. `border-spacing`, `border-collapse`, and `table-layout` are parsed into the model.
+2.  **Grid placement** (`grid.rs`) --- per section, resolve each source cell to a concrete `(row, col)` slot with effective `colspan`/`rowspan` (rowspan clamped to its section, so nothing spans out of a `<thead>`). The result is a `SectionGrid` that can answer "which cells are in row *i*" and "which columns are spanned across a row boundary".
+3.  **Column widths** (`sizing/columns.rs`) --- available space is the table width minus all border-spacing gutters. The first non-empty row is scanned: single-column cells with an explicit CSS width get it (clamped to at least their content's natural width --- a `width: 18px` cell holding a 20 px image must not clip it). Remaining space goes to the auto columns **proportionally to their natural content width** (from `cell_content_width`), with a threshold heuristic: narrow columns (\< 50 px intrinsic --- rank numbers, vote buttons) keep their natural width with a 14 px floor, wide content columns share what's left. Equal distribution is the fallback when no content-width data exists (mock trees).
+4.  **Row heights** (`sizing/rows.rs`) --- per non-spanning cell: `layout_cell(inner_width)` asks the host to lay out the cell's children at the now-final column width; the row height is the max over its cells of \`max(content height, explicit CSS height) + border
+    -   padding\`. Explicit height is a *minimum* --- content can grow past it.
+5.  **Placement** (`compute.rs`) --- sections render header → body → footer regardless of source order, per CSS. Groups are positioned relative to the table, rows relative to their group, cells relative to their row; spanning cells sum the widths/heights of the columns/rows they cover. Everything is written back through `set_layout` as *relative* positions --- the adapter converts to absolute coordinates (the pipeline's does so in `apply_positions`).
 
 ## Trying it standalone
 
 The crate is self-contained enough to play with in isolation:
 
-- `mock.rs` provides a `MockTable` builder implementing `TableTree` with no DOM at all —
-  it powers the unit tests.
-- `cargo run --bin table_console -p gosub_lattice` renders demo tables (spans, explicit
-  widths, headers/footers) as ASCII grids in the terminal — handy for eyeballing algorithm
-  changes without a browser build.
+-   `mock.rs` provides a `MockTable` builder implementing `TableTree` with no DOM at all --- it powers the unit tests.
+-   `cargo run --bin table_console -p gosub_lattice` renders demo tables (spans, explicit widths, headers/footers) as ASCII grids in the terminal --- handy for eyeballing algorithm changes without a browser build.
 
 ## Current limitations
 
-- **`rowspan > 1` heights**: spanning cells are skipped during row-height computation;
-  distributing their height across the spanned rows is deferred.
-- **`border-collapse`, `table-layout: fixed`, captions**: parsed into the model but not
-  yet consumed by the algorithm — layout always uses the separate-borders model with
-  auto sizing, and captions get no box.
-- Column-width resolution scans only the first non-empty row for explicit widths, rather
-  than the full min/max-content pass of the spec's auto algorithm.
+-   **`rowspan > 1` heights**: spanning cells are skipped during row-height computation; distributing their height across the spanned rows is deferred.
+-   **`border-collapse`, `table-layout: fixed`, captions**: parsed into the model but not yet consumed by the algorithm --- layout always uses the separate-borders model with auto sizing, and captions get no box.
+-   Column-width resolution scans only the first non-empty row for explicit widths, rather than the full min/max-content pass of the spec's auto algorithm.

--- a/docs/moduleconfig.md
+++ b/docs/moduleconfig.md
@@ -1,0 +1,190 @@
+# Module configuration
+
+The Gosub engine is **generic over a configuration type** that names every swappable component as an associated type. You pick the implementations you want --- CSS system, DOM, HTML parser, render backend, compositor --- once, at compile time, and the engine is monomorphized against that choice. The engine code itself only ever talks to the component *traits*, so it never knows (or needs to know) which concrete implementations you chose.
+
+``` rust
+use gosub_engine::{GosubEngine, DefaultConfig};
+use gosub_renderer_cairo::CairoBackend;
+
+// "The default parse stack, rendering with Cairo."
+let engine = GosubEngine::<DefaultConfig<CairoBackend>>::new(
+    None,                                  // engine settings (see note below)
+    Arc::new(CairoBackend::new()),         // the backend instance
+    Arc::new(RwLock::new(DefaultCompositor::default())),
+);
+```
+
+This document describes it from the perspective of someone *embedding* the engine.
+
+------------------------------------------------------------------------
+
+## The mental model
+
+A configuration is a **zero-sized marker type** that implements one or two traits. The traits have no methods --- they only carry associated types that say "use *this* implementation for *that* role":
+
+| Role | Associated type | Example implementation |
+|------|-----------------|------------------------|
+| CSS parsing & cascade | `CssSystem` | `gosub_css3::system::Css3System` |
+| DOM storage | `Document` | `gosub_html5::…::DocumentImpl<Self>` |
+| HTML5 parsing | `HtmlParser` | `gosub_html5::parser::Html5Parser<'static, Self>` |
+| Render backend | `RenderBackend` | `CairoBackend` / `SkiaBackend` / `VelloBackend` / `NullBackend` |
+| Frame sink | `CompositorSink` | `DefaultCompositor` |
+
+Because the engine is generic over your config, swapping any of these is a one-line change in one place, checked by the compiler --- there is no runtime registry or plugin lookup.
+
+> **You must compile in what you name.** Writing `type RenderBackend = CairoBackend` only works if your crate depends on `gosub_renderer_cairo`. The config *is* the wiring, and the wiring has to exist at build time.
+
+------------------------------------------------------------------------
+
+## The two traits
+
+The roles are split across **two** traits, by layer:
+
+### `ModuleConfiguration` --- the parse/document stack
+
+`gosub_interface::config::ModuleConfiguration`
+
+``` rust
+pub trait ModuleConfiguration: Clone + Debug + PartialEq + Send + Sync + 'static {
+    type CssSystem: CssSystem;
+    type Document: Document<Self>;
+    type HtmlParser: Html5Parser<Self>;
+}
+```
+
+This is everything needed to parse HTML+CSS into a DOM. It does **not** mention rendering, so parse-only tools (test harnesses, fuzz targets, the standalone parser binaries) can implement just this without ever depending on a renderer crate.
+
+The narrow `Has*` view traits (`HasCssSystem`, `HasDocument`, `HasHtmlParser`) are **derived automatically** from a `ModuleConfiguration` --- you never implement them by hand.
+
+### `EngineConfig` --- the full engine stack
+
+`gosub_engine::html::EngineConfig`
+
+``` rust
+pub trait EngineConfig: ModuleConfiguration<Document = DocumentImpl<Self>> {
+    type RenderBackend: RenderBackend + Send + Sync;
+    type CompositorSink: CompositorSink;
+}
+```
+
+`GosubEngine<C>` requires `C: EngineConfig`. It extends `ModuleConfiguration` with the runtime render components, and pins `Document = DocumentImpl<Self>` (the HTML parser produces that concrete document type, so the document and parser are a coupled pair rather than independently swappable).
+
+Render components live here, not on `ModuleConfiguration`, specifically so that parse-only configs stay free of any renderer dependency.
+
+------------------------------------------------------------------------
+
+## `DefaultConfig<B, S>` --- the easy path
+
+Most embedders want the standard gosub parse stack (gosub_css3 + gosub_html5) and only care about *which backend* to render with. For that, use the provided generic config:
+
+``` rust
+pub struct DefaultConfig<B = NullBackend, S = DefaultCompositor>;
+```
+
+-   `B` --- the render backend.
+-   `S` --- the compositor sink (almost always `DefaultCompositor`).
+
+It implements both `ModuleConfiguration` (Css3System + DocumentImpl + Html5Parser) and `EngineConfig` (`RenderBackend = B`, `CompositorSink = S`) for you. So:
+
+-   `DefaultConfig` --- headless: `DefaultConfig<NullBackend, DefaultCompositor>`.
+-   `DefaultConfig<CairoBackend>` --- render with Cairo, default compositor.
+-   `DefaultConfig<SkiaBackend>` --- render with Skia.
+-   `DefaultConfig<VelloBackend<MyWgpuProvider>>` --- render with Vello.
+
+------------------------------------------------------------------------
+
+## Recipes
+
+### 1. Headless (no rendering)
+
+``` rust
+use gosub_engine::{GosubEngine, DefaultConfig};
+use gosub_render_pipeline::render::{backends::null::NullBackend, DefaultCompositor};
+
+let engine = GosubEngine::<DefaultConfig>::new(
+    None,
+    Arc::new(NullBackend::new()),
+    Arc::new(RwLock::new(DefaultCompositor::default())),
+);
+```
+
+`GosubEngine` defaults its type parameter to `DefaultConfig`, so in type position you can also just write `GosubEngine` (e.g. a struct field `engine: GosubEngine`).
+
+### 2. Pick a render backend (the common case)
+
+``` rust
+use gosub_engine::{GosubEngine, DefaultConfig};
+use gosub_renderer_skia::SkiaBackend;
+
+let engine = GosubEngine::<DefaultConfig<SkiaBackend>>::new(
+    None,
+    Arc::new(SkiaBackend::new()),
+    Arc::new(RwLock::new(DefaultCompositor::default())),
+);
+```
+
+If you store the engine in your own struct, name the full type there too:
+
+``` rust
+struct App {
+    engine: GosubEngine<DefaultConfig<SkiaBackend>>,
+    // …
+}
+```
+
+### 3. A fully custom config (swap CSS/DOM too)
+
+When you want to replace the CSS system (or other parse-stack pieces) as well, define your own marker type and implement both traits:
+
+``` rust
+#[derive(Clone, Debug, PartialEq)]
+struct MyConfig;
+
+impl ModuleConfiguration for MyConfig {
+    type CssSystem  = MyCustomCssSystem;        // your CSS implementation
+    type Document   = DocumentImpl<Self>;       // keep the gosub DOM
+    type HtmlParser = Html5Parser<'static, Self>;
+}
+
+impl EngineConfig for MyConfig {
+    type RenderBackend  = CairoBackend;
+    type CompositorSink = DefaultCompositor;
+}
+
+let engine = GosubEngine::<MyConfig>::new(None, Arc::new(CairoBackend::new()), compositor);
+```
+
+`MyCustomCssSystem` only has to implement the `gosub_interface::css3::CssSystem` trait --- the engine never refers to it by name, only through that trait.
+
+------------------------------------------------------------------------
+
+## What is and isn't swappable yet
+
+| Component        | Status |
+|------------------|--------|
+| `CssSystem`      | ✅ config-driven |
+| `Document`       | ✅ config-driven; coupled to the parser, in practice `DocumentImpl` |
+| `HtmlParser`     | ✅ config-driven |
+| `RenderBackend`  | ✅ config-driven |
+| `CompositorSink` | ✅ config-driven |
+| `FontSystem`     | ⏳ not yet a config member; currently a concrete font system |
+| `NetworkStack`   | ⏳ not yet a config member |
+
+Runtime backend switching (flipping Cairo↔Skia↔Vello without recompiling) is still available separately via the `gosub_renderer_dynamic` crate --- set `type RenderBackend = DynamicRenderBackend` and switch inside that one type.
+
+------------------------------------------------------------------------
+
+## Why the components are passed to `new()`
+
+`GosubEngine::<C>::new(settings, backend, compositor)` still *takes* the backend and compositor **instances**, even though their types come from the config. This is deliberate: some backends need runtime context to construct (e.g. Vello needs a wgpu device/queue). The config fixes the *type* (`Arc<C::RenderBackend>`), and the compiler verifies the instance you pass matches it --- you can't accidentally hand a `SkiaBackend` to a config that declared `CairoBackend`.
+
+------------------------------------------------------------------------
+
+## Config vs. settings
+
+Two different things, two different names --- don't confuse them:
+
+-   **Config** = *which components* (the traits): `ModuleConfiguration` and `EngineConfig` (`gosub_engine::html::EngineConfig`). This is what this document is about.
+-   **Settings** = *tuning knobs*: `EngineSettings` (`gosub_engine::EngineSettings`) --- channel capacities, limits, etc. It's the first argument to `GosubEngine::new` (`None` uses the defaults), built via `EngineSettings::builder()`.
+
+Rule of thumb: **Config picks the pieces; Settings tunes them.**

--- a/docs/network/net-design.md
+++ b/docs/network/net-design.md
@@ -1,203 +1,126 @@
 # The architecture of the network stack of Gosub
 
-This document is kind of a blog post / brain dump of the current state of the network architecture that currently
-is implemented in this respository. Even though fetching resources over the network is easy enough with crates likes 
-`reqwest`, there is much more that needs to be taken care of when designing a network stack for browser.
-
+This document is kind of a blog post / brain dump of the current state of the network architecture that currently is implemented in this respository. Even though fetching resources over the network is easy enough with crates likes `reqwest`, there is much more that needs to be taken care of when designing a network stack for browser.
 
 ## Starting with the beginning
 
 Let assume a very naive network stack:
 
-```rust
+``` rust
 
 async fn fetch(url: &str) -> Result<String, Error> {
     let response = reqwest::get(url).await?;
     let body = response.text().await?;
     Ok(body)
 }
-
 ```
 
 This, in theory, should be enough to fetch a resource over the network. But there are a few problems with this approach:
 
-1. **Blocking**: The above function is asynchronous, but it still blocks the current thread until the request is 
-   complete. In a browser, we want to be able to fetch resources without blocking the main thread.
-2. **Memory usage**: The above function reads the entire response body into memory before returning it. This can be a 
-   problem for large resources, as it can lead to high memory usage.
-3. **Coalsecing**: Suppose you have multiple tabs open in your browser, and each tab is trying to fetch resources from 
-   the same domain. If each tab makes its own request, this can lead to a lot of redundant network traffic. Instead, we 
-   want to be able to coalesce requests for the same resource, so that only one request is made and the response is 
-   shared among all the tabs that need it.
-4. **Cancellation** : In a browser, users can navigate away from a page or close a tab at any time. If a request is in 
-   progress when this happens, we want to be able to cancel the request to avoid wasting network resources
-5. **Priority**: Some resources are more important than others. For example, the HTML of a page is more important than 
-   an image on the page. We want to be able to prioritize requests so that more important resources are fetched first.
-6. **Error handling**: Network requests can fail for a variety of reasons (e.g., network errors, server errors, etc.). 
-   We want to be able to handle these errors gracefully and retry requests when appropriate.
+1.  **Blocking**: The above function is asynchronous, but it still blocks the current thread until the request is complete. In a browser, we want to be able to fetch resources without blocking the main thread.
+2.  **Memory usage**: The above function reads the entire response body into memory before returning it. This can be a problem for large resources, as it can lead to high memory usage.
+3.  **Coalsecing**: Suppose you have multiple tabs open in your browser, and each tab is trying to fetch resources from the same domain. If each tab makes its own request, this can lead to a lot of redundant network traffic. Instead, we want to be able to coalesce requests for the same resource, so that only one request is made and the response is shared among all the tabs that need it.
+4.  **Cancellation** : In a browser, users can navigate away from a page or close a tab at any time. If a request is in progress when this happens, we want to be able to cancel the request to avoid wasting network resources
+5.  **Priority**: Some resources are more important than others. For example, the HTML of a page is more important than an image on the page. We want to be able to prioritize requests so that more important resources are fetched first.
+6.  **Error handling**: Network requests can fail for a variety of reasons (e.g., network errors, server errors, etc.). We want to be able to handle these errors gracefully and retry requests when appropriate.
 
-These, and other problems we will solve by using a more complex setup that involves multiple components working 
-together.
-
+These, and other problems we will solve by using a more complex setup that involves multiple components working together.
 
 ## Reader
+
 Every time we read data from the network, we take care of a few things:
 
-1. We take into account the "cancellation" of the request. If the request is cancelled, we stop reading data from 
-   the network immediately.
-2. We keep in mind an idle timeout. If we don't receive any data from the network for a certain amount of time, we 
-   consider the request to be stalled and we cancel it.
-3. We keep in mind a total timeout. If the request takes too long to complete, we cancel it.
-4. Sometimes, but not always, we want to limit the amount of data we read from the network. This is useful for 
-   example when we are downloading a large file and we want to limit the amount of data we read into memory at once.
+1.  We take into account the "cancellation" of the request. If the request is cancelled, we stop reading data from the network immediately.
+2.  We keep in mind an idle timeout. If we don't receive any data from the network for a certain amount of time, we consider the request to be stalled and we cancel it.
+3.  We keep in mind a total timeout. If the request takes too long to complete, we cancel it.
+4.  Sometimes, but not always, we want to limit the amount of data we read from the network. This is useful for example when we are downloading a large file and we want to limit the amount of data we read into memory at once.
 
 ## I/O Thread
 
-First, we move all the IO related task away from the main thread. For this we make a new thread that will be the 
-`I/O Thread`. This thread will be responsible for all the network related tasks, and will communicate with the main
-thread using channels.
+First, we move all the IO related task away from the main thread. For this we make a new thread that will be the `I/O Thread`. This thread will be responsible for all the network related tasks, and will communicate with the main thread using channels.
 
-The `io_runtime.rs` file contains the code for the I/O thread. It spawns a new thread and returns a handle to it. This 
-handle can be used to send tasks to the I/O thread. It contains a channel (`io_handle.subscribe()`) that can be passed
-around different components to send tasks to the I/O thread.
+The `io_runtime.rs` file contains the code for the I/O thread. It spawns a new thread and returns a handle to it. This handle can be used to send tasks to the I/O thread. It contains a channel (`io_handle.subscribe()`) that can be passed around different components to send tasks to the I/O thread.
 
-The I/O Thread works by using an `IoRouter` to route requests to per-zone `Fetcher` instances, spawning them on
-first use. You submit a `FetchRequest` via `IoCommand::Fetch` to the I/O thread, which routes it to the appropriate
-zone's fetcher. That's basically it.
+The I/O Thread works by using an `IoRouter` to route requests to per-zone `Fetcher` instances, spawning them on first use. You submit a `FetchRequest` via `IoCommand::Fetch` to the I/O thread, which routes it to the appropriate zone's fetcher. That's basically it.
 
 The actual work will be done in the fetcher itself, leaving the I/O thread loop pretty simple.
 
-
 ## Fetcher
-The `fetcher.run()` function is the main loop of the fetcher. It is responsible for processing requests.
-It works by fetching a request from the priority queues, and process it. If none a present, it will sleep until a new
-request has been submitted through `submit()`.
+
+The `fetcher.run()` function is the main loop of the fetcher. It is responsible for processing requests. It works by fetching a request from the priority queues, and process it. If none a present, it will sleep until a new request has been submitted through `submit()`.
 
 ### Priority queues
-Since some requests are more important than others, we need to be able to prioritize requests. For this we use multiple
-priority queues. Each queue has a different priority level, and requests are processed in order of priority. The 
-priority levels are:
 
-- High
-- Normal
-- Low
-- Idle
+Since some requests are more important than others, we need to be able to prioritize requests. For this we use multiple priority queues. Each queue has a different priority level, and requests are processed in order of priority. The priority levels are:
 
-The scheduler will try and fetch requests from the highest priority queue first. If there are no requests in the 
-highest priority queue, it will try and fetch from the next highest priority queue, and so on. Note that it will not 
-starve lower priority queues. 
-If a lower priority queue has been waiting for a while, it will be given a chance to be processed, even when higer 
-priority queues are not empty.
+-   High
+-   Normal
+-   Low
+-   Idle
 
-Once the fetcher has selected a request to process, it will check if there is already an ongoing request for the same 
-URL. If so, we can coalesce the requests, and just add the new request to the list of listeners for the ongoing request.
-This way, when the ongoing request completes, all the listeners will be notified with the result. 
+The scheduler will try and fetch requests from the highest priority queue first. If there are no requests in the highest priority queue, it will try and fetch from the next highest priority queue, and so on. Note that it will not starve lower priority queues. If a lower priority queue has been waiting for a while, it will be given a chance to be processed, even when higer priority queues are not empty.
 
-To find out if we can coalesce, we need to generate some kind of key for the request. This takes elements like the URL, 
-method, headers, etc. Once we have the key, we can check if there is an ongoing request with the same key. If so, we 
-can coalesce the requests. If not, we can start a new request.
+Once the fetcher has selected a request to process, it will check if there is already an ongoing request for the same URL. If so, we can coalesce the requests, and just add the new request to the list of listeners for the ongoing request. This way, when the ongoing request completes, all the listeners will be notified with the result.
 
-There is some small thing we need to consider when coalescing requests. Some consumers can requests to be fetch as 
-streaming, others as buffered. Streaming requests will return a stream of data, while buffered requests will return the 
-entire response body as a single buffer.
+To find out if we can coalesce, we need to generate some kind of key for the request. This takes elements like the URL, method, headers, etc. Once we have the key, we can check if there is an ongoing request with the same key. If so, we can coalesce the requests. If not, we can start a new request.
 
-Each unique non-coalseced request will be represented by a `FetchInflightEntry`. This struct will contain the request,
-the list of listeners, and the state of the job. This system will also take care of streamable vs buffered requests,
-and can serve both types of requests from the same inflight job.
+There is some small thing we need to consider when coalescing requests. Some consumers can requests to be fetch as streaming, others as buffered. Streaming requests will return a stream of data, while buffered requests will return the entire response body as a single buffer.
 
-If the request wasn't coalescable, we can fetch the actual request. This is done by spawning a new task `Fetcher`. The 
-first thing it does is to check if we have too many requests to a single origin. There can be 100 independent requests 
-running, but we only allow a number of requests running simultaneously to a single origin. This is to avoid overloading
-the server, and to avoid running into issues with browsers that limit the number of connections to a single origin.
+Each unique non-coalseced request will be represented by a `FetchInflightEntry`. This struct will contain the request, the list of listeners, and the state of the job. This system will also take care of streamable vs buffered requests, and can serve both types of requests from the same inflight job.
 
-In total, the fetcher will limit the total amount of connections that can be open at the same time, as well as the 
-amount of connections that can be open to a single origin.
+If the request wasn't coalescable, we can fetch the actual request. This is done by spawning a new task `Fetcher`. The first thing it does is to check if we have too many requests to a single origin. There can be 100 independent requests running, but we only allow a number of requests running simultaneously to a single origin. This is to avoid overloading the server, and to avoid running into issues with browsers that limit the number of connections to a single origin.
 
-At this point we can actualy fetch the request. If the request is a streaming request, we will use `perform_streaming`, 
-otherwise we will use the `perform_buffered` function.
+In total, the fetcher will limit the total amount of connections that can be open at the same time, as well as the amount of connections that can be open to a single origin.
 
-There is a bit of a subtlety here. If the request is a streaming request, it could be possible that we coalesce a 
-buffered request with a streaming request. Same goes the other way: when we have a buffered request, we could coalesce 
-a streaming request with it.
+At this point we can actualy fetch the request. If the request is a streaming request, we will use `perform_streaming`, otherwise we will use the `perform_buffered` function.
 
-The last thing is not a problem: once we have the buffered response, we can just create a stream from it, and send it 
-to the streaming listeners. The first case is a bit more tricky. If we have a streaming request, we can't just buffer 
-the response and send it to the buffered listeners. This can ONLY be done if the stream hasn't started yet. Since we 
-don't keep the entire response in memory, we can't just buffer it and send it to the buffered listeners. In that case, 
-we can't coalesce the requests, and we need to start a new request for the buffered listener.
+There is a bit of a subtlety here. If the request is a streaming request, it could be possible that we coalesce a buffered request with a streaming request. Same goes the other way: when we have a buffered request, we could coalesce a streaming request with it.
 
-Both the `perform_buffered` and `perform_streaming` function will return a `FetchResult`. This result will be sent to 
-all the listeners of the request, and the inflight job will be removed. That will finish up the `Fetcher` spawned task.
+The last thing is not a problem: once we have the buffered response, we can just create a stream from it, and send it to the streaming listeners. The first case is a bit more tricky. If we have a streaming request, we can't just buffer the response and send it to the buffered listeners. This can ONLY be done if the stream hasn't started yet. Since we don't keep the entire response in memory, we can't just buffer it and send it to the buffered listeners. In that case, we can't coalesce the requests, and we need to start a new request for the buffered listener.
+
+Both the `perform_buffered` and `perform_streaming` function will return a `FetchResult`. This result will be sent to all the listeners of the request, and the inflight job will be removed. That will finish up the `Fetcher` spawned task.
 
 ## Inflights and waiters
 
-Before we go into more detail of the buffered and streaming fetchers, let's take a look at the `FetchInflightEntry`
-struct. This struct is responsible for keeping track of the state of a request. It contains the request, the list of
-listeners, and wether or not streaming is being used. The most important part is the set of listeners, also called
-`Waiter`s. It allows you to register channels that will receive the `FetchResult` from the `perform_buffered` and
-`perform_streaming` functions.
+Before we go into more detail of the buffered and streaming fetchers, let's take a look at the `FetchInflightEntry` struct. This struct is responsible for keeping track of the state of a request. It contains the request, the list of listeners, and wether or not streaming is being used. The most important part is the set of listeners, also called `Waiter`s. It allows you to register channels that will receive the `FetchResult` from the `perform_buffered` and `perform_streaming` functions.
 
-Most of the work is done in the `Waiter.finish` function. Here is where we try to duplicate the result to all the 
-listeners. 
+Most of the work is done in the `Waiter.finish` function. Here is where we try to duplicate the result to all the listeners.
 
-`FetchResult::Buffered` will be sent to all the listeners as-is.
-`FetchResult::Stream` is a bit more tricky. We will create cloned stream results for all the listeners that 
-requested a streaming response. Then, we will fetch the stream ourselves into a buffer, and send the buffer to all the 
-buffered listeners. This way, we can serve both streaming and buffered requests from the same inflight job.
-
+`FetchResult::Buffered` will be sent to all the listeners as-is. `FetchResult::Stream` is a bit more tricky. We will create cloned stream results for all the listeners that requested a streaming response. Then, we will fetch the stream ourselves into a buffer, and send the buffer to all the buffered listeners. This way, we can serve both streaming and buffered requests from the same inflight job.
 
 ### fetch-response_complete
-This function is responsible for fetching the complete response. It will first fetch the top of the request through 
-`fetch_response_top`. Then it will stream the rest of the response into a buffer, and return the complete response.
+
+This function is responsible for fetching the complete response. It will first fetch the top of the request through `fetch_response_top`. Then it will stream the rest of the response into a buffer, and return the complete response.
 
 ### fetch_response_top
-This function is responsible for fetching the top of the response. These are the headers of the response, plus the
-initial 5KB of the body. With this information, the client (or engine) can decide how to treat the response. For 
-instance, if the response is a HTML document, the engine could decide to send the stream to the HTML5 parser etc.
 
-There are a small issues:
-If you read the first 5KB of the body, you can't read the rest of the body from the stream, it's possible that you
-have read more than 5KB. Since we only want to have 5KB, we need to "unread" the extra bytes. This is done by dumping
-the extra bytes into a 'excess' buffer.
+This function is responsible for fetching the top of the response. These are the headers of the response, plus the initial 5KB of the body. With this information, the client (or engine) can decide how to treat the response. For instance, if the response is a HTML document, the engine could decide to send the stream to the HTML5 parser etc.
 
-When we return the stream back to the caller, we will not return the existing stream (since that already read the 
-excess bytes), but we recreate a new stream that first reads the excess bytes, and then reads the rest of the body 
-from the original
+There are a small issues: If you read the first 5KB of the body, you can't read the rest of the body from the stream, it's possible that you have read more than 5KB. Since we only want to have 5KB, we need to "unread" the extra bytes. This is done by dumping the extra bytes into a 'excess' buffer.
 
-```
-    //
-    //  |--- Peek buffer ---|---- Excess buffer ----| ---- body stream ----|
-    //                                              ^ stream starts here
-    //                      ^  new body stream "rereads" the excess buffer and starts here
-```
+When we return the stream back to the caller, we will not return the existing stream (since that already read the excess bytes), but we recreate a new stream that first reads the excess bytes, and then reads the rest of the body from the original
 
-This means that now the FetchResult::Stream contains the 'peek_buf' and the reader that reads DIRECTLY behind
-the peek_buf. (resulting in a small bit over 'rereading' the excess buffer).
+        //
+        //  |--- Peek buffer ---|---- Excess buffer ----| ---- body stream ----|
+        //                                              ^ stream starts here
+        //                      ^  new body stream "rereads" the excess buffer and starts here
+
+This means that now the FetchResult::Stream contains the 'peek_buf' and the reader that reads DIRECTLY behind the peek_buf. (resulting in a small bit over 'rereading' the excess buffer).
 
 ### perform_streaming
-This function calls `fetch_response_top` to get the top of the response and turns the result into a
-`FetchResult::Stream`.
+
+This function calls `fetch_response_top` to get the top of the response and turns the result into a `FetchResult::Stream`.
 
 ### perform_buffered
+
 This will simply call the `fetch_response_complete` function, and turns the result into a `FetchResult::Buffered`.
 
-
-
 ## Sending notification during reading of data
-The network stack will send notifications on certain events during reading. For instance, when a request has been 
-queued, when it has started, when it is in progress of reading, etc. The fetch functionality uses `NetEvent` enum for 
-this. But ultimately, we want to send other type of events to the client. In order to facilitate this, we use an 
-"observer" system. This system is passed around to the actual fetch functions, and can be used to send events to the 
-client. They will convert any `NetEvent` into a more suitable event for the client, and send it through a channel.
 
-When reading a streaming response, we will send a `NetEvent::Progress` event every time we read a chunk of data. This 
-way, the client can be notified of the progress of the request. For this, we wrap the read stream into a 
-`ProgressReader`, which does nothing more than read the stream, and send a `NetEvent::Progress` events. Besides that,
-it also takes care of idle timeouts, and total timeouts, cancellation and max size limits.
+The network stack will send notifications on certain events during reading. For instance, when a request has been queued, when it has started, when it is in progress of reading, etc. The fetch functionality uses `NetEvent` enum for this. But ultimately, we want to send other type of events to the client. In order to facilitate this, we use an "observer" system. This system is passed around to the actual fetch functions, and can be used to send events to the client. They will convert any `NetEvent` into a more suitable event for the client, and send it through a channel.
 
+When reading a streaming response, we will send a `NetEvent::Progress` event every time we read a chunk of data. This way, the client can be notified of the progress of the request. For this, we wrap the read stream into a `ProgressReader`, which does nothing more than read the stream, and send a `NetEvent::Progress` events. Besides that, it also takes care of idle timeouts, and total timeouts, cancellation and max size limits.
 
 ## Sharedbody
-Sometimes, we don't return directly a stream, but a `SharedBody`. This works the same way as a normal stream, but it 
-can be read by multiple consumers. You can call `subscribe_stream()` (or `subscribe_with_cap()` for a bounded variant)
-to get a new stream that reads the same data as the original stream. This is useful when you have multiple consumers
-that want to read the same stream, but you don't want to read the stream multiple times from the network.
+
+Sometimes, we don't return directly a stream, but a `SharedBody`. This works the same way as a normal stream, but it can be read by multiple consumers. You can call `subscribe_stream()` (or `subscribe_with_cap()` for a bounded variant) to get a new stream that reads the same data as the original stream. This is useful when you have multiple consumers that want to read the same stream, but you don't want to read the stream multiple times from the network.

--- a/docs/network/pump.md
+++ b/docs/network/pump.md
@@ -1,23 +1,14 @@
 # Pump
 
-The pump component moves stream data from a HTTP response over to different 
-locations. These locations are called `PumpTargets`. At the moment there can
-be only one target, but each target has two different (optional) destinations:
+The pump component moves stream data from a HTTP response over to different locations. These locations are called `PumpTargets`. At the moment there can be only one target, but each target has two different (optional) destinations:
 
-- a shared body reader
-- a disk file
+-   a shared body reader
+-   a disk file
 
-A pump will receive the peek buffer of a HTTP response (it's first 5KB of 
-data), plus the stream data that follows. These two will be combined into a 
-single stream of file and pushed out to the target.
+A pump will receive the peek buffer of a HTTP response (it's first 5KB of data), plus the stream data that follows. These two will be combined into a single stream of file and pushed out to the target.
 
-A shared body has the property that multiple subscribers can listen to it. So
-it's possible to have multiple listeners listening to the same stream of data.
-When the pump is done, the shared body will be closed and all listeners will be
-notified.
+A shared body has the property that multiple subscribers can listen to it. So it's possible to have multiple listeners listening to the same stream of data. When the pump is done, the shared body will be closed and all listeners will be notified.
 
-If a stream in the shared body is not read fast enough, the pump will close and
-remove the target. This is to prevent a slow reader from blocking the entire
-system.
+If a stream in the shared body is not read fast enough, the pump will close and remove the target. This is to prevent a slow reader from blocking the entire system.
 
 ![pump flow](../img.png)

--- a/docs/resource-pipeline.md
+++ b/docs/resource-pipeline.md
@@ -1,11 +1,8 @@
 # Resource pipelines
 
-Where fetched bytes become typed assets. `crates/gosub_engine/src/engine/resource_pipeline/`
-defines one pipeline per asset kind — HTML, CSS, JS, images, fonts — bundled into a
-`ResourcePipelines<C>` struct that each [tab worker](zones-and-tabs.md) owns and hands to
-the network response router.
+Where fetched bytes become typed assets. `crates/gosub_engine/src/engine/resource_pipeline/` defines one pipeline per asset kind --- HTML, CSS, JS, images, fonts --- bundled into a `ResourcePipelines<C>` struct that each [tab worker](zones-and-tabs.md) owns and hands to the network response router.
 
-```text
+``` text
   fetch result ──► route_response_for (net/router.rs)      destination + UaPolicy decide:
                         │                                   render? download? DecisionRequired?
                         ▼
@@ -17,53 +14,23 @@ the network response router.
                 └── FontPipeline   ──► font bytes        (placeholder)
 ```
 
-Each pipeline is a small async trait with two entry points: `parse_stream` (a streaming
-body plus the peek buffer the router already consumed for sniffing) and `parse_bytes`
-(a fully buffered body). The router picks based on how the response arrived.
+Each pipeline is a small async trait with two entry points: `parse_stream` (a streaming body plus the peek buffer the router already consumed for sniffing) and `parse_bytes` (a fully buffered body). The router picks based on how the response arrived.
 
 ## The HTML pipeline (the real one)
 
-`HtmlPipelineImpl` is the pipeline with actual machinery. `parse_main_document_stream`
-(`src/html/parser.rs`) buffers the response body (capped, 1 MiB by default), parses it
-into a real `EngineDocument<C>` DOM, and invokes an `on_discover` callback for every
-sub-resource reference found — stylesheets (`<link rel="stylesheet">`), scripts
-(`<script src>`), and images (`<img src>`).
+`HtmlPipelineImpl` is the pipeline with actual machinery. `parse_main_document_stream` (`src/html/parser.rs`) buffers the response body (capped, 1 MiB by default), parses it into a real `EngineDocument<C>` DOM, and invokes an `on_discover` callback for every sub-resource reference found --- stylesheets (`<link rel="stylesheet">`), scripts (`<script src>`), and images (`<img src>`).
 
-The discovery callback is where early fetching happens: each `ResourceHint` becomes a
-`FetchRequest` (initiator `Parser`, streaming, with the hint's priority) submitted straight
-to the zone's I/O channel — so sub-resource downloads start as soon as the document parse
-finds them, before layout ever asks for them.
+The discovery callback is where early fetching happens: each `ResourceHint` becomes a `FetchRequest` (initiator `Parser`, streaming, with the hint's priority) submitted straight to the zone's I/O channel --- so sub-resource downloads start as soon as the document parse finds them, before layout ever asks for them.
 
-Cancellation is hierarchical: every child fetch's token derives from the parent
-navigation's `CancellationToken`. When the parse finishes (or fails, or the navigation is
-cancelled), the parent token is cancelled and all in-flight child fetches die with it — no
-orphaned downloads from an abandoned navigation. This behaviour is unit-tested in
-`html.rs` (discovery submits three fetches for a three-resource page; all children are
-cancelled after parse end).
+Cancellation is hierarchical: every child fetch's token derives from the parent navigation's `CancellationToken`. When the parse finishes (or fails, or the navigation is cancelled), the parent token is cancelled and all in-flight child fetches die with it --- no orphaned downloads from an abandoned navigation. This behaviour is unit-tested in `html.rs` (discovery submits three fetches for a three-resource page; all children are cancelled after parse end).
 
-Note the buffering: the *stream* interface is already in place end-to-end, but the parse
-itself needs the full document first — the same non-incremental limitation described in
-[html5.md](html5.md). When the parser becomes push-driven, discovery (and therefore
-sub-resource fetching) moves earlier still: mid-download instead of after it.
+Note the buffering: the *stream* interface is already in place end-to-end, but the parse itself needs the full document first --- the same non-incremental limitation described in [html5.md](html5.md). When the parser becomes push-driven, discovery (and therefore sub-resource fetching) moves earlier still: mid-download instead of after it.
 
 ## The others (mostly placeholders)
 
-- **`ImagePipeline`** — decodes the body via the `image` crate (`with_guessed_format`) into
-  a `DynamicImage`. Real, but note that images referenced from CSS/layout are *also*
-  fetched via the render pipeline's `MediaStore` at layout time (see
-  [render-pipeline/layout.md](render-pipeline/layout.md)); the parser-discovered fetch
-  serves to warm the network layer early.
-- **`CssPipeline`, `JsPipeline`, `FontPipeline`** — currently collect the body to a string
-  (`DummyStylesheet` / `DummyJsDocument` / `DummyFont` are type aliases for `String`).
-  The intended shape is chunk-feeding into the CSS parser / JS engine / font system; the
-  traits exist so the router and tab worker don't change when the implementations land.
+-   **`ImagePipeline`** --- decodes the body via the `image` crate (`with_guessed_format`) into a `DynamicImage`. Real, but note that images referenced from CSS/layout are *also* fetched via the render pipeline's `MediaStore` at layout time (see [render-pipeline/layout.md](render-pipeline/layout.md)); the parser-discovered fetch serves to warm the network layer early.
+-   **`CssPipeline`, `JsPipeline`, `FontPipeline`** --- currently collect the body to a string (`DummyStylesheet` / `DummyJsDocument` / `DummyFont` are type aliases for `String`). The intended shape is chunk-feeding into the CSS parser / JS engine / font system; the traits exist so the router and tab worker don't change when the implementations land.
 
 ## Relation to routing and `UaPolicy`
 
-The pipelines only see responses the router decided to *process*. `route_response_for`
-consults the request's destination and the zone's `UaPolicy` (MIME sniffing, PDF viewer,
-render-unknown-text-in-tab, download rules) first; responses that shouldn't be rendered go
-to the download path or raise a `DecisionRequired` for the UA instead — see the navigation
-flow in [zones-and-tabs.md](zones-and-tabs.md). The networking stack underneath
-(`gosub_net`) is moving to the **gosub_sonar** project; the pipeline traits are the seam
-the engine keeps regardless of where the fetcher lives.
+The pipelines only see responses the router decided to *process*. `route_response_for` consults the request's destination and the zone's `UaPolicy` (MIME sniffing, PDF viewer, render-unknown-text-in-tab, download rules) first; responses that shouldn't be rendered go to the download path or raise a `DecisionRequired` for the UA instead --- see the navigation flow in [zones-and-tabs.md](zones-and-tabs.md). The networking stack underneath (`gosub_net`) is moving to the **gosub_sonar** project; the pipeline traits are the seam the engine keeps regardless of where the fetcher lives.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,62 +1,40 @@
 # Getting started with the Gosub engine
 
-This tutorial walks you through the core lifecycle of the Gosub engine. By the
-end you will have a working program that starts the engine, opens a tab,
-navigates to a URL, and reacts to events - the same pattern used by every
-embedding that builds on Gosub.
+This tutorial walks you through the core lifecycle of the Gosub engine. By the end you will have a working program that starts the engine, opens a tab, navigates to a URL, and reacts to events - the same pattern used by every embedding that builds on Gosub.
 
-The companion runnable example lives at [`examples/tutorial.rs`](../examples/tutorial.rs).
-Run it directly with:
+The companion runnable example lives at [`examples/tutorial.rs`](../examples/tutorial.rs). Run it directly with:
 
-```bash
+``` bash
 cargo run --example tutorial -- https://example.com
 ```
 
----
+------------------------------------------------------------------------
 
 ## Key concepts
 
-Before touching any code, it helps to understand the five things you interact
-with constantly.
+Before touching any code, it helps to understand the five things you interact with constantly.
 
 ### Engine
 
-`GosubEngine` is the central hub. It owns the event bus, networking stack, and
-render backend. You create it once, call `start()`, and then drive it entirely
-through commands and events. The engine itself runs on Tokio, so your
-application needs an async runtime.
+`GosubEngine` is the central hub. It owns the event bus, networking stack, and render backend. You create it once, call `start()`, and then drive it entirely through commands and events. The engine itself runs on Tokio, so your application needs an async runtime.
 
 ### Zone
 
-A **Zone** is an isolated browsing profile. It owns its own cookies, local
-storage, session storage, and tabs. Think of it like a browser profile or a
-private window. Multiple zones can coexist in one engine instance - you might
-use this for separate user accounts, or to sandbox untrusted content.
+A **Zone** is an isolated browsing profile. It owns its own cookies, local storage, session storage, and tabs. Think of it like a browser profile or a private window. Multiple zones can coexist in one engine instance - you might use this for separate user accounts, or to sandbox untrusted content.
 
 ### Tab
 
-A **Tab** is a single browsing context, like a browser tab. Every tab lives
-inside exactly one zone and inherits that zone's cookies and storage unless you
-override them. You control a tab through its `TabHandle` by sending
-`TabCommand` values.
+A **Tab** is a single browsing context, like a browser tab. Every tab lives inside exactly one zone and inherits that zone's cookies and storage unless you override them. You control a tab through its `TabHandle` by sending `TabCommand` values.
 
 ### Events
 
-The engine is **event-driven**. It communicates with your application by emitting
-`EngineEvent` values over a channel. Your application receives these events and
-reacts - rendering a frame, updating a progress bar, following a redirect. You
-never poll the engine directly; you wait for events.
+The engine is **event-driven**. It communicates with your application by emitting `EngineEvent` values over a channel. Your application receives these events and reacts - rendering a frame, updating a progress bar, following a redirect. You never poll the engine directly; you wait for events.
 
 ### DecisionRequired
 
-When the engine fetches a URL it needs to know what to do with the response: render
-the page, or save the file? It can't decide on its own (it doesn't know your
-UI), so it pauses the navigation and emits a `NavigationEvent::DecisionRequired`
-event. Your application must reply with `TabCommand::SubmitDecision` carrying
-either `Action::Render` or `Action::Download`. If you do not reply, the navigation
-stalls indefinitely.
+When the engine fetches a URL it needs to know what to do with the response: render the page, or save the file? It can't decide on its own (it doesn't know your UI), so it pauses the navigation and emits a `NavigationEvent::DecisionRequired` event. Your application must reply with `TabCommand::SubmitDecision` carrying either `Action::Render` or `Action::Download`. If you do not reply, the navigation stalls indefinitely.
 
----
+------------------------------------------------------------------------
 
 ## Step-by-step walkthrough
 
@@ -64,7 +42,7 @@ stalls indefinitely.
 
 In your `Cargo.toml`:
 
-```toml
+``` toml
 [dependencies]
 gosub_engine = { git = "https://github.com/gosub-io/gosub-engine", package = "gosub_engine" }
 tokio = { version = "1", features = ["full"] }
@@ -72,7 +50,7 @@ tokio = { version = "1", features = ["full"] }
 
 ### 2. Create the engine
 
-```rust
+``` rust
 use std::sync::{Arc, RwLock};
 use gosub_engine::{EngineSettings, GosubEngine};
 use gosub_render_pipeline::render::{backends::null::NullBackend, DefaultCompositor};
@@ -87,21 +65,17 @@ let mut engine = GosubEngine::new(
 let join_handle = engine.start().expect("cannot start engine");
 ```
 
-`NullBackend` skips all pixel rendering - useful for headless scenarios or
-whenever you just want navigation and events without a visible window. Swap it
-for `CairoBackend` or `VelloBackend` to get an actual rendered surface — see
-[`configuration.md`](configuration.md) for how to wire a real backend into the engine config.
+`NullBackend` skips all pixel rendering - useful for headless scenarios or whenever you just want navigation and events without a visible window. Swap it for `CairoBackend` or `VelloBackend` to get an actual rendered surface --- see [`configuration.md`](configuration.md) for how to wire a real backend into the engine config.
 
-Subscribe to events **before** creating any zones or tabs, so you don't miss
-events emitted during setup:
+Subscribe to events **before** creating any zones or tabs, so you don't miss events emitted during setup:
 
-```rust
+``` rust
 let mut events = engine.subscribe_events();
 ```
 
 ### 3. Create a zone
 
-```rust
+``` rust
 use gosub_engine::cookies::DefaultCookieJar;
 use gosub_engine::storage::{
     InMemoryLocalStore, InMemorySessionStore, PartitionPolicy, StorageService,
@@ -121,13 +95,11 @@ let services = ZoneServices {
 let mut zone = engine.create_zone(ZoneConfig::default(), services, None)?;
 ```
 
-`InMemoryLocalStore` and `InMemorySessionStore` give you ephemeral storage that
-disappears when the zone is dropped. For persistent cookies, pass a
-`CookieStore` in `ZoneServices::cookie_store` and set `cookie_jar` to `None`.
+`InMemoryLocalStore` and `InMemorySessionStore` give you ephemeral storage that disappears when the zone is dropped. For persistent cookies, pass a `CookieStore` in `ZoneServices::cookie_store` and set `cookie_jar` to `None`.
 
 ### 4. Open a tab
 
-```rust
+``` rust
 use gosub_render_pipeline::render::Viewport;
 use gosub_engine::tab::TabDefaults;
 
@@ -140,12 +112,11 @@ let tab = zone.create_tab(
 ).await?;
 ```
 
-`create_tab` returns a `TabHandle`. Hold on to it - you need it to send
-commands and to match events back to the right tab.
+`create_tab` returns a `TabHandle`. Hold on to it - you need it to send commands and to match events back to the right tab.
 
 ### 5. Navigate
 
-```rust
+``` rust
 use gosub_engine::events::TabCommand;
 
 tab.send(TabCommand::Navigate {
@@ -153,12 +124,11 @@ tab.send(TabCommand::Navigate {
 }).await?;
 ```
 
-This queues a navigation request. The engine starts fetching asynchronously and
-begins emitting `EngineEvent::Navigation` events.
+This queues a navigation request. The engine starts fetching asynchronously and begins emitting `EngineEvent::Navigation` events.
 
 ### 6. Event loop
 
-```rust
+``` rust
 use gosub_engine::events::{EngineEvent, NavigationEvent};
 
 loop {
@@ -199,45 +169,48 @@ loop {
 }
 ```
 
-The `DecisionRequired` arm is important: without it the navigation stalls
-because the engine is waiting for your reply.
+The `DecisionRequired` arm is important: without it the navigation stalls because the engine is waiting for your reply.
 
 ### 7. Shutdown
 
-```rust
+``` rust
 engine.shutdown().await?;
 if let Some(handle) = join_handle {
     let _ = handle.await;
 }
 ```
 
-Always shut down cleanly. This drains in-flight network requests and flushes
-any pending state before the process exits.
+Always shut down cleanly. This drains in-flight network requests and flushes any pending state before the process exits.
 
----
+------------------------------------------------------------------------
 
 ## Full example
 
 The steps above are assembled into a single, runnable file:
 
-```
-examples/tutorial.rs
-```
+    examples/tutorial.rs
 
-```bash
+``` bash
 # Navigate to a URL and print events until loading is complete
 cargo run --example tutorial -- https://news.ycombinator.com
 ```
 
----
+------------------------------------------------------------------------
 
 ## What to try next
 
-| Goal | Where to look |
-|---|---|
-| Handle multiple tabs | [`examples/multi-tab.rs`](../examples/multi-tab.rs) |
-| Render with GTK4 / Cairo | [`examples/gtk4-cairo/`](../examples/gtk4-cairo/) |
-| Render with wgpu / Vello | [`examples/egui-vello/`](../examples/egui-vello/) |
-| Parse HTML directly (no engine) | [`examples/html5-parser.rs`](../examples/html5-parser.rs) |
-| Understand all the crates | [`docs/crates.md`](crates.md) |
-| Use the component tools | [`docs/binaries.md`](binaries.md) |
+  -----------------------------------------------------------------------------------------------
+  Goal                                Where to look
+  ----------------------------------- -----------------------------------------------------------
+  Handle multiple tabs                [`examples/multi-tab.rs`](../examples/multi-tab.rs)
+
+  Render with GTK4 / Cairo            [`examples/gtk4-cairo/`](../examples/gtk4-cairo/)
+
+  Render with wgpu / Vello            [`examples/egui-vello/`](../examples/egui-vello/)
+
+  Parse HTML directly (no engine)     [`examples/html5-parser.rs`](../examples/html5-parser.rs)
+
+  Understand all the crates           [`docs/crates.md`](crates.md)
+
+  Use the component tools             [`docs/binaries.md`](binaries.md)
+  -----------------------------------------------------------------------------------------------

--- a/docs/two-worlds.md
+++ b/docs/two-worlds.md
@@ -1,86 +1,51 @@
-# The two worlds: interface DOM vs. pipeline document
+# The two worlds: interface DOM vs. pipeline document
 
-The most confusing architectural fact in this workspace, stated up front: **there are two
-parallel document/style/layout stacks.** Both wrap the Taffy layout engine, both bridge
-table layout to `gosub_lattice`, and both even have a struct named `TaffyLayouter`. They
-are different types in different crates, and only one of them is on the live rendering
-path. This page explains what each world is, where the seam between them sits, and which
-code runs when.
+The most confusing architectural fact in this workspace, stated up front: **there are two parallel document/style/layout stacks.** Both wrap the Taffy layout engine, both bridge table layout to `gosub_lattice`, and both even have a struct named `TaffyLayouter`. They are different types in different crates, and only one of them is on the live rendering path. This page explains what each world is, where the seam between them sits, and which code runs when.
 
 ## World 1: the interface world (parsing and styles)
 
-`gosub_interface` defines trait families for the engine's components — `Document`,
-`Html5Parser`, `CssSystem`, `Layouter` — tied together by `ModuleConfiguration`: a config
-type `C` names concrete implementations as associated types, checked at compile time (no
-runtime registry). The implementations:
+`gosub_interface` defines trait families for the engine's components --- `Document`, `Html5Parser`, `CssSystem`, `Layouter` --- tied together by `ModuleConfiguration`: a config type `C` names concrete implementations as associated types, checked at compile time (no runtime registry).
+
+The implementations:
 
 | Trait | Implementation | Crate |
-|---|---|---|
+|-------|----------------|-------|
 | `Document`, `Html5Parser` | DOM + spec-conformant HTML5 parser | `gosub_html5` |
 | `CssSystem` | tokenizer, parser, selector matcher, cascade | `gosub_css3` |
 | `Layouter` | `gosub_taffy::TaffyLayouter` | `gosub_taffy` |
 
-This is the world where **parsing happens**. When a tab loads a page, the engine parses
-HTML into `C::Document` and stylesheets into `C::CssSystem` stylesheets. Generic engine
-code only ever sees the traits.
+This is the world where **parsing happens**. When a tab loads a page, the engine parses HTML into `C::Document` and stylesheets into `C::CssSystem` stylesheets. Generic engine code only ever sees the traits.
 
-`gosub_taffy` is the interesting resident: its `LayoutDocument<C>` implements Taffy's own
-traits (`TraversePartialTree`, `LayoutPartialTree`, `CacheTree`) *directly over the
-interface-world DOM*, so Taffy walks the real document without an intermediate tree. It is
-architecturally elegant — and currently **dormant**: `gosub_engine` does not depend on it,
-and nothing in the workspace uses it on the rendering path. It survives as a re-export in
-the root crate's prelude (`src/prelude.rs`).
+`gosub_taffy` is the interesting resident: its `LayoutDocument<C>` implements Taffy's own traits (`TraversePartialTree`, `LayoutPartialTree`, `CacheTree`) *directly over the interface-world DOM*, so Taffy walks the real document without an intermediate tree. It is architecturally elegant --- and currently **dormant**: `gosub_engine` does not depend on it, and nothing in the workspace uses it on the rendering path. It survives as a re-export in the root crate's prelude (`src/prelude.rs`).
 
 ## World 2: the pipeline world (rendering)
 
-`gosub_render_pipeline` — everything documented under [render-pipeline/](render-pipeline/README.md) —
-has its **own, self-contained document model** under `src/common/document/`:
+`gosub_render_pipeline` --- everything documented under [render-pipeline/](render-pipeline/README.md) --- has its **own, self-contained document model** under `src/common/document/`:
 
-- its own `Node` / `NodeType` / element data (`node.rs`);
-- its own style model (`style.rs`): a closed `StyleProperty` enum and `Value` type with
-  interned keywords, per-property metadata (inherited? initial value?), and its own
-  inheritance + `em`/`rem` resolution;
-- its own layouter (`layouter/taffy.rs` — the *other* `TaffyLayouter`, behind the
-  pipeline-local `CanLayout` trait, documented in [render-pipeline/layout.md](render-pipeline/layout.md));
-- its own table bridge to `gosub_lattice` (`layouter/table.rs`).
+-   its own `Node` / `NodeType` / element data (`node.rs`);
+-   its own style model (`style.rs`): a closed `StyleProperty` enum and `Value` type with interned keywords, per-property metadata (inherited? initial value?), and its own inheritance + `em`/`rem` resolution;
+-   its own layouter (`layouter/taffy.rs` --- the *other* `TaffyLayouter`, behind the pipeline-local `CanLayout` trait, documented in [render-pipeline/layout.md](render-pipeline/layout.md));
+-   its own table bridge to `gosub_lattice` (`layouter/table.rs`).
 
-None of these types implement `gosub_interface` traits. The pipeline's style model is small
-and rendering-oriented (exactly the properties the painter needs, as plain enums), where
-the css3 world's property maps are fully general. This is what makes the pipeline
-independently testable — its unit tests build documents from pipeline types directly,
-without an HTML parser or CSS engine in sight.
+None of these types implement `gosub_interface` traits. The pipeline's style model is small and rendering-oriented (exactly the properties the painter needs, as plain enums), where the css3 world's property maps are fully general. This is what makes the pipeline independently testable --- its unit tests build documents from pipeline types directly, without an HTML parser or CSS engine in sight.
 
 ## The seam: `PipelineDocument` + `GosubDocumentAdapter`
 
-The two worlds meet in one file:
-[`common/document/pipeline_doc.rs`](../crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs).
+The two worlds meet in one file: [`common/document/pipeline_doc.rs`](../crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs).
 
-**`PipelineDocument`** is the narrow trait the whole pipeline consumes: tree navigation
-(`root`/`children`/`parent`), node classification (`node_kind`/`tag_name`), and styles —
-`get_own_style(id, prop) -> Option<Value>` plus a provided `get_style` that layers
-inheritance, initial values, and `em`/`rem` → px resolution on top.
+**`PipelineDocument`** is the narrow trait the whole pipeline consumes: tree navigation (`root`/`children`/`parent`), node classification (`node_kind`/`tag_name`), and styles --- `get_own_style(id, prop) -> Option<Value>` plus a provided `get_style` that layers inheritance, initial values, and `em`/`rem` → px resolution on top.
 
-**`GosubDocumentAdapter<C: HasDocument>`** implements that trait over an
-`Arc<C::Document>` from world 1. It is where all the translation lives:
+**`GosubDocumentAdapter<C: HasDocument>`** implements that trait over an `Arc<C::Document>` from world 1. It is where all the translation lives:
 
-- **Lazy computed styles**: on first `get_own_style` for a node, the adapter runs world 1's
-  CSS selector matching (`C::CssSystem`) and caches the resulting property map per node.
-  Nothing is computed for nodes the pipeline never asks about.
-- **Value translation**: `css_property_to_value` maps each generic `CssProperty` into the
-  pipeline's closed `Value` enum (colors, display keywords, lengths, gradients, …).
-- **Inline styles**: the `style=""` attribute is parsed and cached separately, taking
-  precedence as highest-specificity.
-- **Generated content**: `::before` / `::after` have no DOM node, so the adapter mints
-  *synthetic* `NodeId`s (bit-encoded: flag + role + owner id) and materializes pseudo-boxes
-  lazily. The rest of the pipeline treats them as ordinary nodes.
-- **Invalidation**: `invalidate_style_for_nodes` / `clear_style_cache` let hover repaints
-  re-run selector matching (`:hover`) for just the affected nodes.
+-   **Lazy computed styles**: on first `get_own_style` for a node, the adapter runs world 1's CSS selector matching (`C::CssSystem`) and caches the resulting property map per node. Nothing is computed for nodes the pipeline never asks about.
+-   **Value translation**: `css_property_to_value` maps each generic `CssProperty` into the pipeline's closed `Value` enum (colors, display keywords, lengths, gradients, ...).
+-   **Inline styles**: the `style=""` attribute is parsed and cached separately, taking precedence as highest-specificity.
+-   **Generated content**: `::before` / `::after` have no DOM node, so the adapter mints *synthetic* `NodeId`s (bit-encoded: flag + role + owner id) and materializes pseudo-boxes lazily. The rest of the pipeline treats them as ordinary nodes.
+-   **Invalidation**: `invalidate_style_for_nodes` / `clear_style_cache` let hover repaints re-run selector matching (`:hover`) for just the affected nodes.
 
-The handoff happens in `gosub_engine`'s pipeline entry points
-(`crates/gosub_engine/src/engine/context.rs`): each rebuild wraps the parsed document in a
-fresh adapter and hands it to the pipeline's render-tree builder:
+The handoff happens in `gosub_engine`'s pipeline entry points (`crates/gosub_engine/src/engine/context.rs`): each rebuild wraps the parsed document in a fresh adapter and hands it to the pipeline's render-tree builder:
 
-```rust
+``` rust
 let adapter = GosubDocumentAdapter::<C>::new(doc);   // world 1 in, world 2 out
 let mut render_tree = RenderTree::new(Arc::new(adapter));
 ```
@@ -89,7 +54,7 @@ Everything upstream of that line is world 1; everything downstream is world 2.
 
 ## The full picture
 
-```text
+``` text
         WORLD 1 (gosub_interface traits)          │            WORLD 2 (pipeline types)
                                                   │
   HTML  ──► gosub_html5 ──► C::Document ──┐       │
@@ -102,21 +67,15 @@ Everything upstream of that line is world 1; everything downstream is world 2.
 ## Duplications to be aware of
 
 | Concept | World 1 | World 2 |
-|---|---|---|
-| Layouter struct | `gosub_taffy::TaffyLayouter` (dormant) | `gosub_render_pipeline::layouter::taffy::TaffyLayouter` (live) |
+|---------|---------|---------|
+| Layouter struct | `gosub_taffy::TaffyLayouter`; dormant | `gosub_render_pipeline::layouter::taffy::TaffyLayouter`; live |
 | Layouter trait | `gosub_interface::layout::Layouter` | pipeline-local `CanLayout` |
-| Lattice table bridge | `gosub_taffy`'s `TableTree` adapter | `PipelineTableTree` in `layouter/table.rs` |
-| Style representation | `CssSystem` property maps (general) | `StyleProperty`/`Value` enums (closed, render-oriented) |
+| Lattice table bridge | `gosub_taffy`’s `TableTree` adapter | `PipelineTableTree` in `layouter/table.rs` |
+| Style representation | `CssSystem` property maps; general | `StyleProperty`/`Value` enums; closed, render-oriented |
 | Node identity | `gosub_shared::node::NodeId` | same `NodeId`, plus synthetic pseudo-element ids |
 
-When you search the workspace for `TaffyLayouter`, check the crate before drawing
-conclusions — the two share a name and a dependency, nothing else.
+When you search the workspace for `TaffyLayouter`, check the crate before drawing conclusions --- the two share a name and a dependency, nothing else.
 
 ## Why it is this way (and where it might go)
 
-The trade is isolation versus duplication. Owning its document model lets the pipeline be
-developed and tested without routing every experiment through the full parse/cascade
-machinery, and gives the painter a closed style enum it can match on exhaustively; the
-cost is the duplicated layouters/bridges above and a translation layer on every rebuild.
-Should the two layouters ever merge, `gosub_taffy`'s trait-over-the-real-DOM approach and
-the pipeline's battle-tested inline/table handling are the two halves worth keeping.
+The trade is isolation versus duplication. Owning its document model lets the pipeline be developed and tested without routing every experiment through the full parse/cascade machinery, and gives the painter a closed style enum it can match on exhaustively; the cost is the duplicated layouters/bridges above and a translation layer on every rebuild. Should the two layouters ever merge, `gosub_taffy`'s trait-over-the-real-DOM approach and the pipeline's battle-tested inline/table handling are the two halves worth keeping.

--- a/docs/zones-and-tabs.md
+++ b/docs/zones-and-tabs.md
@@ -1,67 +1,46 @@
 # Zones and tabs
 
-How the engine organizes running state: one `GosubEngine`, containing isolated **zones**,
-each containing **tabs** that run as independent tasks. This is the architecture view; for
-a hands-on walkthrough see [tutorial.md](tutorial.md).
+How the engine organizes running state: one `GosubEngine`, containing isolated **zones**, each containing **tabs** that run as independent tasks. This is the architecture view; for a hands-on walkthrough see [tutorial.md](tutorial.md).
 
-```text
+``` text
 GosubEngine<C>                        (owns backend, compositor, font system, event bus)
- ├── Zone "Home"     (profile: own cookies, storage, identity)
+ ├── Zone "Home"                      (profile: own cookies, storage, identity)
  │     ├── Tab ──► TabWorker task     (own DOM, navigation, render state)
  │     └── Tab ──► TabWorker task
- └── Zone "Work"     (a second, fully isolated profile)
+ └── Zone "Work"                      (a second, fully isolated profile)
        └── Tab ──► TabWorker task
 ```
 
 ## Why zones
 
-A zone is a **browser profile/container** (in the Firefox-containers sense): it
-encapsulates everything that constitutes an identity on the web — cookies, local/session
-storage, and runtime services — so "Work" and "Home" zones browsing the same site are two
-different users as far as that site can tell. Zones also carry UI metadata (title, icon,
-color, description) so a user agent can render them as visible containers.
+A zone is a **browser profile/container** (in the Firefox-containers sense): it encapsulates everything that constitutes an identity on the web --- cookies, local/session storage, and runtime services --- so "Work" and "Home" zones browsing the same site are two different users as far as that site can tell. Zones also carry UI metadata (title, icon, color, description) so a user agent can render them as visible containers.
 
-Isolation is the default; sharing is opt-in per data class via `SharedFlags`
-(autocomplete, bookmarks, passwords, cookie jar).
+Isolation is the default; sharing is opt-in per data class via `SharedFlags` (autocomplete, bookmarks, passwords, cookie jar).
 
 A zone is created with:
 
-- **`ZoneConfig`** — limits and settings (e.g. maximum tabs);
-- **`ZoneServices`** — the isolation boundary made concrete: a `StorageService`
-  (local + session stores — see [datastores.md](datastores.md)), an optional cookie
-  store/jar (see [cookies.md](cookies.md)), and a `PartitionPolicy` describing how storage
-  is keyed (e.g. per-origin partitioning);
-- an optional fixed `ZoneId` (a UUID — pass one to restore a persisted zone across runs).
+-   **`ZoneConfig`** --- limits and settings (e.g. maximum tabs);
+-   **`ZoneServices`** --- the isolation boundary made concrete: a `StorageService` (local + session stores --- see [datastores.md](datastores.md)), an optional cookie store/jar (see [cookies.md](cookies.md)), and a `PartitionPolicy` describing how storage is keyed (e.g. per-origin partitioning);
+-   an optional fixed `ZoneId` (a UUID --- pass one to restore a persisted zone across runs).
 
-Internally the zone builds a `ZoneContext` that flows down to every tab it creates: the
-services above plus the engine-wide pieces — event channel, network I/O channel, the render
-backend, compositor sink, and the single shared font system (all concrete types per the
-config `C`, see [configuration.md](configuration.md)).
+Internally the zone builds a `ZoneContext` that flows down to every tab it creates: the services above plus the engine-wide pieces --- event channel, network I/O channel, the render backend, compositor sink, and the single shared font system (all concrete types per the config `C`, see [configuration.md](configuration.md)).
 
 ## The engine around them
 
 `GosubEngine<C: RenderConfiguration>` owns what zones share:
 
-- the **render backend** and **compositor sink** (one instance each, per the config);
-- the **font system** — one instance, handed to both layout and rasterization so
-  measurement and drawing agree (see [fonts.md](fonts.md));
-- the **network I/O thread** — networking runs on its own thread with an `IoChannel`;
-  responses are routed back to the right tab via a request-reference map;
-- the **command channel** (`EngineCommand`, mpsc into the engine run loop) and the
-  **event bus** (`EngineEvent`, a tokio broadcast channel — `subscribe_events()` gives
-  every listener its own receiver).
+-   the **render backend** and **compositor sink** (one instance each, per the config);
+-   the **font system** --- one instance, handed to both layout and rasterization so measurement and drawing agree (see [fonts.md](fonts.md));
+-   the **network I/O thread** --- networking runs on its own thread with an `IoChannel`; responses are routed back to the right tab via a request-reference map;
+-   the **command channel** (`EngineCommand`, mpsc into the engine run loop) and the **event bus** (`EngineEvent`, a tokio broadcast channel --- `subscribe_events()` gives every listener its own receiver).
 
-The command/event flow is strictly layered: commands travel *down* (UA → engine → zone →
-tab, each over its own mpsc channel), events travel *up* onto the one broadcast bus,
-tagged with their `tab_id`/`zone_id` so the UA can demultiplex.
+The command/event flow is strictly layered: commands travel *down* (UA → engine → zone → tab, each over its own mpsc channel), events travel *up* onto the one broadcast bus, tagged with their `tab_id`/`zone_id` so the UA can demultiplex.
 
 ## Tabs
 
-A tab is a browsing context. `zone.create_tab(TabDefaults, overrides)` spawns a
-**`TabWorker`** — a dedicated tokio task owning everything about that page — and returns a
-`TabHandle`:
+A tab is a browsing context. `zone.create_tab(TabDefaults, overrides)` spawns a **`TabWorker`** --- a dedicated tokio task owning everything about that page --- and returns a `TabHandle`:
 
-```rust
+``` rust
 pub struct TabHandle {
     pub tab_id: TabId,
     pub cmd_tx: TabChannel,   // mpsc of TabCommand into the worker
@@ -69,12 +48,10 @@ pub struct TabHandle {
 }
 ```
 
-The handle is the *entire* control surface: everything is a `TabCommand` message
-(convenience methods like `navigate()` / `set_viewport()` wrap `send()`). The command set
-falls into four groups:
+The handle is the *entire* control surface: everything is a `TabCommand` message (convenience methods like `navigate()` / `set_viewport()` wrap `send()`). The command set falls into four groups:
 
 | Group | Commands |
-|---|---|
+|-------|----------|
 | Navigation | `Navigate`, `Reload`, `CancelNavigation`, `SubmitDecision` |
 | Lifecycle | `CloseTab`, `SetTitle` |
 | Drawing | `ResumeDrawing { fps }`, `SuspendDrawing`, `SetViewport` |
@@ -82,34 +59,14 @@ falls into four groups:
 
 Inside the worker:
 
-- **Navigation is a cancellable async job.** Each navigation gets a `NavigationId` and a
-  `CancellationToken`; the fetch/parse runs concurrently and reports back over a oneshot
-  channel, so a new `Navigate` (or `CancelNavigation`) cleanly aborts the old one. Progress
-  is published as `NavigationEvent`s (`Started`, `Finished`, `Failed`, …).
-- **`DecisionRequired`**: when a response arrives that isn't obviously a renderable page
-  (content-type/disposition says download, unknown type, …), the worker emits a
-  `NavigationEvent::DecisionRequired` and waits for the UA's `SubmitDecision` — render it,
-  download it, or cancel. The engine never decides this on its own.
-- **Drawing is pull-based and rate-limited.** Nothing paints until the UA sends
-  `ResumeDrawing { fps }`; the worker then runs a tick loop at that rate, driving the
-  [render pipeline](render-pipeline/README.md) (per the backend's `RasterStrategy`) and
-  submitting finished frames to the compositor sink, which notifies the UA (e.g.
-  `EngineEvent::Redraw` with an `ExternalHandle`). `SuspendDrawing` stops the ticks — a
-  backgrounded tab costs nothing.
-- The worker owns the tab's `BrowsingContext` — document, styles, pipeline caches, scroll
-  state — none of which is reachable from outside except through commands and events.
+-   **Navigation is a cancellable async job.** Each navigation gets a `NavigationId` and a `CancellationToken`; the fetch/parse runs concurrently and reports back over a oneshot channel, so a new `Navigate` (or `CancelNavigation`) cleanly aborts the old one. Progress is published as `NavigationEvent`s (`Started`, `Finished`, `Failed`, ...).
+-   **`DecisionRequired`**: when a response arrives that isn't obviously a renderable page (content-type/disposition says download, unknown type, ...), the worker emits a `NavigationEvent::DecisionRequired` and waits for the UA's `SubmitDecision` --- render it, download it, or cancel. The engine never decides this on its own.
+-   **Drawing is pull-based and rate-limited.** Nothing paints until the UA sends `ResumeDrawing { fps }`; the worker then runs a tick loop at that rate, driving the [render pipeline](render-pipeline/README.md) (per the backend's `RasterStrategy`) and submitting finished frames to the compositor sink, which notifies the UA (e.g. `EngineEvent::Redraw` with an `ExternalHandle`). `SuspendDrawing` stops the ticks --- a backgrounded tab costs nothing.
+-   The worker owns the tab's `BrowsingContext` --- document, styles, pipeline caches, scroll state --- none of which is reachable from outside except through commands and events.
 
 ## Why this shape
 
-- **Isolation by construction.** Zone state lives in `ZoneServices`; a tab can only reach
-  what its `ZoneContext` hands it. Cross-zone leaks would require explicit plumbing.
-- **One slow tab can't stall the rest.** Each `TabWorker` is its own task; heavy layout or
-  a hung fetch affects only that tab. Networking is off on its own thread entirely.
-- **Message passing over shared state.** The UA ↔ engine boundary is channels in both
-  directions, so a GUI event loop (winit, GTK, egui) and the engine's tokio runtime never
-  lock each other — the [headless tool](headless.md) drives the exact same interface
-  without a window.
-- **Compile-time config all the way down.** `ZoneContext` carries the *concrete*
-  backend/compositor/font types of `C: RenderConfiguration` — no dynamic dispatch on the
-  hot rendering path and no possibility of a zone mixing components from different
-  configs.
+-   **Isolation by construction.** Zone state lives in `ZoneServices`; a tab can only reach what its `ZoneContext` hands it. Cross-zone leaks would require explicit plumbing.
+-   **One slow tab can't stall the rest.** Each `TabWorker` is its own task; heavy layout or a hung fetch affects only that tab. Networking is off on its own thread entirely.
+-   **Message passing over shared state.** The UA ↔ engine boundary is channels in both directions, so a GUI event loop (winit, GTK, egui) and the engine's tokio runtime never lock each other --- the [headless tool](headless.md) drives the exact same interface without a window.
+-   **Compile-time config all the way down.** `ZoneContext` carries the *concrete* backend/compositor/font types of `C: RenderConfiguration` --- no dynamic dispatch on the hot rendering path and no possibility of a zone mixing components from different configs.


### PR DESCRIPTION
Reflow and some modifications on the markdown documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified several guides across cookies, configuration, CSS, HTML5 parsing, networking, fonts, tabs/zones, and the engine/tutorial workflow.
  * Added a new module configuration guide and improved architecture overviews for storage, resource loading, and crate responsibilities.
  * Reworked formatting throughout the docs for cleaner reading, more consistent section structure, and updated examples and diagrams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->