### PR TITLE
Cleanup gosub lattice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3303,7 +3303,6 @@ name = "gosub_lattice"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "log",
 ]
 
 [[package]]

--- a/crates/gosub_lattice/Cargo.toml
+++ b/crates/gosub_lattice/Cargo.toml
@@ -8,7 +8,6 @@ description = "CSS table layout engine for Gosub"
 
 [dependencies]
 anyhow = { workspace = true }
-log = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/gosub_lattice/src/bin/table_console.rs
+++ b/crates/gosub_lattice/src/bin/table_console.rs
@@ -1,6 +1,10 @@
 /// Console table renderer — run with:
 ///   cargo run --bin table_console -p gosub_lattice
-use gosub_lattice::mock::{cell, MockTable};
+///
+/// Each demo mirrors an integration test in `src/tests.rs`, so the same
+/// scenarios the tests assert numerically can be eyeballed here.
+use gosub_lattice::mock::{cell, render_tree, MockTable, MockTree};
+use gosub_lattice::{compute_table_layout, TableRole};
 
 fn main() {
     // 1. Simple 3-column table, no spanning
@@ -56,4 +60,89 @@ fn main() {
         .footer_row(vec![cell("Footer").colspan(3)])
         .render();
     println!("{out}");
+
+    // 6. Content-driven column widths (tests 18/19): narrow columns keep their
+    //    natural width (with a 14px floor), the wide content column absorbs the
+    //    rest. Column sizing scans the first row, so content widths go there.
+    println!("=== content-proportional columns (narrow cols keep natural width) ===");
+    let out = MockTable::new(80.0)
+        .body_row(vec![
+            cell("1.").content_width(3.0),
+            cell("A story title that wants all the room").content_width(52.0),
+            cell("312").content_width(6.0),
+        ])
+        .body_row(vec![cell("2."), cell("Shorter title"), cell("41")])
+        .render();
+    println!("{out}");
+
+    // 7. Explicit width clamped to content (test 20): width=6 on a cell whose
+    //    content is naturally 12 wide — the column comes out 12, not 6.
+    println!("=== explicit width clamped up to content width ===");
+    let out = MockTable::new(50.0)
+        .body_row(vec![
+            cell("img w=6 c=12").width(6.0).content_width(12.0),
+            cell("caption gets the rest"),
+        ])
+        .render();
+    println!("{out}");
+
+    // 8. Anonymous-box fixups (tests 14/15): bare rows directly under the table
+    //    get an anonymous body group — the table renders as if wrapped in <tbody>.
+    println!("=== anonymous group: bare rows directly under the table ===");
+    let mut tree = MockTree::new(1.0, 0.0);
+    let root = tree.alloc(TableRole::Table, None, 1, 1, None, None, 0.0, 0.0);
+    for labels in [["bare", "row"], ["no", "tbody"]] {
+        let row = tree.alloc(TableRole::Row, None, 1, 1, None, None, 0.0, 0.0);
+        tree.add_child(root, row);
+        for label in labels {
+            let c = tree.alloc_cell(cell(label));
+            tree.add_child(row, c);
+        }
+    }
+    if compute_table_layout(&mut tree, root, 30.0, None).is_ok() {
+        println!("{}", render_tree(&tree, root));
+    }
+
+    // 9. Section order normalization (test 13): source order is tfoot, tbody,
+    //    thead — the layout renders header → body → footer regardless.
+    println!("=== source order tfoot/tbody/thead → renders head/body/foot ===");
+    let mut tree = MockTree::new(1.0, 0.0);
+    let root = tree.alloc(TableRole::Table, None, 1, 1, None, None, 0.0, 0.0);
+    for (role, label) in [
+        (TableRole::FooterGroup, "footer (first in source)"),
+        (TableRole::RowGroup, "body (second in source)"),
+        (TableRole::HeaderGroup, "header (last in source)"),
+    ] {
+        let group = tree.alloc(role, None, 1, 1, None, None, 0.0, 0.0);
+        tree.add_child(root, group);
+        let row = tree.alloc(TableRole::Row, None, 1, 1, None, None, 0.0, 0.0);
+        tree.add_child(group, row);
+        let c = tree.alloc_cell(cell(label));
+        tree.add_child(row, c);
+    }
+    if compute_table_layout(&mut tree, root, 40.0, None).is_ok() {
+        println!("{}", render_tree(&tree, root));
+    }
+
+    // 10. Nested table (test 23): the outer host column's width flows down as
+    //     the inner table's available width. The real engine recurses through
+    //     `layout_cell`; here the inner table is rendered separately at the
+    //     width the outer layout assigned to its host column.
+    println!("=== nested table: inner table laid out at the host column's width ===");
+    let (mut outer, outer_root) = MockTable::new(60.0)
+        .body_row(vec![cell("nested table below"), cell("plain cell")])
+        .into_tree();
+    if compute_table_layout(&mut outer, outer_root, 60.0, None).is_ok() {
+        println!("{}", render_tree(&outer, outer_root));
+        let host = outer.nodes_with_role(TableRole::Cell)[0];
+        if let Some(layout) = outer.layout(host) {
+            let host_w = layout.size.width;
+            println!("inner table, rendered at the host column's {host_w}px:");
+            let out = MockTable::new(host_w)
+                .body_row(vec![cell("in"), cell("ner")])
+                .body_row(vec![cell("ta"), cell("ble")])
+                .render();
+            println!("{out}");
+        }
+    }
 }

--- a/crates/gosub_lattice/src/compute.rs
+++ b/crates/gosub_lattice/src/compute.rs
@@ -104,7 +104,11 @@ pub fn compute_table_layout<T: TableTree>(
     //    Each cell is positioned relative to its row.
     let inner_width = col_widths.iter().sum::<f32>() + (n_cols as f32 + 1.0) * spacing_x;
 
-    let mut group_y = spacing_y; // Y offset of the next group, relative to the table
+    // Y offset of the next group, relative to the table. Vertically the table is one
+    // flat stack of rows: one gutter above the first row, one between any two adjacent
+    // rows (also across group boundaries), one below the last. Groups therefore carry
+    // only the (n_rows - 1) *internal* gutters; the shared boundary gutters live here.
+    let mut group_y = spacing_y;
 
     #[allow(clippy::type_complexity)]
     let section_data: &[(&[RowGroup<T::NodeId>], &[SectionGrid<T::NodeId>], &[Vec<f32>])] = &[
@@ -129,18 +133,28 @@ pub fn compute_table_layout<T: TableTree>(
                 );
             }
 
-            place_rows(tree, group, grid, row_heights, &col_x, &col_widths, spacing_y);
+            place_rows(
+                tree,
+                group,
+                grid,
+                row_heights,
+                &col_x,
+                &col_widths,
+                spacing_x,
+                spacing_y,
+            );
 
-            group_y += group_height;
+            group_y += group_height + spacing_y;
         }
     }
 
-    let total_height = group_y + spacing_y;
+    let total_height = group_y;
 
     Ok((table_width, total_height))
 }
 
 /// Write layouts for every row and cell within one section.
+#[allow(clippy::too_many_arguments)]
 fn place_rows<T: TableTree>(
     tree: &mut T,
     group: &RowGroup<T::NodeId>,
@@ -148,6 +162,7 @@ fn place_rows<T: TableTree>(
     row_heights: &[f32],
     col_x: &[f32],
     col_widths: &[f32],
+    spacing_x: f32,
     spacing_y: f32,
 ) {
     // Precompute y offset of each row within the group.
@@ -172,12 +187,13 @@ fn place_rows<T: TableTree>(
 
         // Cells for this row.
         for cell in grid.cells_in_row(row_idx) {
-            place_cell(tree, cell, row_heights, col_x, col_widths, &row_y);
+            place_cell(tree, cell, row_heights, col_x, col_widths, &row_y, spacing_x, spacing_y);
         }
     }
 }
 
 /// Write the layout for one placed cell.
+#[allow(clippy::too_many_arguments)]
 fn place_cell<T: TableTree>(
     tree: &mut T,
     cell: &PlacedCell<T::NodeId>,
@@ -185,20 +201,18 @@ fn place_cell<T: TableTree>(
     col_x: &[f32],
     col_widths: &[f32],
     row_y: &[f32],
+    spacing_x: f32,
+    spacing_y: f32,
 ) {
-    // Width = sum of spanned column widths (col_widths already excludes spacing).
-    let cell_width: f32 = col_widths
-        .get(cell.col..cell.col + cell.colspan)
-        .unwrap_or(&[])
-        .iter()
-        .sum();
+    // Width = sum of spanned column widths, plus the border-spacing gutters the
+    // spanning cell covers (a colspan=2 cell runs across the gutter between its
+    // two columns). `col_widths` itself excludes spacing.
+    let spanned_cols = col_widths.get(cell.col..cell.col + cell.colspan).unwrap_or(&[]);
+    let cell_width: f32 = spanned_cols.iter().sum::<f32>() + spacing_x * spanned_cols.len().saturating_sub(1) as f32;
 
-    // Height = sum of spanned row heights.
-    let cell_height: f32 = row_heights
-        .get(cell.row..cell.row + cell.rowspan)
-        .unwrap_or(&[])
-        .iter()
-        .sum();
+    // Height = sum of spanned row heights, plus the gutters between them.
+    let spanned_rows = row_heights.get(cell.row..cell.row + cell.rowspan).unwrap_or(&[]);
+    let cell_height: f32 = spanned_rows.iter().sum::<f32>() + spacing_y * spanned_rows.len().saturating_sub(1) as f32;
 
     let x = col_x.get(cell.col).copied().unwrap_or(0.0);
 
@@ -236,9 +250,11 @@ fn col_x_offsets(col_widths: &[f32], spacing_x: f32) -> Vec<f32> {
 }
 
 /// `row_y[i]` = y of the top edge of row `i` within its group, in px.
+/// The first row starts at 0 — the gutter above it belongs to the table
+/// (or to the previous group's bottom boundary), not to this group.
 fn row_y_offsets(row_heights: &[f32], spacing_y: f32) -> Vec<f32> {
     let mut offsets = Vec::with_capacity(row_heights.len());
-    let mut y = spacing_y;
+    let mut y = 0.0;
     for &h in row_heights {
         offsets.push(y);
         y += h + spacing_y;
@@ -246,10 +262,12 @@ fn row_y_offsets(row_heights: &[f32], spacing_y: f32) -> Vec<f32> {
     offsets
 }
 
-/// Total height of a section including surrounding border-spacing gutters.
+/// Total height of a section: its rows plus the gutters *between* them.
+/// Boundary gutters (above the first row / below the last) are added by the
+/// caller when stacking groups, so they are not counted here.
 fn section_height(row_heights: &[f32], spacing_y: f32) -> f32 {
     let rows_h: f32 = row_heights.iter().sum();
-    let gaps = (row_heights.len() as f32 + 1.0) * spacing_y;
+    let gaps = spacing_y * row_heights.len().saturating_sub(1) as f32;
     rows_h + gaps
 }
 

--- a/crates/gosub_lattice/src/geo.rs
+++ b/crates/gosub_lattice/src/geo.rs
@@ -2,7 +2,7 @@
 //!
 //! Lattice only needs a 2D point and a 2D size in `f32`, so it carries its own tiny
 //! definitions rather than depending on a larger shared geometry crate. This keeps the
-//! crate freestanding (its only dependencies are `anyhow` and `log`).
+//! crate freestanding (its only dependency is `anyhow`).
 
 /// A 2D point in `f32` space.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]

--- a/crates/gosub_lattice/src/mock.rs
+++ b/crates/gosub_lattice/src/mock.rs
@@ -27,6 +27,10 @@ pub struct MockCell {
     pub border: f32,
     /// Uniform padding on all sides.
     pub padding: f32,
+    /// Natural (pre-pass) border-box width reported via `cell_content_width`.
+    pub content_width: f32,
+    /// Content height reported by `layout_cell` (as if children were laid out).
+    pub content_height: f32,
 }
 
 impl MockCell {
@@ -39,6 +43,8 @@ impl MockCell {
             height: None,
             border: 0.0,
             padding: 1.0,
+            content_width: 0.0,
+            content_height: 0.0,
         }
     }
 
@@ -64,6 +70,14 @@ impl MockCell {
     }
     pub fn padding(mut self, p: f32) -> Self {
         self.padding = p;
+        self
+    }
+    pub fn content_width(mut self, w: f32) -> Self {
+        self.content_width = w;
+        self
+    }
+    pub fn content_height(mut self, h: f32) -> Self {
+        self.content_height = h;
         self
     }
 }
@@ -136,16 +150,7 @@ impl MockTable {
                 let row = tree.alloc(TableRole::Row, None, 1, 1, None, None, 0.0, 0.0);
                 tree.add_child(hg, row);
                 for mc in row_cells {
-                    let cell_id = tree.alloc(
-                        TableRole::Cell,
-                        Some(mc.label),
-                        mc.colspan,
-                        mc.rowspan,
-                        mc.width,
-                        mc.height,
-                        mc.border,
-                        mc.padding,
-                    );
+                    let cell_id = tree.alloc_cell(mc);
                     tree.add_child(row, cell_id);
                 }
             }
@@ -158,16 +163,7 @@ impl MockTable {
                 let row = tree.alloc(TableRole::Row, None, 1, 1, None, None, 0.0, 0.0);
                 tree.add_child(bg, row);
                 for mc in row_cells {
-                    let cell_id = tree.alloc(
-                        TableRole::Cell,
-                        Some(mc.label),
-                        mc.colspan,
-                        mc.rowspan,
-                        mc.width,
-                        mc.height,
-                        mc.border,
-                        mc.padding,
-                    );
+                    let cell_id = tree.alloc_cell(mc);
                     tree.add_child(row, cell_id);
                 }
             }
@@ -180,16 +176,7 @@ impl MockTable {
                 let row = tree.alloc(TableRole::Row, None, 1, 1, None, None, 0.0, 0.0);
                 tree.add_child(fg, row);
                 for mc in row_cells {
-                    let cell_id = tree.alloc(
-                        TableRole::Cell,
-                        Some(mc.label),
-                        mc.colspan,
-                        mc.rowspan,
-                        mc.width,
-                        mc.height,
-                        mc.border,
-                        mc.padding,
-                    );
+                    let cell_id = tree.alloc_cell(mc);
                     tree.add_child(row, cell_id);
                 }
             }
@@ -212,6 +199,8 @@ struct MockNode {
     height: Option<f32>,
     border: f32,
     padding: f32,
+    content_width: f32,
+    content_height: f32,
 }
 
 pub struct MockTree {
@@ -222,7 +211,7 @@ pub struct MockTree {
 }
 
 impl MockTree {
-    fn new(border_spacing_x: f32, border_spacing_y: f32) -> Self {
+    pub fn new(border_spacing_x: f32, border_spacing_y: f32) -> Self {
         Self {
             nodes: HashMap::new(),
             next_id: 0,
@@ -232,7 +221,7 @@ impl MockTree {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn alloc(
+    pub fn alloc(
         &mut self,
         role: TableRole,
         label: Option<String>,
@@ -258,12 +247,33 @@ impl MockTree {
                 height,
                 border,
                 padding,
+                content_width: 0.0,
+                content_height: 0.0,
             },
         );
         id
     }
 
-    fn add_child(&mut self, parent: u32, child: u32) {
+    /// Allocate a cell node from a [`MockCell`] spec.
+    pub fn alloc_cell(&mut self, mc: MockCell) -> u32 {
+        let id = self.alloc(
+            TableRole::Cell,
+            Some(mc.label),
+            mc.colspan,
+            mc.rowspan,
+            mc.width,
+            mc.height,
+            mc.border,
+            mc.padding,
+        );
+        if let Some(node) = self.nodes.get_mut(&id) {
+            node.content_width = mc.content_width;
+            node.content_height = mc.content_height;
+        }
+        id
+    }
+
+    pub fn add_child(&mut self, parent: u32, child: u32) {
         if let Some(node) = self.nodes.get_mut(&parent) {
             node.children.push(child);
         }
@@ -336,10 +346,16 @@ impl TableTree for MockTree {
         }
     }
 
-    fn layout_cell(&mut self, _id: u32, _available_width: f32) -> f32 {
-        // MockTree carries no real child content — row heights are driven by
-        // explicit CSS `height` values set on the cell nodes instead.
-        0.0
+    fn layout_cell(&mut self, id: u32, _available_width: f32) -> f32 {
+        // MockTree carries no real child content; a cell's `content_height`
+        // spec field stands in for the height its children would occupy.
+        // Cells without one (the default 0.0) are driven by explicit CSS
+        // `height` instead (see rows.rs).
+        self.nodes.get(&id).map(|n| n.content_height).unwrap_or(0.0)
+    }
+
+    fn cell_content_width(&self, id: u32) -> f32 {
+        self.nodes.get(&id).map(|n| n.content_width).unwrap_or(0.0)
     }
 }
 

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -247,4 +247,403 @@ mod layout_tests {
         assert_approx!(w, 0.0, "empty table width");
         assert_approx!(h, 0.0, "empty table height");
     }
+
+    // 9. Vertical border-spacing: one gutter above the first row, one between
+    //    rows, one below the last — never doubled at group boundaries.
+    #[test]
+    fn vertical_spacing_gutters() {
+        let (mut tree, root) = MockTable::new(100.0)
+            .spacing(0.0, 5.0)
+            .body_row(vec![cell("A").height(10.0).padding(0.0)])
+            .body_row(vec![cell("B").height(20.0).padding(0.0)])
+            .into_tree();
+
+        let (_, h) = compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+        assert_approx!(h, 45.0, "5 + 10 + 5 + 20 + 5");
+
+        let groups = tree.nodes_with_role(TableRole::RowGroup);
+        let g = tree.layout(groups[0]).expect("group layout");
+        assert_approx!(g.position.y, 5.0, "group starts below the top gutter");
+        assert_approx!(g.size.height, 35.0, "10 + 5 + 20 (internal gutter only)");
+
+        let rows = tree.nodes_with_role(TableRole::Row);
+        let r0 = tree.layout(rows[0]).expect("row0");
+        let r1 = tree.layout(rows[1]).expect("row1");
+        assert_approx!(r0.position.y, 0.0, "row0 at group top");
+        assert_approx!(r1.position.y, 15.0, "row1 after row0 + gutter");
+    }
+
+    // 10. Vertical spacing across group boundaries: exactly one gutter between
+    //     the last row of one section and the first row of the next.
+    #[test]
+    fn vertical_spacing_between_sections() {
+        let (mut tree, root) = MockTable::new(100.0)
+            .spacing(0.0, 5.0)
+            .header_row(vec![cell("H").height(10.0).padding(0.0)])
+            .body_row(vec![cell("B").height(10.0).padding(0.0)])
+            .into_tree();
+
+        let (_, h) = compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+        assert_approx!(h, 35.0, "5 + 10 + 5 + 10 + 5");
+
+        let hg = tree.nodes_with_role(TableRole::HeaderGroup);
+        let bg = tree.nodes_with_role(TableRole::RowGroup);
+        assert_approx!(tree.layout(hg[0]).expect("hg").position.y, 5.0, "header group y");
+        assert_approx!(
+            tree.layout(bg[0]).expect("bg").position.y,
+            20.0,
+            "body group y = 5 + 10 + 5"
+        );
+    }
+
+    // 11. A colspan cell covers the horizontal gutters between its columns.
+    #[test]
+    fn colspan_covers_gutter() {
+        // spacing_x=4 → available = 100 - 3*4 = 88 → two 44px columns.
+        let (mut tree, root) = MockTable::new(100.0)
+            .spacing(4.0, 0.0)
+            .body_row(vec![
+                cell("A").height(10.0).padding(0.0),
+                cell("B").height(10.0).padding(0.0),
+            ])
+            .body_row(vec![cell("Wide").colspan(2).height(10.0).padding(0.0)])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        let wide = tree.layout(cells[2]).expect("wide cell");
+        assert_approx!(wide.size.width, 92.0, "44 + 4 (gutter) + 44");
+        assert_approx!(wide.position.x, 4.0, "starts after the first gutter");
+    }
+
+    // 12. A rowspan cell covers the vertical gutters between its rows.
+    #[test]
+    fn rowspan_covers_gutter() {
+        let (mut tree, root) = MockTable::new(100.0)
+            .spacing(0.0, 6.0)
+            .body_row(vec![
+                cell("Span").rowspan(2).padding(0.0),
+                cell("R0").height(20.0).padding(0.0),
+            ])
+            .body_row(vec![cell("R1").height(30.0).padding(0.0)])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        let span = tree.layout(cells[0]).expect("span cell");
+        assert_approx!(span.size.height, 56.0, "20 + 6 (gutter) + 30");
+    }
+
+    // 13. Sections render header → body → footer regardless of source order.
+    #[test]
+    fn sections_reordered_from_source_order() {
+        use crate::mock::MockTree;
+
+        // Source order: footer, body, header — like <tfoot> before <tbody> in HTML.
+        let mut tree = MockTree::new(0.0, 0.0);
+        let root = tree.alloc(TableRole::Table, None, 1, 1, None, None, 0.0, 0.0);
+        for (role, label, h) in [
+            (TableRole::FooterGroup, "F", 30.0),
+            (TableRole::RowGroup, "B", 20.0),
+            (TableRole::HeaderGroup, "H", 10.0),
+        ] {
+            let group = tree.alloc(role, None, 1, 1, None, None, 0.0, 0.0);
+            tree.add_child(root, group);
+            let row = tree.alloc(TableRole::Row, None, 1, 1, None, None, 0.0, 0.0);
+            tree.add_child(group, row);
+            let c = tree.alloc_cell(cell(label).height(h).padding(0.0));
+            tree.add_child(row, c);
+        }
+
+        let (_, total_h) = compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+        assert_approx!(total_h, 60.0, "10 + 20 + 30");
+
+        let hg = tree.nodes_with_role(TableRole::HeaderGroup);
+        let bg = tree.nodes_with_role(TableRole::RowGroup);
+        let fg = tree.nodes_with_role(TableRole::FooterGroup);
+        assert_approx!(tree.layout(hg[0]).expect("header").position.y, 0.0, "header first");
+        assert_approx!(tree.layout(bg[0]).expect("body").position.y, 10.0, "body second");
+        assert_approx!(tree.layout(fg[0]).expect("footer").position.y, 30.0, "footer last");
+    }
+
+    // 14. Anonymous fixup: a bare row directly under the table gets an
+    //     anonymous body group (CSS 2.1 §17.2.1).
+    #[test]
+    fn anonymous_group_for_bare_row() {
+        use crate::mock::MockTree;
+
+        let mut tree = MockTree::new(0.0, 0.0);
+        let root = tree.alloc(TableRole::Table, None, 1, 1, None, None, 0.0, 0.0);
+        let row = tree.alloc(TableRole::Row, None, 1, 1, None, None, 0.0, 0.0);
+        tree.add_child(root, row);
+        for label in ["A", "B"] {
+            let c = tree.alloc_cell(cell(label).height(10.0).padding(0.0));
+            tree.add_child(row, c);
+        }
+
+        let (w, h) = compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+        assert_approx!(w, 100.0, "table width");
+        assert_approx!(h, 10.0, "row height");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        let lb = tree.layout(cells[1]).expect("cell B laid out");
+        assert_approx!(lb.size.width, 50.0, "two equal auto columns");
+        assert_approx!(lb.position.x, 50.0, "second column x");
+        assert!(tree.layout(row).is_some(), "the real row node gets a layout");
+    }
+
+    // 15. Anonymous fixup: a bare cell directly under a row group gets an
+    //     anonymous row.
+    #[test]
+    fn anonymous_row_for_bare_cell() {
+        use crate::mock::MockTree;
+
+        let mut tree = MockTree::new(0.0, 0.0);
+        let root = tree.alloc(TableRole::Table, None, 1, 1, None, None, 0.0, 0.0);
+        let group = tree.alloc(TableRole::RowGroup, None, 1, 1, None, None, 0.0, 0.0);
+        tree.add_child(root, group);
+        let c = tree.alloc_cell(cell("Bare").height(12.0).padding(0.0));
+        tree.add_child(group, c);
+
+        let (_, h) = compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+        assert_approx!(h, 12.0, "cell height drives the table");
+
+        let l = tree.layout(c).expect("bare cell laid out");
+        assert_approx!(l.size.width, 100.0, "single column takes full width");
+    }
+
+    // 16. Rowspan never escapes its section: a rowspan=3 in a 1-row header is
+    //     clamped and does not reach into the body rows.
+    #[test]
+    fn rowspan_clamped_to_section() {
+        let (mut tree, root) = MockTable::new(100.0)
+            .spacing(0.0, 0.0)
+            .header_row(vec![cell("H").rowspan(3).height(10.0).padding(0.0)])
+            .body_row(vec![cell("B").height(30.0).padding(0.0)])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        let h_cell = tree.layout(cells[0]).expect("header cell");
+        assert_approx!(h_cell.size.height, 10.0, "clamped to the header's single row");
+    }
+
+    // 17. Auto columns share space proportionally to their natural content width.
+    #[test]
+    fn proportional_content_width_distribution() {
+        // Both columns are "content" columns (natural >= 50px threshold).
+        let (mut tree, root) = MockTable::new(200.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![
+                cell("A").content_width(60.0).height(10.0).padding(0.0),
+                cell("B").content_width(140.0).height(10.0).padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 200.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        assert_approx!(tree.layout(cells[0]).expect("A").size.width, 60.0, "200 * 60/200");
+        assert_approx!(tree.layout(cells[1]).expect("B").size.width, 140.0, "200 * 140/200");
+    }
+
+    // 18. Narrow columns (natural < 50px) keep their natural width; wide
+    //     content columns absorb the remaining space.
+    #[test]
+    fn narrow_column_keeps_natural_width() {
+        let (mut tree, root) = MockTable::new(200.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![
+                cell("rank").content_width(20.0).height(10.0).padding(0.0),
+                cell("story").content_width(100.0).height(10.0).padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 200.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        assert_approx!(
+            tree.layout(cells[0]).expect("rank").size.width,
+            20.0,
+            "narrow keeps natural"
+        );
+        assert_approx!(
+            tree.layout(cells[1]).expect("story").size.width,
+            180.0,
+            "content col absorbs rest"
+        );
+    }
+
+    // 19. Very narrow columns are floored at 14px so they stay visible.
+    #[test]
+    fn narrow_column_floor() {
+        let (mut tree, root) = MockTable::new(200.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![
+                cell("dot").content_width(5.0).height(10.0).padding(0.0),
+                cell("text").content_width(100.0).height(10.0).padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 200.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        assert_approx!(tree.layout(cells[0]).expect("dot").size.width, 14.0, "floored at 14px");
+        assert_approx!(tree.layout(cells[1]).expect("text").size.width, 186.0, "200 - 14");
+    }
+
+    // 20. An explicit CSS width cannot shrink a column below its content's
+    //     natural width (used width = max(specified, min-content)).
+    #[test]
+    fn explicit_width_clamped_to_content() {
+        let (mut tree, root) = MockTable::new(100.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![
+                cell("img").width(18.0).content_width(20.0).height(10.0).padding(0.0),
+                cell("rest").height(10.0).padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        assert_approx!(
+            tree.layout(cells[0]).expect("img").size.width,
+            20.0,
+            "width:18 clamped up to 20px content"
+        );
+        assert_approx!(
+            tree.layout(cells[1]).expect("rest").size.width,
+            80.0,
+            "auto col gets remainder"
+        );
+    }
+
+    // 21. Explicit CSS height is a minimum: taller content grows the row.
+    #[test]
+    fn explicit_height_is_minimum() {
+        let (mut tree, root) = MockTable::new(100.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![cell("tall").height(10.0).content_height(30.0).padding(0.0)])
+            .into_tree();
+
+        let (_, h) = compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+        assert_approx!(h, 30.0, "content height 30 wins over explicit 10");
+    }
+
+    // 22. Content height comes from layout_cell and gets border + padding added.
+    #[test]
+    fn content_height_plus_border_padding() {
+        let (mut tree, root) = MockTable::new(100.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![cell("boxed").content_height(10.0).border(1.0).padding(2.0)])
+            .into_tree();
+
+        let (_, h) = compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+        assert_approx!(h, 16.0, "10 content + 2*1 border + 2*2 padding");
+    }
+
+    // 23. Nested tables: lattice treats a nested table as opaque cell content —
+    //     the host's `layout_cell` recurses (as the pipeline's post_process_tables
+    //     does). This exercises the cooperation contract: the outer column width
+    //     flows *down* as the inner table's available width, and the inner
+    //     table's computed height flows back *up* into the outer row height.
+    #[test]
+    fn nested_table_via_layout_cell() {
+        use crate::mock::MockTree;
+        use crate::types::{CellLayout, CssLength, CssProp};
+        use crate::TableTree;
+
+        /// Delegates everything to `outer`, except that laying out `host_cell`
+        /// runs a full table layout on `inner` — a table inside a table.
+        struct NestedTree {
+            outer: MockTree,
+            inner: MockTree,
+            inner_root: u32,
+            host_cell: u32,
+            inner_size: Option<(f32, f32)>,
+        }
+
+        impl TableTree for NestedTree {
+            type NodeId = u32;
+
+            fn children(&self, id: u32) -> Vec<u32> {
+                self.outer.children(id)
+            }
+            fn table_role(&self, id: u32) -> crate::types::TableRole {
+                self.outer.table_role(id)
+            }
+            fn css_length(&self, id: u32, prop: CssProp) -> CssLength {
+                self.outer.css_length(id, prop)
+            }
+            fn attr_usize(&self, id: u32, attr: &str) -> Option<usize> {
+                self.outer.attr_usize(id, attr)
+            }
+            fn set_layout(&mut self, id: u32, layout: CellLayout) {
+                self.outer.set_layout(id, layout);
+            }
+            fn cell_content_width(&self, id: u32) -> f32 {
+                self.outer.cell_content_width(id)
+            }
+
+            fn layout_cell(&mut self, id: u32, available_width: f32) -> f32 {
+                if id == self.host_cell {
+                    let (w, h) = compute_table_layout(&mut self.inner, self.inner_root, available_width, None)
+                        .expect("inner layout");
+                    self.inner_size = Some((w, h));
+                    h
+                } else {
+                    self.outer.layout_cell(id, available_width)
+                }
+            }
+        }
+
+        // Outer: 200px wide, one row, two auto columns (100px each).
+        let (outer, outer_root) = MockTable::new(200.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![cell("host").padding(0.0), cell("plain").height(10.0).padding(0.0)])
+            .into_tree();
+        let host_cell = outer.nodes_with_role(TableRole::Cell)[0];
+
+        // Inner: two columns × two rows, heights 15 and 25.
+        let (inner, inner_root) = MockTable::new(0.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![
+                cell("a").height(15.0).padding(0.0),
+                cell("b").height(15.0).padding(0.0),
+            ])
+            .body_row(vec![
+                cell("c").height(25.0).padding(0.0),
+                cell("d").height(25.0).padding(0.0),
+            ])
+            .into_tree();
+
+        let mut tree = NestedTree {
+            outer,
+            inner,
+            inner_root,
+            host_cell,
+            inner_size: None,
+        };
+
+        let (_, outer_h) = compute_table_layout(&mut tree, outer_root, 200.0, None).expect("outer layout");
+
+        // Width flowed down: the inner table was laid out at the host column's width.
+        let (inner_w, inner_h) = tree.inner_size.expect("inner table was laid out");
+        assert_approx!(inner_w, 100.0, "inner table width = outer column width");
+        assert_approx!(inner_h, 40.0, "inner table height = 15 + 25");
+
+        // Inner columns split the host cell's width, not the outer table's.
+        let inner_cells = tree.inner.nodes_with_role(TableRole::Cell);
+        let ia = tree.inner.layout(inner_cells[0]).expect("inner cell a");
+        assert_approx!(ia.size.width, 50.0, "inner column = 100 / 2");
+
+        // Height flowed up: the outer row grew to hold the inner table.
+        assert_approx!(outer_h, 40.0, "outer row height = inner table height");
+        let host_layout = tree.outer.layout(host_cell).expect("host cell");
+        assert_approx!(host_layout.size.height, 40.0, "host cell height");
+    }
 }

--- a/docs/lattice.md
+++ b/docs/lattice.md
@@ -1,4 +1,4 @@
-    # Lattice: the table layout engine (`gosub_lattice`)
+# Lattice: the table layout engine (`gosub_lattice`)
 
 Taffy covers flexbox, grid, and block layout --- but not CSS tables. `gosub_lattice` fills that gap: a standalone implementation of the CSS table layout algorithm that works *in conjunction with* a general layout engine rather than replacing it. Taffy (or any host) lays out everything, tables included, as ordinary boxes; lattice then recomputes the table grid geometry --- column widths, row heights, cell positions --- and writes it back, while delegating the layout *inside* each cell right back to the host engine.
 
@@ -29,7 +29,7 @@ One call per table; returns the table's `(width, height)` border-box size (the c
 3.  **Column widths** (`sizing/columns.rs`) --- available space is the table width minus all border-spacing gutters. The first non-empty row is scanned: single-column cells with an explicit CSS width get it (clamped to at least their content's natural width --- a `width: 18px` cell holding a 20 px image must not clip it). Remaining space goes to the auto columns **proportionally to their natural content width** (from `cell_content_width`), with a threshold heuristic: narrow columns (\< 50 px intrinsic --- rank numbers, vote buttons) keep their natural width with a 14 px floor, wide content columns share what's left. Equal distribution is the fallback when no content-width data exists (mock trees).
 4.  **Row heights** (`sizing/rows.rs`) --- per non-spanning cell: `layout_cell(inner_width)` asks the host to lay out the cell's children at the now-final column width; the row height is the max over its cells of \`max(content height, explicit CSS height) + border
     -   padding\`. Explicit height is a *minimum* --- content can grow past it.
-5.  **Placement** (`compute.rs`) --- sections render header → body → footer regardless of source order, per CSS. Groups are positioned relative to the table, rows relative to their group, cells relative to their row; spanning cells sum the widths/heights of the columns/rows they cover. Everything is written back through `set_layout` as *relative* positions --- the adapter converts to absolute coordinates (the pipeline's does so in `apply_positions`).
+5.  **Placement** (`compute.rs`) --- sections render header → body → footer regardless of source order, per CSS. Groups are positioned relative to the table, rows relative to their group, cells relative to their row; spanning cells sum the widths/heights of the columns/rows they cover, plus the border-spacing gutters between them. Everything is written back through `set_layout` as *relative* positions --- the adapter converts to absolute coordinates (the pipeline's does so in `apply_positions`).
 
 ## Trying it standalone
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced table layout for content-based sizing, nested tables, and explicit width/height clamping.
  * Added handling for anonymous table groups/rows when markup is incomplete.
* **Bug Fixes**
  * Corrected `border-spacing` gutter behavior across rows, sections, and `colspan`/`rowspan` spans.
  * Improved section render ordering (header → body → footer) and related row-group placement offsets.
* **Documentation**
  * Updated lattice/table placement docs to reflect gutter-inclusive sizing for spanning cells.
* **Tests**
  * Expanded table layout integration coverage for spacing, spanning, sizing, ordering, and nested-table scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->