### PR TITLE
Css3 syntax matcher updates

### DIFF
--- a/crates/gosub_css3/examples/css_corpus_match.rs
+++ b/crates/gosub_css3/examples/css_corpus_match.rs
@@ -1,0 +1,215 @@
+// This is a developer diagnostic tool, not library/production code: panicking on bad CLI
+// input and using the simplest string APIs is fine here.
+#![allow(clippy::panic, clippy::disallowed_methods)]
+
+//! Real-world validation harness for the CSS value-syntax matcher.
+//!
+//! Runs a directory of `.css` files through the property-definition matcher and reports
+//! how much real-world CSS it accepts, plus a ranked breakdown of what it rejects — the
+//! rejections are the interesting output, since they point at the next matcher gaps.
+//!
+//! Note: normal parsing does NOT run the matcher (`ParserConfig::match_values` is inert),
+//! so this drives it explicitly, exactly like the unit tests: parse each stylesheet, then
+//! for every declaration look up the property definition and call `matches()`.
+//!
+//! Usage:
+//!   cargo run --release --example css_corpus_match -- [DIR] [--limit N] [--top N] [--samples N]
+//!
+//! DIR defaults to ~/code/gosub/domains/css.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use gosub_css3::matcher::property_definitions::get_css_definitions;
+use gosub_css3::stylesheet::CssValue;
+use gosub_css3::Css3;
+use gosub_interface::css3::CssOrigin;
+use gosub_shared::config::ParserConfig;
+
+/// Flatten a declaration value into the `&[CssValue]` slice the matcher expects.
+fn flatten(value: &CssValue) -> Vec<CssValue> {
+    match value {
+        CssValue::List(v) => v.clone(),
+        other => vec![other.clone()],
+    }
+}
+
+/// Render a value back into a readable CSS-ish string for failure samples (the built-in
+/// `Display` wraps lists in `List(...)`, which is noise here).
+fn render(value: &CssValue) -> String {
+    match value {
+        CssValue::List(v) => {
+            let mut out = String::new();
+            for (i, item) in v.iter().enumerate() {
+                let is_comma = matches!(item, CssValue::Comma);
+                if i > 0 && !is_comma {
+                    out.push(' ');
+                }
+                out.push_str(&render(item));
+            }
+            out
+        }
+        other => other.to_string(),
+    }
+}
+
+struct PropStats {
+    total: u64,
+    failed: u64,
+    samples: Vec<String>,
+}
+
+fn main() {
+    let mut dir: Option<PathBuf> = None;
+    let mut limit = usize::MAX;
+    let mut top = 25usize;
+    let mut samples = 4usize;
+
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        let mut take = |name: &str| -> usize {
+            args.next()
+                .unwrap_or_else(|| panic!("{name} needs a value"))
+                .parse()
+                .unwrap_or_else(|_| panic!("{name} needs a number"))
+        };
+        match arg.as_str() {
+            "--limit" => limit = take("--limit"),
+            "--top" => top = take("--top"),
+            "--samples" => samples = take("--samples"),
+            _ => dir = Some(PathBuf::from(arg)),
+        }
+    }
+
+    let dir = dir.unwrap_or_else(|| {
+        let home = std::env::var("HOME").unwrap_or_default();
+        PathBuf::from(home).join("code/gosub/domains/css")
+    });
+
+    let mut files: Vec<PathBuf> = fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", dir.display()))
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|x| x.eq_ignore_ascii_case("css")))
+        .collect();
+    files.sort();
+    files.truncate(limit);
+
+    let defs = get_css_definitions();
+
+    let (mut files_ok, mut files_err) = (0u64, 0u64);
+    let (mut total_decls, mut custom_decls, mut known_decls, mut matched) = (0u64, 0u64, 0u64, 0u64);
+    let mut unknown_props: HashMap<String, u64> = HashMap::new();
+    let mut per_prop: HashMap<String, PropStats> = HashMap::new();
+
+    let total_files = files.len();
+    for (i, path) in files.iter().enumerate() {
+        if i % 200 == 0 && i > 0 {
+            eprintln!("  .. {i}/{total_files} files");
+        }
+        let Ok(bytes) = fs::read(path) else {
+            files_err += 1;
+            continue;
+        };
+        let css = String::from_utf8_lossy(&bytes);
+        let config = ParserConfig {
+            match_values: false,
+            ignore_errors: true,
+            ..Default::default()
+        };
+        let name = path.file_name().unwrap_or_default().to_string_lossy();
+        let Ok(sheet) = Css3::parse_str(&css, config, CssOrigin::Author, &name) else {
+            files_err += 1;
+            continue;
+        };
+        files_ok += 1;
+
+        for rule in &sheet.rules {
+            for decl in &rule.declarations {
+                total_decls += 1;
+                if decl.property.starts_with("--") {
+                    custom_decls += 1;
+                    continue;
+                }
+                let prop = decl.property.to_ascii_lowercase();
+                let Some(def) = defs.find_property(&prop) else {
+                    *unknown_props.entry(prop).or_default() += 1;
+                    continue;
+                };
+                known_decls += 1;
+                let values = flatten(&decl.value);
+                let ok = def.matches(&values);
+                let stats = per_prop.entry(prop).or_insert(PropStats {
+                    total: 0,
+                    failed: 0,
+                    samples: Vec::new(),
+                });
+                stats.total += 1;
+                if ok {
+                    matched += 1;
+                } else {
+                    stats.failed += 1;
+                    if stats.samples.len() < samples {
+                        stats.samples.push(render(&decl.value));
+                    }
+                }
+            }
+        }
+    }
+
+    let pct = |n: u64, d: u64| if d == 0 { 0.0 } else { 100.0 * n as f64 / d as f64 };
+
+    println!("\n===== CSS matcher corpus report =====");
+    println!("dir: {}", dir.display());
+    println!("files: {} parsed, {} failed to parse", files_ok, files_err);
+    println!("declarations: {total_decls} total");
+    println!(
+        "  custom (--*):      {custom_decls:>8} ({:.1}%)",
+        pct(custom_decls, total_decls)
+    );
+    let unknown_total: u64 = unknown_props.values().sum();
+    println!(
+        "  unknown property:  {unknown_total:>8} ({:.1}%)  [{} distinct]",
+        pct(unknown_total, total_decls),
+        unknown_props.len()
+    );
+    println!(
+        "  known property:    {known_decls:>8} ({:.1}%)",
+        pct(known_decls, total_decls)
+    );
+    println!(
+        "\nMATCHER ACCURACY on known properties: {} / {} = {:.2}%",
+        matched,
+        known_decls,
+        pct(matched, known_decls)
+    );
+
+    // Ranked failing known properties (by absolute failure count).
+    let mut failing: Vec<(&String, &PropStats)> = per_prop.iter().filter(|(_, s)| s.failed > 0).collect();
+    failing.sort_by(|a, b| b.1.failed.cmp(&a.1.failed).then(a.0.cmp(b.0)));
+    println!("\n----- top {top} rejected known properties (property: failed/total, rate) -----");
+    for (prop, s) in failing.iter().take(top) {
+        println!(
+            "{:>28}: {:>7}/{:<7} ({:5.1}% rejected)  e.g. {}",
+            prop,
+            s.failed,
+            s.total,
+            pct(s.failed, s.total),
+            s.samples
+                .iter()
+                .map(|v| format!("`{v}`"))
+                .collect::<Vec<_>>()
+                .join("  ")
+        );
+    }
+
+    // Unknown (vendor / typo / not-in-definitions) properties by frequency.
+    let mut unknown: Vec<(&String, &u64)> = unknown_props.iter().collect();
+    unknown.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
+    println!("\n----- top {top} unknown properties (not in definitions) -----");
+    for (prop, n) in unknown.iter().take(top) {
+        println!("{:>28}: {:>8}", prop, n);
+    }
+    println!();
+}

--- a/crates/gosub_css3/resources/definitions/definitions.json
+++ b/crates/gosub_css3/resources/definitions/definitions.json
@@ -717,7 +717,7 @@
       "name": "-webkit-border-after-width",
       "syntax": "<'border-top-width'>",
       "computed": [
-        "absoluteLength"
+        "absoluteLengthSnappedAsLineWidth"
       ],
       "initial": "medium",
       "inherited": false
@@ -759,7 +759,7 @@
       "name": "-webkit-border-before-width",
       "syntax": "<'border-top-width'>",
       "computed": [
-        "absoluteLength"
+        "absoluteLengthSnappedAsLineWidth"
       ],
       "initial": "medium",
       "inherited": false
@@ -801,7 +801,7 @@
       "name": "-webkit-border-end-width",
       "syntax": "<'border-top-width'>",
       "computed": [
-        "absoluteLength"
+        "absoluteLengthSnappedAsLineWidth"
       ],
       "initial": "medium",
       "inherited": false
@@ -843,7 +843,7 @@
       "name": "-webkit-border-start-width",
       "syntax": "<'border-top-width'>",
       "computed": [
-        "absoluteLength"
+        "absoluteLengthSnappedAsLineWidth"
       ],
       "initial": "medium",
       "inherited": false
@@ -868,7 +868,7 @@
     },
     {
       "name": "-webkit-mask",
-      "syntax": "[ <mask-reference> || <position> [ / <bg-size> ]? || <repeat-style> || [ <visual-box> | border | padding | content | text ] || [ <visual-box> | border | padding | content ] ]#",
+      "syntax": "<mask-layer>#",
       "computed": [
         "-webkit-mask-image",
         "-webkit-mask-repeat",
@@ -898,7 +898,7 @@
     },
     {
       "name": "-webkit-mask-clip",
-      "syntax": "[ <coord-box> | no-clip | border | padding | content | text ]#",
+      "syntax": "[ <coord-box> | no-clip ]#",
       "computed": [
         "asSpecified"
       ],
@@ -907,7 +907,7 @@
     },
     {
       "name": "-webkit-mask-composite",
-      "syntax": "<composite-style>#",
+      "syntax": "<compositing-operator>#",
       "computed": [
         "asSpecified"
       ],
@@ -925,7 +925,7 @@
     },
     {
       "name": "-webkit-mask-origin",
-      "syntax": "[ <coord-box> | border | padding | content ]#",
+      "syntax": "<coord-box>#",
       "computed": [
         "asSpecified"
       ],
@@ -1024,7 +1024,7 @@
     },
     {
       "name": "-webkit-text-stroke",
-      "syntax": "<length> || <color>",
+      "syntax": "<line-width> || <color>",
       "computed": [
         "-webkit-text-stroke-width",
         "-webkit-text-stroke-color"
@@ -1046,7 +1046,7 @@
     },
     {
       "name": "-webkit-text-stroke-width",
-      "syntax": "<length>",
+      "syntax": "<line-width>",
       "computed": [
         "absoluteLength"
       ],
@@ -1073,7 +1073,7 @@
     },
     {
       "name": "-webkit-user-select",
-      "syntax": "auto | text | none | all",
+      "syntax": "auto | text | none | contain | all",
       "computed": [
         "asSpecified"
       ],
@@ -1100,7 +1100,7 @@
     },
     {
       "name": "align-items",
-      "syntax": "normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ] | anchor-center",
+      "syntax": "normal | stretch | <baseline-position> | <overflow-position>? <self-position>",
       "computed": [
         "asSpecified"
       ],
@@ -1109,7 +1109,7 @@
     },
     {
       "name": "align-self",
-      "syntax": "auto | normal | stretch | <baseline-position> | <overflow-position>? <self-position> | anchor-center",
+      "syntax": "auto | <overflow-position>? [ normal | <self-position> ]| stretch | <baseline-position> | anchor-center",
       "computed": [
         "autoOnAbsolutelyPositionedElementsValueOfAlignItemsOnParent"
       ],
@@ -1127,7 +1127,7 @@
     },
     {
       "name": "alignment-baseline",
-      "syntax": "baseline | alphabetic | ideographic | middle | central | mathematical | text-before-edge | text-after-edge",
+      "syntax": "baseline | <baseline-metric>",
       "computed": [
         "theSpecifiedKeyword"
       ],
@@ -1136,7 +1136,7 @@
     },
     {
       "name": "all",
-      "syntax": "initial | inherit | unset | revert | revert-layer",
+      "syntax": "initial | inherit | unset | revert | revert-layer | revert-rule",
       "computed": [
         "asSpecifiedAppliesToEachProperty"
       ],
@@ -1145,7 +1145,7 @@
     },
     {
       "name": "anchor-name",
-      "syntax": "none | <dashed-ident>#",
+      "syntax": "none | <anchor-name>#",
       "computed": [
         "asSpecified"
       ],
@@ -1154,7 +1154,7 @@
     },
     {
       "name": "anchor-scope",
-      "syntax": "none | all | <dashed-ident>#",
+      "syntax": "none | all | <anchor-name>#",
       "computed": [
         "asSpecified"
       ],
@@ -1217,7 +1217,7 @@
     },
     {
       "name": "animation-duration",
-      "syntax": "[ auto | <time [0s,∞]> ]#",
+      "syntax": "<time [0s,∞]>#",
       "computed": [
         "asSpecified"
       ],
@@ -1320,7 +1320,7 @@
     },
     {
       "name": "appearance",
-      "syntax": "none | auto | <compat-auto> | <compat-special>",
+      "syntax": "none | auto | base | base-select | <compat-auto> | <compat-special> | base",
       "computed": [
         "asSpecified"
       ],
@@ -1390,7 +1390,7 @@
     },
     {
       "name": "background-blend-mode",
-      "syntax": "<blend-mode>#",
+      "syntax": "<'mix-blend-mode'>#",
       "computed": [
         "asSpecified"
       ],
@@ -1399,7 +1399,7 @@
     },
     {
       "name": "background-clip",
-      "syntax": "<bg-clip>#",
+      "syntax": "<visual-box>#",
       "computed": [
         "asSpecified"
       ],
@@ -1481,7 +1481,7 @@
     },
     {
       "name": "baseline-shift",
-      "syntax": "<length-percentage> | sub | super | baseline",
+      "syntax": "<length-percentage> | sub | super | top | center | bottom",
       "computed": [
         "theSpecifiedKeywordOrAComputedLengthPercentageValue"
       ],
@@ -1523,7 +1523,7 @@
     },
     {
       "name": "border-block",
-      "syntax": "<'border-top'>",
+      "syntax": "<'border-block-start'>",
       "computed": [
         "border-block-width",
         "border-block-style",
@@ -1551,7 +1551,7 @@
     },
     {
       "name": "border-block-end",
-      "syntax": "<'border-top'>",
+      "syntax": "<line-width> || <line-style> || <color>",
       "computed": [
         "border-block-end-width",
         "border-block-end-style",
@@ -1566,7 +1566,7 @@
     },
     {
       "name": "border-block-end-color",
-      "syntax": "<'border-top-color'>",
+      "syntax": "<color> | <image-1D>",
       "computed": [
         "computedColor"
       ],
@@ -1575,7 +1575,7 @@
     },
     {
       "name": "border-block-end-style",
-      "syntax": "<'border-top-style'>",
+      "syntax": "<line-style>",
       "computed": [
         "asSpecified"
       ],
@@ -1584,16 +1584,16 @@
     },
     {
       "name": "border-block-end-width",
-      "syntax": "<'border-top-width'>",
+      "syntax": "<line-width>",
       "computed": [
-        "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+        "absoluteLengthSnappedAsLineWidth"
       ],
       "initial": "medium",
       "inherited": false
     },
     {
       "name": "border-block-start",
-      "syntax": "<'border-top'>",
+      "syntax": "<line-width> || <line-style> || <color>",
       "computed": [
         "border-block-start-width",
         "border-block-start-style",
@@ -1608,7 +1608,7 @@
     },
     {
       "name": "border-block-start-color",
-      "syntax": "<'border-top-color'>",
+      "syntax": "<color> | <image-1D>",
       "computed": [
         "computedColor"
       ],
@@ -1617,7 +1617,7 @@
     },
     {
       "name": "border-block-start-style",
-      "syntax": "<'border-top-style'>",
+      "syntax": "<line-style>",
       "computed": [
         "asSpecified"
       ],
@@ -1626,9 +1626,9 @@
     },
     {
       "name": "border-block-start-width",
-      "syntax": "<'border-top-width'>",
+      "syntax": "<line-width>",
       "computed": [
-        "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+        "absoluteLengthSnappedAsLineWidth"
       ],
       "initial": "medium",
       "inherited": false
@@ -1676,7 +1676,7 @@
     },
     {
       "name": "border-bottom-color",
-      "syntax": "<'border-top-color'>",
+      "syntax": "<color> | <image-1D>",
       "computed": [
         "computedColor"
       ],
@@ -1685,7 +1685,7 @@
     },
     {
       "name": "border-bottom-left-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2}",
+      "syntax": "<border-radius>",
       "computed": [
         "twoAbsoluteLengthOrPercentages"
       ],
@@ -1694,7 +1694,7 @@
     },
     {
       "name": "border-bottom-right-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2}",
+      "syntax": "<border-radius>",
       "computed": [
         "twoAbsoluteLengthOrPercentages"
       ],
@@ -1714,7 +1714,7 @@
       "name": "border-bottom-width",
       "syntax": "<line-width>",
       "computed": [
-        "absoluteLengthOr0IfBorderBottomStyleNoneOrHidden"
+        "absoluteLengthSnappedAsLineWidth"
       ],
       "initial": "medium",
       "inherited": false
@@ -1730,7 +1730,7 @@
     },
     {
       "name": "border-color",
-      "syntax": "<color>{1,4}",
+      "syntax": "[ <color> | <image-1D> ]{1,4}",
       "computed": [
         "border-top-color",
         "border-right-color",
@@ -1747,7 +1747,7 @@
     },
     {
       "name": "border-end-end-radius",
-      "syntax": "<'border-top-left-radius'>",
+      "syntax": "<border-radius>",
       "computed": [
         "twoAbsoluteLengthOrPercentages"
       ],
@@ -1756,7 +1756,7 @@
     },
     {
       "name": "border-end-start-radius",
-      "syntax": "<'border-top-left-radius'>",
+      "syntax": "<border-radius>",
       "computed": [
         "twoAbsoluteLengthOrPercentages"
       ],
@@ -1802,7 +1802,7 @@
     },
     {
       "name": "border-image-slice",
-      "syntax": "[ <number [0,∞]> | <percentage [0,∞]> ]{1,4} && fill?",
+      "syntax": "[<number [0,∞]> | <percentage [0,∞]>]{1,4} && fill?",
       "computed": [
         "oneToFourPercentagesOrAbsoluteLengthsPlusFill"
       ],
@@ -1829,7 +1829,7 @@
     },
     {
       "name": "border-inline",
-      "syntax": "<'border-top'>",
+      "syntax": "<'border-block-start'>",
       "computed": [
         "border-inline-width",
         "border-inline-style",
@@ -1857,7 +1857,7 @@
     },
     {
       "name": "border-inline-end",
-      "syntax": "<'border-top'>",
+      "syntax": "<line-width> || <line-style> || <color>",
       "computed": [
         "border-inline-end-width",
         "border-inline-end-style",
@@ -1872,7 +1872,7 @@
     },
     {
       "name": "border-inline-end-color",
-      "syntax": "<'border-top-color'>",
+      "syntax": "<color> | <image-1D>",
       "computed": [
         "computedColor"
       ],
@@ -1881,7 +1881,7 @@
     },
     {
       "name": "border-inline-end-style",
-      "syntax": "<'border-top-style'>",
+      "syntax": "<line-style>",
       "computed": [
         "asSpecified"
       ],
@@ -1890,16 +1890,16 @@
     },
     {
       "name": "border-inline-end-width",
-      "syntax": "<'border-top-width'>",
+      "syntax": "<line-width>",
       "computed": [
-        "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+        "absoluteLengthSnappedAsLineWidth"
       ],
       "initial": "medium",
       "inherited": false
     },
     {
       "name": "border-inline-start",
-      "syntax": "<'border-top'>",
+      "syntax": "<line-width> || <line-style> || <color>",
       "computed": [
         "border-inline-start-width",
         "border-inline-start-style",
@@ -1914,7 +1914,7 @@
     },
     {
       "name": "border-inline-start-color",
-      "syntax": "<'border-top-color'>",
+      "syntax": "<color> | <image-1D>",
       "computed": [
         "computedColor"
       ],
@@ -1923,7 +1923,7 @@
     },
     {
       "name": "border-inline-start-style",
-      "syntax": "<'border-top-style'>",
+      "syntax": "<line-style>",
       "computed": [
         "asSpecified"
       ],
@@ -1932,9 +1932,9 @@
     },
     {
       "name": "border-inline-start-width",
-      "syntax": "<'border-top-width'>",
+      "syntax": "<line-width>",
       "computed": [
-        "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+        "absoluteLengthSnappedAsLineWidth"
       ],
       "initial": "medium",
       "inherited": false
@@ -1982,7 +1982,7 @@
     },
     {
       "name": "border-left-color",
-      "syntax": "<color>",
+      "syntax": "<color> | <image-1D>",
       "computed": [
         "computedColor"
       ],
@@ -2002,7 +2002,7 @@
       "name": "border-left-width",
       "syntax": "<line-width>",
       "computed": [
-        "absoluteLengthOr0IfBorderLeftStyleNoneOrHidden"
+        "absoluteLengthSnappedAsLineWidth"
       ],
       "initial": "medium",
       "inherited": false
@@ -2041,7 +2041,7 @@
     },
     {
       "name": "border-right-color",
-      "syntax": "<color>",
+      "syntax": "<color> | <image-1D>",
       "computed": [
         "computedColor"
       ],
@@ -2061,7 +2061,7 @@
       "name": "border-right-width",
       "syntax": "<line-width>",
       "computed": [
-        "absoluteLengthOr0IfBorderRightStyleNoneOrHidden"
+        "absoluteLengthSnappedAsLineWidth"
       ],
       "initial": "medium",
       "inherited": false
@@ -2077,7 +2077,7 @@
     },
     {
       "name": "border-spacing",
-      "syntax": "<length>{1,2}",
+      "syntax": "<length [0,∞]>{1,2}",
       "computed": [
         "twoAbsoluteLengths"
       ],
@@ -2086,7 +2086,7 @@
     },
     {
       "name": "border-start-end-radius",
-      "syntax": "<'border-top-left-radius'>",
+      "syntax": "<border-radius>",
       "computed": [
         "twoAbsoluteLengthOrPercentages"
       ],
@@ -2095,7 +2095,7 @@
     },
     {
       "name": "border-start-start-radius",
-      "syntax": "<'border-top-left-radius'>",
+      "syntax": "<border-radius>",
       "computed": [
         "twoAbsoluteLengthOrPercentages"
       ],
@@ -2104,7 +2104,7 @@
     },
     {
       "name": "border-style",
-      "syntax": "<line-style>{1,4}",
+      "syntax": "<'border-top-style'>{1,4}",
       "computed": [
         "border-top-style",
         "border-right-style",
@@ -2136,7 +2136,7 @@
     },
     {
       "name": "border-top-color",
-      "syntax": "<color>",
+      "syntax": "<color> | <image-1D>",
       "computed": [
         "computedColor"
       ],
@@ -2145,7 +2145,7 @@
     },
     {
       "name": "border-top-left-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2}",
+      "syntax": "<border-radius>",
       "computed": [
         "twoAbsoluteLengthOrPercentages"
       ],
@@ -2154,7 +2154,7 @@
     },
     {
       "name": "border-top-right-radius",
-      "syntax": "<length-percentage [0,∞]>{1,2}",
+      "syntax": "<border-radius>",
       "computed": [
         "twoAbsoluteLengthOrPercentages"
       ],
@@ -2174,14 +2174,14 @@
       "name": "border-top-width",
       "syntax": "<line-width>",
       "computed": [
-        "absoluteLengthOr0IfBorderTopStyleNoneOrHidden"
+        "absoluteLengthSnappedAsLineWidth"
       ],
       "initial": "medium",
       "inherited": false
     },
     {
       "name": "border-width",
-      "syntax": "<line-width>{1,4}",
+      "syntax": "<'border-top-width'>{1,4}",
       "computed": [
         "border-top-width",
         "border-right-width",
@@ -2288,7 +2288,7 @@
     },
     {
       "name": "box-shadow",
-      "syntax": "none | <shadow>#",
+      "syntax": "<spread-shadow>#",
       "computed": [
         "absoluteLengthsSpecifiedColorAsSpecified"
       ],
@@ -2366,7 +2366,7 @@
     },
     {
       "name": "caret-color",
-      "syntax": "auto | <color>",
+      "syntax": "auto | <color> [auto | <color>]?",
       "computed": [
         "asAutoOrColor"
       ],
@@ -2384,7 +2384,7 @@
     },
     {
       "name": "clear",
-      "syntax": "none | left | right | both | inline-start | inline-end",
+      "syntax": "inline-start | inline-end | block-start | block-end | left | right | top | bottom | both-inline | both-block | both | none",
       "computed": [
         "asSpecified"
       ],
@@ -2393,7 +2393,7 @@
     },
     {
       "name": "clip",
-      "syntax": "<shape> | auto",
+      "syntax": "<rect()> | auto",
       "computed": [
         "autoOrRectangle"
       ],
@@ -2447,7 +2447,7 @@
     },
     {
       "name": "column-count",
-      "syntax": "<integer> | auto",
+      "syntax": "auto | <integer [1,∞]>",
       "computed": [
         "asSpecified"
       ],
@@ -2456,7 +2456,7 @@
     },
     {
       "name": "column-fill",
-      "syntax": "auto | balance",
+      "syntax": "auto | balance | balance-all",
       "computed": [
         "asSpecified"
       ],
@@ -2465,7 +2465,7 @@
     },
     {
       "name": "column-gap",
-      "syntax": "normal | <length-percentage>",
+      "syntax": "normal | <length-percentage [0,∞]> | <line-width>",
       "computed": [
         "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn"
       ],
@@ -2483,7 +2483,7 @@
     },
     {
       "name": "column-rule",
-      "syntax": "<'column-rule-width'> || <'column-rule-style'> || <'column-rule-color'>",
+      "syntax": "<gap-rule-list> | <gap-auto-rule-list>",
       "computed": [
         "column-rule-width",
         "column-rule-style",
@@ -2498,7 +2498,7 @@
     },
     {
       "name": "column-rule-color",
-      "syntax": "<color>",
+      "syntax": "<line-color-list> | <auto-line-color-list>",
       "computed": [
         "computedColor"
       ],
@@ -2507,7 +2507,7 @@
     },
     {
       "name": "column-rule-style",
-      "syntax": "<line-style>",
+      "syntax": "<line-style-list> | <auto-line-style-list>",
       "computed": [
         "asSpecified"
       ],
@@ -2516,16 +2516,16 @@
     },
     {
       "name": "column-rule-width",
-      "syntax": "<line-width>",
+      "syntax": "<line-width-list> | <auto-line-width-list>",
       "computed": [
-        "absoluteLength0IfColumnRuleStyleNoneOrHidden"
+        "absoluteLengthSnappedAsLineWidth"
       ],
       "initial": "medium",
       "inherited": false
     },
     {
       "name": "column-span",
-      "syntax": "none | all",
+      "syntax": "none | <integer [1,∞]> | all | auto",
       "computed": [
         "asSpecified"
       ],
@@ -2534,7 +2534,7 @@
     },
     {
       "name": "column-width",
-      "syntax": "auto | <length [0,∞]>",
+      "syntax": "auto | <length [0,∞]> | min-content | max-content | fit-content(<length-percentage>)",
       "computed": [
         "autoOrAbsoluteLength"
       ],
@@ -2567,7 +2567,7 @@
     },
     {
       "name": "contain",
-      "syntax": "none | strict | content | [ [ size || inline-size ] || layout || style || paint ]",
+      "syntax": "none | strict | content | [ [size | inline-size] || layout || style || paint ]",
       "computed": [
         "asSpecified"
       ],
@@ -2656,7 +2656,7 @@
     },
     {
       "name": "content",
-      "syntax": "normal | none | [ <content-replacement> | <content-list> ] [ / [ <string> | <counter> | <attr()> ]+ ]?",
+      "syntax": "normal | none | [ <content-replacement> | <content-list> ] [/ [ <string> | <counter> | <attr()> ]+ ]? | <element()>",
       "computed": [
         "normalOnElementsForPseudosNoneAbsoluteURIStringOrAsSpecified"
       ],
@@ -2674,7 +2674,7 @@
     },
     {
       "name": "corner-block-end-shape",
-      "syntax": "<corner-shape-value>{1,2}",
+      "syntax": "<'corner-top-left-shape'>{1,2}",
       "computed": [
         "corner-end-start-shape",
         "corner-end-end-shape"
@@ -2687,7 +2687,7 @@
     },
     {
       "name": "corner-block-start-shape",
-      "syntax": "<corner-shape-value>{1,2}",
+      "syntax": "<'corner-top-left-shape'>{1,2}",
       "computed": [
         "corner-start-start-shape",
         "corner-start-end-shape"
@@ -2718,7 +2718,7 @@
     },
     {
       "name": "corner-bottom-shape",
-      "syntax": "<corner-shape-value>{1,2}",
+      "syntax": "<'corner-top-left-shape'>{1,2}",
       "computed": [
         "corner-bottom-left-shape",
         "corner-bottom-right-shape"
@@ -2749,7 +2749,7 @@
     },
     {
       "name": "corner-inline-end-shape",
-      "syntax": "<corner-shape-value>{1,2}",
+      "syntax": "<'corner-top-left-shape'>{1,2}",
       "computed": [
         "corner-start-end-shape",
         "corner-end-end-shape"
@@ -2762,7 +2762,7 @@
     },
     {
       "name": "corner-inline-start-shape",
-      "syntax": "<corner-shape-value>{1,2}",
+      "syntax": "<'corner-top-left-shape'>{1,2}",
       "computed": [
         "corner-start-start-shape",
         "corner-start-end-shape"
@@ -2775,7 +2775,7 @@
     },
     {
       "name": "corner-left-shape",
-      "syntax": "<corner-shape-value>{1,2}",
+      "syntax": "<'corner-top-left-shape'>{1,2}",
       "computed": [
         "corner-top-left-shape",
         "corner-bottom-left-shape"
@@ -2788,7 +2788,7 @@
     },
     {
       "name": "corner-right-shape",
-      "syntax": "<corner-shape-value>{1,2}",
+      "syntax": "<'corner-top-left-shape'>{1,2}",
       "computed": [
         "corner-top-right-shape",
         "corner-bottom-right-shape"
@@ -2801,7 +2801,7 @@
     },
     {
       "name": "corner-shape",
-      "syntax": "<corner-shape-value>{1,4}",
+      "syntax": "<'corner-top-left-shape'>{1,4}",
       "computed": [
         "corner-top-left-shape",
         "corner-top-right-shape",
@@ -2854,7 +2854,7 @@
     },
     {
       "name": "corner-top-shape",
-      "syntax": "<corner-shape-value>{1,2}",
+      "syntax": "<'corner-top-left-shape'>{1,2}",
       "computed": [
         "corner-top-left-shape",
         "corner-top-right-shape"
@@ -2894,7 +2894,7 @@
     },
     {
       "name": "cursor",
-      "syntax": "[ [ <url> [ <x> <y> ]? , ]* <cursor-predefined> ]",
+      "syntax": "[<cursor-image>,]* <cursor-predefined>",
       "computed": [
         "asSpecifiedURLsAbsolute"
       ],
@@ -2903,7 +2903,7 @@
     },
     {
       "name": "cx",
-      "syntax": "<length> | <percentage>",
+      "syntax": "<length-percentage>",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
@@ -2912,7 +2912,7 @@
     },
     {
       "name": "cy",
-      "syntax": "<length> | <percentage>",
+      "syntax": "<length-percentage>",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
@@ -2921,7 +2921,7 @@
     },
     {
       "name": "d",
-      "syntax": "none | path(<string>)",
+      "syntax": "none | <string>",
       "computed": [
         "asSpecified"
       ],
@@ -2939,7 +2939,7 @@
     },
     {
       "name": "display",
-      "syntax": "[ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy>",
+      "syntax": "[ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy> | <display-outside> || [ <display-inside> | math ]",
       "computed": [
         "asSpecifiedExceptPositionedFloatingAndRootElementsKeywordMaybeDifferent"
       ],
@@ -2948,7 +2948,7 @@
     },
     {
       "name": "dominant-baseline",
-      "syntax": "auto | text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top",
+      "syntax": "auto | <baseline-metric>",
       "computed": [
         "asSpecified"
       ],
@@ -2975,7 +2975,7 @@
     },
     {
       "name": "field-sizing",
-      "syntax": "content | fixed",
+      "syntax": "fixed | content",
       "computed": [
         "asSpecified"
       ],
@@ -3066,7 +3066,7 @@
     },
     {
       "name": "flex-grow",
-      "syntax": "<number>",
+      "syntax": "<number [0,∞]>",
       "computed": [
         "asSpecified"
       ],
@@ -3075,7 +3075,7 @@
     },
     {
       "name": "flex-shrink",
-      "syntax": "<number>",
+      "syntax": "<number [0,∞]>",
       "computed": [
         "asSpecified"
       ],
@@ -3084,7 +3084,7 @@
     },
     {
       "name": "flex-wrap",
-      "syntax": "nowrap | wrap | wrap-reverse",
+      "syntax": "nowrap | [ wrap | wrap-reverse ] || balance",
       "computed": [
         "asSpecified"
       ],
@@ -3093,7 +3093,7 @@
     },
     {
       "name": "float",
-      "syntax": "left | right | none | inline-start | inline-end",
+      "syntax": "block-start | block-end | inline-start | inline-end | snap-block | <snap-block()> | snap-inline | <snap-inline()> | left | right | top | bottom | none | footnote",
       "computed": [
         "asSpecified"
       ],
@@ -3120,7 +3120,7 @@
     },
     {
       "name": "font",
-      "syntax": "[ [ <'font-style'> || <font-variant-css2> || <'font-weight'> || <font-width-css3> ]? <'font-size'> [ / <'line-height'> ]? <'font-family'># ] | <system-family-name>",
+      "syntax": "[ [ <'font-style'> || <font-variant-css2> || <'font-weight'> || <font-width-css3> ]? <'font-size'> [ / <'line-height'> ]? <'font-family'># ] | <system-font-family-name>",
       "computed": [
         "font-style",
         "font-variant",
@@ -3143,7 +3143,7 @@
     },
     {
       "name": "font-family",
-      "syntax": "[ <family-name> | <generic-family> ]#",
+      "syntax": "[ <font-family-name> | <generic-font-family> ]#",
       "computed": [
         "asSpecified"
       ],
@@ -3206,7 +3206,7 @@
     },
     {
       "name": "font-size-adjust",
-      "syntax": "none | [ ex-height | cap-height | ch-width | ic-width | ic-height ]? [ from-font | <number> ]",
+      "syntax": "none | <number [0,∞]>",
       "computed": [
         "asSpecified"
       ],
@@ -3224,7 +3224,7 @@
     },
     {
       "name": "font-stretch",
-      "syntax": "<font-stretch-absolute>",
+      "syntax": "normal | <percentage [0,∞]> | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded",
       "computed": [
         "asSpecified"
       ],
@@ -3233,7 +3233,7 @@
     },
     {
       "name": "font-style",
-      "syntax": "normal | italic | oblique <angle>?",
+      "syntax": "normal | italic | left | right | oblique <angle [-90deg,90deg]>?",
       "computed": [
         "asSpecified"
       ],
@@ -3269,7 +3269,7 @@
     },
     {
       "name": "font-synthesis-style",
-      "syntax": "auto | none",
+      "syntax": "auto | none | oblique-only",
       "computed": [
         "asSpecified"
       ],
@@ -3287,7 +3287,7 @@
     },
     {
       "name": "font-variant",
-      "syntax": "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> || stylistic( <feature-value-name> ) || historical-forms || styleset( <feature-value-name># ) || character-variant( <feature-value-name># ) || swash( <feature-value-name> ) || ornaments( <feature-value-name> ) || annotation( <feature-value-name> ) || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero || <east-asian-variant-values> || <east-asian-width-values> || ruby ]",
+      "syntax": "normal | none | [ [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ] || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || [ stylistic(<font-feature-value-name>) || historical-forms || styleset(<font-feature-value-name>#) || character-variant(<font-feature-value-name>#) || swash(<font-feature-value-name>) || ornaments(<font-feature-value-name>) || annotation(<font-feature-value-name>) ] || [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ] || [ <east-asian-variant-values> || <east-asian-width-values> || ruby ] || [ sub | super ] || [ text | emoji | unicode ] ]",
       "computed": [
         "asSpecified"
       ],
@@ -3296,7 +3296,7 @@
     },
     {
       "name": "font-variant-alternates",
-      "syntax": "normal | [ stylistic( <feature-value-name> ) || historical-forms || styleset( <feature-value-name># ) || character-variant( <feature-value-name># ) || swash( <feature-value-name> ) || ornaments( <feature-value-name> ) || annotation( <feature-value-name> ) ]",
+      "syntax": "normal | [ stylistic(<font-feature-value-name>) || historical-forms || styleset(<font-feature-value-name>#) || character-variant(<font-feature-value-name>#) || swash(<font-feature-value-name>) || ornaments(<font-feature-value-name>) || annotation(<font-feature-value-name>) ]",
       "computed": [
         "asSpecified"
       ],
@@ -3359,7 +3359,7 @@
     },
     {
       "name": "font-variation-settings",
-      "syntax": "normal | [ <string> <number> ]#",
+      "syntax": "normal | [ <opentype-tag> <number> ]#",
       "computed": [
         "asSpecified"
       ],
@@ -3392,6 +3392,15 @@
       ],
       "initial": "auto",
       "inherited": true
+    },
+    {
+      "name": "frame-sizing",
+      "syntax": "auto | content-width | content-height | content-block-size | content-inline-size",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "auto",
+      "inherited": false
     },
     {
       "name": "gap",
@@ -3503,7 +3512,7 @@
     },
     {
       "name": "grid-column-gap",
-      "syntax": "<length-percentage>",
+      "syntax": "normal | <length-percentage [0,∞]> | <line-width>",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
@@ -3521,7 +3530,7 @@
     },
     {
       "name": "grid-gap",
-      "syntax": "<'grid-row-gap'> <'grid-column-gap'>?",
+      "syntax": "<'row-gap'> <'column-gap'>?",
       "computed": [
         "grid-row-gap",
         "grid-column-gap"
@@ -3556,7 +3565,7 @@
     },
     {
       "name": "grid-row-gap",
-      "syntax": "<length-percentage>",
+      "syntax": "normal | <length-percentage [0,∞]> | <line-width>",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
@@ -3625,7 +3634,7 @@
     },
     {
       "name": "height",
-      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
       "computed": [
         "percentageAutoOrAbsoluteLength"
       ],
@@ -3661,7 +3670,7 @@
     },
     {
       "name": "image-orientation",
-      "syntax": "from-image | <angle> | [ <angle>? flip ]",
+      "syntax": "from-image | none | [ <angle> || flip ]",
       "computed": [
         "angleRoundedToNextQuarter"
       ],
@@ -3670,7 +3679,7 @@
     },
     {
       "name": "image-rendering",
-      "syntax": "auto | crisp-edges | pixelated | smooth",
+      "syntax": "auto | smooth | high-quality | pixelated | crisp-edges",
       "computed": [
         "asSpecified"
       ],
@@ -3697,7 +3706,7 @@
     },
     {
       "name": "initial-letter",
-      "syntax": "normal | [ <number> <integer>? ]",
+      "syntax": "normal | <number [1,∞]> <integer [1,∞]> | <number [1,∞]> && [ drop | raise ]?",
       "computed": [
         "asSpecified"
       ],
@@ -3706,7 +3715,7 @@
     },
     {
       "name": "initial-letter-align",
-      "syntax": "[ auto | alphabetic | hanging | ideographic ]",
+      "syntax": "[ border-box? [ alphabetic | ideographic | hanging | leading ]? ]!",
       "computed": [
         "asSpecified"
       ],
@@ -3754,7 +3763,7 @@
     },
     {
       "name": "inset-block-end",
-      "syntax": "<'top'>",
+      "syntax": "auto | <length-percentage>",
       "computed": [
         "sameAsBoxOffsets"
       ],
@@ -3763,7 +3772,7 @@
     },
     {
       "name": "inset-block-start",
-      "syntax": "<'top'>",
+      "syntax": "auto | <length-percentage>",
       "computed": [
         "sameAsBoxOffsets"
       ],
@@ -3785,7 +3794,7 @@
     },
     {
       "name": "inset-inline-end",
-      "syntax": "<'top'>",
+      "syntax": "auto | <length-percentage>",
       "computed": [
         "sameAsBoxOffsets"
       ],
@@ -3794,7 +3803,7 @@
     },
     {
       "name": "inset-inline-start",
-      "syntax": "<'top'>",
+      "syntax": "auto | <length-percentage>",
       "computed": [
         "sameAsBoxOffsets"
       ],
@@ -3852,7 +3861,7 @@
     },
     {
       "name": "isolation",
-      "syntax": "auto | isolate",
+      "syntax": "<isolation-mode>",
       "computed": [
         "asSpecified"
       ],
@@ -3870,7 +3879,7 @@
     },
     {
       "name": "justify-items",
-      "syntax": "normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | legacy | legacy && [ left | right | center ] | anchor-center",
+      "syntax": "normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | legacy | legacy && [ left | right | center ]",
       "computed": [
         "asSpecified"
       ],
@@ -3879,7 +3888,7 @@
     },
     {
       "name": "justify-self",
-      "syntax": "auto | normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | anchor-center",
+      "syntax": "auto | <overflow-position>? [ normal | <self-position> | left | right ] | stretch | <baseline-position> | anchor-center",
       "computed": [
         "asSpecified"
       ],
@@ -3942,7 +3951,7 @@
     },
     {
       "name": "line-height",
-      "syntax": "normal | <number> | <length> | <percentage>",
+      "syntax": "normal | <number [0,∞]> | <length-percentage [0,∞]>",
       "computed": [
         "absoluteLengthOrAsSpecified"
       ],
@@ -3951,7 +3960,7 @@
     },
     {
       "name": "line-height-step",
-      "syntax": "<length>",
+      "syntax": "<length [0,∞]>",
       "computed": [
         "absoluteLength"
       ],
@@ -3960,7 +3969,7 @@
     },
     {
       "name": "list-style",
-      "syntax": "<'list-style-type'> || <'list-style-position'> || <'list-style-image'>",
+      "syntax": "<'list-style-position'> || <'list-style-image'> || <'list-style-type'>",
       "computed": [
         "list-style-image",
         "list-style-position",
@@ -4117,7 +4126,7 @@
     },
     {
       "name": "margin-trim",
-      "syntax": "none | in-flow | all",
+      "syntax": "none | [ block || inline ] | [ block-start || inline-start || block-end || inline-end ]",
       "computed": [
         "asSpecified"
       ],
@@ -4126,7 +4135,7 @@
     },
     {
       "name": "marker",
-      "syntax": "none | <url>",
+      "syntax": "none | <marker-ref>",
       "computed": [
         "asSpecified"
       ],
@@ -4139,7 +4148,7 @@
     },
     {
       "name": "marker-end",
-      "syntax": "none | <url>",
+      "syntax": "none | <marker-ref>",
       "computed": [
         "asSpecifiedURLsAbsolute"
       ],
@@ -4148,7 +4157,7 @@
     },
     {
       "name": "marker-mid",
-      "syntax": "none | <url>",
+      "syntax": "none | <marker-ref>",
       "computed": [
         "asSpecifiedURLsAbsolute"
       ],
@@ -4157,7 +4166,7 @@
     },
     {
       "name": "marker-start",
-      "syntax": "none | <url>",
+      "syntax": "none | <marker-ref>",
       "computed": [
         "asSpecifiedURLsAbsolute"
       ],
@@ -4221,7 +4230,7 @@
     },
     {
       "name": "mask-border-outset",
-      "syntax": "[ <length> | <number> ]{1,4}",
+      "syntax": "<'border-image-outset'>",
       "computed": [
         "asSpecifiedRelativeToAbsoluteLengths"
       ],
@@ -4230,7 +4239,7 @@
     },
     {
       "name": "mask-border-repeat",
-      "syntax": "[ stretch | repeat | round | space ]{1,2}",
+      "syntax": "<'border-image-repeat'>",
       "computed": [
         "asSpecified"
       ],
@@ -4239,7 +4248,7 @@
     },
     {
       "name": "mask-border-slice",
-      "syntax": "<number-percentage>{1,4} fill?",
+      "syntax": "<'border-image-slice'>",
       "computed": [
         "asSpecified"
       ],
@@ -4248,7 +4257,7 @@
     },
     {
       "name": "mask-border-source",
-      "syntax": "none | <image>",
+      "syntax": "<'border-image-source'>",
       "computed": [
         "asSpecifiedURLsAbsolute"
       ],
@@ -4257,7 +4266,7 @@
     },
     {
       "name": "mask-border-width",
-      "syntax": "[ <length-percentage> | <number> | auto ]{1,4}",
+      "syntax": "<'border-image-width'>",
       "computed": [
         "asSpecifiedRelativeToAbsoluteLengths"
       ],
@@ -4392,7 +4401,7 @@
     },
     {
       "name": "max-height",
-      "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+      "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
       "computed": [
         "percentageAsSpecifiedAbsoluteLengthOrNone"
       ],
@@ -4419,7 +4428,7 @@
     },
     {
       "name": "max-width",
-      "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+      "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
       "computed": [
         "percentageAsSpecifiedAbsoluteLengthOrNone"
       ],
@@ -4437,7 +4446,7 @@
     },
     {
       "name": "min-height",
-      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
@@ -4455,7 +4464,7 @@
     },
     {
       "name": "min-width",
-      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
@@ -4464,7 +4473,7 @@
     },
     {
       "name": "mix-blend-mode",
-      "syntax": "<blend-mode> | plus-darker | plus-lighter",
+      "syntax": "<blend-mode> | plus-lighter",
       "computed": [
         "asSpecified"
       ],
@@ -4487,7 +4496,7 @@
         "asSpecified"
       ],
       "initial": "50% 50%",
-      "inherited": true
+      "inherited": false
     },
     {
       "name": "object-view-box",
@@ -4582,7 +4591,7 @@
     },
     {
       "name": "orphans",
-      "syntax": "<integer>",
+      "syntax": "<integer [1,∞]>",
       "computed": [
         "asSpecified"
       ],
@@ -4606,7 +4615,7 @@
     },
     {
       "name": "outline-color",
-      "syntax": "auto | <color>",
+      "syntax": "auto | <'border-top-color'>",
       "computed": [
         "autoForTranslucentColorRGBAOtherwiseRGB"
       ],
@@ -4617,7 +4626,7 @@
       "name": "outline-offset",
       "syntax": "<length>",
       "computed": [
-        "asSpecifiedRelativeToAbsoluteLengths"
+        "absoluteLengthSnappedAsLineWidth"
       ],
       "initial": "0",
       "inherited": false
@@ -4635,14 +4644,14 @@
       "name": "outline-width",
       "syntax": "<line-width>",
       "computed": [
-        "absoluteLength0ForNone"
+        "absoluteLengthSnappedAsLineWidth"
       ],
       "initial": "medium",
       "inherited": false
     },
     {
       "name": "overflow",
-      "syntax": "[ visible | hidden | clip | scroll | auto ]{1,2}",
+      "syntax": "<'overflow-block'>{1,2}",
       "computed": [
         "overflow-x",
         "overflow-y"
@@ -4679,7 +4688,7 @@
     },
     {
       "name": "overflow-clip-margin",
-      "syntax": "<visual-box> || <length [0,∞]>",
+      "syntax": "<visual-box> || <length>",
       "computed": [
         "theComputedLengthAndVisualBox"
       ],
@@ -4733,7 +4742,7 @@
     },
     {
       "name": "overscroll-behavior",
-      "syntax": "[ contain | none | auto ]{1,2}",
+      "syntax": "[ contain | none | auto | chain ]{1,2}",
       "computed": [
         "overscroll-behavior-x",
         "overscroll-behavior-y"
@@ -4743,7 +4752,7 @@
     },
     {
       "name": "overscroll-behavior-block",
-      "syntax": "contain | none | auto",
+      "syntax": "contain | none | auto | chain",
       "computed": [
         "asSpecified"
       ],
@@ -4752,7 +4761,7 @@
     },
     {
       "name": "overscroll-behavior-inline",
-      "syntax": "contain | none | auto",
+      "syntax": "contain | none | auto | chain",
       "computed": [
         "asSpecified"
       ],
@@ -4761,7 +4770,7 @@
     },
     {
       "name": "overscroll-behavior-x",
-      "syntax": "contain | none | auto",
+      "syntax": "contain | none | auto | chain",
       "computed": [
         "asSpecified"
       ],
@@ -4770,7 +4779,7 @@
     },
     {
       "name": "overscroll-behavior-y",
-      "syntax": "contain | none | auto",
+      "syntax": "contain | none | auto | chain",
       "computed": [
         "asSpecified"
       ],
@@ -4903,7 +4912,7 @@
     },
     {
       "name": "page-break-after",
-      "syntax": "auto | always | avoid | left | right | recto | verso",
+      "syntax": "auto | always | avoid | left | right | inherit",
       "computed": [
         "asSpecified"
       ],
@@ -4912,7 +4921,7 @@
     },
     {
       "name": "page-break-before",
-      "syntax": "auto | always | avoid | left | right | recto | verso",
+      "syntax": "auto | always | avoid | left | right | inherit",
       "computed": [
         "asSpecified"
       ],
@@ -4921,7 +4930,7 @@
     },
     {
       "name": "page-break-inside",
-      "syntax": "auto | avoid",
+      "syntax": "avoid | auto | inherit",
       "computed": [
         "asSpecified"
       ],
@@ -4996,7 +5005,7 @@
     },
     {
       "name": "pointer-events",
-      "syntax": "auto | none | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all | inherit",
+      "syntax": "auto | bounding-box | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all | none",
       "computed": [
         "asSpecified"
       ],
@@ -5005,7 +5014,7 @@
     },
     {
       "name": "position",
-      "syntax": "static | relative | absolute | sticky | fixed",
+      "syntax": "static | relative | absolute | sticky | fixed | <running()>",
       "computed": [
         "asSpecified"
       ],
@@ -5014,7 +5023,7 @@
     },
     {
       "name": "position-anchor",
-      "syntax": "normal | auto | none | <anchor-name> | match-parent",
+      "syntax": "normal | none | auto | <anchor-name> | match-parent",
       "computed": [
         "asSpecified"
       ],
@@ -5045,7 +5054,7 @@
     },
     {
       "name": "position-try-fallbacks",
-      "syntax": "none | [ [<dashed-ident> || <try-tactic>] | <'position-area'> ]#",
+      "syntax": "none | [ [<dashed-ident> || <try-tactic>] | <position-area> ]#",
       "computed": [
         "asSpecified"
       ],
@@ -5063,7 +5072,7 @@
     },
     {
       "name": "position-visibility",
-      "syntax": "always | [ anchors-valid || anchors-visible || no-overflow ]",
+      "syntax": "always | [ anchor-valid || anchor-visible || no-overflow ]",
       "computed": [
         "asSpecified"
       ],
@@ -5081,7 +5090,7 @@
     },
     {
       "name": "quotes",
-      "syntax": "none | auto | [ <string> <string> ]+",
+      "syntax": "auto | none | match-parent | [ <string> <string> ]+",
       "computed": [
         "asSpecified"
       ],
@@ -5090,7 +5099,7 @@
     },
     {
       "name": "r",
-      "syntax": "<length> | <percentage>",
+      "syntax": "<length-percentage>",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
@@ -5144,7 +5153,7 @@
     },
     {
       "name": "row-gap",
-      "syntax": "normal | <length-percentage>",
+      "syntax": "normal | <length-percentage [0,∞]> | <line-width>",
       "computed": [
         "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn"
       ],
@@ -5162,7 +5171,7 @@
     },
     {
       "name": "ruby-merge",
-      "syntax": "separate | collapse | auto",
+      "syntax": "separate | merge | auto",
       "computed": [
         "asSpecified"
       ],
@@ -5171,7 +5180,7 @@
     },
     {
       "name": "ruby-overhang",
-      "syntax": "auto | none",
+      "syntax": "auto | spaces",
       "computed": [
         "theSpecifiedKeyword"
       ],
@@ -5358,7 +5367,7 @@
     },
     {
       "name": "scroll-padding",
-      "syntax": "[ auto | <length-percentage> ]{1,4}",
+      "syntax": "[ auto | <length-percentage [0,∞]> ]{1,4}",
       "computed": [
         "scroll-padding-bottom",
         "scroll-padding-left",
@@ -5375,7 +5384,7 @@
     },
     {
       "name": "scroll-padding-block",
-      "syntax": "[ auto | <length-percentage> ]{1,2}",
+      "syntax": "[ auto | <length-percentage [0,∞]> ]{1,2}",
       "computed": [
         "scroll-padding-block-start",
         "scroll-padding-block-end"
@@ -5388,7 +5397,7 @@
     },
     {
       "name": "scroll-padding-block-end",
-      "syntax": "auto | <length-percentage>",
+      "syntax": "auto | <length-percentage [0,∞]>",
       "computed": [
         "asSpecified"
       ],
@@ -5397,7 +5406,7 @@
     },
     {
       "name": "scroll-padding-block-start",
-      "syntax": "auto | <length-percentage>",
+      "syntax": "auto | <length-percentage [0,∞]>",
       "computed": [
         "asSpecified"
       ],
@@ -5406,7 +5415,7 @@
     },
     {
       "name": "scroll-padding-bottom",
-      "syntax": "auto | <length-percentage>",
+      "syntax": "auto | <length-percentage [0,∞]>",
       "computed": [
         "asSpecified"
       ],
@@ -5415,7 +5424,7 @@
     },
     {
       "name": "scroll-padding-inline",
-      "syntax": "[ auto | <length-percentage> ]{1,2}",
+      "syntax": "[ auto | <length-percentage [0,∞]> ]{1,2}",
       "computed": [
         "scroll-padding-inline-start",
         "scroll-padding-inline-end"
@@ -5428,7 +5437,7 @@
     },
     {
       "name": "scroll-padding-inline-end",
-      "syntax": "auto | <length-percentage>",
+      "syntax": "auto | <length-percentage [0,∞]>",
       "computed": [
         "asSpecified"
       ],
@@ -5437,7 +5446,7 @@
     },
     {
       "name": "scroll-padding-inline-start",
-      "syntax": "auto | <length-percentage>",
+      "syntax": "auto | <length-percentage [0,∞]>",
       "computed": [
         "asSpecified"
       ],
@@ -5446,7 +5455,7 @@
     },
     {
       "name": "scroll-padding-left",
-      "syntax": "auto | <length-percentage>",
+      "syntax": "auto | <length-percentage [0,∞]>",
       "computed": [
         "asSpecified"
       ],
@@ -5455,7 +5464,7 @@
     },
     {
       "name": "scroll-padding-right",
-      "syntax": "auto | <length-percentage>",
+      "syntax": "auto | <length-percentage [0,∞]>",
       "computed": [
         "asSpecified"
       ],
@@ -5464,7 +5473,7 @@
     },
     {
       "name": "scroll-padding-top",
-      "syntax": "auto | <length-percentage>",
+      "syntax": "auto | <length-percentage [0,∞]>",
       "computed": [
         "asSpecified"
       ],
@@ -5630,7 +5639,7 @@
     },
     {
       "name": "shape-margin",
-      "syntax": "<length-percentage>",
+      "syntax": "<length-percentage [0,∞]>",
       "computed": [
         "asSpecifiedRelativeToAbsoluteLengths"
       ],
@@ -5639,7 +5648,7 @@
     },
     {
       "name": "shape-outside",
-      "syntax": "none | [ <shape-box> || <basic-shape> ] | <image>",
+      "syntax": "none | [ <basic-shape> || <shape-box> ] | <image>",
       "computed": [
         "asDefinedForBasicShapeWithAbsoluteURIOtherwiseAsSpecified"
       ],
@@ -5701,7 +5710,7 @@
     },
     {
       "name": "stroke-color",
-      "syntax": "<color>",
+      "syntax": "<color>#",
       "computed": [
         "computedColor"
       ],
@@ -5710,7 +5719,7 @@
     },
     {
       "name": "stroke-dasharray",
-      "syntax": "none | <dasharray>",
+      "syntax": "none | [<length-percentage> | <number>]+#",
       "computed": [
         "listEachItemConsistingOfAbsoluteLengthPercentageOrKeyword"
       ],
@@ -5737,7 +5746,7 @@
     },
     {
       "name": "stroke-linejoin",
-      "syntax": "miter | miter-clip | round | bevel | arcs",
+      "syntax": "[ crop | arcs | miter ] || [ bevel | round | fallback ]",
       "computed": [
         "asSpecified"
       ],
@@ -5764,7 +5773,7 @@
     },
     {
       "name": "stroke-width",
-      "syntax": "<length-percentage> | <number>",
+      "syntax": "[ <length-percentage> | <line-width> | <number> ]#",
       "computed": [
         "absoluteLengthOrPercentageNumbersConverted"
       ],
@@ -5773,7 +5782,7 @@
     },
     {
       "name": "tab-size",
-      "syntax": "<integer> | <length>",
+      "syntax": "<number [0,∞]> | <length [0,∞]>",
       "computed": [
         "specifiedIntegerOrAbsoluteLength"
       ],
@@ -5791,7 +5800,7 @@
     },
     {
       "name": "text-align",
-      "syntax": "start | end | left | right | center | justify | match-parent",
+      "syntax": "start | end | left | right | center | justify | match-parent | justify-all",
       "computed": [
         "asSpecifiedExceptMatchParent"
       ],
@@ -5800,7 +5809,7 @@
     },
     {
       "name": "text-align-last",
-      "syntax": "auto | start | end | left | right | center | justify",
+      "syntax": "auto | start | end | left | right | center | justify | match-parent",
       "computed": [
         "asSpecified"
       ],
@@ -5854,7 +5863,7 @@
     },
     {
       "name": "text-combine-upright",
-      "syntax": "none | all | [ digits <integer>? ]",
+      "syntax": "none | all | [ digits <integer [2,4]>? ]",
       "computed": [
         "keywordPlusIntegerIfDigits"
       ],
@@ -5863,7 +5872,7 @@
     },
     {
       "name": "text-decoration",
-      "syntax": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'> || <'text-decoration-thickness'>",
+      "syntax": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'>",
       "computed": [
         "text-decoration-line",
         "text-decoration-style",
@@ -5897,7 +5906,7 @@
     },
     {
       "name": "text-decoration-line",
-      "syntax": "none | [ underline || overline || line-through || blink ] | spelling-error | grammar-error",
+      "syntax": "none | [ underline || overline || line-through || blink ]",
       "computed": [
         "asSpecified"
       ],
@@ -5964,7 +5973,7 @@
     },
     {
       "name": "text-emphasis-position",
-      "syntax": "auto | [ over | under ] && [ right | left ]?",
+      "syntax": "[ over | under ] && [ right | left ]?",
       "computed": [
         "asSpecified"
       ],
@@ -5982,7 +5991,7 @@
     },
     {
       "name": "text-indent",
-      "syntax": "<length-percentage> && hanging? && each-line?",
+      "syntax": "[ <length-percentage> ] && hanging? && each-line?",
       "computed": [
         "percentageOrAbsoluteLengthPlusKeywords"
       ],
@@ -5991,7 +6000,7 @@
     },
     {
       "name": "text-justify",
-      "syntax": "auto | inter-character | inter-word | none",
+      "syntax": "auto | none | inter-word | inter-character",
       "computed": [
         "asSpecified"
       ],
@@ -6009,7 +6018,7 @@
     },
     {
       "name": "text-overflow",
-      "syntax": "[ clip | ellipsis | <string> ]{1,2}",
+      "syntax": "clip | ellipsis",
       "computed": [
         "asSpecified"
       ],
@@ -6027,7 +6036,7 @@
     },
     {
       "name": "text-shadow",
-      "syntax": "none | <shadow-t>#",
+      "syntax": "none | [ <color>? && [ <length>{2} <length [0,∞]>? ] ]#",
       "computed": [
         "colorPlusThreeAbsoluteLengths"
       ],
@@ -6036,7 +6045,7 @@
     },
     {
       "name": "text-size-adjust",
-      "syntax": "none | auto | <percentage>",
+      "syntax": "auto | none | <percentage [0,∞]>",
       "computed": [
         "asSpecified"
       ],
@@ -6054,7 +6063,7 @@
     },
     {
       "name": "text-transform",
-      "syntax": "none | [ capitalize | uppercase | lowercase ] || full-width || full-size-kana | math-auto",
+      "syntax": "none | [capitalize | uppercase | lowercase ] || full-width || full-size-kana",
       "computed": [
         "asSpecified"
       ],
@@ -6072,7 +6081,7 @@
     },
     {
       "name": "text-underline-position",
-      "syntax": "auto | from-font | [ under || [ left | right ] ]",
+      "syntax": "auto | [ under || [ left | right ] ]",
       "computed": [
         "asSpecified"
       ],
@@ -6109,7 +6118,7 @@
     },
     {
       "name": "timeline-scope",
-      "syntax": "none | <dashed-ident>#",
+      "syntax": "none | all | <dashed-ident>#",
       "computed": [
         "noneOrOrderedListOfIdentifiers"
       ],
@@ -6118,7 +6127,7 @@
     },
     {
       "name": "timeline-trigger",
-      "syntax": "none | [ <'timeline-trigger-name'> <'timeline-trigger-source'> <'timeline-trigger-activation-range'> [ '/' <'timeline-trigger-active-range'> ]? ]#",
+      "syntax": "none | [ <'timeline-trigger-name'> <'timeline-trigger-source'> <'timeline-trigger-activation-range'> [ / <'timeline-trigger-active-range'> ]? ]#",
       "computed": [
         "timeline-trigger-name",
         "timeline-trigger-source",
@@ -6251,7 +6260,7 @@
     },
     {
       "name": "transform-origin",
-      "syntax": "[ <length-percentage> | left | center | right | top | bottom ] | [ [ <length-percentage> | left | center | right ] && [ <length-percentage> | top | center | bottom ] ] <length>?",
+      "syntax": "[ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] <length>? | [ [ center | left | right ] && [ center | top | bottom ] ] <length>?",
       "computed": [
         "forLengthAbsoluteValueOtherwisePercentage"
       ],
@@ -6306,7 +6315,7 @@
     },
     {
       "name": "transition-duration",
-      "syntax": "<time>#",
+      "syntax": "<time [0s,∞]>#",
       "computed": [
         "asSpecified"
       ],
@@ -6360,7 +6369,7 @@
     },
     {
       "name": "user-select",
-      "syntax": "auto | text | none | all",
+      "syntax": "auto | text | none | contain | all",
       "computed": [
         "asSpecified"
       ],
@@ -6378,7 +6387,7 @@
     },
     {
       "name": "vertical-align",
-      "syntax": "baseline | sub | super | text-top | text-bottom | middle | top | bottom | <percentage> | <length>",
+      "syntax": "[ first | last] || <'alignment-baseline'> || <'baseline-shift'>",
       "computed": [
         "asLonghands"
       ],
@@ -6436,7 +6445,16 @@
     },
     {
       "name": "view-transition-name",
-      "syntax": "none | <custom-ident> | match-element",
+      "syntax": "none | <custom-ident>",
+      "computed": [
+        "asSpecified"
+      ],
+      "initial": "none",
+      "inherited": false
+    },
+    {
+      "name": "view-transition-scope",
+      "syntax": "none | all",
       "computed": [
         "asSpecified"
       ],
@@ -6445,7 +6463,7 @@
     },
     {
       "name": "visibility",
-      "syntax": "visible | hidden | collapse",
+      "syntax": "visible | hidden | force-hidden | collapse",
       "computed": [
         "asSpecified"
       ],
@@ -6454,7 +6472,7 @@
     },
     {
       "name": "white-space",
-      "syntax": "normal | pre | pre-wrap | pre-line | <'white-space-collapse'> || <'text-wrap-mode'>",
+      "syntax": "normal | pre | nowrap | pre-wrap | break-spaces | pre-line",
       "computed": [
         "asSpecified"
       ],
@@ -6472,7 +6490,7 @@
     },
     {
       "name": "widows",
-      "syntax": "<integer>",
+      "syntax": "<integer [1,∞]>",
       "computed": [
         "asSpecified"
       ],
@@ -6481,7 +6499,7 @@
     },
     {
       "name": "width",
-      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+      "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
       "computed": [
         "percentageAutoOrAbsoluteLength"
       ],
@@ -6499,7 +6517,7 @@
     },
     {
       "name": "word-break",
-      "syntax": "normal | break-all | keep-all | break-word | auto-phrase",
+      "syntax": "normal | keep-all | break-all | break-word",
       "computed": [
         "asSpecified"
       ],
@@ -6517,7 +6535,7 @@
     },
     {
       "name": "word-wrap",
-      "syntax": "normal | break-word",
+      "syntax": "normal | break-word | anywhere",
       "computed": [
         "asSpecified"
       ],
@@ -6535,7 +6553,7 @@
     },
     {
       "name": "x",
-      "syntax": "<length> | <percentage>",
+      "syntax": "<length-percentage>",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
@@ -6544,7 +6562,7 @@
     },
     {
       "name": "y",
-      "syntax": "<length> | <percentage>",
+      "syntax": "<length-percentage>",
       "computed": [
         "percentageAsSpecifiedOrAbsoluteLength"
       ],
@@ -6553,7 +6571,7 @@
     },
     {
       "name": "z-index",
-      "syntax": "auto | <integer>",
+      "syntax": "auto | <integer> | inherit",
       "computed": [
         "asSpecified"
       ],
@@ -6562,7 +6580,7 @@
     },
     {
       "name": "zoom",
-      "syntax": "normal | reset | <number [0,∞]> || <percentage [0,∞]>",
+      "syntax": "<number [0,∞]> | <percentage [0,∞]>",
       "computed": [
         "asSpecifiedButWithPercentageConvertedToTheEquivalentNumber"
       ],
@@ -6572,8 +6590,20 @@
   ],
   "values": [
     {
+      "name": "<a-n-plus-b>",
+      "syntax": "odd | even | <integer> | <n-dimension> | '+'? n | -n | <ndashdigit-dimension> | '+'? <ndashdigit-ident> | <dashndashdigit-ident> | <n-dimension> <signed-integer> | '+'? n <signed-integer> | -n <signed-integer> | <ndash-dimension> <signless-integer> | '+'? n- <signless-integer> | -n- <signless-integer> | <n-dimension> ['+' | '-'] <signless-integer> | '+'? n ['+' | '-'] <signless-integer> | -n ['+' | '-'] <signless-integer>"
+    },
+    {
+      "name": "<abs()>",
+      "syntax": "abs( <calc-sum> )"
+    },
+    {
       "name": "<absolute-size>",
-      "syntax": "xx-small | x-small | small | medium | large | x-large | xx-large | xxx-large"
+      "syntax": "[ xx-small | x-small | small | medium | large | x-large | xx-large | xxx-large ]"
+    },
+    {
+      "name": "<acos()>",
+      "syntax": "acos( <calc-sum> )"
     },
     {
       "name": "<alpha-value>",
@@ -6581,7 +6611,11 @@
     },
     {
       "name": "<an+b>",
-      "syntax": "odd | even | <integer> | <n-dimension> | '+'? n | -n | <ndashdigit-dimension> | '+'? <ndashdigit-ident> | <dashndashdigit-ident> | <n-dimension> <signed-integer> | '+'? n <signed-integer> | -n <signed-integer> | <ndash-dimension> <signless-integer> | '+'? n- <signless-integer> | -n- <signless-integer> | <n-dimension> ['+' | '-'] <signless-integer> | '+'? n ['+' | '-'] <signless-integer> | -n ['+' | '-'] <signless-integer>"
+      "syntax": "odd | even | <integer> | <n-dimension> | '+'?† n | -n | <ndashdigit-dimension> | '+'?† <ndashdigit-ident> | <dashndashdigit-ident> | <n-dimension> <signed-integer> | '+'?† n <signed-integer> | -n <signed-integer> | <ndash-dimension> <signless-integer> | '+'?† n- <signless-integer> | -n- <signless-integer> | <n-dimension> ['+' | '-'] <signless-integer> | '+'?† n ['+' | '-'] <signless-integer> | -n ['+' | '-'] <signless-integer>"
+    },
+    {
+      "name": "<anchor()>",
+      "syntax": "anchor( <anchor-name>? && <anchor-side>, <length-percentage>? )"
     },
     {
       "name": "<anchor-name>",
@@ -6592,16 +6626,16 @@
       "syntax": "inside | outside | top | left | right | bottom | start | end | self-start | self-end | <percentage> | center"
     },
     {
+      "name": "<anchor-size()>",
+      "syntax": "anchor-size( [ <anchor-name> || <anchor-size> ]? , <length-percentage>? )"
+    },
+    {
       "name": "<anchor-size>",
       "syntax": "width | height | block | inline | self-block | self-inline"
     },
     {
       "name": "<angle-percentage>",
-      "syntax": "<angle> | <percentage>"
-    },
-    {
-      "name": "<angle>",
-      "syntax": ""
+      "syntax": "[ <angle> | <percentage> ]"
     },
     {
       "name": "<angular-color-hint>",
@@ -6624,8 +6658,36 @@
       "syntax": "none | play | play-once | play-forwards | play-backwards | pause | reset | replay"
     },
     {
+      "name": "<arc-command>",
+      "syntax": "arc <command-end-point> [ [ of <length-percentage>{1,2} ] && <arc-sweep>? && <arc-size>? && [rotate <angle>]? ]"
+    },
+    {
+      "name": "<arc-size>",
+      "syntax": "large | small"
+    },
+    {
+      "name": "<arc-sweep>",
+      "syntax": "cw | ccw"
+    },
+    {
+      "name": "<asin()>",
+      "syntax": "asin( <calc-sum> )"
+    },
+    {
+      "name": "<atan()>",
+      "syntax": "atan( <calc-sum> )"
+    },
+    {
+      "name": "<atan2()>",
+      "syntax": "atan2( <calc-sum>, <calc-sum> )"
+    },
+    {
       "name": "<attachment>",
       "syntax": "scroll | fixed | local"
+    },
+    {
+      "name": "<attr()>",
+      "syntax": "attr( <attr-name> <attr-type>? , <declaration-value>? )"
     },
     {
       "name": "<attr-matcher>",
@@ -6644,20 +6706,52 @@
       "syntax": "'[' <wq-name> ']' | '[' <wq-name> <attr-matcher> [ <string-token> | <ident-token> ] <attr-modifier>? ']'"
     },
     {
+      "name": "<auto-line-color-list>",
+      "syntax": "<line-color-or-repeat>#? ',' <auto-repeat-line-color> ',' <line-color-or-repeat>#?"
+    },
+    {
+      "name": "<auto-line-style-list>",
+      "syntax": "<line-style-or-repeat>#? ',' <auto-repeat-line-style> ',' <line-style-or-repeat>#?"
+    },
+    {
+      "name": "<auto-line-width-list>",
+      "syntax": "<line-width-or-repeat>#? ',' <auto-repeat-line-width> ',' <line-width-or-repeat>#?"
+    },
+    {
+      "name": "<auto-repeat-line-color>",
+      "syntax": "repeat( auto ',' [ <color> ]# )"
+    },
+    {
+      "name": "<auto-repeat-line-style>",
+      "syntax": "repeat( auto ',' [ <line-style> ]# )"
+    },
+    {
+      "name": "<auto-repeat-line-width>",
+      "syntax": "repeat( auto ',' [ <line-width> ]# )"
+    },
+    {
       "name": "<auto-repeat>",
-      "syntax": "repeat( [ auto-fill | auto-fit ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
+      "syntax": "repeat( [ auto-fill | auto-fit ] ',' [ <line-names>? <fixed-size> ]+ <line-names>? )"
     },
     {
       "name": "<auto-track-list>",
-      "syntax": "[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>? <auto-repeat>\n[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>?"
+      "syntax": "[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>? <auto-repeat> [ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>?"
     },
     {
       "name": "<axis>",
       "syntax": "block | inline | x | y"
     },
     {
+      "name": "<base-descriptor>",
+      "syntax": "base-url ':' stylesheet | document | <url>"
+    },
+    {
+      "name": "<baseline-metric>",
+      "syntax": "text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top"
+    },
+    {
       "name": "<baseline-position>",
-      "syntax": "[ first | last ]? baseline"
+      "syntax": "[ first | last ]? && baseline"
     },
     {
       "name": "<basic-shape-rect>",
@@ -6665,7 +6759,7 @@
     },
     {
       "name": "<basic-shape>",
-      "syntax": "<inset()> | <xywh()> | <rect()> | <circle()> | <ellipse()> | <polygon()> | <path()> | shape()"
+      "syntax": "<basic-shape-rect> | <circle()> | <ellipse()> | <polygon()> | <path()> | <shape()>"
     },
     {
       "name": "<bg-clip>",
@@ -6689,15 +6783,55 @@
     },
     {
       "name": "<blend-mode>",
-      "syntax": "normal | multiply | screen | overlay | darken | lighten | color-dodge | color-burn | hard-light | soft-light | difference | exclusion | hue | saturation | color | luminosity"
+      "syntax": "normal | darken | multiply | color-burn | lighten | screen | color-dodge | overlay | soft-light | hard-light | difference | exclusion | hue | saturation | color | luminosity"
+    },
+    {
+      "name": "<blur()>",
+      "syntax": "blur( <length>? )"
+    },
+    {
+      "name": "<border-radius>",
+      "syntax": "<slash-separated-border-radius-syntax> | <legacy-border-radius-syntax>"
+    },
+    {
+      "name": "<box-shadow-blur>",
+      "syntax": "<length [0,∞]>#"
+    },
+    {
+      "name": "<box-shadow-color>",
+      "syntax": "<color>#"
+    },
+    {
+      "name": "<box-shadow-position>",
+      "syntax": "[ outset | inset ]#"
+    },
+    {
+      "name": "<box-shadow-spread>",
+      "syntax": "<length>#"
+    },
+    {
+      "name": "<brightness()>",
+      "syntax": "brightness( [ <number> | <percentage> ]? )"
+    },
+    {
+      "name": "<calc()>",
+      "syntax": "calc( <calc-sum> )"
     },
     {
       "name": "<calc-constant>",
       "syntax": "e | pi | infinity | -infinity | NaN"
     },
     {
+      "name": "<calc-keyword>",
+      "syntax": "e | pi | infinity | -infinity | NaN"
+    },
+    {
       "name": "<calc-product>",
-      "syntax": "<calc-value> [ '*' <calc-value> | '/' <number> ]*"
+      "syntax": "<calc-value> [ [ '*' | / ] <calc-value> ]*"
+    },
+    {
+      "name": "<calc-size()>",
+      "syntax": "calc-size( <calc-size-basis>, <calc-sum> )"
     },
     {
       "name": "<calc-size-basis>",
@@ -6709,7 +6843,7 @@
     },
     {
       "name": "<calc-value>",
-      "syntax": "<number> | <dimension> | <percentage> | <calc-constant> | ( <calc-sum> )"
+      "syntax": "<number> | <dimension> | <percentage> | <calc-keyword> | '(' <calc-sum> ')'"
     },
     {
       "name": "<cf-final-image>",
@@ -6720,6 +6854,14 @@
       "syntax": "<percentage>? && <image>"
     },
     {
+      "name": "<circle()>",
+      "syntax": "circle( <radial-size>? [ at <position> ]? )"
+    },
+    {
+      "name": "<clamp()>",
+      "syntax": "clamp( <calc-sum>#{3} )"
+    },
+    {
       "name": "<class-selector>",
       "syntax": "'.' <ident-token>"
     },
@@ -6728,16 +6870,32 @@
       "syntax": "<url>"
     },
     {
+      "name": "<color()>",
+      "syntax": "color( [ from <color> ]? <colorspace-params> [ / [ <alpha-value> | none ] ]? )"
+    },
+    {
       "name": "<color-base>",
-      "syntax": "<hex-color> | <color-function> | <named-color> | <color-mix()> | transparent"
+      "syntax": "<hex-color> | <color-function> | <named-color> | transparent"
+    },
+    {
+      "name": "<color-font-tech>",
+      "syntax": "[ color-COLRv0 | color-COLRv1 | color-SVG | color-sbix | color-CBDT ]"
     },
     {
       "name": "<color-function>",
-      "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <oklab()> | <oklch()> | <color()>"
+      "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <oklab()> | <oklch()> | <ictcp()> | <jzazbz()> | <jzczhz()> | <alpha()> | <color()> | <hdr-color()>"
     },
     {
       "name": "<color-interpolation-method>",
-      "syntax": "in [ <rectangular-color-space> | <polar-color-space> <hue-interpolation-method>? | <custom-color-space> ]"
+      "syntax": "in [ <rectangular-color-space> | <polar-color-space> <hue-interpolation-method>? ]"
+    },
+    {
+      "name": "<color-mix()>",
+      "syntax": "color-mix( <color-interpolation-method> , [ <color> && <percentage [0,100]>? ]#{2})"
+    },
+    {
+      "name": "<color-space>",
+      "syntax": "<rectangular-color-space> | <polar-color-space>"
     },
     {
       "name": "<color-stop-angle>",
@@ -6749,7 +6907,7 @@
     },
     {
       "name": "<color-stop-list>",
-      "syntax": "<linear-color-stop> , [ <linear-color-hint>? , <linear-color-stop> ]#?"
+      "syntax": "<linear-color-stop> ',' [ <linear-color-hint>? ',' <linear-color-stop> ]#?"
     },
     {
       "name": "<color-stop>",
@@ -6757,15 +6915,19 @@
     },
     {
       "name": "<color>",
-      "syntax": "<color-base> | currentColor | <system-color> | <light-dark()> | <deprecated-system-color>"
+      "syntax": "<color-base> | currentColor | <system-color>"
     },
     {
       "name": "<colorspace-params>",
-      "syntax": "[<custom-params> | <predefined-rgb-params> | <xyz-params>]"
+      "syntax": "[ <predefined-rgb-params> | <xyz-params>]"
     },
     {
       "name": "<combinator>",
-      "syntax": "'>' | '+' | '~' | [ '||' ]"
+      "syntax": "'>' | '+' | '~'"
+    },
+    {
+      "name": "<command-end-point>",
+      "syntax": "[ to <position> | by <coordinate-pair> ]"
     },
     {
       "name": "<common-lig-values>",
@@ -6780,12 +6942,28 @@
       "syntax": "textfield | menulist-button"
     },
     {
+      "name": "<complex-real-selector-list>",
+      "syntax": "<complex-real-selector>#"
+    },
+    {
+      "name": "<complex-real-selector>",
+      "syntax": "<compound-selector> [ <combinator>? <compound-selector> ]*"
+    },
+    {
       "name": "<complex-selector-list>",
       "syntax": "<complex-selector>#"
     },
     {
+      "name": "<complex-selector-unit>",
+      "syntax": "[ <compound-selector>? <pseudo-compound-selector>* ]!"
+    },
+    {
       "name": "<complex-selector>",
-      "syntax": "<compound-selector> [ <combinator>? <compound-selector> ]*"
+      "syntax": "<complex-selector-unit> [ <combinator>? <complex-selector-unit> ]*"
+    },
+    {
+      "name": "<composite-mode>",
+      "syntax": "clear | copy | source-over | destination-over | source-in | destination-in | source-out | destination-out | source-atop | destination-atop | xor | lighter | plus-darker | plus-lighter"
     },
     {
       "name": "<composite-style>",
@@ -6801,7 +6979,11 @@
     },
     {
       "name": "<compound-selector>",
-      "syntax": "[ <type-selector>? <subclass-selector>* [ <pseudo-element-selector> <pseudo-class-selector>* ]* ]!"
+      "syntax": "[ <type-selector>? <subclass-selector>* ]!"
+    },
+    {
+      "name": "<conic-gradient()>",
+      "syntax": "conic-gradient( [ <conic-gradient-syntax> ] )"
     },
     {
       "name": "<conic-gradient-syntax>",
@@ -6825,7 +7007,7 @@
     },
     {
       "name": "<content-list>",
-      "syntax": "[ <string> | <image> | <attr()> | <quote> | <counter> ]+"
+      "syntax": "[ <string> | <image> | <attr()> | contents | <quote> | <leader()> | <target> | <string()> | <content()> | <counter> ]+"
     },
     {
       "name": "<content-position>",
@@ -6840,12 +7022,32 @@
       "syntax": "[ contextual | no-contextual ]"
     },
     {
+      "name": "<contrast()>",
+      "syntax": "contrast( [ <number> | <percentage> ]? )"
+    },
+    {
+      "name": "<control-point>",
+      "syntax": "[ <position> | <relative-control-point> ]"
+    },
+    {
       "name": "<coord-box>",
       "syntax": "<paint-box> | view-box"
     },
     {
+      "name": "<coordinate-pair>",
+      "syntax": "<length-percentage>{2}"
+    },
+    {
       "name": "<corner-shape-value>",
       "syntax": "round | scoop | bevel | notch | square | squircle | <superellipse()>"
+    },
+    {
+      "name": "<cos()>",
+      "syntax": "cos( <calc-sum> )"
+    },
+    {
+      "name": "<counter()>",
+      "syntax": "counter( <counter-name>, <counter-style>? )"
     },
     {
       "name": "<counter-name>",
@@ -6857,51 +7059,79 @@
     },
     {
       "name": "<counter-style>",
-      "syntax": "<counter-style-name> | symbols()"
+      "syntax": "<counter-style-name> | <symbols()>"
     },
     {
       "name": "<counter>",
       "syntax": "<counter()> | <counters()>"
     },
     {
+      "name": "<counters()>",
+      "syntax": "counters( <counter-name>, <string>, <counter-style>? )"
+    },
+    {
+      "name": "<cross-fade()>",
+      "syntax": "cross-fade( <cf-mixing-image> , <cf-final-image>? )"
+    },
+    {
+      "name": "<css-type>",
+      "syntax": "<syntax-component> | <type()>"
+    },
+    {
+      "name": "<cubic-bezier()>",
+      "syntax": "cubic-bezier( [ <number [0,1]>, <number> ]#{2} )"
+    },
+    {
       "name": "<cubic-bezier-easing-function>",
       "syntax": "ease | ease-in | ease-out | ease-in-out | <cubic-bezier()>"
     },
     {
+      "name": "<cursor-image>",
+      "syntax": "[ <url> | <url-set> ] <number>{2}?"
+    },
+    {
       "name": "<cursor-predefined>",
-      "syntax": "auto | default | none | context-menu | help | pointer | progress | wait | cell | crosshair | text | vertical-text | alias | copy | move | no-drop | not-allowed | e-resize | n-resize | ne-resize | nw-resize | s-resize | se-resize | sw-resize | w-resize | ew-resize | ns-resize | nesw-resize | nwse-resize | col-resize | row-resize | all-scroll | zoom-in | zoom-out | grab | grabbing"
+      "syntax": "auto | default | none | context-menu | help | pointer | progress | wait | cell | crosshair | text | vertical-text | alias | copy | move | no-drop | not-allowed | grab | grabbing | e-resize | n-resize | ne-resize | nw-resize | s-resize | se-resize | sw-resize | w-resize | ew-resize | ns-resize | nesw-resize | nwse-resize | col-resize | row-resize | all-scroll | zoom-in | zoom-out"
+    },
+    {
+      "name": "<curve-command>",
+      "syntax": "curve [ [ to <position> with <control-point> [ / <control-point> ]? ] | [ by <coordinate-pair> with <relative-control-point> [ / <relative-control-point> ]? ] ]"
+    },
+    {
+      "name": "<custom-arg>",
+      "syntax": "'$' <ident-token>"
     },
     {
       "name": "<custom-color-space>",
       "syntax": "<dashed-ident>"
     },
     {
-      "name": "<custom-ident>",
-      "syntax": ""
-    },
-    {
       "name": "<custom-params>",
       "syntax": "<dashed-ident> [ <number> | <percentage> | none ]+"
+    },
+    {
+      "name": "<custom-selector>",
+      "syntax": "<custom-arg>? ':' <extension-name> [ '(' <custom-arg>+#? ')' ]?"
     },
     {
       "name": "<dasharray>",
       "syntax": "[ [ <length-percentage> | <number> ]+ ]#"
     },
     {
-      "name": "<dashed-ident>",
-      "syntax": ""
-    },
-    {
       "name": "<dashndashdigit-ident>",
       "syntax": "<ident-token>"
     },
     {
-      "name": "<deprecated-system-color>",
+      "name": "<default-value>",
+      "syntax": "<declaration-value>"
+    },
+    {
+      "name": "<deprecated-color>",
       "syntax": "ActiveBorder | ActiveCaption | AppWorkspace | Background | ButtonHighlight | ButtonShadow | CaptionText | InactiveBorder | InactiveCaption | InactiveCaptionText | InfoBackground | InfoText | Menu | MenuText | Scrollbar | ThreeDDarkShadow | ThreeDFace | ThreeDHighlight | ThreeDLightShadow | ThreeDShadow | Window | WindowFrame | WindowText"
     },
     {
-      "name": "<dimension>",
-      "syntax": ""
+      "name": "<deprecated-system-color>",
+      "syntax": "ActiveBorder | ActiveCaption | AppWorkspace | Background | ButtonHighlight | ButtonShadow | CaptionText | InactiveBorder | InactiveCaption | InactiveCaptionText | InfoBackground | InfoText | Menu | MenuText | Scrollbar | ThreeDDarkShadow | ThreeDFace | ThreeDHighlight | ThreeDLightShadow | ThreeDShadow | Window | WindowFrame | WindowText"
     },
     {
       "name": "<discretionary-lig-values>",
@@ -6921,7 +7151,7 @@
     },
     {
       "name": "<display-legacy>",
-      "syntax": "inline-block | inline-list-item | inline-table | inline-flex | inline-grid"
+      "syntax": "inline-block | inline-table | inline-flex | inline-grid"
     },
     {
       "name": "<display-listitem>",
@@ -6930,6 +7160,14 @@
     {
       "name": "<display-outside>",
       "syntax": "block | inline | run-in"
+    },
+    {
+      "name": "<drop-shadow()>",
+      "syntax": "drop-shadow( [ <color>? && <length>{2,3} ] )"
+    },
+    {
+      "name": "<dynamic-range-limit-mix()>",
+      "syntax": "dynamic-range-limit-mix( [ <'dynamic-range-limit'> && <percentage [0,100]> ]#{2,} )"
     },
     {
       "name": "<easing-function>",
@@ -6944,6 +7182,30 @@
       "syntax": "[ full-width | proportional-width ]"
     },
     {
+      "name": "<element()>",
+      "syntax": "element( <id-selector> )"
+    },
+    {
+      "name": "<ellipse()>",
+      "syntax": "ellipse( <radial-size>? [ at <position> ]? )"
+    },
+    {
+      "name": "<env()>",
+      "syntax": "env( <custom-ident> , <declaration-value>? )"
+    },
+    {
+      "name": "<env-args>",
+      "syntax": "env( <declaration-value>, <declaration-value>? )"
+    },
+    {
+      "name": "<event-trigger-event>",
+      "syntax": "activate | interest | click | touch | dblclick | keypress(<string>) | ..."
+    },
+    {
+      "name": "<exp()>",
+      "syntax": "exp( <calc-sum> )"
+    },
+    {
       "name": "<explicit-track-list>",
       "syntax": "[ <line-names>? <track-size> ]+ <line-names>?"
     },
@@ -6953,7 +7215,7 @@
     },
     {
       "name": "<feature-tag-value>",
-      "syntax": "<string> [ <integer> | on | off ]?"
+      "syntax": "<opentype-tag> [ <integer [0,∞]> | on | off ]?"
     },
     {
       "name": "<feature-type>",
@@ -6981,7 +7243,7 @@
     },
     {
       "name": "<filter-function>",
-      "syntax": "<blur()> | <brightness()> | <contrast()> | <drop-shadow()> | <grayscale()> | <hue-rotate()> | <invert()> | <opacity()> | <saturate()> | <sepia()>"
+      "syntax": "<blur()> | <brightness()> | <contrast()> | <drop-shadow()> | <grayscale()> | <hue-rotate()> | <invert()> | <opacity()> | <sepia()> | <saturate()>"
     },
     {
       "name": "<filter-value-list>",
@@ -6992,24 +7254,52 @@
       "syntax": "<bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <visual-box> || <visual-box> || <'background-color'>"
     },
     {
+      "name": "<fit-content()>",
+      "syntax": "fit-content( <length-percentage [0,∞]> )"
+    },
+    {
       "name": "<fixed-breadth>",
-      "syntax": "<length-percentage>"
+      "syntax": "<length-percentage [0,∞]>"
     },
     {
       "name": "<fixed-repeat>",
-      "syntax": "repeat( [ <integer [1,∞]> ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
+      "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-names>? <fixed-size> ]+ <line-names>? )"
     },
     {
       "name": "<fixed-size>",
-      "syntax": "<fixed-breadth> | minmax( <fixed-breadth> , <track-breadth> ) | minmax( <inflexible-breadth> , <fixed-breadth> )"
+      "syntax": "<fixed-breadth> | minmax( <fixed-breadth> ',' <track-breadth> ) | minmax( <inflexible-breadth> ',' <fixed-breadth> )"
     },
     {
-      "name": "<flex>",
-      "syntax": ""
+      "name": "<font-family-name>",
+      "syntax": "<string> | <custom-ident>+"
+    },
+    {
+      "name": "<font-feature-index>",
+      "syntax": "<integer>"
+    },
+    {
+      "name": "<font-feature-value-name>",
+      "syntax": "<ident>"
+    },
+    {
+      "name": "<font-features-tech>",
+      "syntax": "[ features-opentype | features-aat | features-graphite ]"
+    },
+    {
+      "name": "<font-format>",
+      "syntax": "[ <string> | collection | embedded-opentype | opentype | svg | truetype | woff | woff2 ]"
+    },
+    {
+      "name": "<font-src>",
+      "syntax": "<url> [ format( <font-format> ) ]? [ tech( <font-tech># ) ]? | local( <font-family-name> )"
     },
     {
       "name": "<font-stretch-absolute>",
       "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded | <percentage>"
+    },
+    {
+      "name": "<font-tech>",
+      "syntax": "[ <font-features-tech> | <color-font-tech> | variations | palettes | incremental ]"
     },
     {
       "name": "<font-variant-css2>",
@@ -7017,7 +7307,7 @@
     },
     {
       "name": "<font-weight-absolute>",
-      "syntax": "normal | bold | <number [1,1000]>"
+      "syntax": "[ normal | bold | <number [1,1000]> ]"
     },
     {
       "name": "<font-width-css3>",
@@ -7029,15 +7319,39 @@
     },
     {
       "name": "<frequency-percentage>",
-      "syntax": "<frequency> | <percentage>"
+      "syntax": "[ <frequency> | <percentage> ]"
     },
     {
-      "name": "<frequency>",
-      "syntax": ""
+      "name": "<function-parameter>",
+      "syntax": "<custom-property-name> <css-type>? [ ':' <default-value> ]?"
+    },
+    {
+      "name": "<gap-auto-repeat-rule>",
+      "syntax": "repeat( auto ',' <gap-rule># )"
+    },
+    {
+      "name": "<gap-auto-rule-list>",
+      "syntax": "<gap-rule-or-repeat>#? ',' <gap-auto-repeat-rule> ',' <gap-rule-or-repeat>#?"
+    },
+    {
+      "name": "<gap-repeat-rule>",
+      "syntax": "repeat( <integer [1,∞]> ',' <gap-rule># )"
+    },
+    {
+      "name": "<gap-rule-list>",
+      "syntax": "<gap-rule-or-repeat>#"
+    },
+    {
+      "name": "<gap-rule-or-repeat>",
+      "syntax": "<gap-rule> | <gap-repeat-rule>"
+    },
+    {
+      "name": "<gap-rule>",
+      "syntax": "<line-width> || <line-style> || <color>"
     },
     {
       "name": "<general-enclosed>",
-      "syntax": "[ <function-token> <any-value> ) ] | ( <ident> <any-value> )"
+      "syntax": "[ <function-token> <any-value>? ')' ] | [ '(' <any-value>? ')' ]"
     },
     {
       "name": "<generic-complete>",
@@ -7048,8 +7362,28 @@
       "syntax": "<generic-complete> | <generic-incomplete> | emoji | fangsong"
     },
     {
+      "name": "<generic-font-complete>",
+      "syntax": "serif | sans-serif | system-ui | cursive | fantasy | math | monospace"
+    },
+    {
+      "name": "<generic-font-family>",
+      "syntax": "<generic-font-script-specific>| <generic-font-complete> | <generic-font-incomplete>"
+    },
+    {
+      "name": "<generic-font-incomplete>",
+      "syntax": "ui-serif | ui-sans-serif | ui-monospace | ui-rounded"
+    },
+    {
+      "name": "<generic-font-script-specific>",
+      "syntax": "generic(fangsong) | generic(kai) | generic(khmer-mul) | generic(nastaliq)"
+    },
+    {
       "name": "<generic-incomplete>",
       "syntax": "ui-serif | ui-sans-serif | ui-monospace | ui-rounded"
+    },
+    {
+      "name": "<generic-voice>",
+      "syntax": "<age>? <gender> <integer [1,∞]>?"
     },
     {
       "name": "<geometry-box>",
@@ -7057,31 +7391,63 @@
     },
     {
       "name": "<gradient>",
-      "syntax": "<linear-gradient()> | <repeating-linear-gradient()> | <radial-gradient()> | <repeating-radial-gradient()> | <conic-gradient()> | <repeating-conic-gradient()>"
+      "syntax": "<linear-gradient()> | <repeating-linear-gradient()> | <radial-gradient()> | <repeating-radial-gradient()>"
+    },
+    {
+      "name": "<grayscale()>",
+      "syntax": "grayscale( [ <number> | <percentage> ]? )"
     },
     {
       "name": "<grid-line>",
-      "syntax": "auto | <custom-ident> | [ <integer> && <custom-ident>? ] | [ span && [ <integer> || <custom-ident> ] ]"
+      "syntax": "auto | <custom-ident> | [ [ <integer [-∞,-1]> | <integer [1,∞]> ] && <custom-ident>? ] | [ span && [ <integer [1,∞]> || <custom-ident> ] ]"
     },
     {
       "name": "<historical-lig-values>",
       "syntax": "[ historical-ligatures | no-historical-ligatures ]"
     },
     {
+      "name": "<horizontal-line-command>",
+      "syntax": "hline [ to [ <length-percentage> | left | center | right | x-start | x-end ] | by <length-percentage> ]"
+    },
+    {
+      "name": "<hsl()>",
+      "syntax": "hsl( <hue>, <percentage>, <percentage>, <alpha-value>? ) | hsl( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
+    },
+    {
+      "name": "<hsla()>",
+      "syntax": "hsla( <hue>, <percentage>, <percentage>, <alpha-value>? ) | hsla( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
+    },
+    {
       "name": "<hue-interpolation-method>",
       "syntax": "[ shorter | longer | increasing | decreasing ] hue"
+    },
+    {
+      "name": "<hue-rotate()>",
+      "syntax": "hue-rotate( [ <angle> | <zero> ]? )"
     },
     {
       "name": "<hue>",
       "syntax": "<number> | <angle>"
     },
     {
+      "name": "<hwb()>",
+      "syntax": "hwb( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
+    },
+    {
+      "name": "<hypot()>",
+      "syntax": "hypot( <calc-sum># )"
+    },
+    {
       "name": "<id-selector>",
       "syntax": "<hash-token>"
     },
     {
-      "name": "<ident>",
-      "syntax": ""
+      "name": "<image()>",
+      "syntax": "image( <image-tags>? [ <image-src>? , <color>? ]! )"
+    },
+    {
+      "name": "<image-set()>",
+      "syntax": "image-set( <image-set-option># )"
     },
     {
       "name": "<image-set-option>",
@@ -7097,43 +7463,127 @@
     },
     {
       "name": "<image>",
-      "syntax": "<url> | <image()> | <image-set()> | <element()> | <paint()> | <cross-fade()> | <gradient>"
+      "syntax": "<url> | <gradient>"
+    },
+    {
+      "name": "<import-conditions>",
+      "syntax": "[ supports( [ <supports-condition> | <declaration> ] ) ]? <media-query-list>?"
     },
     {
       "name": "<inflexible-breadth>",
-      "syntax": "<length-percentage> | min-content | max-content | auto"
+      "syntax": "<length-percentage [0,∞]> | min-content | max-content | auto"
+    },
+    {
+      "name": "<init-descriptor-name>",
+      "syntax": "protocol | hostname | port | pathname | search | hash"
+    },
+    {
+      "name": "<init-descriptor>",
+      "syntax": "<init-descriptor-name> ':' <string>"
+    },
+    {
+      "name": "<inset()>",
+      "syntax": "inset( <length-percentage>{1,4} [ round <'border-radius'> ]? )"
+    },
+    {
+      "name": "<inset-value>",
+      "syntax": "<length-percentage> | overlap-join"
     },
     {
       "name": "<integer>",
       "syntax": "<number-token>"
     },
     {
+      "name": "<invert()>",
+      "syntax": "invert( [ <number> | <percentage> ]? )"
+    },
+    {
+      "name": "<isolation-mode>",
+      "syntax": "auto | isolate"
+    },
+    {
       "name": "<keyframe-block>",
-      "syntax": "<keyframe-selector># {\n  <declaration-list>\n}"
+      "syntax": "<keyframe-selector># '{' <declaration-list> '}'"
     },
     {
       "name": "<keyframe-selector>",
-      "syntax": "from | to | <percentage [0,100]> | <timeline-range-name> <percentage>"
+      "syntax": "from | to | <percentage [0,100]>"
     },
     {
       "name": "<keyframes-name>",
       "syntax": "<custom-ident> | <string>"
     },
     {
+      "name": "<lab()>",
+      "syntax": "lab( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "<layer()>",
+      "syntax": "layer( <layer-name> )"
+    },
+    {
       "name": "<layer-name>",
       "syntax": "<ident> [ '.' <ident> ]*"
+    },
+    {
+      "name": "<layout-box>",
+      "syntax": "<visual-box> | margin-box"
+    },
+    {
+      "name": "<lch()>",
+      "syntax": "lch( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "<leader()>",
+      "syntax": "leader( <leader-type> )"
     },
     {
       "name": "<leader-type>",
       "syntax": "dotted | solid | space | <string>"
     },
     {
-      "name": "<length-percentage>",
-      "syntax": "<length> | <percentage>"
+      "name": "<legacy-border-radius-syntax>",
+      "syntax": "<length-percentage [0,∞]>{1,2}"
     },
     {
-      "name": "<length>",
-      "syntax": ""
+      "name": "<legacy-hsl-syntax>",
+      "syntax": "hsl( <hue>, <percentage>, <percentage>, <alpha-value>? )"
+    },
+    {
+      "name": "<legacy-hsla-syntax>",
+      "syntax": "hsla( <hue>, <percentage>, <percentage>, <alpha-value>? )"
+    },
+    {
+      "name": "<legacy-pseudo-element-selector>",
+      "syntax": "':' [before | after | first-line | first-letter]"
+    },
+    {
+      "name": "<legacy-rgb-syntax>",
+      "syntax": "rgb( <percentage>#{3} ',' <alpha-value>? ) | rgb( <number>#{3} ',' <alpha-value>? )"
+    },
+    {
+      "name": "<legacy-rgba-syntax>",
+      "syntax": "rgba( <percentage>#{3} ',' <alpha-value>? ) | rgba( <number>#{3} ',' <alpha-value>? )"
+    },
+    {
+      "name": "<length-percentage>",
+      "syntax": "[ <length> | <percentage> ]"
+    },
+    {
+      "name": "<light-dark()>",
+      "syntax": "light-dark( <color>, <color> )"
+    },
+    {
+      "name": "<line-color-list>",
+      "syntax": "<line-color-or-repeat>#"
+    },
+    {
+      "name": "<line-color-or-repeat>",
+      "syntax": "[ <color> | <repeat-line-color> ]"
+    },
+    {
+      "name": "<line-command>",
+      "syntax": "line <command-end-point>"
     },
     {
       "name": "<line-name-list>",
@@ -7144,12 +7594,32 @@
       "syntax": "'[' <custom-ident>* ']'"
     },
     {
+      "name": "<line-style-list>",
+      "syntax": "<line-style-or-repeat>#"
+    },
+    {
+      "name": "<line-style-or-repeat>",
+      "syntax": "[ <line-style> | <repeat-line-style> ]"
+    },
+    {
       "name": "<line-style>",
       "syntax": "none | hidden | dotted | dashed | solid | double | groove | ridge | inset | outset"
     },
     {
+      "name": "<line-width-list>",
+      "syntax": "<line-width-or-repeat>#"
+    },
+    {
+      "name": "<line-width-or-repeat>",
+      "syntax": "[ <line-width> | <repeat-line-width> ]"
+    },
+    {
       "name": "<line-width>",
-      "syntax": "<length> | thin | medium | thick"
+      "syntax": "<length [0,∞]> | hairline | thin | medium | thick"
+    },
+    {
+      "name": "<linear()>",
+      "syntax": "linear( [ <number> && <percentage>{0,2} ]# )"
     },
     {
       "name": "<linear-color-hint>",
@@ -7157,15 +7627,27 @@
     },
     {
       "name": "<linear-color-stop>",
-      "syntax": "<color> <color-stop-length>?"
+      "syntax": "<color> <length-percentage>?"
     },
     {
       "name": "<linear-easing-function>",
       "syntax": "linear | <linear()>"
     },
     {
+      "name": "<linear-gradient()>",
+      "syntax": "linear-gradient( [ <linear-gradient-syntax> ] )"
+    },
+    {
       "name": "<linear-gradient-syntax>",
-      "syntax": "[ [ <angle> | <zero> | to <side-or-corner> ] || <color-interpolation-method> ]? , <color-stop-list>"
+      "syntax": "[ <angle> | <zero> | to <side-or-corner> ]? ',' <color-stop-list>"
+    },
+    {
+      "name": "<log()>",
+      "syntax": "log( <calc-sum>, <calc-sum>? )"
+    },
+    {
+      "name": "<marker-ref>",
+      "syntax": "<url>"
     },
     {
       "name": "<mask-layer>",
@@ -7188,24 +7670,36 @@
       "syntax": "alpha | luminance | match-source"
     },
     {
+      "name": "<matrix()>",
+      "syntax": "matrix( <number>#{6} )"
+    },
+    {
+      "name": "<matrix3d()>",
+      "syntax": "matrix3d( <number>#{16} )"
+    },
+    {
+      "name": "<max()>",
+      "syntax": "max( <calc-sum># )"
+    },
+    {
       "name": "<media-and>",
-      "syntax": "<media-in-parens> [ and <media-in-parens> ]+"
+      "syntax": "and <media-in-parens>"
     },
     {
       "name": "<media-condition-without-or>",
-      "syntax": "<media-not> | <media-and> | <media-in-parens>"
+      "syntax": "<media-not> | <media-in-parens> <media-and>*"
     },
     {
       "name": "<media-condition>",
-      "syntax": "<media-not> | <media-and> | <media-or> | <media-in-parens>"
+      "syntax": "<media-not> | <media-in-parens> [ <media-and>* | <media-or>* ]"
     },
     {
       "name": "<media-feature>",
-      "syntax": "( [ <mf-plain> | <mf-boolean> | <mf-range> ] )"
+      "syntax": "[ <mf-plain> | <mf-boolean> | <mf-range> ]"
     },
     {
       "name": "<media-in-parens>",
-      "syntax": "( <media-condition> ) | <media-feature> | <general-enclosed>"
+      "syntax": "'(' <media-condition> ')' | '(' <media-feature> ')' | <general-enclosed>"
     },
     {
       "name": "<media-not>",
@@ -7213,7 +7707,7 @@
     },
     {
       "name": "<media-or>",
-      "syntax": "<media-in-parens> [ or <media-in-parens> ]+"
+      "syntax": "or <media-in-parens>"
     },
     {
       "name": "<media-query-list>",
@@ -7232,20 +7726,72 @@
       "syntax": "<mf-name>"
     },
     {
+      "name": "<mf-comparison>",
+      "syntax": "<mf-lt> | <mf-gt> | <mf-eq>"
+    },
+    {
+      "name": "<mf-eq>",
+      "syntax": "'='"
+    },
+    {
+      "name": "<mf-gt>",
+      "syntax": "'>' '='?"
+    },
+    {
+      "name": "<mf-lt>",
+      "syntax": "'<' '='?"
+    },
+    {
       "name": "<mf-name>",
       "syntax": "<ident>"
     },
     {
       "name": "<mf-plain>",
-      "syntax": "<mf-name> : <mf-value>"
+      "syntax": "<mf-name> ':' <mf-value>"
     },
     {
       "name": "<mf-range>",
-      "syntax": "<mf-name> [ '<' | '>' ]? '='? <mf-value>\n| <mf-value> [ '<' | '>' ]? '='? <mf-name>\n| <mf-value> '<' '='? <mf-name> '<' '='? <mf-value>\n| <mf-value> '>' '='? <mf-name> '>' '='? <mf-value>"
+      "syntax": "<mf-name> <mf-comparison> <mf-value> | <mf-value> <mf-comparison> <mf-name> | <mf-value> <mf-lt> <mf-name> <mf-lt> <mf-value> | <mf-value> <mf-gt> <mf-name> <mf-gt> <mf-value>"
     },
     {
       "name": "<mf-value>",
       "syntax": "<number> | <dimension> | <ident> | <ratio>"
+    },
+    {
+      "name": "<min()>",
+      "syntax": "min( <calc-sum># )"
+    },
+    {
+      "name": "<minmax()>",
+      "syntax": "minmax( [ <length-percentage> | min-content | max-content | auto ] , [ <length-percentage> | <flex> | min-content | max-content | auto ] )"
+    },
+    {
+      "name": "<mod()>",
+      "syntax": "mod( <calc-sum>, <calc-sum> )"
+    },
+    {
+      "name": "<modern-hsl-syntax>",
+      "syntax": "hsl( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "<modern-hsla-syntax>",
+      "syntax": "hsla( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "<modern-rgb-syntax>",
+      "syntax": "rgb( [ <number> | <percentage> | none]{3} [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "<modern-rgba-syntax>",
+      "syntax": "rgba( [ <number> | <percentage> | none]{3} [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "<move-command>",
+      "syntax": "move <command-end-point>"
+    },
+    {
+      "name": "<mq-boolean>",
+      "syntax": "<integer [0,1]>"
     },
     {
       "name": "<n-dimension>",
@@ -7253,15 +7799,55 @@
     },
     {
       "name": "<name-repeat>",
-      "syntax": "repeat( [ <integer [1,∞]> | auto-fill ], <line-names>+ )"
+      "syntax": "repeat( [ <integer [1,∞]> | auto-fill ], <line-names>+)"
     },
     {
       "name": "<named-color>",
-      "syntax": "aliceblue | antiquewhite | aqua | aquamarine | azure | beige | bisque | black | blanchedalmond | blue | blueviolet | brown | burlywood | cadetblue | chartreuse | chocolate | coral | cornflowerblue | cornsilk | crimson | cyan | darkblue | darkcyan | darkgoldenrod | darkgray | darkgreen | darkgrey | darkkhaki | darkmagenta | darkolivegreen | darkorange | darkorchid | darkred | darksalmon | darkseagreen | darkslateblue | darkslategray | darkslategrey | darkturquoise | darkviolet | deeppink | deepskyblue | dimgray | dimgrey | dodgerblue | firebrick | floralwhite | forestgreen | fuchsia | gainsboro | ghostwhite | gold | goldenrod | gray | green | greenyellow | grey | honeydew | hotpink | indianred | indigo | ivory | khaki | lavender | lavenderblush | lawngreen | lemonchiffon | lightblue | lightcoral | lightcyan | lightgoldenrodyellow | lightgray | lightgreen | lightgrey | lightpink | lightsalmon | lightseagreen | lightskyblue | lightslategray | lightslategrey | lightsteelblue | lightyellow | lime | limegreen | linen | magenta | maroon | mediumaquamarine | mediumblue | mediumorchid | mediumpurple | mediumseagreen | mediumslateblue | mediumspringgreen | mediumturquoise | mediumvioletred | midnightblue | mintcream | mistyrose | moccasin | navajowhite | navy | oldlace | olive | olivedrab | orange | orangered | orchid | palegoldenrod | palegreen | paleturquoise | palevioletred | papayawhip | peachpuff | peru | pink | plum | powderblue | purple | rebeccapurple | red | rosybrown | royalblue | saddlebrown | salmon | sandybrown | seagreen | seashell | sienna | silver | skyblue | slateblue | slategray | slategrey | snow | springgreen | steelblue | tan | teal | thistle | tomato | turquoise | violet | wheat | white | whitesmoke | yellow | yellowgreen"
+      "syntax": "aliceblue | antiquewhite | aqua | aquamarine | azure | beige | bisque | black | blanchedalmond | blue | blueviolet | brown | burlywood | cadetblue | chartreuse | chocolate | coral | cornflowerblue | cornsilk | crimson | cyan | darkblue | darkcyan | darkgoldenrod | darkgray | darkgreen | darkgrey | darkkhaki | darkmagenta | darkolivegreen | darkorange | darkorchid | darkred | darksalmon | darkseagreen | darkslateblue | darkslategray | darkslategrey | darkturquoise | darkviolet | deeppink | deepskyblue | dimgray | dimgrey | dodgerblue | firebrick | floralwhite | forestgreen | fuchsia | gainsboro | ghostwhite | gold | goldenrod | gray | green | greenyellow | grey | honeydew | hotpink | indianred | indigo | ivory | khaki | lavender | lavenderblush | lawngreen | lemonchiffon | lightblue | lightcoral | lightcyan | lightgoldenrodyellow | lightgray | lightgreen | lightgrey | lightpink | lightsalmon | lightseagreen | lightskyblue | lightslategray | lightslategrey | lightsteelblue | lightyellow | lime | limegreen | linen | magenta | maroon | mediumaquamarine | mediumblue | mediumorchid | mediumpurple | mediumseagreen | mediumslateblue | mediumspringgreen | mediumturquoise | mediumvioletred | midnightblue | mintcream | mistyrose | moccasin | navajowhite | navy | oldlace | olive | olivedrab | orange | orangered | orchid | palegoldenrod | palegreen | paleturquoise | palevioletred | papayawhip | peachpuff | peru | pink | plum | powderblue | purple | rebeccapurple | red | rosybrown | royalblue | saddlebrown | salmon | sandybrown | seagreen | seashell | sienna | silver | skyblue | slateblue | slategray | slategrey | snow | springgreen | steelblue | tan | teal | thistle | tomato | turquoise | violet | wheat | white | whitesmoke | yellow | yellowgreen | transparent"
     },
     {
       "name": "<namespace-prefix>",
       "syntax": "<ident>"
+    },
+    {
+      "name": "<navigation-condition>",
+      "syntax": "not <navigation-in-parens> | <navigation-in-parens> [ and <navigation-in-parens> ]* | <navigation-in-parens> [ or <navigation-in-parens> ]*"
+    },
+    {
+      "name": "<navigation-in-parens>",
+      "syntax": "'(' <navigation-condition> ')' | '(' <navigation-test> ')' | <general-enclosed>"
+    },
+    {
+      "name": "<navigation-location-between-test>",
+      "syntax": "between ':' <route-location> and <route-location>"
+    },
+    {
+      "name": "<navigation-location-test>",
+      "syntax": "<navigation-relation> ':' <route-location>"
+    },
+    {
+      "name": "<navigation-phase-keyword>",
+      "syntax": "loading | ready | committed"
+    },
+    {
+      "name": "<navigation-phase-test>",
+      "syntax": "phase ':' <navigation-phase-keyword>"
+    },
+    {
+      "name": "<navigation-relation>",
+      "syntax": "at | with | from | to"
+    },
+    {
+      "name": "<navigation-test>",
+      "syntax": "<navigation-location-test> | <navigation-location-between-test> | <navigation-type-test> | <navigation-phase-test>"
+    },
+    {
+      "name": "<navigation-type-keyword>",
+      "syntax": "traverse | back | forward | reload"
+    },
+    {
+      "name": "<navigation-type-test>",
+      "syntax": "history ':' <navigation-type-keyword>"
     },
     {
       "name": "<ndash-dimension>",
@@ -7280,12 +7866,12 @@
       "syntax": "[ <ident-token> | '*' ]? '|'"
     },
     {
-      "name": "<number-percentage>",
-      "syntax": "<number> | <percentage>"
+      "name": "<number-optional-number>",
+      "syntax": "<number> <number>?"
     },
     {
-      "name": "<number>",
-      "syntax": ""
+      "name": "<number-percentage>",
+      "syntax": "<number> | <percentage>"
     },
     {
       "name": "<numeric-figure-values>",
@@ -7304,12 +7890,28 @@
       "syntax": "<ray()> | <url> | <basic-shape>"
     },
     {
+      "name": "<oklab()>",
+      "syntax": "oklab( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "<oklch()>",
+      "syntax": "oklch( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "<opacity()>",
+      "syntax": "opacity( [ <number> | <percentage> ]? )"
+    },
+    {
       "name": "<opacity-value>",
       "syntax": "<number> | <percentage>"
     },
     {
+      "name": "<opentype-tag>",
+      "syntax": "<string>"
+    },
+    {
       "name": "<outline-line-style>",
-      "syntax": "none | dotted | dashed | solid | double | groove | ridge | inset | outset"
+      "syntax": "none | auto | dotted | dashed | solid | double | groove | ridge | inset | outset"
     },
     {
       "name": "<outline-radius>",
@@ -7318,10 +7920,6 @@
     {
       "name": "<overflow-position>",
       "syntax": "unsafe | safe"
-    },
-    {
-      "name": "<overflow>",
-      "syntax": ""
     },
     {
       "name": "<page-body>",
@@ -7337,15 +7935,19 @@
     },
     {
       "name": "<page-selector-list>",
-      "syntax": "[ <page-selector># ]?"
+      "syntax": "<page-selector>#"
     },
     {
       "name": "<page-selector>",
-      "syntax": "<pseudo-page>+ | <ident> <pseudo-page>*"
+      "syntax": "[ <ident-token>? <pseudo-page>* ]!"
     },
     {
       "name": "<page-size>",
       "syntax": "A5 | A4 | A3 | B5 | B4 | JIS-B5 | JIS-B4 | letter | legal | ledger"
+    },
+    {
+      "name": "<paint()>",
+      "syntax": "paint( <ident>, <declaration-value>? )"
     },
     {
       "name": "<paint-box>",
@@ -7353,27 +7955,59 @@
     },
     {
       "name": "<paint>",
-      "syntax": "none | <color> | <url> [none | <color>]? | context-fill | context-stroke"
+      "syntax": "none | <image> | <svg-paint>"
     },
     {
       "name": "<palette-identifier>",
       "syntax": "<dashed-ident>"
     },
     {
-      "name": "<percentage>",
-      "syntax": ""
+      "name": "<palette-mix()>",
+      "syntax": "palette-mix(<color-interpolation-method> , [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})"
+    },
+    {
+      "name": "<path()>",
+      "syntax": "path( <'fill-rule'>? , <string> )"
+    },
+    {
+      "name": "<pattern-descriptor>",
+      "syntax": "pattern ':' <url-pattern()>"
+    },
+    {
+      "name": "<perspective()>",
+      "syntax": "perspective( [ <length [0,∞]> | none ] )"
+    },
+    {
+      "name": "<pointer-axis>",
+      "syntax": "block | inline | x | y"
+    },
+    {
+      "name": "<pointer-source>",
+      "syntax": "root | nearest | self"
+    },
+    {
+      "name": "<points>",
+      "syntax": "[ <number>+ ]#"
     },
     {
       "name": "<polar-color-space>",
       "syntax": "hsl | hwb | lch | oklch"
     },
     {
+      "name": "<polygon()>",
+      "syntax": "polygon( <'fill-rule'>? , [ <length-percentage> <length-percentage> ]# )"
+    },
+    {
       "name": "<position-area>",
-      "syntax": "[ left | center | right | span-left | span-right | x-start | x-end | span-x-start | span-x-end | x-self-start | x-self-end | span-x-self-start | span-x-self-end | span-all ] || [ top | center | bottom | span-top | span-bottom | y-start | y-end | span-y-start | span-y-end | y-self-start | y-self-end | span-y-self-start | span-y-self-end | span-all ] | [ block-start | center | block-end | span-block-start | span-block-end | span-all ] || [ inline-start | center | inline-end | span-inline-start | span-inline-end | span-all ] | [ self-block-start | center | self-block-end | span-self-block-start | span-self-block-end | span-all ] || [ self-inline-start | center | self-inline-end | span-self-inline-start | span-self-inline-end | span-all ] | [ start | center | end | span-start | span-end | span-all ]{1,2} | [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2}"
+      "syntax": "[ [ left | center | right | span-left | span-right | x-start | x-end | span-x-start | span-x-end | self-x-start | self-x-end | span-self-x-start | span-self-x-end | span-all ] || [ top | center | bottom | span-top | span-bottom | y-start | y-end | span-y-start | span-y-end | self-y-start | self-y-end | span-self-y-start | span-self-y-end | span-all ] | [ block-start | center | block-end | span-block-start | span-block-end | span-all ] || [ inline-start | center | inline-end | span-inline-start | span-inline-end | span-all ] | [ self-block-start | center | self-block-end | span-self-block-start | span-self-block-end | span-all ] || [ self-inline-start | center | self-inline-end | span-self-inline-start | span-self-inline-end | span-all ] | [ start | center | end | span-start | span-end | span-all ]{1,2} | [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2} ]"
     },
     {
       "name": "<position>",
-      "syntax": "[ [ left | center | right ] || [ top | center | bottom ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ]? | [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ] ]"
+      "syntax": "[ [ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right ] && [ top | center | bottom ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ] ]"
+    },
+    {
+      "name": "<pow()>",
+      "syntax": "pow( <calc-sum>, <calc-sum> )"
     },
     {
       "name": "<predefined-rgb-params>",
@@ -7381,19 +8015,35 @@
     },
     {
       "name": "<predefined-rgb>",
-      "syntax": "srgb | srgb-linear | display-p3 | display-p3-linear | a98-rgb | prophoto-rgb | rec2020"
+      "syntax": "srgb | srgb-linear | display-p3 | display-p3-linear | a98-rgb | prophoto-rgb | rec2020 | rec2100-pq | rec2100-hlg | rec2100-linear"
     },
     {
       "name": "<pseudo-class-selector>",
       "syntax": "':' <ident-token> | ':' <function-token> <any-value> ')'"
     },
     {
+      "name": "<pseudo-compound-selector>",
+      "syntax": "<pseudo-element-selector> <pseudo-class-selector>*"
+    },
+    {
       "name": "<pseudo-element-selector>",
-      "syntax": "':' <pseudo-class-selector>"
+      "syntax": "':' <pseudo-class-selector> | <legacy-pseudo-element-selector>"
     },
     {
       "name": "<pseudo-page>",
-      "syntax": ": [ left | right | first | blank ]"
+      "syntax": "':' [ left | right | first | blank ]"
+    },
+    {
+      "name": "<pt-class-selector>",
+      "syntax": "['.' <custom-ident>]+"
+    },
+    {
+      "name": "<pt-name-and-class-selector>",
+      "syntax": "<pt-name-selector> <pt-class-selector>? | <pt-class-selector>"
+    },
+    {
+      "name": "<pt-name-selector>",
+      "syntax": "'*' | <custom-ident>"
     },
     {
       "name": "<query-in-parens>",
@@ -7408,8 +8058,12 @@
       "syntax": "closest-corner | closest-side | farthest-corner | farthest-side"
     },
     {
+      "name": "<radial-gradient()>",
+      "syntax": "radial-gradient( [ <radial-gradient-syntax> ] )"
+    },
+    {
       "name": "<radial-gradient-syntax>",
-      "syntax": "[ [ [ <radial-shape> || <radial-size> ]? [ at <position> ]? ] || <color-interpolation-method> ]? , <color-stop-list>"
+      "syntax": "[ <radial-shape> || <radial-size> ]? [ at <position> ]? ',' <color-stop-list>"
     },
     {
       "name": "<radial-shape>",
@@ -7424,12 +8078,32 @@
       "syntax": "<number [0,∞]> [ / <number [0,∞]> ]?"
     },
     {
+      "name": "<ray()>",
+      "syntax": "ray( <angle> && <ray-size>? && contain? && [at <position>]? )"
+    },
+    {
       "name": "<ray-size>",
-      "syntax": "closest-side | closest-corner | farthest-side | farthest-corner | sides"
+      "syntax": "<radial-extent> | sides"
+    },
+    {
+      "name": "<rect()>",
+      "syntax": "rect( [ <length-percentage> | auto ]{4} [ round <'border-radius'> ]? )"
     },
     {
       "name": "<rectangular-color-space>",
-      "syntax": "srgb | srgb-linear | display-p3 | display-p3-linear | a98-rgb | prophoto-rgb | rec2020 | lab | oklab | xyz | xyz-d50 | xyz-d65"
+      "syntax": "srgb | srgb-linear | display-p3 | display-p3-linear | a98-rgb | prophoto-rgb | rec2020 | lab | oklab | <xyz-space>"
+    },
+    {
+      "name": "<relative-control-point>",
+      "syntax": "<coordinate-pair> [ from [ start | end | origin ] ]?"
+    },
+    {
+      "name": "<relative-real-selector-list>",
+      "syntax": "<relative-real-selector>#"
+    },
+    {
+      "name": "<relative-real-selector>",
+      "syntax": "<combinator>? <complex-real-selector>"
     },
     {
       "name": "<relative-selector-list>",
@@ -7441,23 +8115,119 @@
     },
     {
       "name": "<relative-size>",
-      "syntax": "larger | smaller"
+      "syntax": "[ larger | smaller ]"
+    },
+    {
+      "name": "<rem()>",
+      "syntax": "rem( <calc-sum>, <calc-sum> )"
+    },
+    {
+      "name": "<repeat-line-color>",
+      "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <color> ]# )"
+    },
+    {
+      "name": "<repeat-line-style>",
+      "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-style> ]# )"
+    },
+    {
+      "name": "<repeat-line-width>",
+      "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-width> ]# )"
     },
     {
       "name": "<repeat-style>",
-      "syntax": "repeat-x | repeat-y | [ repeat | space | round | no-repeat ]{1,2}"
+      "syntax": "repeat-x | repeat-y | [repeat | space | round | no-repeat]{1,2}"
     },
     {
-      "name": "<resolution>",
-      "syntax": ""
+      "name": "<repeating-conic-gradient()>",
+      "syntax": "repeating-conic-gradient( [ <conic-gradient-syntax> ] )"
+    },
+    {
+      "name": "<repeating-linear-gradient()>",
+      "syntax": "repeating-linear-gradient( [ <linear-gradient-syntax> ] )"
+    },
+    {
+      "name": "<repeating-radial-gradient()>",
+      "syntax": "repeating-radial-gradient( [ <radial-gradient-syntax> ] )"
     },
     {
       "name": "<reversed-counter-name>",
       "syntax": "reversed( <counter-name> )"
     },
     {
+      "name": "<rgb()>",
+      "syntax": "rgb( <percentage>#{3} , <alpha-value>? ) | rgb( <number>#{3} , <alpha-value>? ) | rgb( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )"
+    },
+    {
+      "name": "<rgba()>",
+      "syntax": "rgba( <percentage>#{3} , <alpha-value>? ) | rgba( <number>#{3} , <alpha-value>? ) | rgba( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )"
+    },
+    {
+      "name": "<rotate()>",
+      "syntax": "rotate( [ <angle> | <zero> ] )"
+    },
+    {
+      "name": "<rotate3d()>",
+      "syntax": "rotate3d( <number> , <number> , <number> , [ <angle> | <zero> ] )"
+    },
+    {
+      "name": "<rotateX()>",
+      "syntax": "rotateX( [ <angle> | <zero> ] )"
+    },
+    {
+      "name": "<rotateY()>",
+      "syntax": "rotateY( [ <angle> | <zero> ] )"
+    },
+    {
+      "name": "<rotateZ()>",
+      "syntax": "rotateZ( [ <angle> | <zero> ] )"
+    },
+    {
+      "name": "<round()>",
+      "syntax": "round( <rounding-strategy>?, <calc-sum>, <calc-sum> )"
+    },
+    {
       "name": "<rounding-strategy>",
-      "syntax": "nearest | up | down | to-zero"
+      "syntax": "nearest | up | down | to-zero | line-width"
+    },
+    {
+      "name": "<route-descriptor>",
+      "syntax": "<pattern-descriptor> | <init-descriptor> | <base-descriptor>"
+    },
+    {
+      "name": "<route-location>",
+      "syntax": "<url> | [ <route-name> | <url-pattern()> ]"
+    },
+    {
+      "name": "<route-name>",
+      "syntax": "<dashed-ident>"
+    },
+    {
+      "name": "<route-rule>",
+      "syntax": "@route <dashed-ident> '{' <declaration-list> '}'"
+    },
+    {
+      "name": "<saturate()>",
+      "syntax": "saturate( [ <number> | <percentage> ]? )"
+    },
+    {
+      "name": "<scale()>",
+      "syntax": "scale( [ <number> | <percentage> ]#{1,2} )"
+    },
+    {
+      "name": "<scale3d()>",
+      "syntax": "scale3d( [ <number> | <percentage> ]#{3} )"
+    },
+    {
+      "name": "<scaleX()>",
+      "syntax": "scaleX( [ <number> | <percentage> ] )"
+    },
+    {
+      "name": "<scaleY()>",
+      "syntax": "scaleY( [ <number> | <percentage> ] )"
+    },
+    {
+      "name": "<scaleZ()>",
+      "syntax": "scaleZ( [ <number> | <percentage> ] )"
     },
     {
       "name": "<scope-end>",
@@ -7466,6 +8236,10 @@
     {
       "name": "<scope-start>",
       "syntax": "<selector-list>"
+    },
+    {
+      "name": "<scroll()>",
+      "syntax": "scroll( [ <scroller> || <axis> ]? )"
     },
     {
       "name": "<scroll-state-feature>",
@@ -7492,16 +8266,24 @@
       "syntax": "center | start | end | self-start | self-end | flex-start | flex-end"
     },
     {
+      "name": "<sepia()>",
+      "syntax": "sepia( [ <number> | <percentage> ]? )"
+    },
+    {
       "name": "<shadow-t>",
       "syntax": "[ <length>{2,3} && <color>? ]"
     },
     {
       "name": "<shadow>",
-      "syntax": "inset? && <length>{2,4} && <color>?"
+      "syntax": "<color>? && [ <length>{2} [ <length [0,∞]> <length>? ]? ] && inset?"
     },
     {
       "name": "<shape-box>",
-      "syntax": "<visual-box> | margin-box"
+      "syntax": "<visual-box> | margin-box | half-border-box"
+    },
+    {
+      "name": "<shape-command>",
+      "syntax": "<move-command> | <line-command> | close | <horizontal-line-command> | <vertical-line-command> | <curve-command> | <smooth-command> | <arc-command>"
     },
     {
       "name": "<shape>",
@@ -7509,7 +8291,11 @@
     },
     {
       "name": "<side-or-corner>",
-      "syntax": "[ left | right ] || [ top | bottom ]"
+      "syntax": "[left | right] || [top | bottom]"
+    },
+    {
+      "name": "<sign()>",
+      "syntax": "sign( <calc-sum> )"
     },
     {
       "name": "<signed-integer>",
@@ -7518,6 +8304,18 @@
     {
       "name": "<signless-integer>",
       "syntax": "<number-token>"
+    },
+    {
+      "name": "<simple-selector-list>",
+      "syntax": "<simple-selector>#"
+    },
+    {
+      "name": "<simple-selector>",
+      "syntax": "<type-selector> | <subclass-selector>"
+    },
+    {
+      "name": "<sin()>",
+      "syntax": "sin( <calc-sum> )"
     },
     {
       "name": "<single-animation-composition>",
@@ -7533,7 +8331,7 @@
     },
     {
       "name": "<single-animation-iteration-count>",
-      "syntax": "infinite | <number>"
+      "syntax": "infinite | <number [0,∞]>"
     },
     {
       "name": "<single-animation-play-state>",
@@ -7545,7 +8343,7 @@
     },
     {
       "name": "<single-animation>",
-      "syntax": "<'animation-duration'> || <easing-function> || <'animation-delay'> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ] || <single-animation-timeline>"
+      "syntax": "<time [0s,∞]> || <easing-function> || <time> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ]"
     },
     {
       "name": "<single-transition-property>",
@@ -7553,7 +8351,7 @@
     },
     {
       "name": "<single-transition>",
-      "syntax": "[ none | <single-transition-property> ] || <time> || <easing-function> || <time> || <transition-behavior-value>"
+      "syntax": "[ none | <single-transition-property> ] || <time> || <easing-function> || <time>"
     },
     {
       "name": "<size-feature>",
@@ -7564,6 +8362,46 @@
       "syntax": "closest-side | farthest-side | closest-corner | farthest-corner | <length> | <length-percentage>{2}"
     },
     {
+      "name": "<skew()>",
+      "syntax": "skew( [ <angle> | <zero> ] , [ <angle> | <zero> ]? )"
+    },
+    {
+      "name": "<skewX()>",
+      "syntax": "skewX( [ <angle> | <zero> ] )"
+    },
+    {
+      "name": "<skewY()>",
+      "syntax": "skewY( [ <angle> | <zero> ] )"
+    },
+    {
+      "name": "<slash-separated-border-radius-syntax>",
+      "syntax": "<length-percentage [0,∞]> [ / <length-percentage [0,∞]> ]?"
+    },
+    {
+      "name": "<smooth-command>",
+      "syntax": "smooth [ [ to <position> [ with <control-point> ]? ] | [ by <coordinate-pair> [ with <relative-control-point> ]? ] ]"
+    },
+    {
+      "name": "<source-size-list>",
+      "syntax": "<source-size>#? ',' <source-size-value>"
+    },
+    {
+      "name": "<source-size-value>",
+      "syntax": "<length> | auto"
+    },
+    {
+      "name": "<source-size>",
+      "syntax": "<media-condition> <source-size-value> | auto"
+    },
+    {
+      "name": "<spread-shadow>",
+      "syntax": "<'box-shadow-color'>? && [ [ none | <length>{2} ] [ <'box-shadow-blur'> <'box-shadow-spread'>? ]? ] && <'box-shadow-position'>?"
+    },
+    {
+      "name": "<sqrt()>",
+      "syntax": "sqrt( <calc-sum> )"
+    },
+    {
       "name": "<step-easing-function>",
       "syntax": "step-start | step-end | <steps()>"
     },
@@ -7572,8 +8410,8 @@
       "syntax": "jump-start | jump-end | jump-none | jump-both | start | end"
     },
     {
-      "name": "<string>",
-      "syntax": ""
+      "name": "<steps()>",
+      "syntax": "steps( <integer>, <step-position>? )"
     },
     {
       "name": "<style-feature>",
@@ -7592,28 +8430,40 @@
       "syntax": "<id-selector> | <class-selector> | <attribute-selector> | <pseudo-class-selector>"
     },
     {
+      "name": "<superellipse()>",
+      "syntax": "superellipse( [ <number> | infinity | -infinity ] )"
+    },
+    {
       "name": "<supports-condition>",
       "syntax": "not <supports-in-parens> | <supports-in-parens> [ and <supports-in-parens> ]* | <supports-in-parens> [ or <supports-in-parens> ]*"
     },
     {
       "name": "<supports-decl>",
-      "syntax": "( <declaration> )"
+      "syntax": "'(' <declaration> ')'"
     },
     {
       "name": "<supports-feature>",
-      "syntax": "<supports-decl> | <supports-selector-fn>"
+      "syntax": "<supports-decl>"
     },
     {
       "name": "<supports-in-parens>",
-      "syntax": "( <supports-condition> ) | <supports-feature> | <general-enclosed>"
+      "syntax": "'(' <supports-condition> ')' | <supports-feature> | <general-enclosed>"
     },
     {
       "name": "<supports-selector-fn>",
       "syntax": "selector( <complex-selector> )"
     },
     {
+      "name": "<svg-paint>",
+      "syntax": "child | child( <integer> )"
+    },
+    {
       "name": "<symbol>",
       "syntax": "<string> | <image> | <custom-ident>"
+    },
+    {
+      "name": "<symbols()>",
+      "syntax": "symbols( <symbols-type>? [ <string> | <image> ]+ )"
     },
     {
       "name": "<symbols-type>",
@@ -7621,11 +8471,31 @@
     },
     {
       "name": "<system-color>",
-      "syntax": "AccentColor | AccentColorText | ActiveText | ButtonBorder | ButtonFace | ButtonText | Canvas | CanvasText | Field | FieldText | GrayText | Highlight | HighlightText | LinkText | Mark | MarkText | SelectedItem | SelectedItemText | VisitedText"
+      "syntax": "AccentColor | AccentColorText | ActiveText | ButtonBorder | ButtonFace | ButtonText | Canvas | CanvasText | Field | FieldText | GrayText | Highlight | HighlightText | LinkText | Mark | MarkText | SelectedItem | SelectedItemText | VisitedText | <deprecated-color>"
     },
     {
       "name": "<system-family-name>",
       "syntax": "caption | icon | menu | message-box | small-caption | status-bar"
+    },
+    {
+      "name": "<system-font-family-name>",
+      "syntax": "caption | icon | menu | message-box | small-caption | status-bar"
+    },
+    {
+      "name": "<tan()>",
+      "syntax": "tan( <calc-sum> )"
+    },
+    {
+      "name": "<target-counter()>",
+      "syntax": "target-counter( [ <string> | <url> ] , <custom-ident> , <counter-style>? )"
+    },
+    {
+      "name": "<target-counters()>",
+      "syntax": "target-counters( [ <string> | <url> ] , <custom-ident> , <string> , <counter-style>? )"
+    },
+    {
+      "name": "<target-text()>",
+      "syntax": "target-text( [ <string> | <url> ] , [ content | before | after | first-letter ]? )"
     },
     {
       "name": "<target>",
@@ -7633,15 +8503,11 @@
     },
     {
       "name": "<text-edge>",
-      "syntax": "[ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]?"
+      "syntax": "[ text | ideographic | ideographic-ink ] | [ text | ideographic | ideographic-ink | cap | ex ] [ text | ideographic | ideographic-ink | alphabetic ]"
     },
     {
       "name": "<time-percentage>",
-      "syntax": "<time> | <percentage>"
-    },
-    {
-      "name": "<time>",
-      "syntax": ""
+      "syntax": "[ <time> | <percentage> ]"
     },
     {
       "name": "<timeline-range-name>",
@@ -7649,7 +8515,7 @@
     },
     {
       "name": "<track-breadth>",
-      "syntax": "<length-percentage> | <flex> | min-content | max-content | auto"
+      "syntax": "<length-percentage [0,∞]> | <flex [0,∞]> | min-content | max-content | auto"
     },
     {
       "name": "<track-list>",
@@ -7657,11 +8523,11 @@
     },
     {
       "name": "<track-repeat>",
-      "syntax": "repeat( [ <integer [1,∞]> ] , [ <line-names>? <track-size> ]+ <line-names>? )"
+      "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-names>? <track-size> ]+ <line-names>? )"
     },
     {
       "name": "<track-size>",
-      "syntax": "<track-breadth> | minmax( <inflexible-breadth> , <track-breadth> ) | fit-content( <length-percentage> )"
+      "syntax": "<track-breadth> | minmax( <inflexible-breadth> ',' <track-breadth> ) | fit-content( <length-percentage [0,∞]> )"
     },
     {
       "name": "<transform-function>",
@@ -7676,12 +8542,32 @@
       "syntax": "normal | allow-discrete"
     },
     {
+      "name": "<translate()>",
+      "syntax": "translate( <length-percentage> , <length-percentage>? )"
+    },
+    {
+      "name": "<translate3d()>",
+      "syntax": "translate3d( <length-percentage> , <length-percentage> , <length> )"
+    },
+    {
+      "name": "<translateX()>",
+      "syntax": "translateX( <length-percentage> )"
+    },
+    {
+      "name": "<translateY()>",
+      "syntax": "translateY( <length-percentage> )"
+    },
+    {
+      "name": "<translateZ()>",
+      "syntax": "translateZ( <length> )"
+    },
+    {
       "name": "<try-size>",
       "syntax": "most-width | most-height | most-block-size | most-inline-size"
     },
     {
       "name": "<try-tactic>",
-      "syntax": "flip-block || flip-inline || flip-start"
+      "syntax": "flip-block || flip-inline || flip-start || flip-x || flip-y"
     },
     {
       "name": "<type-or-unit>",
@@ -7692,8 +8578,28 @@
       "syntax": "<wq-name> | <ns-prefix>? '*'"
     },
     {
+      "name": "<type>",
+      "syntax": "'<' [ number | string ] '>'"
+    },
+    {
       "name": "<url>",
-      "syntax": ""
+      "syntax": "<url()> | <src()>"
+    },
+    {
+      "name": "<var()>",
+      "syntax": "var( <custom-property-name> , <declaration-value>? )"
+    },
+    {
+      "name": "<var-args>",
+      "syntax": "var( <declaration-value> ',' <declaration-value>? )"
+    },
+    {
+      "name": "<vertical-line-command>",
+      "syntax": "vline [ to [ <length-percentage> | top | center | bottom | y-start | y-end ] | by <length-percentage> ]"
+    },
+    {
+      "name": "<view()>",
+      "syntax": "view([<axis> || <'view-timeline-inset'>]?)"
     },
     {
       "name": "<viewport-length>",
@@ -7708,8 +8614,16 @@
       "syntax": "<ns-prefix>? <ident-token>"
     },
     {
+      "name": "<xywh()>",
+      "syntax": "xywh( <length-percentage>{2} <length-percentage [0,∞]>{2} [ round <'border-radius'> ]? )"
+    },
+    {
       "name": "<xyz-params>",
-      "syntax": "<xyz> [ <number> | <percentage> | none ]{3}"
+      "syntax": "<xyz-space> [ <number> | <percentage> | none ]{3}"
+    },
+    {
+      "name": "<xyz-space>",
+      "syntax": "xyz | xyz-d50 | xyz-d65"
     },
     {
       "name": "<xyz>",
@@ -7729,7 +8643,7 @@
     },
     {
       "name": "anchor-size()",
-      "syntax": "anchor-size( [ <anchor-name> || <anchor-size> ]? , <length-percentage>? )"
+      "syntax": "anchor-size( [ <anchor-name> || <anchor-size> ]? ',' <length-percentage>? )"
     },
     {
       "name": "asin()",
@@ -7744,10 +8658,6 @@
       "syntax": "atan2( <calc-sum>, <calc-sum> )"
     },
     {
-      "name": "attr()",
-      "syntax": "attr( <attr-name> <attr-type>? , <declaration-value>? )"
-    },
-    {
       "name": "blur()",
       "syntax": "blur( <length>? )"
     },
@@ -7760,32 +8670,28 @@
       "syntax": "calc( <calc-sum> )"
     },
     {
-      "name": "calc-size()",
-      "syntax": "calc-size( <calc-size-basis>, <calc-sum> )"
-    },
-    {
       "name": "circle()",
       "syntax": "circle( <radial-size>? [ at <position> ]? )"
     },
     {
       "name": "clamp()",
-      "syntax": "clamp( <calc-sum>#{3} )"
+      "syntax": "clamp( [ <calc-sum> | none ], <calc-sum>, [ <calc-sum> | none ] )"
     },
     {
       "name": "color()",
-      "syntax": "color( [ from <color> ]? <colorspace-params> [ / [ <alpha-value> | none ] ]? )"
+      "syntax": "color( <colorspace-params> [ / [ <alpha-value> | none ] ]? )"
     },
     {
-      "name": "color-mix()",
-      "syntax": "color-mix( <color-interpolation-method> , [ <color> && <percentage [0,100]>? ]#{2})"
-    },
-    {
-      "name": "conic-gradient()",
-      "syntax": "conic-gradient( [ <conic-gradient-syntax> ] )"
+      "name": "content()",
+      "syntax": "content( [ text | before | after | first-letter | marker ]? )"
     },
     {
       "name": "contrast()",
       "syntax": "contrast( [ <number> | <percentage> ]? )"
+    },
+    {
+      "name": "control-value()",
+      "syntax": "control-value( <type>? )"
     },
     {
       "name": "cos()",
@@ -7800,10 +8706,6 @@
       "syntax": "counters( <counter-name>, <string>, <counter-style>? )"
     },
     {
-      "name": "cross-fade()",
-      "syntax": "cross-fade( <cf-mixing-image> , <cf-final-image>? )"
-    },
-    {
       "name": "cubic-bezier()",
       "syntax": "cubic-bezier( [ <number [0,1]>, <number> ]#{2} )"
     },
@@ -7816,36 +8718,40 @@
       "syntax": "dynamic-range-limit-mix( [ <'dynamic-range-limit'> && <percentage [0,100]> ]#{2,} )"
     },
     {
-      "name": "element()",
-      "syntax": "element( <id-selector> )"
-    },
-    {
       "name": "ellipse()",
       "syntax": "ellipse( <radial-size>? [ at <position> ]? )"
     },
     {
       "name": "env()",
-      "syntax": "env( <custom-ident> , <declaration-value>? )"
+      "syntax": "env( <custom-ident> <integer [0,∞]>*, <declaration-value>? )"
     },
     {
       "name": "exp()",
       "syntax": "exp( <calc-sum> )"
     },
     {
+      "name": "filter()",
+      "syntax": "filter( [ <image> | <string> ], <filter-value-list> )"
+    },
+    {
       "name": "fit-content()",
-      "syntax": "fit-content( <length-percentage [0,∞]> )"
+      "syntax": "fit-content(<length-percentage [0,∞]>)"
     },
     {
       "name": "grayscale()",
       "syntax": "grayscale( [ <number> | <percentage> ]? )"
     },
     {
+      "name": "hdr-color()",
+      "syntax": "color-hdr([ <color> && <number [0,∞]>? ]#{2})"
+    },
+    {
       "name": "hsl()",
-      "syntax": "hsl( <hue>, <percentage>, <percentage>, <alpha-value>? ) | hsl( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
+      "syntax": "[ <legacy-hsl-syntax> | <modern-hsl-syntax> ]"
     },
     {
       "name": "hsla()",
-      "syntax": "hsla( <hue>, <percentage>, <percentage>, <alpha-value>? ) | hsla( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
+      "syntax": "[ <legacy-hsla-syntax> | <modern-hsla-syntax> ]"
     },
     {
       "name": "hue-rotate()",
@@ -7853,19 +8759,15 @@
     },
     {
       "name": "hwb()",
-      "syntax": "hwb( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
+      "syntax": "hwb( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
     },
     {
       "name": "hypot()",
       "syntax": "hypot( <calc-sum># )"
     },
     {
-      "name": "image()",
-      "syntax": "image( <image-tags>? [ <image-src>? , <color>? ]! )"
-    },
-    {
-      "name": "image-set()",
-      "syntax": "image-set( <image-set-option># )"
+      "name": "ictcp()",
+      "syntax": "ictcp([from <color>]? [<percentage> | <number> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
     },
     {
       "name": "inset()",
@@ -7876,12 +8778,16 @@
       "syntax": "invert( [ <number> | <percentage> ]? )"
     },
     {
-      "name": "lab()",
-      "syntax": "lab( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+      "name": "jzazbz()",
+      "syntax": "jzazbz([from <color>]? [<percentage> | <number> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
     },
     {
-      "name": "layer()",
-      "syntax": "layer( <layer-name> )"
+      "name": "jzczhz()",
+      "syntax": "jzczhz([from <color>]? [<percentage> | <number> | none] [<percentage> | <number> | none] [<hue> | none] [ / [<alpha-value> | none] ]? )"
+    },
+    {
+      "name": "lab()",
+      "syntax": "lab( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
     },
     {
       "name": "lch()",
@@ -7890,10 +8796,6 @@
     {
       "name": "leader()",
       "syntax": "leader( <leader-type> )"
-    },
-    {
-      "name": "light-dark()",
-      "syntax": "light-dark( <color>, <color> )"
     },
     {
       "name": "linear()",
@@ -7912,10 +8814,6 @@
       "syntax": "matrix( <number>#{6} )"
     },
     {
-      "name": "matrix3d()",
-      "syntax": "matrix3d( <number>#{16} )"
-    },
-    {
       "name": "max()",
       "syntax": "max( <calc-sum># )"
     },
@@ -7925,7 +8823,7 @@
     },
     {
       "name": "minmax()",
-      "syntax": "minmax( [ <length-percentage> | min-content | max-content | auto ] , [ <length-percentage> | <flex> | min-content | max-content | auto ] )"
+      "syntax": "minmax(min, max)"
     },
     {
       "name": "mod()",
@@ -7949,19 +8847,23 @@
     },
     {
       "name": "palette-mix()",
-      "syntax": "palette-mix(<color-interpolation-method> , [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})"
+      "syntax": "palette-mix(<color-interpolation-method> ',' [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})"
+    },
+    {
+      "name": "param()",
+      "syntax": "param( <dashed-ident> ',' <declaration-value>? )"
     },
     {
       "name": "path()",
-      "syntax": "path( <'fill-rule'>? , <string> )"
+      "syntax": "path( <'fill-rule'>? ',' <string> )"
     },
     {
-      "name": "perspective()",
-      "syntax": "perspective( [ <length [0,∞]> | none ] )"
+      "name": "pointer()",
+      "syntax": "pointer( [ <pointer-source> || <pointer-axis> ]? )"
     },
     {
       "name": "polygon()",
-      "syntax": "polygon( <'fill-rule'>? , [ <length-percentage> <length-percentage> ]# )"
+      "syntax": "polygon( <'fill-rule'>? [ round <length> ]? ',' [<length-percentage> <length-percentage>]# )"
     },
     {
       "name": "pow()",
@@ -7984,10 +8886,6 @@
       "syntax": "rem( <calc-sum>, <calc-sum> )"
     },
     {
-      "name": "repeating-conic-gradient()",
-      "syntax": "repeating-conic-gradient( [ <conic-gradient-syntax> ] )"
-    },
-    {
       "name": "repeating-linear-gradient()",
       "syntax": "repeating-linear-gradient( [ <linear-gradient-syntax> ] )"
     },
@@ -7997,35 +8895,23 @@
     },
     {
       "name": "rgb()",
-      "syntax": "rgb( <percentage>#{3} , <alpha-value>? ) | rgb( <number>#{3} , <alpha-value>? ) | rgb( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )"
+      "syntax": "[ <legacy-rgb-syntax> | <modern-rgb-syntax> ]"
     },
     {
       "name": "rgba()",
-      "syntax": "rgba( <percentage>#{3} , <alpha-value>? ) | rgba( <number>#{3} , <alpha-value>? ) | rgba( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )"
+      "syntax": "[ <legacy-rgba-syntax> | <modern-rgba-syntax> ]"
     },
     {
       "name": "rotate()",
       "syntax": "rotate( [ <angle> | <zero> ] )"
     },
     {
-      "name": "rotate3d()",
-      "syntax": "rotate3d( <number> , <number> , <number> , [ <angle> | <zero> ] )"
-    },
-    {
-      "name": "rotateX()",
-      "syntax": "rotateX( [ <angle> | <zero> ] )"
-    },
-    {
-      "name": "rotateY()",
-      "syntax": "rotateY( [ <angle> | <zero> ] )"
-    },
-    {
-      "name": "rotateZ()",
-      "syntax": "rotateZ( [ <angle> | <zero> ] )"
-    },
-    {
       "name": "round()",
-      "syntax": "round( <rounding-strategy>?, <calc-sum>, <calc-sum> )"
+      "syntax": "round( <rounding-strategy>?, <calc-sum>, <calc-sum>? )"
+    },
+    {
+      "name": "running()",
+      "syntax": "running( <custom-ident> )"
     },
     {
       "name": "saturate()",
@@ -8033,23 +8919,15 @@
     },
     {
       "name": "scale()",
-      "syntax": "scale( [ <number> | <percentage> ]#{1,2} )"
-    },
-    {
-      "name": "scale3d()",
-      "syntax": "scale3d( [ <number> | <percentage> ]#{3} )"
+      "syntax": "scale( <number> ',' <number>? )"
     },
     {
       "name": "scaleX()",
-      "syntax": "scaleX( [ <number> | <percentage> ] )"
+      "syntax": "scaleX( <number> )"
     },
     {
       "name": "scaleY()",
-      "syntax": "scaleY( [ <number> | <percentage> ] )"
-    },
-    {
-      "name": "scaleZ()",
-      "syntax": "scaleZ( [ <number> | <percentage> ] )"
+      "syntax": "scaleY( <number> )"
     },
     {
       "name": "scroll()",
@@ -8058,6 +8936,10 @@
     {
       "name": "sepia()",
       "syntax": "sepia( [ <number> | <percentage> ]? )"
+    },
+    {
+      "name": "shape()",
+      "syntax": "shape( <'fill-rule'>? from <position> ',' <shape-command># )"
     },
     {
       "name": "sign()",
@@ -8069,7 +8951,7 @@
     },
     {
       "name": "skew()",
-      "syntax": "skew( [ <angle> | <zero> ] , [ <angle> | <zero> ]? )"
+      "syntax": "skew( [ <angle> | <zero> ] ',' [ <angle> | <zero> ]? )"
     },
     {
       "name": "skewX()",
@@ -8080,16 +8962,32 @@
       "syntax": "skewY( [ <angle> | <zero> ] )"
     },
     {
+      "name": "snap-block()",
+      "syntax": "snap-block( <length> ',' [ start | end | near ]? )"
+    },
+    {
+      "name": "snap-inline()",
+      "syntax": "snap-inline( <length> ',' [ left | right | near ]? )"
+    },
+    {
       "name": "sqrt()",
       "syntax": "sqrt( <calc-sum> )"
     },
     {
+      "name": "src()",
+      "syntax": "src( <string> <url-modifier>* )"
+    },
+    {
       "name": "steps()",
-      "syntax": "steps( <integer>, <step-position>? )"
+      "syntax": "steps( <integer>, <step-position>?)"
+    },
+    {
+      "name": "string()",
+      "syntax": "string( <custom-ident> ',' [ first | start | last | first-except ]? )"
     },
     {
       "name": "superellipse()",
-      "syntax": "superellipse( [ <number> | infinity | -infinity ] )"
+      "syntax": "superellipse(<number> | infinity | -infinity)"
     },
     {
       "name": "symbols()",
@@ -8101,23 +8999,19 @@
     },
     {
       "name": "target-counter()",
-      "syntax": "target-counter( [ <string> | <url> ] , <custom-ident> , <counter-style>? )"
+      "syntax": "target-counter( [ <string> | <url> ] ',' <custom-ident> ',' <counter-style>? )"
     },
     {
       "name": "target-counters()",
-      "syntax": "target-counters( [ <string> | <url> ] , <custom-ident> , <string> , <counter-style>? )"
+      "syntax": "target-counters( [ <string> | <url> ] ',' <custom-ident> ',' <string> ',' <counter-style>? )"
     },
     {
       "name": "target-text()",
-      "syntax": "target-text( [ <string> | <url> ] , [ content | before | after | first-letter ]? )"
+      "syntax": "target-text( [ <string> | <url> ] ',' [ content | before | after | first-letter ]? )"
     },
     {
       "name": "translate()",
-      "syntax": "translate( <length-percentage> , <length-percentage>? )"
-    },
-    {
-      "name": "translate3d()",
-      "syntax": "translate3d( <length-percentage> , <length-percentage> , <length> )"
+      "syntax": "translate( <length-percentage> ',' <length-percentage>? )"
     },
     {
       "name": "translateX()",
@@ -8128,16 +9022,20 @@
       "syntax": "translateY( <length-percentage> )"
     },
     {
-      "name": "translateZ()",
-      "syntax": "translateZ( <length> )"
+      "name": "url()",
+      "syntax": "url( <string> <url-modifier>* ) | <url-token>"
+    },
+    {
+      "name": "url-pattern()",
+      "syntax": "url-pattern( <string> )"
     },
     {
       "name": "var()",
-      "syntax": "var( <custom-property-name> , <declaration-value>? )"
+      "syntax": "var( <custom-property-name> ',' <declaration-value>? )"
     },
     {
       "name": "view()",
-      "syntax": "view([<axis> || <'view-timeline-inset'>]?)"
+      "syntax": "view( [ <axis> || <'view-timeline-inset'> ]? )"
     },
     {
       "name": "xywh()",
@@ -8146,12 +9044,47 @@
   ],
   "atrules": [
     {
+      "name": "@-webkit-keyframes",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@apply",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@bottom-center",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@bottom-left",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@bottom-left-corner",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@bottom-right",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@bottom-right-corner",
+      "descriptors": [],
+      "Values": null
+    },
+    {
       "name": "@charset",
       "descriptors": [],
       "Values": null
     },
     {
-      "name": "@container",
+      "name": "@contents",
       "descriptors": [],
       "Values": null
     },
@@ -8159,24 +9092,14 @@
       "name": "@counter-style",
       "descriptors": [
         {
-          "name": "additive-symbols",
-          "syntax": "[ <integer [0,∞]> && <symbol> ]#",
-          "initial": ""
-        },
-        {
-          "name": "fallback",
-          "syntax": "<counter-style-name>",
-          "initial": "decimal"
+          "name": "system",
+          "syntax": "cyclic | numeric | alphabetic | symbolic | additive | [fixed <integer>?] | [ extends <counter-style-name> ]",
+          "initial": "symbolic"
         },
         {
           "name": "negative",
           "syntax": "<symbol> <symbol>?",
-          "initial": "\"-\" hyphen-minus"
-        },
-        {
-          "name": "pad",
-          "syntax": "<integer [0,∞]> && <symbol>",
-          "initial": "0 \"\""
+          "initial": "\"-\""
         },
         {
           "name": "prefix",
@@ -8184,19 +9107,24 @@
           "initial": "\"\""
         },
         {
+          "name": "suffix",
+          "syntax": "<symbol>",
+          "initial": "\". \""
+        },
+        {
           "name": "range",
           "syntax": "[ [ <integer> | infinite ]{2} ]# | auto",
           "initial": "auto"
         },
         {
-          "name": "speak-as",
-          "syntax": "auto | bullets | numbers | words | spell-out | <counter-style-name>",
-          "initial": "auto"
+          "name": "pad",
+          "syntax": "<integer [0,∞]> && <symbol>",
+          "initial": "0 \"\""
         },
         {
-          "name": "suffix",
-          "syntax": "<symbol>",
-          "initial": "\". \""
+          "name": "fallback",
+          "syntax": "<counter-style-name>",
+          "initial": "decimal"
         },
         {
           "name": "symbols",
@@ -8204,15 +9132,20 @@
           "initial": ""
         },
         {
-          "name": "system",
-          "syntax": "cyclic | numeric | alphabetic | symbolic | additive | [ fixed <integer>? ] | [ extends <counter-style-name> ]",
-          "initial": "symbolic"
+          "name": "additive-symbols",
+          "syntax": "[ <integer [0,∞]> && <symbol> ]#",
+          "initial": ""
+        },
+        {
+          "name": "speak-as",
+          "syntax": "auto | bullets | numbers | words | spell-out | <counter-style-name>",
+          "initial": "auto"
         }
       ],
       "Values": null
     },
     {
-      "name": "@document",
+      "name": "@custom-selector",
       "descriptors": [],
       "Values": null
     },
@@ -8220,14 +9153,49 @@
       "name": "@font-face",
       "descriptors": [
         {
-          "name": "ascent-override",
-          "syntax": "normal | <percentage>",
-          "initial": "normal"
+          "name": "font-family",
+          "syntax": "<font-family-name>",
+          "initial": ""
         },
         {
-          "name": "descent-override",
-          "syntax": "normal | <percentage>",
-          "initial": "normal"
+          "name": "src",
+          "syntax": "<font-src-list>",
+          "initial": ""
+        },
+        {
+          "name": "font-style",
+          "syntax": "auto | normal | italic | left | right | oblique [ <angle [-90deg,90deg]>{1,2} ]?",
+          "initial": "auto"
+        },
+        {
+          "name": "font-weight",
+          "syntax": "auto | <font-weight-absolute>{1,2}",
+          "initial": "auto"
+        },
+        {
+          "name": "font-width",
+          "syntax": "auto | <'font-width'>{1,2}",
+          "initial": "auto"
+        },
+        {
+          "name": "unicode-range",
+          "syntax": "<unicode-range-token>#",
+          "initial": "U+0-10FFFF"
+        },
+        {
+          "name": "font-feature-settings",
+          "syntax": "normal | <feature-tag-value>#",
+          "initial": ""
+        },
+        {
+          "name": "font-variation-settings",
+          "syntax": "normal | [ <string> <number>]#",
+          "initial": ""
+        },
+        {
+          "name": "font-named-instance",
+          "syntax": "auto | <string>",
+          "initial": "auto"
         },
         {
           "name": "font-display",
@@ -8235,74 +9203,90 @@
           "initial": "auto"
         },
         {
-          "name": "font-family",
-          "syntax": "<family-name>",
+          "name": "font-language-override",
+          "syntax": "normal | <string>",
           "initial": ""
         },
         {
-          "name": "font-feature-settings",
-          "syntax": "normal | <feature-tag-value>#",
-          "initial": "normal"
+          "name": "ascent-override",
+          "syntax": "normal | <percentage [0,∞]>",
+          "initial": ""
         },
         {
-          "name": "font-stretch",
-          "syntax": "<font-stretch-absolute>{1,2}",
-          "initial": "normal"
-        },
-        {
-          "name": "font-style",
-          "syntax": "normal | italic | oblique <angle>{0,2}",
-          "initial": "normal"
-        },
-        {
-          "name": "font-variation-settings",
-          "syntax": "normal | [ <string> <number> ]#",
-          "initial": "normal"
-        },
-        {
-          "name": "font-weight",
-          "syntax": "<font-weight-absolute>{1,2}",
-          "initial": "normal"
+          "name": "descent-override",
+          "syntax": "normal | <percentage [0,∞]>",
+          "initial": ""
         },
         {
           "name": "line-gap-override",
-          "syntax": "normal | <percentage>",
-          "initial": "normal"
-        },
-        {
-          "name": "size-adjust",
-          "syntax": "<percentage>",
-          "initial": "100%"
-        },
-        {
-          "name": "src",
-          "syntax": "[ <url> [ format( <string># ) ]? | local( <family-name> ) ]#",
+          "syntax": "normal | <percentage [0,∞]>",
           "initial": ""
-        },
-        {
-          "name": "unicode-range",
-          "syntax": "<unicode-range-token>#",
-          "initial": "U+0-10FFFF"
         }
       ],
       "Values": null
     },
     {
       "name": "@font-feature-values",
-      "descriptors": [],
-      "Values": null
+      "descriptors": [
+        {
+          "name": "font-display",
+          "syntax": "auto | block | swap | fallback | optional",
+          "initial": "auto"
+        },
+        {
+          "name": "@stylistic",
+          "syntax": "@stylistic { <declaration-list> }",
+          "initial": ""
+        },
+        {
+          "name": "@historical-forms",
+          "syntax": "@historical-forms { <declaration-list> }",
+          "initial": ""
+        },
+        {
+          "name": "@styleset",
+          "syntax": "@styleset { <declaration-list> }",
+          "initial": ""
+        },
+        {
+          "name": "@character-variant",
+          "syntax": "@character-variant { <declaration-list> }",
+          "initial": ""
+        },
+        {
+          "name": "@swash",
+          "syntax": "@swash { <declaration-list> }",
+          "initial": ""
+        },
+        {
+          "name": "@ornaments",
+          "syntax": "@ornaments { <declaration-list> }",
+          "initial": ""
+        },
+        {
+          "name": "@annotation",
+          "syntax": "@annotation { <declaration-list> }",
+          "initial": ""
+        }
+      ],
+      "Values": [
+        {
+          "name": "<font-feature-value-type>",
+          "Values": null
+        }
+      ]
     },
     {
       "name": "@font-palette-values",
       "descriptors": [
         {
-          "name": "base-palette",
-          "syntax": "light | dark | <integer [0,∞]>",
+          "name": "font-family",
+          "syntax": "<font-family-name>#",
           "initial": ""
         },
         {
-          "name": "font-family",
-          "syntax": "<family-name>#",
+          "name": "base-palette",
+          "syntax": "light | dark | <integer [0,∞]>",
           "initial": ""
         },
         {
@@ -8312,6 +9296,23 @@
         }
       ],
       "Values": null
+    },
+    {
+      "name": "@function",
+      "descriptors": [
+        {
+          "name": "result",
+          "syntax": "<declaration-value>?",
+          "initial": ""
+        }
+      ],
+      "Values": [
+        {
+          "name": "type()",
+          "value": "type( <syntax> )",
+          "Values": null
+        }
+      ]
     },
     {
       "name": "@import",
@@ -8329,7 +9330,284 @@
       "Values": null
     },
     {
+      "name": "@left-bottom",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@left-middle",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@left-top",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@macro",
+      "descriptors": [],
+      "Values": null
+    },
+    {
       "name": "@media",
+      "descriptors": [
+        {
+          "name": "display-state",
+          "syntax": "normal | minimized | maximized | fullscreen",
+          "initial": ""
+        },
+        {
+          "name": "resizable",
+          "syntax": "true | false",
+          "initial": ""
+        },
+        {
+          "name": "-webkit-device-pixel-ratio",
+          "syntax": "<number>",
+          "initial": ""
+        },
+        {
+          "name": "-webkit-transform-3d",
+          "syntax": "<mq-boolean>",
+          "initial": ""
+        },
+        {
+          "name": "shape",
+          "syntax": "rect | round",
+          "initial": ""
+        },
+        {
+          "name": "width",
+          "syntax": "<length>",
+          "initial": ""
+        },
+        {
+          "name": "height",
+          "syntax": "<length>",
+          "initial": ""
+        },
+        {
+          "name": "aspect-ratio",
+          "syntax": "<ratio>",
+          "initial": ""
+        },
+        {
+          "name": "orientation",
+          "syntax": "portrait | landscape",
+          "initial": ""
+        },
+        {
+          "name": "resolution",
+          "syntax": "<resolution> | infinite",
+          "initial": ""
+        },
+        {
+          "name": "scan",
+          "syntax": "interlace | progressive",
+          "initial": ""
+        },
+        {
+          "name": "grid",
+          "syntax": "<mq-boolean>",
+          "initial": ""
+        },
+        {
+          "name": "update",
+          "syntax": "none | slow | fast",
+          "initial": ""
+        },
+        {
+          "name": "overflow-block",
+          "syntax": "none | scroll | paged",
+          "initial": ""
+        },
+        {
+          "name": "overflow-inline",
+          "syntax": "none | scroll",
+          "initial": ""
+        },
+        {
+          "name": "color",
+          "syntax": "<integer>",
+          "initial": ""
+        },
+        {
+          "name": "color-index",
+          "syntax": "<integer>",
+          "initial": ""
+        },
+        {
+          "name": "monochrome",
+          "syntax": "<integer>",
+          "initial": ""
+        },
+        {
+          "name": "color-gamut",
+          "syntax": "srgb | p3 | rec2020",
+          "initial": ""
+        },
+        {
+          "name": "pointer",
+          "syntax": "none | coarse | fine",
+          "initial": ""
+        },
+        {
+          "name": "hover",
+          "syntax": "none | hover",
+          "initial": ""
+        },
+        {
+          "name": "any-pointer",
+          "syntax": "none | coarse | fine",
+          "initial": ""
+        },
+        {
+          "name": "any-hover",
+          "syntax": "none | hover",
+          "initial": ""
+        },
+        {
+          "name": "device-width",
+          "syntax": "<length>",
+          "initial": ""
+        },
+        {
+          "name": "device-height",
+          "syntax": "<length>",
+          "initial": ""
+        },
+        {
+          "name": "device-aspect-ratio",
+          "syntax": "<ratio>",
+          "initial": ""
+        }
+      ],
+      "Values": [
+        {
+          "name": "all",
+          "value": "all",
+          "Values": [
+            {
+              "name": "inherit",
+              "value": "inherit"
+            }
+          ]
+        },
+        {
+          "name": "braille",
+          "value": "braille",
+          "Values": null
+        },
+        {
+          "name": "embossed",
+          "value": "embossed",
+          "Values": null
+        },
+        {
+          "name": "handheld",
+          "value": "handheld",
+          "Values": null
+        },
+        {
+          "name": "print",
+          "value": "print",
+          "Values": null
+        },
+        {
+          "name": "projection",
+          "value": "projection",
+          "Values": null
+        },
+        {
+          "name": "screen",
+          "value": "screen",
+          "Values": null
+        },
+        {
+          "name": "speech",
+          "value": "speech",
+          "Values": null
+        },
+        {
+          "name": "tty",
+          "value": "tty",
+          "Values": null
+        },
+        {
+          "name": "tv",
+          "value": "tv",
+          "Values": null
+        },
+        {
+          "name": "not",
+          "value": "not",
+          "Values": null
+        },
+        {
+          "name": "only",
+          "value": "only",
+          "Values": null
+        },
+        {
+          "name": "all",
+          "value": "all",
+          "Values": null
+        },
+        {
+          "name": "print",
+          "value": "print",
+          "Values": null
+        },
+        {
+          "name": "screen",
+          "value": "screen",
+          "Values": null
+        },
+        {
+          "name": "tty",
+          "value": "tty",
+          "Values": null
+        },
+        {
+          "name": "tv",
+          "value": "tv",
+          "Values": null
+        },
+        {
+          "name": "projection",
+          "value": "projection",
+          "Values": null
+        },
+        {
+          "name": "handheld",
+          "value": "handheld",
+          "Values": null
+        },
+        {
+          "name": "braille",
+          "value": "braille",
+          "Values": null
+        },
+        {
+          "name": "embossed",
+          "value": "embossed",
+          "Values": null
+        },
+        {
+          "name": "aural",
+          "value": "aural",
+          "Values": null
+        },
+        {
+          "name": "speech",
+          "value": "speech",
+          "Values": null
+        }
+      ]
+    },
+    {
+      "name": "@mixin",
       "descriptors": [],
       "Values": null
     },
@@ -8339,17 +9617,17 @@
       "Values": null
     },
     {
+      "name": "@navigation",
+      "descriptors": [],
+      "Values": null
+    },
+    {
       "name": "@page",
       "descriptors": [
         {
-          "name": "bleed",
-          "syntax": "auto | <length>",
+          "name": "size",
+          "syntax": "<length [0,∞]>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]",
           "initial": "auto"
-        },
-        {
-          "name": "marks",
-          "syntax": "none | [ crop || cross ]",
-          "initial": "none"
         },
         {
           "name": "page-orientation",
@@ -8357,12 +9635,43 @@
           "initial": "upright"
         },
         {
-          "name": "size",
-          "syntax": "<length [0,∞]>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]",
+          "name": "marks",
+          "syntax": "none | [ crop || cross ]",
+          "initial": ""
+        },
+        {
+          "name": "bleed",
+          "syntax": "auto | <length>",
+          "initial": "auto"
+        },
+        {
+          "name": "page-margin-safety",
+          "syntax": "none | clamp | add",
           "initial": "auto"
         }
       ],
-      "Values": null
+      "Values": [
+        {
+          "name": ":left",
+          "value": ":left",
+          "Values": null
+        },
+        {
+          "name": ":right",
+          "value": ":right",
+          "Values": null
+        },
+        {
+          "name": ":first",
+          "value": ":first",
+          "Values": null
+        },
+        {
+          "name": ":blank",
+          "value": ":blank",
+          "Values": null
+        }
+      ]
     },
     {
       "name": "@position-try",
@@ -8373,30 +9682,45 @@
       "name": "@property",
       "descriptors": [
         {
+          "name": "syntax",
+          "syntax": "<string>",
+          "initial": ""
+        },
+        {
           "name": "inherits",
           "syntax": "true | false",
-          "initial": "auto"
+          "initial": ""
         },
         {
           "name": "initial-value",
           "syntax": "<declaration-value>?",
-          "initial": ""
-        },
-        {
-          "name": "syntax",
-          "syntax": "<string>",
-          "initial": ""
+          "initial": "the guaranteed-invalid value (but see prose)"
         }
       ],
       "Values": null
     },
     {
-      "name": "@scope",
+      "name": "@result",
       "descriptors": [],
       "Values": null
     },
     {
-      "name": "@starting-style",
+      "name": "@right-bottom",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@right-middle",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@right-top",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@route",
       "descriptors": [],
       "Values": null
     },
@@ -8406,17 +9730,42 @@
       "Values": null
     },
     {
+      "name": "@top-center",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@top-left",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@top-left-corner",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@top-right",
+      "descriptors": [],
+      "Values": null
+    },
+    {
+      "name": "@top-right-corner",
+      "descriptors": [],
+      "Values": null
+    },
+    {
       "name": "@view-transition",
       "descriptors": [
         {
           "name": "navigation",
           "syntax": "auto | none",
-          "initial": "none"
+          "initial": ""
         },
         {
           "name": "types",
-          "syntax": "none | <custom-ident>+",
-          "initial": "none"
+          "syntax": "none | <view-transition-type>+",
+          "initial": ""
         }
       ],
       "Values": null
@@ -8424,85 +9773,28 @@
   ],
   "selectors": [
     {
-      "name": "::-moz-progress-bar"
+      "name": "&"
     },
     {
-      "name": "::-moz-range-progress"
-    },
-    {
-      "name": "::-moz-range-thumb"
-    },
-    {
-      "name": "::-moz-range-track"
-    },
-    {
-      "name": "::-ms-browse"
-    },
-    {
-      "name": "::-ms-check"
-    },
-    {
-      "name": "::-ms-clear"
-    },
-    {
-      "name": "::-ms-expand"
-    },
-    {
-      "name": "::-ms-fill"
-    },
-    {
-      "name": "::-ms-fill-lower"
-    },
-    {
-      "name": "::-ms-fill-upper"
-    },
-    {
-      "name": "::-ms-reveal"
-    },
-    {
-      "name": "::-ms-thumb"
-    },
-    {
-      "name": "::-ms-ticks-after"
-    },
-    {
-      "name": "::-ms-ticks-before"
-    },
-    {
-      "name": "::-ms-tooltip"
-    },
-    {
-      "name": "::-ms-track"
-    },
-    {
-      "name": "::-ms-value"
-    },
-    {
-      "name": "::-webkit-progress-bar"
-    },
-    {
-      "name": "::-webkit-progress-inner-value"
-    },
-    {
-      "name": "::-webkit-progress-value"
-    },
-    {
-      "name": "::-webkit-slider-runnable-track"
-    },
-    {
-      "name": "::-webkit-slider-thumb"
+      "name": "+"
     },
     {
       "name": "::after"
-    },
-    {
-      "name": "::backdrop"
     },
     {
       "name": "::before"
     },
     {
       "name": "::checkmark"
+    },
+    {
+      "name": "::clear-icon"
+    },
+    {
+      "name": "::color-swatch"
+    },
+    {
+      "name": "::column"
     },
     {
       "name": "::cue"
@@ -8518,6 +9810,15 @@
     },
     {
       "name": "::details-content"
+    },
+    {
+      "name": "::field-component"
+    },
+    {
+      "name": "::field-separator"
+    },
+    {
+      "name": "::field-text"
     },
     {
       "name": "::file-selector-button"
@@ -8550,19 +9851,37 @@
       "name": "::placeholder"
     },
     {
-      "name": "::scroll-marker"
+      "name": "::reveal-icon"
     },
     {
-      "name": "::scroll-marker-group"
+      "name": "::search-text"
     },
     {
       "name": "::selection"
+    },
+    {
+      "name": "::slider-fill"
+    },
+    {
+      "name": "::slider-thumb"
+    },
+    {
+      "name": "::slider-track"
     },
     {
       "name": "::slotted()"
     },
     {
       "name": "::spelling-error"
+    },
+    {
+      "name": "::step-control"
+    },
+    {
+      "name": "::step-down"
+    },
+    {
+      "name": "::step-up"
     },
     {
       "name": "::target-text"
@@ -8572,6 +9891,9 @@
     },
     {
       "name": "::view-transition-group()"
+    },
+    {
+      "name": "::view-transition-group-children()"
     },
     {
       "name": "::view-transition-image-pair()"
@@ -8592,22 +9914,25 @@
       "name": ":active-view-transition-type()"
     },
     {
+      "name": ":after"
+    },
+    {
+      "name": ":animated-image"
+    },
+    {
       "name": ":any-link"
     },
     {
       "name": ":autofill"
     },
     {
-      "name": ":blank"
+      "name": ":before"
     },
     {
       "name": ":buffering"
     },
     {
       "name": ":checked"
-    },
-    {
-      "name": ":current"
     },
     {
       "name": ":default"
@@ -8634,6 +9959,12 @@
       "name": ":first-child"
     },
     {
+      "name": ":first-letter"
+    },
+    {
+      "name": ":first-line"
+    },
+    {
       "name": ":first-of-type"
     },
     {
@@ -8649,13 +9980,13 @@
       "name": ":fullscreen"
     },
     {
-      "name": ":future"
-    },
-    {
       "name": ":has()"
     },
     {
       "name": ":has-slotted"
+    },
+    {
+      "name": ":high-value"
     },
     {
       "name": ":host"
@@ -8697,7 +10028,13 @@
       "name": ":link"
     },
     {
-      "name": ":local-link"
+      "name": ":link-to()"
+    },
+    {
+      "name": ":low-value"
+    },
+    {
+      "name": ":matches()"
     },
     {
       "name": ":modal"
@@ -8706,7 +10043,13 @@
       "name": ":muted"
     },
     {
+      "name": ":nav-source"
+    },
+    {
       "name": ":not()"
+    },
+    {
+      "name": ":nth()"
     },
     {
       "name": ":nth-child()"
@@ -8730,13 +10073,13 @@
       "name": ":open"
     },
     {
+      "name": ":optimal-value"
+    },
+    {
       "name": ":optional"
     },
     {
       "name": ":out-of-range"
-    },
-    {
-      "name": ":past"
     },
     {
       "name": ":paused"
@@ -8778,16 +10121,10 @@
       "name": ":stalled"
     },
     {
-      "name": ":state()"
-    },
-    {
       "name": ":target"
     },
     {
-      "name": ":target-current"
-    },
-    {
-      "name": ":target-within"
+      "name": ":unchecked"
     },
     {
       "name": ":user-invalid"
@@ -8809,6 +10146,12 @@
     },
     {
       "name": ":xr-overlay"
+    },
+    {
+      "name": ">"
+    },
+    {
+      "name": "~"
     }
   ]
 }

--- a/crates/gosub_css3/resources/definitions/definitions_at-rules.json
+++ b/crates/gosub_css3/resources/definitions/definitions_at-rules.json
@@ -1,11 +1,46 @@
 [
   {
+    "name": "@-webkit-keyframes",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@apply",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@bottom-center",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@bottom-left",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@bottom-left-corner",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@bottom-right",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@bottom-right-corner",
+    "descriptors": [],
+    "Values": null
+  },
+  {
     "name": "@charset",
     "descriptors": [],
     "Values": null
   },
   {
-    "name": "@container",
+    "name": "@contents",
     "descriptors": [],
     "Values": null
   },
@@ -13,24 +48,14 @@
     "name": "@counter-style",
     "descriptors": [
       {
-        "name": "additive-symbols",
-        "syntax": "[ <integer [0,∞]> && <symbol> ]#",
-        "initial": ""
-      },
-      {
-        "name": "fallback",
-        "syntax": "<counter-style-name>",
-        "initial": "decimal"
+        "name": "system",
+        "syntax": "cyclic | numeric | alphabetic | symbolic | additive | [fixed <integer>?] | [ extends <counter-style-name> ]",
+        "initial": "symbolic"
       },
       {
         "name": "negative",
         "syntax": "<symbol> <symbol>?",
-        "initial": "\"-\" hyphen-minus"
-      },
-      {
-        "name": "pad",
-        "syntax": "<integer [0,∞]> && <symbol>",
-        "initial": "0 \"\""
+        "initial": "\"-\""
       },
       {
         "name": "prefix",
@@ -38,19 +63,24 @@
         "initial": "\"\""
       },
       {
+        "name": "suffix",
+        "syntax": "<symbol>",
+        "initial": "\". \""
+      },
+      {
         "name": "range",
         "syntax": "[ [ <integer> | infinite ]{2} ]# | auto",
         "initial": "auto"
       },
       {
-        "name": "speak-as",
-        "syntax": "auto | bullets | numbers | words | spell-out | <counter-style-name>",
-        "initial": "auto"
+        "name": "pad",
+        "syntax": "<integer [0,∞]> && <symbol>",
+        "initial": "0 \"\""
       },
       {
-        "name": "suffix",
-        "syntax": "<symbol>",
-        "initial": "\". \""
+        "name": "fallback",
+        "syntax": "<counter-style-name>",
+        "initial": "decimal"
       },
       {
         "name": "symbols",
@@ -58,15 +88,20 @@
         "initial": ""
       },
       {
-        "name": "system",
-        "syntax": "cyclic | numeric | alphabetic | symbolic | additive | [ fixed <integer>? ] | [ extends <counter-style-name> ]",
-        "initial": "symbolic"
+        "name": "additive-symbols",
+        "syntax": "[ <integer [0,∞]> && <symbol> ]#",
+        "initial": ""
+      },
+      {
+        "name": "speak-as",
+        "syntax": "auto | bullets | numbers | words | spell-out | <counter-style-name>",
+        "initial": "auto"
       }
     ],
     "Values": null
   },
   {
-    "name": "@document",
+    "name": "@custom-selector",
     "descriptors": [],
     "Values": null
   },
@@ -74,14 +109,49 @@
     "name": "@font-face",
     "descriptors": [
       {
-        "name": "ascent-override",
-        "syntax": "normal | <percentage>",
-        "initial": "normal"
+        "name": "font-family",
+        "syntax": "<font-family-name>",
+        "initial": ""
       },
       {
-        "name": "descent-override",
-        "syntax": "normal | <percentage>",
-        "initial": "normal"
+        "name": "src",
+        "syntax": "<font-src-list>",
+        "initial": ""
+      },
+      {
+        "name": "font-style",
+        "syntax": "auto | normal | italic | left | right | oblique [ <angle [-90deg,90deg]>{1,2} ]?",
+        "initial": "auto"
+      },
+      {
+        "name": "font-weight",
+        "syntax": "auto | <font-weight-absolute>{1,2}",
+        "initial": "auto"
+      },
+      {
+        "name": "font-width",
+        "syntax": "auto | <'font-width'>{1,2}",
+        "initial": "auto"
+      },
+      {
+        "name": "unicode-range",
+        "syntax": "<unicode-range-token>#",
+        "initial": "U+0-10FFFF"
+      },
+      {
+        "name": "font-feature-settings",
+        "syntax": "normal | <feature-tag-value>#",
+        "initial": ""
+      },
+      {
+        "name": "font-variation-settings",
+        "syntax": "normal | [ <string> <number>]#",
+        "initial": ""
+      },
+      {
+        "name": "font-named-instance",
+        "syntax": "auto | <string>",
+        "initial": "auto"
       },
       {
         "name": "font-display",
@@ -89,74 +159,90 @@
         "initial": "auto"
       },
       {
-        "name": "font-family",
-        "syntax": "<family-name>",
+        "name": "font-language-override",
+        "syntax": "normal | <string>",
         "initial": ""
       },
       {
-        "name": "font-feature-settings",
-        "syntax": "normal | <feature-tag-value>#",
-        "initial": "normal"
+        "name": "ascent-override",
+        "syntax": "normal | <percentage [0,∞]>",
+        "initial": ""
       },
       {
-        "name": "font-stretch",
-        "syntax": "<font-stretch-absolute>{1,2}",
-        "initial": "normal"
-      },
-      {
-        "name": "font-style",
-        "syntax": "normal | italic | oblique <angle>{0,2}",
-        "initial": "normal"
-      },
-      {
-        "name": "font-variation-settings",
-        "syntax": "normal | [ <string> <number> ]#",
-        "initial": "normal"
-      },
-      {
-        "name": "font-weight",
-        "syntax": "<font-weight-absolute>{1,2}",
-        "initial": "normal"
+        "name": "descent-override",
+        "syntax": "normal | <percentage [0,∞]>",
+        "initial": ""
       },
       {
         "name": "line-gap-override",
-        "syntax": "normal | <percentage>",
-        "initial": "normal"
-      },
-      {
-        "name": "size-adjust",
-        "syntax": "<percentage>",
-        "initial": "100%"
-      },
-      {
-        "name": "src",
-        "syntax": "[ <url> [ format( <string># ) ]? | local( <family-name> ) ]#",
+        "syntax": "normal | <percentage [0,∞]>",
         "initial": ""
-      },
-      {
-        "name": "unicode-range",
-        "syntax": "<unicode-range-token>#",
-        "initial": "U+0-10FFFF"
       }
     ],
     "Values": null
   },
   {
     "name": "@font-feature-values",
-    "descriptors": [],
-    "Values": null
+    "descriptors": [
+      {
+        "name": "font-display",
+        "syntax": "auto | block | swap | fallback | optional",
+        "initial": "auto"
+      },
+      {
+        "name": "@stylistic",
+        "syntax": "@stylistic { <declaration-list> }",
+        "initial": ""
+      },
+      {
+        "name": "@historical-forms",
+        "syntax": "@historical-forms { <declaration-list> }",
+        "initial": ""
+      },
+      {
+        "name": "@styleset",
+        "syntax": "@styleset { <declaration-list> }",
+        "initial": ""
+      },
+      {
+        "name": "@character-variant",
+        "syntax": "@character-variant { <declaration-list> }",
+        "initial": ""
+      },
+      {
+        "name": "@swash",
+        "syntax": "@swash { <declaration-list> }",
+        "initial": ""
+      },
+      {
+        "name": "@ornaments",
+        "syntax": "@ornaments { <declaration-list> }",
+        "initial": ""
+      },
+      {
+        "name": "@annotation",
+        "syntax": "@annotation { <declaration-list> }",
+        "initial": ""
+      }
+    ],
+    "Values": [
+      {
+        "name": "<font-feature-value-type>",
+        "Values": null
+      }
+    ]
   },
   {
     "name": "@font-palette-values",
     "descriptors": [
       {
-        "name": "base-palette",
-        "syntax": "light | dark | <integer [0,∞]>",
+        "name": "font-family",
+        "syntax": "<font-family-name>#",
         "initial": ""
       },
       {
-        "name": "font-family",
-        "syntax": "<family-name>#",
+        "name": "base-palette",
+        "syntax": "light | dark | <integer [0,∞]>",
         "initial": ""
       },
       {
@@ -166,6 +252,23 @@
       }
     ],
     "Values": null
+  },
+  {
+    "name": "@function",
+    "descriptors": [
+      {
+        "name": "result",
+        "syntax": "<declaration-value>?",
+        "initial": ""
+      }
+    ],
+    "Values": [
+      {
+        "name": "type()",
+        "value": "type( <syntax> )",
+        "Values": null
+      }
+    ]
   },
   {
     "name": "@import",
@@ -183,7 +286,284 @@
     "Values": null
   },
   {
+    "name": "@left-bottom",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@left-middle",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@left-top",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@macro",
+    "descriptors": [],
+    "Values": null
+  },
+  {
     "name": "@media",
+    "descriptors": [
+      {
+        "name": "display-state",
+        "syntax": "normal | minimized | maximized | fullscreen",
+        "initial": ""
+      },
+      {
+        "name": "resizable",
+        "syntax": "true | false",
+        "initial": ""
+      },
+      {
+        "name": "-webkit-device-pixel-ratio",
+        "syntax": "<number>",
+        "initial": ""
+      },
+      {
+        "name": "-webkit-transform-3d",
+        "syntax": "<mq-boolean>",
+        "initial": ""
+      },
+      {
+        "name": "shape",
+        "syntax": "rect | round",
+        "initial": ""
+      },
+      {
+        "name": "width",
+        "syntax": "<length>",
+        "initial": ""
+      },
+      {
+        "name": "height",
+        "syntax": "<length>",
+        "initial": ""
+      },
+      {
+        "name": "aspect-ratio",
+        "syntax": "<ratio>",
+        "initial": ""
+      },
+      {
+        "name": "orientation",
+        "syntax": "portrait | landscape",
+        "initial": ""
+      },
+      {
+        "name": "resolution",
+        "syntax": "<resolution> | infinite",
+        "initial": ""
+      },
+      {
+        "name": "scan",
+        "syntax": "interlace | progressive",
+        "initial": ""
+      },
+      {
+        "name": "grid",
+        "syntax": "<mq-boolean>",
+        "initial": ""
+      },
+      {
+        "name": "update",
+        "syntax": "none | slow | fast",
+        "initial": ""
+      },
+      {
+        "name": "overflow-block",
+        "syntax": "none | scroll | paged",
+        "initial": ""
+      },
+      {
+        "name": "overflow-inline",
+        "syntax": "none | scroll",
+        "initial": ""
+      },
+      {
+        "name": "color",
+        "syntax": "<integer>",
+        "initial": ""
+      },
+      {
+        "name": "color-index",
+        "syntax": "<integer>",
+        "initial": ""
+      },
+      {
+        "name": "monochrome",
+        "syntax": "<integer>",
+        "initial": ""
+      },
+      {
+        "name": "color-gamut",
+        "syntax": "srgb | p3 | rec2020",
+        "initial": ""
+      },
+      {
+        "name": "pointer",
+        "syntax": "none | coarse | fine",
+        "initial": ""
+      },
+      {
+        "name": "hover",
+        "syntax": "none | hover",
+        "initial": ""
+      },
+      {
+        "name": "any-pointer",
+        "syntax": "none | coarse | fine",
+        "initial": ""
+      },
+      {
+        "name": "any-hover",
+        "syntax": "none | hover",
+        "initial": ""
+      },
+      {
+        "name": "device-width",
+        "syntax": "<length>",
+        "initial": ""
+      },
+      {
+        "name": "device-height",
+        "syntax": "<length>",
+        "initial": ""
+      },
+      {
+        "name": "device-aspect-ratio",
+        "syntax": "<ratio>",
+        "initial": ""
+      }
+    ],
+    "Values": [
+      {
+        "name": "all",
+        "value": "all",
+        "Values": [
+          {
+            "name": "inherit",
+            "value": "inherit"
+          }
+        ]
+      },
+      {
+        "name": "braille",
+        "value": "braille",
+        "Values": null
+      },
+      {
+        "name": "embossed",
+        "value": "embossed",
+        "Values": null
+      },
+      {
+        "name": "handheld",
+        "value": "handheld",
+        "Values": null
+      },
+      {
+        "name": "print",
+        "value": "print",
+        "Values": null
+      },
+      {
+        "name": "projection",
+        "value": "projection",
+        "Values": null
+      },
+      {
+        "name": "screen",
+        "value": "screen",
+        "Values": null
+      },
+      {
+        "name": "speech",
+        "value": "speech",
+        "Values": null
+      },
+      {
+        "name": "tty",
+        "value": "tty",
+        "Values": null
+      },
+      {
+        "name": "tv",
+        "value": "tv",
+        "Values": null
+      },
+      {
+        "name": "not",
+        "value": "not",
+        "Values": null
+      },
+      {
+        "name": "only",
+        "value": "only",
+        "Values": null
+      },
+      {
+        "name": "all",
+        "value": "all",
+        "Values": null
+      },
+      {
+        "name": "print",
+        "value": "print",
+        "Values": null
+      },
+      {
+        "name": "screen",
+        "value": "screen",
+        "Values": null
+      },
+      {
+        "name": "tty",
+        "value": "tty",
+        "Values": null
+      },
+      {
+        "name": "tv",
+        "value": "tv",
+        "Values": null
+      },
+      {
+        "name": "projection",
+        "value": "projection",
+        "Values": null
+      },
+      {
+        "name": "handheld",
+        "value": "handheld",
+        "Values": null
+      },
+      {
+        "name": "braille",
+        "value": "braille",
+        "Values": null
+      },
+      {
+        "name": "embossed",
+        "value": "embossed",
+        "Values": null
+      },
+      {
+        "name": "aural",
+        "value": "aural",
+        "Values": null
+      },
+      {
+        "name": "speech",
+        "value": "speech",
+        "Values": null
+      }
+    ]
+  },
+  {
+    "name": "@mixin",
     "descriptors": [],
     "Values": null
   },
@@ -193,17 +573,17 @@
     "Values": null
   },
   {
+    "name": "@navigation",
+    "descriptors": [],
+    "Values": null
+  },
+  {
     "name": "@page",
     "descriptors": [
       {
-        "name": "bleed",
-        "syntax": "auto | <length>",
+        "name": "size",
+        "syntax": "<length [0,∞]>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]",
         "initial": "auto"
-      },
-      {
-        "name": "marks",
-        "syntax": "none | [ crop || cross ]",
-        "initial": "none"
       },
       {
         "name": "page-orientation",
@@ -211,12 +591,43 @@
         "initial": "upright"
       },
       {
-        "name": "size",
-        "syntax": "<length [0,∞]>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]",
+        "name": "marks",
+        "syntax": "none | [ crop || cross ]",
+        "initial": ""
+      },
+      {
+        "name": "bleed",
+        "syntax": "auto | <length>",
+        "initial": "auto"
+      },
+      {
+        "name": "page-margin-safety",
+        "syntax": "none | clamp | add",
         "initial": "auto"
       }
     ],
-    "Values": null
+    "Values": [
+      {
+        "name": ":left",
+        "value": ":left",
+        "Values": null
+      },
+      {
+        "name": ":right",
+        "value": ":right",
+        "Values": null
+      },
+      {
+        "name": ":first",
+        "value": ":first",
+        "Values": null
+      },
+      {
+        "name": ":blank",
+        "value": ":blank",
+        "Values": null
+      }
+    ]
   },
   {
     "name": "@position-try",
@@ -227,30 +638,45 @@
     "name": "@property",
     "descriptors": [
       {
+        "name": "syntax",
+        "syntax": "<string>",
+        "initial": ""
+      },
+      {
         "name": "inherits",
         "syntax": "true | false",
-        "initial": "auto"
+        "initial": ""
       },
       {
         "name": "initial-value",
         "syntax": "<declaration-value>?",
-        "initial": ""
-      },
-      {
-        "name": "syntax",
-        "syntax": "<string>",
-        "initial": ""
+        "initial": "the guaranteed-invalid value (but see prose)"
       }
     ],
     "Values": null
   },
   {
-    "name": "@scope",
+    "name": "@result",
     "descriptors": [],
     "Values": null
   },
   {
-    "name": "@starting-style",
+    "name": "@right-bottom",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@right-middle",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@right-top",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@route",
     "descriptors": [],
     "Values": null
   },
@@ -260,17 +686,42 @@
     "Values": null
   },
   {
+    "name": "@top-center",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@top-left",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@top-left-corner",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@top-right",
+    "descriptors": [],
+    "Values": null
+  },
+  {
+    "name": "@top-right-corner",
+    "descriptors": [],
+    "Values": null
+  },
+  {
     "name": "@view-transition",
     "descriptors": [
       {
         "name": "navigation",
         "syntax": "auto | none",
-        "initial": "none"
+        "initial": ""
       },
       {
         "name": "types",
-        "syntax": "none | <custom-ident>+",
-        "initial": "none"
+        "syntax": "none | <view-transition-type>+",
+        "initial": ""
       }
     ],
     "Values": null

--- a/crates/gosub_css3/resources/definitions/definitions_at-rules.json
+++ b/crates/gosub_css3/resources/definitions/definitions_at-rules.json
@@ -48,34 +48,9 @@
     "name": "@counter-style",
     "descriptors": [
       {
-        "name": "system",
-        "syntax": "cyclic | numeric | alphabetic | symbolic | additive | [fixed <integer>?] | [ extends <counter-style-name> ]",
-        "initial": "symbolic"
-      },
-      {
-        "name": "negative",
-        "syntax": "<symbol> <symbol>?",
-        "initial": "\"-\""
-      },
-      {
-        "name": "prefix",
-        "syntax": "<symbol>",
-        "initial": "\"\""
-      },
-      {
-        "name": "suffix",
-        "syntax": "<symbol>",
-        "initial": "\". \""
-      },
-      {
-        "name": "range",
-        "syntax": "[ [ <integer> | infinite ]{2} ]# | auto",
-        "initial": "auto"
-      },
-      {
-        "name": "pad",
-        "syntax": "<integer [0,∞]> && <symbol>",
-        "initial": "0 \"\""
+        "name": "additive-symbols",
+        "syntax": "[ <integer [0,∞]> && <symbol> ]#",
+        "initial": ""
       },
       {
         "name": "fallback",
@@ -83,19 +58,44 @@
         "initial": "decimal"
       },
       {
-        "name": "symbols",
-        "syntax": "<symbol>+",
-        "initial": ""
+        "name": "negative",
+        "syntax": "<symbol> <symbol>?",
+        "initial": "\"-\""
       },
       {
-        "name": "additive-symbols",
-        "syntax": "[ <integer [0,∞]> && <symbol> ]#",
-        "initial": ""
+        "name": "pad",
+        "syntax": "<integer [0,∞]> && <symbol>",
+        "initial": "0 \"\""
+      },
+      {
+        "name": "prefix",
+        "syntax": "<symbol>",
+        "initial": "\"\""
+      },
+      {
+        "name": "range",
+        "syntax": "[ [ <integer> | infinite ]{2} ]# | auto",
+        "initial": "auto"
       },
       {
         "name": "speak-as",
         "syntax": "auto | bullets | numbers | words | spell-out | <counter-style-name>",
         "initial": "auto"
+      },
+      {
+        "name": "suffix",
+        "syntax": "<symbol>",
+        "initial": "\". \""
+      },
+      {
+        "name": "symbols",
+        "syntax": "<symbol>+",
+        "initial": ""
+      },
+      {
+        "name": "system",
+        "syntax": "cyclic | numeric | alphabetic | symbolic | additive | [fixed <integer>?] | [ extends <counter-style-name> ]",
+        "initial": "symbolic"
       }
     ],
     "Values": null
@@ -109,19 +109,49 @@
     "name": "@font-face",
     "descriptors": [
       {
+        "name": "ascent-override",
+        "syntax": "normal | <percentage [0,∞]>",
+        "initial": ""
+      },
+      {
+        "name": "descent-override",
+        "syntax": "normal | <percentage [0,∞]>",
+        "initial": ""
+      },
+      {
+        "name": "font-display",
+        "syntax": "auto | block | swap | fallback | optional",
+        "initial": "auto"
+      },
+      {
         "name": "font-family",
         "syntax": "<font-family-name>",
         "initial": ""
       },
       {
-        "name": "src",
-        "syntax": "<font-src-list>",
+        "name": "font-feature-settings",
+        "syntax": "normal | <feature-tag-value>#",
         "initial": ""
+      },
+      {
+        "name": "font-language-override",
+        "syntax": "normal | <string>",
+        "initial": ""
+      },
+      {
+        "name": "font-named-instance",
+        "syntax": "auto | <string>",
+        "initial": "auto"
       },
       {
         "name": "font-style",
         "syntax": "auto | normal | italic | left | right | oblique [ <angle [-90deg,90deg]>{1,2} ]?",
         "initial": "auto"
+      },
+      {
+        "name": "font-variation-settings",
+        "syntax": "normal | [ <string> <number>]#",
+        "initial": ""
       },
       {
         "name": "font-weight",
@@ -134,49 +164,19 @@
         "initial": "auto"
       },
       {
-        "name": "unicode-range",
-        "syntax": "<unicode-range-token>#",
-        "initial": "U+0-10FFFF"
-      },
-      {
-        "name": "font-feature-settings",
-        "syntax": "normal | <feature-tag-value>#",
-        "initial": ""
-      },
-      {
-        "name": "font-variation-settings",
-        "syntax": "normal | [ <string> <number>]#",
-        "initial": ""
-      },
-      {
-        "name": "font-named-instance",
-        "syntax": "auto | <string>",
-        "initial": "auto"
-      },
-      {
-        "name": "font-display",
-        "syntax": "auto | block | swap | fallback | optional",
-        "initial": "auto"
-      },
-      {
-        "name": "font-language-override",
-        "syntax": "normal | <string>",
-        "initial": ""
-      },
-      {
-        "name": "ascent-override",
-        "syntax": "normal | <percentage [0,∞]>",
-        "initial": ""
-      },
-      {
-        "name": "descent-override",
-        "syntax": "normal | <percentage [0,∞]>",
-        "initial": ""
-      },
-      {
         "name": "line-gap-override",
         "syntax": "normal | <percentage [0,∞]>",
         "initial": ""
+      },
+      {
+        "name": "src",
+        "syntax": "<font-src-list>",
+        "initial": ""
+      },
+      {
+        "name": "unicode-range",
+        "syntax": "<unicode-range-token>#",
+        "initial": "U+0-10FFFF"
       }
     ],
     "Values": null
@@ -185,23 +185,8 @@
     "name": "@font-feature-values",
     "descriptors": [
       {
-        "name": "font-display",
-        "syntax": "auto | block | swap | fallback | optional",
-        "initial": "auto"
-      },
-      {
-        "name": "@stylistic",
-        "syntax": "@stylistic { <declaration-list> }",
-        "initial": ""
-      },
-      {
-        "name": "@historical-forms",
-        "syntax": "@historical-forms { <declaration-list> }",
-        "initial": ""
-      },
-      {
-        "name": "@styleset",
-        "syntax": "@styleset { <declaration-list> }",
+        "name": "@annotation",
+        "syntax": "@annotation { <declaration-list> }",
         "initial": ""
       },
       {
@@ -210,8 +195,8 @@
         "initial": ""
       },
       {
-        "name": "@swash",
-        "syntax": "@swash { <declaration-list> }",
+        "name": "@historical-forms",
+        "syntax": "@historical-forms { <declaration-list> }",
         "initial": ""
       },
       {
@@ -220,9 +205,24 @@
         "initial": ""
       },
       {
-        "name": "@annotation",
-        "syntax": "@annotation { <declaration-list> }",
+        "name": "@styleset",
+        "syntax": "@styleset { <declaration-list> }",
         "initial": ""
+      },
+      {
+        "name": "@stylistic",
+        "syntax": "@stylistic { <declaration-list> }",
+        "initial": ""
+      },
+      {
+        "name": "@swash",
+        "syntax": "@swash { <declaration-list> }",
+        "initial": ""
+      },
+      {
+        "name": "font-display",
+        "syntax": "auto | block | swap | fallback | optional",
+        "initial": "auto"
       }
     ],
     "Values": [
@@ -236,13 +236,13 @@
     "name": "@font-palette-values",
     "descriptors": [
       {
-        "name": "font-family",
-        "syntax": "<font-family-name>#",
+        "name": "base-palette",
+        "syntax": "light | dark | <integer [0,∞]>",
         "initial": ""
       },
       {
-        "name": "base-palette",
-        "syntax": "light | dark | <integer [0,∞]>",
+        "name": "font-family",
+        "syntax": "<font-family-name>#",
         "initial": ""
       },
       {
@@ -309,16 +309,6 @@
     "name": "@media",
     "descriptors": [
       {
-        "name": "display-state",
-        "syntax": "normal | minimized | maximized | fullscreen",
-        "initial": ""
-      },
-      {
-        "name": "resizable",
-        "syntax": "true | false",
-        "initial": ""
-      },
-      {
         "name": "-webkit-device-pixel-ratio",
         "syntax": "<number>",
         "initial": ""
@@ -329,18 +319,13 @@
         "initial": ""
       },
       {
-        "name": "shape",
-        "syntax": "rect | round",
+        "name": "any-hover",
+        "syntax": "none | hover",
         "initial": ""
       },
       {
-        "name": "width",
-        "syntax": "<length>",
-        "initial": ""
-      },
-      {
-        "name": "height",
-        "syntax": "<length>",
+        "name": "any-pointer",
+        "syntax": "none | coarse | fine",
         "initial": ""
       },
       {
@@ -349,18 +334,38 @@
         "initial": ""
       },
       {
-        "name": "orientation",
-        "syntax": "portrait | landscape",
+        "name": "color",
+        "syntax": "<integer>",
         "initial": ""
       },
       {
-        "name": "resolution",
-        "syntax": "<resolution> | infinite",
+        "name": "color-gamut",
+        "syntax": "srgb | p3 | rec2020",
         "initial": ""
       },
       {
-        "name": "scan",
-        "syntax": "interlace | progressive",
+        "name": "color-index",
+        "syntax": "<integer>",
+        "initial": ""
+      },
+      {
+        "name": "device-aspect-ratio",
+        "syntax": "<ratio>",
+        "initial": ""
+      },
+      {
+        "name": "device-height",
+        "syntax": "<length>",
+        "initial": ""
+      },
+      {
+        "name": "device-width",
+        "syntax": "<length>",
+        "initial": ""
+      },
+      {
+        "name": "display-state",
+        "syntax": "normal | minimized | maximized | fullscreen",
         "initial": ""
       },
       {
@@ -369,8 +374,23 @@
         "initial": ""
       },
       {
-        "name": "update",
-        "syntax": "none | slow | fast",
+        "name": "height",
+        "syntax": "<length>",
+        "initial": ""
+      },
+      {
+        "name": "hover",
+        "syntax": "none | hover",
+        "initial": ""
+      },
+      {
+        "name": "monochrome",
+        "syntax": "<integer>",
+        "initial": ""
+      },
+      {
+        "name": "orientation",
+        "syntax": "portrait | landscape",
         "initial": ""
       },
       {
@@ -384,62 +404,47 @@
         "initial": ""
       },
       {
-        "name": "color",
-        "syntax": "<integer>",
-        "initial": ""
-      },
-      {
-        "name": "color-index",
-        "syntax": "<integer>",
-        "initial": ""
-      },
-      {
-        "name": "monochrome",
-        "syntax": "<integer>",
-        "initial": ""
-      },
-      {
-        "name": "color-gamut",
-        "syntax": "srgb | p3 | rec2020",
-        "initial": ""
-      },
-      {
         "name": "pointer",
         "syntax": "none | coarse | fine",
         "initial": ""
       },
       {
-        "name": "hover",
-        "syntax": "none | hover",
+        "name": "resizable",
+        "syntax": "true | false",
         "initial": ""
       },
       {
-        "name": "any-pointer",
-        "syntax": "none | coarse | fine",
+        "name": "resolution",
+        "syntax": "<resolution> | infinite",
         "initial": ""
       },
       {
-        "name": "any-hover",
-        "syntax": "none | hover",
+        "name": "scan",
+        "syntax": "interlace | progressive",
         "initial": ""
       },
       {
-        "name": "device-width",
+        "name": "shape",
+        "syntax": "rect | round",
+        "initial": ""
+      },
+      {
+        "name": "update",
+        "syntax": "none | slow | fast",
+        "initial": ""
+      },
+      {
+        "name": "width",
         "syntax": "<length>",
-        "initial": ""
-      },
-      {
-        "name": "device-height",
-        "syntax": "<length>",
-        "initial": ""
-      },
-      {
-        "name": "device-aspect-ratio",
-        "syntax": "<ratio>",
         "initial": ""
       }
     ],
     "Values": [
+      {
+        "name": "all",
+        "value": "all",
+        "Values": null
+      },
       {
         "name": "all",
         "value": "all",
@@ -451,8 +456,23 @@
         ]
       },
       {
+        "name": "aural",
+        "value": "aural",
+        "Values": null
+      },
+      {
         "name": "braille",
         "value": "braille",
+        "Values": null
+      },
+      {
+        "name": "braille",
+        "value": "braille",
+        "Values": null
+      },
+      {
+        "name": "embossed",
+        "value": "embossed",
         "Values": null
       },
       {
@@ -466,33 +486,8 @@
         "Values": null
       },
       {
-        "name": "print",
-        "value": "print",
-        "Values": null
-      },
-      {
-        "name": "projection",
-        "value": "projection",
-        "Values": null
-      },
-      {
-        "name": "screen",
-        "value": "screen",
-        "Values": null
-      },
-      {
-        "name": "speech",
-        "value": "speech",
-        "Values": null
-      },
-      {
-        "name": "tty",
-        "value": "tty",
-        "Values": null
-      },
-      {
-        "name": "tv",
-        "value": "tv",
+        "name": "handheld",
+        "value": "handheld",
         "Values": null
       },
       {
@@ -506,8 +501,8 @@
         "Values": null
       },
       {
-        "name": "all",
-        "value": "all",
+        "name": "print",
+        "value": "print",
         "Values": null
       },
       {
@@ -516,8 +511,38 @@
         "Values": null
       },
       {
+        "name": "projection",
+        "value": "projection",
+        "Values": null
+      },
+      {
+        "name": "projection",
+        "value": "projection",
+        "Values": null
+      },
+      {
         "name": "screen",
         "value": "screen",
+        "Values": null
+      },
+      {
+        "name": "screen",
+        "value": "screen",
+        "Values": null
+      },
+      {
+        "name": "speech",
+        "value": "speech",
+        "Values": null
+      },
+      {
+        "name": "speech",
+        "value": "speech",
+        "Values": null
+      },
+      {
+        "name": "tty",
+        "value": "tty",
         "Values": null
       },
       {
@@ -531,33 +556,8 @@
         "Values": null
       },
       {
-        "name": "projection",
-        "value": "projection",
-        "Values": null
-      },
-      {
-        "name": "handheld",
-        "value": "handheld",
-        "Values": null
-      },
-      {
-        "name": "braille",
-        "value": "braille",
-        "Values": null
-      },
-      {
-        "name": "embossed",
-        "value": "embossed",
-        "Values": null
-      },
-      {
-        "name": "aural",
-        "value": "aural",
-        "Values": null
-      },
-      {
-        "name": "speech",
-        "value": "speech",
+        "name": "tv",
+        "value": "tv",
         "Values": null
       }
     ]
@@ -581,8 +581,18 @@
     "name": "@page",
     "descriptors": [
       {
-        "name": "size",
-        "syntax": "<length [0,∞]>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]",
+        "name": "bleed",
+        "syntax": "auto | <length>",
+        "initial": "auto"
+      },
+      {
+        "name": "marks",
+        "syntax": "none | [ crop || cross ]",
+        "initial": ""
+      },
+      {
+        "name": "page-margin-safety",
+        "syntax": "none | clamp | add",
         "initial": "auto"
       },
       {
@@ -591,30 +601,15 @@
         "initial": "upright"
       },
       {
-        "name": "marks",
-        "syntax": "none | [ crop || cross ]",
-        "initial": ""
-      },
-      {
-        "name": "bleed",
-        "syntax": "auto | <length>",
-        "initial": "auto"
-      },
-      {
-        "name": "page-margin-safety",
-        "syntax": "none | clamp | add",
+        "name": "size",
+        "syntax": "<length [0,∞]>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]",
         "initial": "auto"
       }
     ],
     "Values": [
       {
-        "name": ":left",
-        "value": ":left",
-        "Values": null
-      },
-      {
-        "name": ":right",
-        "value": ":right",
+        "name": ":blank",
+        "value": ":blank",
         "Values": null
       },
       {
@@ -623,8 +618,13 @@
         "Values": null
       },
       {
-        "name": ":blank",
-        "value": ":blank",
+        "name": ":left",
+        "value": ":left",
+        "Values": null
+      },
+      {
+        "name": ":right",
+        "value": ":right",
         "Values": null
       }
     ]
@@ -638,11 +638,6 @@
     "name": "@property",
     "descriptors": [
       {
-        "name": "syntax",
-        "syntax": "<string>",
-        "initial": ""
-      },
-      {
         "name": "inherits",
         "syntax": "true | false",
         "initial": ""
@@ -651,6 +646,11 @@
         "name": "initial-value",
         "syntax": "<declaration-value>?",
         "initial": "the guaranteed-invalid value (but see prose)"
+      },
+      {
+        "name": "syntax",
+        "syntax": "<string>",
+        "initial": ""
       }
     ],
     "Values": null

--- a/crates/gosub_css3/resources/definitions/definitions_properties.json
+++ b/crates/gosub_css3/resources/definitions/definitions_properties.json
@@ -716,7 +716,7 @@
     "name": "-webkit-border-after-width",
     "syntax": "<'border-top-width'>",
     "computed": [
-      "absoluteLength"
+      "absoluteLengthSnappedAsLineWidth"
     ],
     "initial": "medium",
     "inherited": false
@@ -758,7 +758,7 @@
     "name": "-webkit-border-before-width",
     "syntax": "<'border-top-width'>",
     "computed": [
-      "absoluteLength"
+      "absoluteLengthSnappedAsLineWidth"
     ],
     "initial": "medium",
     "inherited": false
@@ -800,7 +800,7 @@
     "name": "-webkit-border-end-width",
     "syntax": "<'border-top-width'>",
     "computed": [
-      "absoluteLength"
+      "absoluteLengthSnappedAsLineWidth"
     ],
     "initial": "medium",
     "inherited": false
@@ -842,7 +842,7 @@
     "name": "-webkit-border-start-width",
     "syntax": "<'border-top-width'>",
     "computed": [
-      "absoluteLength"
+      "absoluteLengthSnappedAsLineWidth"
     ],
     "initial": "medium",
     "inherited": false
@@ -867,7 +867,7 @@
   },
   {
     "name": "-webkit-mask",
-    "syntax": "[ <mask-reference> || <position> [ / <bg-size> ]? || <repeat-style> || [ <visual-box> | border | padding | content | text ] || [ <visual-box> | border | padding | content ] ]#",
+    "syntax": "<mask-layer>#",
     "computed": [
       "-webkit-mask-image",
       "-webkit-mask-repeat",
@@ -897,7 +897,7 @@
   },
   {
     "name": "-webkit-mask-clip",
-    "syntax": "[ <coord-box> | no-clip | border | padding | content | text ]#",
+    "syntax": "[ <coord-box> | no-clip ]#",
     "computed": [
       "asSpecified"
     ],
@@ -906,7 +906,7 @@
   },
   {
     "name": "-webkit-mask-composite",
-    "syntax": "<composite-style>#",
+    "syntax": "<compositing-operator>#",
     "computed": [
       "asSpecified"
     ],
@@ -924,7 +924,7 @@
   },
   {
     "name": "-webkit-mask-origin",
-    "syntax": "[ <coord-box> | border | padding | content ]#",
+    "syntax": "<coord-box>#",
     "computed": [
       "asSpecified"
     ],
@@ -1023,7 +1023,7 @@
   },
   {
     "name": "-webkit-text-stroke",
-    "syntax": "<length> || <color>",
+    "syntax": "<line-width> || <color>",
     "computed": [
       "-webkit-text-stroke-width",
       "-webkit-text-stroke-color"
@@ -1045,7 +1045,7 @@
   },
   {
     "name": "-webkit-text-stroke-width",
-    "syntax": "<length>",
+    "syntax": "<line-width>",
     "computed": [
       "absoluteLength"
     ],
@@ -1072,7 +1072,7 @@
   },
   {
     "name": "-webkit-user-select",
-    "syntax": "auto | text | none | all",
+    "syntax": "auto | text | none | contain | all",
     "computed": [
       "asSpecified"
     ],
@@ -1099,7 +1099,7 @@
   },
   {
     "name": "align-items",
-    "syntax": "normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ] | anchor-center",
+    "syntax": "normal | stretch | <baseline-position> | <overflow-position>? <self-position>",
     "computed": [
       "asSpecified"
     ],
@@ -1108,7 +1108,7 @@
   },
   {
     "name": "align-self",
-    "syntax": "auto | normal | stretch | <baseline-position> | <overflow-position>? <self-position> | anchor-center",
+    "syntax": "auto | <overflow-position>? [ normal | <self-position> ]| stretch | <baseline-position> | anchor-center",
     "computed": [
       "autoOnAbsolutelyPositionedElementsValueOfAlignItemsOnParent"
     ],
@@ -1126,7 +1126,7 @@
   },
   {
     "name": "alignment-baseline",
-    "syntax": "baseline | alphabetic | ideographic | middle | central | mathematical | text-before-edge | text-after-edge",
+    "syntax": "baseline | <baseline-metric>",
     "computed": [
       "theSpecifiedKeyword"
     ],
@@ -1135,7 +1135,7 @@
   },
   {
     "name": "all",
-    "syntax": "initial | inherit | unset | revert | revert-layer",
+    "syntax": "initial | inherit | unset | revert | revert-layer | revert-rule",
     "computed": [
       "asSpecifiedAppliesToEachProperty"
     ],
@@ -1144,7 +1144,7 @@
   },
   {
     "name": "anchor-name",
-    "syntax": "none | <dashed-ident>#",
+    "syntax": "none | <anchor-name>#",
     "computed": [
       "asSpecified"
     ],
@@ -1153,7 +1153,7 @@
   },
   {
     "name": "anchor-scope",
-    "syntax": "none | all | <dashed-ident>#",
+    "syntax": "none | all | <anchor-name>#",
     "computed": [
       "asSpecified"
     ],
@@ -1216,7 +1216,7 @@
   },
   {
     "name": "animation-duration",
-    "syntax": "[ auto | <time [0s,∞]> ]#",
+    "syntax": "<time [0s,∞]>#",
     "computed": [
       "asSpecified"
     ],
@@ -1319,7 +1319,7 @@
   },
   {
     "name": "appearance",
-    "syntax": "none | auto | <compat-auto> | <compat-special>",
+    "syntax": "none | auto | base | base-select | <compat-auto> | <compat-special> | base",
     "computed": [
       "asSpecified"
     ],
@@ -1389,7 +1389,7 @@
   },
   {
     "name": "background-blend-mode",
-    "syntax": "<blend-mode>#",
+    "syntax": "<'mix-blend-mode'>#",
     "computed": [
       "asSpecified"
     ],
@@ -1398,7 +1398,7 @@
   },
   {
     "name": "background-clip",
-    "syntax": "<bg-clip>#",
+    "syntax": "<visual-box>#",
     "computed": [
       "asSpecified"
     ],
@@ -1480,7 +1480,7 @@
   },
   {
     "name": "baseline-shift",
-    "syntax": "<length-percentage> | sub | super | baseline",
+    "syntax": "<length-percentage> | sub | super | top | center | bottom",
     "computed": [
       "theSpecifiedKeywordOrAComputedLengthPercentageValue"
     ],
@@ -1522,7 +1522,7 @@
   },
   {
     "name": "border-block",
-    "syntax": "<'border-top'>",
+    "syntax": "<'border-block-start'>",
     "computed": [
       "border-block-width",
       "border-block-style",
@@ -1550,7 +1550,7 @@
   },
   {
     "name": "border-block-end",
-    "syntax": "<'border-top'>",
+    "syntax": "<line-width> || <line-style> || <color>",
     "computed": [
       "border-block-end-width",
       "border-block-end-style",
@@ -1565,7 +1565,7 @@
   },
   {
     "name": "border-block-end-color",
-    "syntax": "<'border-top-color'>",
+    "syntax": "<color> | <image-1D>",
     "computed": [
       "computedColor"
     ],
@@ -1574,7 +1574,7 @@
   },
   {
     "name": "border-block-end-style",
-    "syntax": "<'border-top-style'>",
+    "syntax": "<line-style>",
     "computed": [
       "asSpecified"
     ],
@@ -1583,16 +1583,16 @@
   },
   {
     "name": "border-block-end-width",
-    "syntax": "<'border-top-width'>",
+    "syntax": "<line-width>",
     "computed": [
-      "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+      "absoluteLengthSnappedAsLineWidth"
     ],
     "initial": "medium",
     "inherited": false
   },
   {
     "name": "border-block-start",
-    "syntax": "<'border-top'>",
+    "syntax": "<line-width> || <line-style> || <color>",
     "computed": [
       "border-block-start-width",
       "border-block-start-style",
@@ -1607,7 +1607,7 @@
   },
   {
     "name": "border-block-start-color",
-    "syntax": "<'border-top-color'>",
+    "syntax": "<color> | <image-1D>",
     "computed": [
       "computedColor"
     ],
@@ -1616,7 +1616,7 @@
   },
   {
     "name": "border-block-start-style",
-    "syntax": "<'border-top-style'>",
+    "syntax": "<line-style>",
     "computed": [
       "asSpecified"
     ],
@@ -1625,9 +1625,9 @@
   },
   {
     "name": "border-block-start-width",
-    "syntax": "<'border-top-width'>",
+    "syntax": "<line-width>",
     "computed": [
-      "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+      "absoluteLengthSnappedAsLineWidth"
     ],
     "initial": "medium",
     "inherited": false
@@ -1675,7 +1675,7 @@
   },
   {
     "name": "border-bottom-color",
-    "syntax": "<'border-top-color'>",
+    "syntax": "<color> | <image-1D>",
     "computed": [
       "computedColor"
     ],
@@ -1684,7 +1684,7 @@
   },
   {
     "name": "border-bottom-left-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "syntax": "<border-radius>",
     "computed": [
       "twoAbsoluteLengthOrPercentages"
     ],
@@ -1693,7 +1693,7 @@
   },
   {
     "name": "border-bottom-right-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "syntax": "<border-radius>",
     "computed": [
       "twoAbsoluteLengthOrPercentages"
     ],
@@ -1713,7 +1713,7 @@
     "name": "border-bottom-width",
     "syntax": "<line-width>",
     "computed": [
-      "absoluteLengthOr0IfBorderBottomStyleNoneOrHidden"
+      "absoluteLengthSnappedAsLineWidth"
     ],
     "initial": "medium",
     "inherited": false
@@ -1729,7 +1729,7 @@
   },
   {
     "name": "border-color",
-    "syntax": "<color>{1,4}",
+    "syntax": "[ <color> | <image-1D> ]{1,4}",
     "computed": [
       "border-top-color",
       "border-right-color",
@@ -1746,7 +1746,7 @@
   },
   {
     "name": "border-end-end-radius",
-    "syntax": "<'border-top-left-radius'>",
+    "syntax": "<border-radius>",
     "computed": [
       "twoAbsoluteLengthOrPercentages"
     ],
@@ -1755,7 +1755,7 @@
   },
   {
     "name": "border-end-start-radius",
-    "syntax": "<'border-top-left-radius'>",
+    "syntax": "<border-radius>",
     "computed": [
       "twoAbsoluteLengthOrPercentages"
     ],
@@ -1801,7 +1801,7 @@
   },
   {
     "name": "border-image-slice",
-    "syntax": "[ <number [0,∞]> | <percentage [0,∞]> ]{1,4} && fill?",
+    "syntax": "[<number [0,∞]> | <percentage [0,∞]>]{1,4} && fill?",
     "computed": [
       "oneToFourPercentagesOrAbsoluteLengthsPlusFill"
     ],
@@ -1828,7 +1828,7 @@
   },
   {
     "name": "border-inline",
-    "syntax": "<'border-top'>",
+    "syntax": "<'border-block-start'>",
     "computed": [
       "border-inline-width",
       "border-inline-style",
@@ -1856,7 +1856,7 @@
   },
   {
     "name": "border-inline-end",
-    "syntax": "<'border-top'>",
+    "syntax": "<line-width> || <line-style> || <color>",
     "computed": [
       "border-inline-end-width",
       "border-inline-end-style",
@@ -1871,7 +1871,7 @@
   },
   {
     "name": "border-inline-end-color",
-    "syntax": "<'border-top-color'>",
+    "syntax": "<color> | <image-1D>",
     "computed": [
       "computedColor"
     ],
@@ -1880,7 +1880,7 @@
   },
   {
     "name": "border-inline-end-style",
-    "syntax": "<'border-top-style'>",
+    "syntax": "<line-style>",
     "computed": [
       "asSpecified"
     ],
@@ -1889,16 +1889,16 @@
   },
   {
     "name": "border-inline-end-width",
-    "syntax": "<'border-top-width'>",
+    "syntax": "<line-width>",
     "computed": [
-      "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+      "absoluteLengthSnappedAsLineWidth"
     ],
     "initial": "medium",
     "inherited": false
   },
   {
     "name": "border-inline-start",
-    "syntax": "<'border-top'>",
+    "syntax": "<line-width> || <line-style> || <color>",
     "computed": [
       "border-inline-start-width",
       "border-inline-start-style",
@@ -1913,7 +1913,7 @@
   },
   {
     "name": "border-inline-start-color",
-    "syntax": "<'border-top-color'>",
+    "syntax": "<color> | <image-1D>",
     "computed": [
       "computedColor"
     ],
@@ -1922,7 +1922,7 @@
   },
   {
     "name": "border-inline-start-style",
-    "syntax": "<'border-top-style'>",
+    "syntax": "<line-style>",
     "computed": [
       "asSpecified"
     ],
@@ -1931,9 +1931,9 @@
   },
   {
     "name": "border-inline-start-width",
-    "syntax": "<'border-top-width'>",
+    "syntax": "<line-width>",
     "computed": [
-      "absoluteLengthZeroIfBorderStyleNoneOrHidden"
+      "absoluteLengthSnappedAsLineWidth"
     ],
     "initial": "medium",
     "inherited": false
@@ -1981,7 +1981,7 @@
   },
   {
     "name": "border-left-color",
-    "syntax": "<color>",
+    "syntax": "<color> | <image-1D>",
     "computed": [
       "computedColor"
     ],
@@ -2001,7 +2001,7 @@
     "name": "border-left-width",
     "syntax": "<line-width>",
     "computed": [
-      "absoluteLengthOr0IfBorderLeftStyleNoneOrHidden"
+      "absoluteLengthSnappedAsLineWidth"
     ],
     "initial": "medium",
     "inherited": false
@@ -2040,7 +2040,7 @@
   },
   {
     "name": "border-right-color",
-    "syntax": "<color>",
+    "syntax": "<color> | <image-1D>",
     "computed": [
       "computedColor"
     ],
@@ -2060,7 +2060,7 @@
     "name": "border-right-width",
     "syntax": "<line-width>",
     "computed": [
-      "absoluteLengthOr0IfBorderRightStyleNoneOrHidden"
+      "absoluteLengthSnappedAsLineWidth"
     ],
     "initial": "medium",
     "inherited": false
@@ -2076,7 +2076,7 @@
   },
   {
     "name": "border-spacing",
-    "syntax": "<length>{1,2}",
+    "syntax": "<length [0,∞]>{1,2}",
     "computed": [
       "twoAbsoluteLengths"
     ],
@@ -2085,7 +2085,7 @@
   },
   {
     "name": "border-start-end-radius",
-    "syntax": "<'border-top-left-radius'>",
+    "syntax": "<border-radius>",
     "computed": [
       "twoAbsoluteLengthOrPercentages"
     ],
@@ -2094,7 +2094,7 @@
   },
   {
     "name": "border-start-start-radius",
-    "syntax": "<'border-top-left-radius'>",
+    "syntax": "<border-radius>",
     "computed": [
       "twoAbsoluteLengthOrPercentages"
     ],
@@ -2103,7 +2103,7 @@
   },
   {
     "name": "border-style",
-    "syntax": "<line-style>{1,4}",
+    "syntax": "<'border-top-style'>{1,4}",
     "computed": [
       "border-top-style",
       "border-right-style",
@@ -2135,7 +2135,7 @@
   },
   {
     "name": "border-top-color",
-    "syntax": "<color>",
+    "syntax": "<color> | <image-1D>",
     "computed": [
       "computedColor"
     ],
@@ -2144,7 +2144,7 @@
   },
   {
     "name": "border-top-left-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "syntax": "<border-radius>",
     "computed": [
       "twoAbsoluteLengthOrPercentages"
     ],
@@ -2153,7 +2153,7 @@
   },
   {
     "name": "border-top-right-radius",
-    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "syntax": "<border-radius>",
     "computed": [
       "twoAbsoluteLengthOrPercentages"
     ],
@@ -2173,14 +2173,14 @@
     "name": "border-top-width",
     "syntax": "<line-width>",
     "computed": [
-      "absoluteLengthOr0IfBorderTopStyleNoneOrHidden"
+      "absoluteLengthSnappedAsLineWidth"
     ],
     "initial": "medium",
     "inherited": false
   },
   {
     "name": "border-width",
-    "syntax": "<line-width>{1,4}",
+    "syntax": "<'border-top-width'>{1,4}",
     "computed": [
       "border-top-width",
       "border-right-width",
@@ -2287,7 +2287,7 @@
   },
   {
     "name": "box-shadow",
-    "syntax": "none | <shadow>#",
+    "syntax": "<spread-shadow>#",
     "computed": [
       "absoluteLengthsSpecifiedColorAsSpecified"
     ],
@@ -2365,7 +2365,7 @@
   },
   {
     "name": "caret-color",
-    "syntax": "auto | <color>",
+    "syntax": "auto | <color> [auto | <color>]?",
     "computed": [
       "asAutoOrColor"
     ],
@@ -2383,7 +2383,7 @@
   },
   {
     "name": "clear",
-    "syntax": "none | left | right | both | inline-start | inline-end",
+    "syntax": "inline-start | inline-end | block-start | block-end | left | right | top | bottom | both-inline | both-block | both | none",
     "computed": [
       "asSpecified"
     ],
@@ -2392,7 +2392,7 @@
   },
   {
     "name": "clip",
-    "syntax": "<shape> | auto",
+    "syntax": "<rect()> | auto",
     "computed": [
       "autoOrRectangle"
     ],
@@ -2446,7 +2446,7 @@
   },
   {
     "name": "column-count",
-    "syntax": "<integer> | auto",
+    "syntax": "auto | <integer [1,∞]>",
     "computed": [
       "asSpecified"
     ],
@@ -2455,7 +2455,7 @@
   },
   {
     "name": "column-fill",
-    "syntax": "auto | balance",
+    "syntax": "auto | balance | balance-all",
     "computed": [
       "asSpecified"
     ],
@@ -2464,7 +2464,7 @@
   },
   {
     "name": "column-gap",
-    "syntax": "normal | <length-percentage>",
+    "syntax": "normal | <length-percentage [0,∞]> | <line-width>",
     "computed": [
       "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn"
     ],
@@ -2482,7 +2482,7 @@
   },
   {
     "name": "column-rule",
-    "syntax": "<'column-rule-width'> || <'column-rule-style'> || <'column-rule-color'>",
+    "syntax": "<gap-rule-list> | <gap-auto-rule-list>",
     "computed": [
       "column-rule-width",
       "column-rule-style",
@@ -2497,7 +2497,7 @@
   },
   {
     "name": "column-rule-color",
-    "syntax": "<color>",
+    "syntax": "<line-color-list> | <auto-line-color-list>",
     "computed": [
       "computedColor"
     ],
@@ -2506,7 +2506,7 @@
   },
   {
     "name": "column-rule-style",
-    "syntax": "<line-style>",
+    "syntax": "<line-style-list> | <auto-line-style-list>",
     "computed": [
       "asSpecified"
     ],
@@ -2515,16 +2515,16 @@
   },
   {
     "name": "column-rule-width",
-    "syntax": "<line-width>",
+    "syntax": "<line-width-list> | <auto-line-width-list>",
     "computed": [
-      "absoluteLength0IfColumnRuleStyleNoneOrHidden"
+      "absoluteLengthSnappedAsLineWidth"
     ],
     "initial": "medium",
     "inherited": false
   },
   {
     "name": "column-span",
-    "syntax": "none | all",
+    "syntax": "none | <integer [1,∞]> | all | auto",
     "computed": [
       "asSpecified"
     ],
@@ -2533,7 +2533,7 @@
   },
   {
     "name": "column-width",
-    "syntax": "auto | <length [0,∞]>",
+    "syntax": "auto | <length [0,∞]> | min-content | max-content | fit-content(<length-percentage>)",
     "computed": [
       "autoOrAbsoluteLength"
     ],
@@ -2566,7 +2566,7 @@
   },
   {
     "name": "contain",
-    "syntax": "none | strict | content | [ [ size || inline-size ] || layout || style || paint ]",
+    "syntax": "none | strict | content | [ [size | inline-size] || layout || style || paint ]",
     "computed": [
       "asSpecified"
     ],
@@ -2655,7 +2655,7 @@
   },
   {
     "name": "content",
-    "syntax": "normal | none | [ <content-replacement> | <content-list> ] [ / [ <string> | <counter> | <attr()> ]+ ]?",
+    "syntax": "normal | none | [ <content-replacement> | <content-list> ] [/ [ <string> | <counter> | <attr()> ]+ ]? | <element()>",
     "computed": [
       "normalOnElementsForPseudosNoneAbsoluteURIStringOrAsSpecified"
     ],
@@ -2673,7 +2673,7 @@
   },
   {
     "name": "corner-block-end-shape",
-    "syntax": "<corner-shape-value>{1,2}",
+    "syntax": "<'corner-top-left-shape'>{1,2}",
     "computed": [
       "corner-end-start-shape",
       "corner-end-end-shape"
@@ -2686,7 +2686,7 @@
   },
   {
     "name": "corner-block-start-shape",
-    "syntax": "<corner-shape-value>{1,2}",
+    "syntax": "<'corner-top-left-shape'>{1,2}",
     "computed": [
       "corner-start-start-shape",
       "corner-start-end-shape"
@@ -2717,7 +2717,7 @@
   },
   {
     "name": "corner-bottom-shape",
-    "syntax": "<corner-shape-value>{1,2}",
+    "syntax": "<'corner-top-left-shape'>{1,2}",
     "computed": [
       "corner-bottom-left-shape",
       "corner-bottom-right-shape"
@@ -2748,7 +2748,7 @@
   },
   {
     "name": "corner-inline-end-shape",
-    "syntax": "<corner-shape-value>{1,2}",
+    "syntax": "<'corner-top-left-shape'>{1,2}",
     "computed": [
       "corner-start-end-shape",
       "corner-end-end-shape"
@@ -2761,7 +2761,7 @@
   },
   {
     "name": "corner-inline-start-shape",
-    "syntax": "<corner-shape-value>{1,2}",
+    "syntax": "<'corner-top-left-shape'>{1,2}",
     "computed": [
       "corner-start-start-shape",
       "corner-start-end-shape"
@@ -2774,7 +2774,7 @@
   },
   {
     "name": "corner-left-shape",
-    "syntax": "<corner-shape-value>{1,2}",
+    "syntax": "<'corner-top-left-shape'>{1,2}",
     "computed": [
       "corner-top-left-shape",
       "corner-bottom-left-shape"
@@ -2787,7 +2787,7 @@
   },
   {
     "name": "corner-right-shape",
-    "syntax": "<corner-shape-value>{1,2}",
+    "syntax": "<'corner-top-left-shape'>{1,2}",
     "computed": [
       "corner-top-right-shape",
       "corner-bottom-right-shape"
@@ -2800,7 +2800,7 @@
   },
   {
     "name": "corner-shape",
-    "syntax": "<corner-shape-value>{1,4}",
+    "syntax": "<'corner-top-left-shape'>{1,4}",
     "computed": [
       "corner-top-left-shape",
       "corner-top-right-shape",
@@ -2853,7 +2853,7 @@
   },
   {
     "name": "corner-top-shape",
-    "syntax": "<corner-shape-value>{1,2}",
+    "syntax": "<'corner-top-left-shape'>{1,2}",
     "computed": [
       "corner-top-left-shape",
       "corner-top-right-shape"
@@ -2893,7 +2893,7 @@
   },
   {
     "name": "cursor",
-    "syntax": "[ [ <url> [ <x> <y> ]? , ]* <cursor-predefined> ]",
+    "syntax": "[<cursor-image>,]* <cursor-predefined>",
     "computed": [
       "asSpecifiedURLsAbsolute"
     ],
@@ -2902,7 +2902,7 @@
   },
   {
     "name": "cx",
-    "syntax": "<length> | <percentage>",
+    "syntax": "<length-percentage>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -2911,7 +2911,7 @@
   },
   {
     "name": "cy",
-    "syntax": "<length> | <percentage>",
+    "syntax": "<length-percentage>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -2920,7 +2920,7 @@
   },
   {
     "name": "d",
-    "syntax": "none | path(<string>)",
+    "syntax": "none | <string>",
     "computed": [
       "asSpecified"
     ],
@@ -2938,7 +2938,7 @@
   },
   {
     "name": "display",
-    "syntax": "[ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy>",
+    "syntax": "[ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy> | <display-outside> || [ <display-inside> | math ]",
     "computed": [
       "asSpecifiedExceptPositionedFloatingAndRootElementsKeywordMaybeDifferent"
     ],
@@ -2947,7 +2947,7 @@
   },
   {
     "name": "dominant-baseline",
-    "syntax": "auto | text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top",
+    "syntax": "auto | <baseline-metric>",
     "computed": [
       "asSpecified"
     ],
@@ -2974,7 +2974,7 @@
   },
   {
     "name": "field-sizing",
-    "syntax": "content | fixed",
+    "syntax": "fixed | content",
     "computed": [
       "asSpecified"
     ],
@@ -3065,7 +3065,7 @@
   },
   {
     "name": "flex-grow",
-    "syntax": "<number>",
+    "syntax": "<number [0,∞]>",
     "computed": [
       "asSpecified"
     ],
@@ -3074,7 +3074,7 @@
   },
   {
     "name": "flex-shrink",
-    "syntax": "<number>",
+    "syntax": "<number [0,∞]>",
     "computed": [
       "asSpecified"
     ],
@@ -3083,7 +3083,7 @@
   },
   {
     "name": "flex-wrap",
-    "syntax": "nowrap | wrap | wrap-reverse",
+    "syntax": "nowrap | [ wrap | wrap-reverse ] || balance",
     "computed": [
       "asSpecified"
     ],
@@ -3092,7 +3092,7 @@
   },
   {
     "name": "float",
-    "syntax": "left | right | none | inline-start | inline-end",
+    "syntax": "block-start | block-end | inline-start | inline-end | snap-block | <snap-block()> | snap-inline | <snap-inline()> | left | right | top | bottom | none | footnote",
     "computed": [
       "asSpecified"
     ],
@@ -3119,7 +3119,7 @@
   },
   {
     "name": "font",
-    "syntax": "[ [ <'font-style'> || <font-variant-css2> || <'font-weight'> || <font-width-css3> ]? <'font-size'> [ / <'line-height'> ]? <'font-family'># ] | <system-family-name>",
+    "syntax": "[ [ <'font-style'> || <font-variant-css2> || <'font-weight'> || <font-width-css3> ]? <'font-size'> [ / <'line-height'> ]? <'font-family'># ] | <system-font-family-name>",
     "computed": [
       "font-style",
       "font-variant",
@@ -3142,7 +3142,7 @@
   },
   {
     "name": "font-family",
-    "syntax": "[ <family-name> | <generic-family> ]#",
+    "syntax": "[ <font-family-name> | <generic-font-family> ]#",
     "computed": [
       "asSpecified"
     ],
@@ -3205,7 +3205,7 @@
   },
   {
     "name": "font-size-adjust",
-    "syntax": "none | [ ex-height | cap-height | ch-width | ic-width | ic-height ]? [ from-font | <number> ]",
+    "syntax": "none | <number [0,∞]>",
     "computed": [
       "asSpecified"
     ],
@@ -3223,7 +3223,7 @@
   },
   {
     "name": "font-stretch",
-    "syntax": "<font-stretch-absolute>",
+    "syntax": "normal | <percentage [0,∞]> | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded",
     "computed": [
       "asSpecified"
     ],
@@ -3232,7 +3232,7 @@
   },
   {
     "name": "font-style",
-    "syntax": "normal | italic | oblique <angle>?",
+    "syntax": "normal | italic | left | right | oblique <angle [-90deg,90deg]>?",
     "computed": [
       "asSpecified"
     ],
@@ -3268,7 +3268,7 @@
   },
   {
     "name": "font-synthesis-style",
-    "syntax": "auto | none",
+    "syntax": "auto | none | oblique-only",
     "computed": [
       "asSpecified"
     ],
@@ -3286,7 +3286,7 @@
   },
   {
     "name": "font-variant",
-    "syntax": "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> || stylistic( <feature-value-name> ) || historical-forms || styleset( <feature-value-name># ) || character-variant( <feature-value-name># ) || swash( <feature-value-name> ) || ornaments( <feature-value-name> ) || annotation( <feature-value-name> ) || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero || <east-asian-variant-values> || <east-asian-width-values> || ruby ]",
+    "syntax": "normal | none | [ [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ] || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || [ stylistic(<font-feature-value-name>) || historical-forms || styleset(<font-feature-value-name>#) || character-variant(<font-feature-value-name>#) || swash(<font-feature-value-name>) || ornaments(<font-feature-value-name>) || annotation(<font-feature-value-name>) ] || [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ] || [ <east-asian-variant-values> || <east-asian-width-values> || ruby ] || [ sub | super ] || [ text | emoji | unicode ] ]",
     "computed": [
       "asSpecified"
     ],
@@ -3295,7 +3295,7 @@
   },
   {
     "name": "font-variant-alternates",
-    "syntax": "normal | [ stylistic( <feature-value-name> ) || historical-forms || styleset( <feature-value-name># ) || character-variant( <feature-value-name># ) || swash( <feature-value-name> ) || ornaments( <feature-value-name> ) || annotation( <feature-value-name> ) ]",
+    "syntax": "normal | [ stylistic(<font-feature-value-name>) || historical-forms || styleset(<font-feature-value-name>#) || character-variant(<font-feature-value-name>#) || swash(<font-feature-value-name>) || ornaments(<font-feature-value-name>) || annotation(<font-feature-value-name>) ]",
     "computed": [
       "asSpecified"
     ],
@@ -3358,7 +3358,7 @@
   },
   {
     "name": "font-variation-settings",
-    "syntax": "normal | [ <string> <number> ]#",
+    "syntax": "normal | [ <opentype-tag> <number> ]#",
     "computed": [
       "asSpecified"
     ],
@@ -3391,6 +3391,15 @@
     ],
     "initial": "auto",
     "inherited": true
+  },
+  {
+    "name": "frame-sizing",
+    "syntax": "auto | content-width | content-height | content-block-size | content-inline-size",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "auto",
+    "inherited": false
   },
   {
     "name": "gap",
@@ -3502,7 +3511,7 @@
   },
   {
     "name": "grid-column-gap",
-    "syntax": "<length-percentage>",
+    "syntax": "normal | <length-percentage [0,∞]> | <line-width>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -3520,7 +3529,7 @@
   },
   {
     "name": "grid-gap",
-    "syntax": "<'grid-row-gap'> <'grid-column-gap'>?",
+    "syntax": "<'row-gap'> <'column-gap'>?",
     "computed": [
       "grid-row-gap",
       "grid-column-gap"
@@ -3555,7 +3564,7 @@
   },
   {
     "name": "grid-row-gap",
-    "syntax": "<length-percentage>",
+    "syntax": "normal | <length-percentage [0,∞]> | <line-width>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -3624,7 +3633,7 @@
   },
   {
     "name": "height",
-    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "computed": [
       "percentageAutoOrAbsoluteLength"
     ],
@@ -3660,7 +3669,7 @@
   },
   {
     "name": "image-orientation",
-    "syntax": "from-image | <angle> | [ <angle>? flip ]",
+    "syntax": "from-image | none | [ <angle> || flip ]",
     "computed": [
       "angleRoundedToNextQuarter"
     ],
@@ -3669,7 +3678,7 @@
   },
   {
     "name": "image-rendering",
-    "syntax": "auto | crisp-edges | pixelated | smooth",
+    "syntax": "auto | smooth | high-quality | pixelated | crisp-edges",
     "computed": [
       "asSpecified"
     ],
@@ -3696,7 +3705,7 @@
   },
   {
     "name": "initial-letter",
-    "syntax": "normal | [ <number> <integer>? ]",
+    "syntax": "normal | <number [1,∞]> <integer [1,∞]> | <number [1,∞]> && [ drop | raise ]?",
     "computed": [
       "asSpecified"
     ],
@@ -3705,7 +3714,7 @@
   },
   {
     "name": "initial-letter-align",
-    "syntax": "[ auto | alphabetic | hanging | ideographic ]",
+    "syntax": "[ border-box? [ alphabetic | ideographic | hanging | leading ]? ]!",
     "computed": [
       "asSpecified"
     ],
@@ -3753,7 +3762,7 @@
   },
   {
     "name": "inset-block-end",
-    "syntax": "<'top'>",
+    "syntax": "auto | <length-percentage>",
     "computed": [
       "sameAsBoxOffsets"
     ],
@@ -3762,7 +3771,7 @@
   },
   {
     "name": "inset-block-start",
-    "syntax": "<'top'>",
+    "syntax": "auto | <length-percentage>",
     "computed": [
       "sameAsBoxOffsets"
     ],
@@ -3784,7 +3793,7 @@
   },
   {
     "name": "inset-inline-end",
-    "syntax": "<'top'>",
+    "syntax": "auto | <length-percentage>",
     "computed": [
       "sameAsBoxOffsets"
     ],
@@ -3793,7 +3802,7 @@
   },
   {
     "name": "inset-inline-start",
-    "syntax": "<'top'>",
+    "syntax": "auto | <length-percentage>",
     "computed": [
       "sameAsBoxOffsets"
     ],
@@ -3851,7 +3860,7 @@
   },
   {
     "name": "isolation",
-    "syntax": "auto | isolate",
+    "syntax": "<isolation-mode>",
     "computed": [
       "asSpecified"
     ],
@@ -3869,7 +3878,7 @@
   },
   {
     "name": "justify-items",
-    "syntax": "normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | legacy | legacy && [ left | right | center ] | anchor-center",
+    "syntax": "normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | legacy | legacy && [ left | right | center ]",
     "computed": [
       "asSpecified"
     ],
@@ -3878,7 +3887,7 @@
   },
   {
     "name": "justify-self",
-    "syntax": "auto | normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | anchor-center",
+    "syntax": "auto | <overflow-position>? [ normal | <self-position> | left | right ] | stretch | <baseline-position> | anchor-center",
     "computed": [
       "asSpecified"
     ],
@@ -3941,7 +3950,7 @@
   },
   {
     "name": "line-height",
-    "syntax": "normal | <number> | <length> | <percentage>",
+    "syntax": "normal | <number [0,∞]> | <length-percentage [0,∞]>",
     "computed": [
       "absoluteLengthOrAsSpecified"
     ],
@@ -3950,7 +3959,7 @@
   },
   {
     "name": "line-height-step",
-    "syntax": "<length>",
+    "syntax": "<length [0,∞]>",
     "computed": [
       "absoluteLength"
     ],
@@ -3959,7 +3968,7 @@
   },
   {
     "name": "list-style",
-    "syntax": "<'list-style-type'> || <'list-style-position'> || <'list-style-image'>",
+    "syntax": "<'list-style-position'> || <'list-style-image'> || <'list-style-type'>",
     "computed": [
       "list-style-image",
       "list-style-position",
@@ -4116,7 +4125,7 @@
   },
   {
     "name": "margin-trim",
-    "syntax": "none | in-flow | all",
+    "syntax": "none | [ block || inline ] | [ block-start || inline-start || block-end || inline-end ]",
     "computed": [
       "asSpecified"
     ],
@@ -4125,7 +4134,7 @@
   },
   {
     "name": "marker",
-    "syntax": "none | <url>",
+    "syntax": "none | <marker-ref>",
     "computed": [
       "asSpecified"
     ],
@@ -4138,7 +4147,7 @@
   },
   {
     "name": "marker-end",
-    "syntax": "none | <url>",
+    "syntax": "none | <marker-ref>",
     "computed": [
       "asSpecifiedURLsAbsolute"
     ],
@@ -4147,7 +4156,7 @@
   },
   {
     "name": "marker-mid",
-    "syntax": "none | <url>",
+    "syntax": "none | <marker-ref>",
     "computed": [
       "asSpecifiedURLsAbsolute"
     ],
@@ -4156,7 +4165,7 @@
   },
   {
     "name": "marker-start",
-    "syntax": "none | <url>",
+    "syntax": "none | <marker-ref>",
     "computed": [
       "asSpecifiedURLsAbsolute"
     ],
@@ -4220,7 +4229,7 @@
   },
   {
     "name": "mask-border-outset",
-    "syntax": "[ <length> | <number> ]{1,4}",
+    "syntax": "<'border-image-outset'>",
     "computed": [
       "asSpecifiedRelativeToAbsoluteLengths"
     ],
@@ -4229,7 +4238,7 @@
   },
   {
     "name": "mask-border-repeat",
-    "syntax": "[ stretch | repeat | round | space ]{1,2}",
+    "syntax": "<'border-image-repeat'>",
     "computed": [
       "asSpecified"
     ],
@@ -4238,7 +4247,7 @@
   },
   {
     "name": "mask-border-slice",
-    "syntax": "<number-percentage>{1,4} fill?",
+    "syntax": "<'border-image-slice'>",
     "computed": [
       "asSpecified"
     ],
@@ -4247,7 +4256,7 @@
   },
   {
     "name": "mask-border-source",
-    "syntax": "none | <image>",
+    "syntax": "<'border-image-source'>",
     "computed": [
       "asSpecifiedURLsAbsolute"
     ],
@@ -4256,7 +4265,7 @@
   },
   {
     "name": "mask-border-width",
-    "syntax": "[ <length-percentage> | <number> | auto ]{1,4}",
+    "syntax": "<'border-image-width'>",
     "computed": [
       "asSpecifiedRelativeToAbsoluteLengths"
     ],
@@ -4391,7 +4400,7 @@
   },
   {
     "name": "max-height",
-    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "computed": [
       "percentageAsSpecifiedAbsoluteLengthOrNone"
     ],
@@ -4418,7 +4427,7 @@
   },
   {
     "name": "max-width",
-    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "computed": [
       "percentageAsSpecifiedAbsoluteLengthOrNone"
     ],
@@ -4436,7 +4445,7 @@
   },
   {
     "name": "min-height",
-    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -4454,7 +4463,7 @@
   },
   {
     "name": "min-width",
-    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -4463,7 +4472,7 @@
   },
   {
     "name": "mix-blend-mode",
-    "syntax": "<blend-mode> | plus-darker | plus-lighter",
+    "syntax": "<blend-mode> | plus-lighter",
     "computed": [
       "asSpecified"
     ],
@@ -4486,7 +4495,7 @@
       "asSpecified"
     ],
     "initial": "50% 50%",
-    "inherited": true
+    "inherited": false
   },
   {
     "name": "object-view-box",
@@ -4581,7 +4590,7 @@
   },
   {
     "name": "orphans",
-    "syntax": "<integer>",
+    "syntax": "<integer [1,∞]>",
     "computed": [
       "asSpecified"
     ],
@@ -4605,7 +4614,7 @@
   },
   {
     "name": "outline-color",
-    "syntax": "auto | <color>",
+    "syntax": "auto | <'border-top-color'>",
     "computed": [
       "autoForTranslucentColorRGBAOtherwiseRGB"
     ],
@@ -4616,7 +4625,7 @@
     "name": "outline-offset",
     "syntax": "<length>",
     "computed": [
-      "asSpecifiedRelativeToAbsoluteLengths"
+      "absoluteLengthSnappedAsLineWidth"
     ],
     "initial": "0",
     "inherited": false
@@ -4634,14 +4643,14 @@
     "name": "outline-width",
     "syntax": "<line-width>",
     "computed": [
-      "absoluteLength0ForNone"
+      "absoluteLengthSnappedAsLineWidth"
     ],
     "initial": "medium",
     "inherited": false
   },
   {
     "name": "overflow",
-    "syntax": "[ visible | hidden | clip | scroll | auto ]{1,2}",
+    "syntax": "<'overflow-block'>{1,2}",
     "computed": [
       "overflow-x",
       "overflow-y"
@@ -4678,7 +4687,7 @@
   },
   {
     "name": "overflow-clip-margin",
-    "syntax": "<visual-box> || <length [0,∞]>",
+    "syntax": "<visual-box> || <length>",
     "computed": [
       "theComputedLengthAndVisualBox"
     ],
@@ -4732,7 +4741,7 @@
   },
   {
     "name": "overscroll-behavior",
-    "syntax": "[ contain | none | auto ]{1,2}",
+    "syntax": "[ contain | none | auto | chain ]{1,2}",
     "computed": [
       "overscroll-behavior-x",
       "overscroll-behavior-y"
@@ -4742,7 +4751,7 @@
   },
   {
     "name": "overscroll-behavior-block",
-    "syntax": "contain | none | auto",
+    "syntax": "contain | none | auto | chain",
     "computed": [
       "asSpecified"
     ],
@@ -4751,7 +4760,7 @@
   },
   {
     "name": "overscroll-behavior-inline",
-    "syntax": "contain | none | auto",
+    "syntax": "contain | none | auto | chain",
     "computed": [
       "asSpecified"
     ],
@@ -4760,7 +4769,7 @@
   },
   {
     "name": "overscroll-behavior-x",
-    "syntax": "contain | none | auto",
+    "syntax": "contain | none | auto | chain",
     "computed": [
       "asSpecified"
     ],
@@ -4769,7 +4778,7 @@
   },
   {
     "name": "overscroll-behavior-y",
-    "syntax": "contain | none | auto",
+    "syntax": "contain | none | auto | chain",
     "computed": [
       "asSpecified"
     ],
@@ -4902,7 +4911,7 @@
   },
   {
     "name": "page-break-after",
-    "syntax": "auto | always | avoid | left | right | recto | verso",
+    "syntax": "auto | always | avoid | left | right | inherit",
     "computed": [
       "asSpecified"
     ],
@@ -4911,7 +4920,7 @@
   },
   {
     "name": "page-break-before",
-    "syntax": "auto | always | avoid | left | right | recto | verso",
+    "syntax": "auto | always | avoid | left | right | inherit",
     "computed": [
       "asSpecified"
     ],
@@ -4920,7 +4929,7 @@
   },
   {
     "name": "page-break-inside",
-    "syntax": "auto | avoid",
+    "syntax": "avoid | auto | inherit",
     "computed": [
       "asSpecified"
     ],
@@ -4995,7 +5004,7 @@
   },
   {
     "name": "pointer-events",
-    "syntax": "auto | none | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all | inherit",
+    "syntax": "auto | bounding-box | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all | none",
     "computed": [
       "asSpecified"
     ],
@@ -5004,7 +5013,7 @@
   },
   {
     "name": "position",
-    "syntax": "static | relative | absolute | sticky | fixed",
+    "syntax": "static | relative | absolute | sticky | fixed | <running()>",
     "computed": [
       "asSpecified"
     ],
@@ -5013,7 +5022,7 @@
   },
   {
     "name": "position-anchor",
-    "syntax": "normal | auto | none | <anchor-name> | match-parent",
+    "syntax": "normal | none | auto | <anchor-name> | match-parent",
     "computed": [
       "asSpecified"
     ],
@@ -5044,7 +5053,7 @@
   },
   {
     "name": "position-try-fallbacks",
-    "syntax": "none | [ [<dashed-ident> || <try-tactic>] | <'position-area'> ]#",
+    "syntax": "none | [ [<dashed-ident> || <try-tactic>] | <position-area> ]#",
     "computed": [
       "asSpecified"
     ],
@@ -5062,7 +5071,7 @@
   },
   {
     "name": "position-visibility",
-    "syntax": "always | [ anchors-valid || anchors-visible || no-overflow ]",
+    "syntax": "always | [ anchor-valid || anchor-visible || no-overflow ]",
     "computed": [
       "asSpecified"
     ],
@@ -5080,7 +5089,7 @@
   },
   {
     "name": "quotes",
-    "syntax": "none | auto | [ <string> <string> ]+",
+    "syntax": "auto | none | match-parent | [ <string> <string> ]+",
     "computed": [
       "asSpecified"
     ],
@@ -5089,7 +5098,7 @@
   },
   {
     "name": "r",
-    "syntax": "<length> | <percentage>",
+    "syntax": "<length-percentage>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -5143,7 +5152,7 @@
   },
   {
     "name": "row-gap",
-    "syntax": "normal | <length-percentage>",
+    "syntax": "normal | <length-percentage [0,∞]> | <line-width>",
     "computed": [
       "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn"
     ],
@@ -5161,7 +5170,7 @@
   },
   {
     "name": "ruby-merge",
-    "syntax": "separate | collapse | auto",
+    "syntax": "separate | merge | auto",
     "computed": [
       "asSpecified"
     ],
@@ -5170,7 +5179,7 @@
   },
   {
     "name": "ruby-overhang",
-    "syntax": "auto | none",
+    "syntax": "auto | spaces",
     "computed": [
       "theSpecifiedKeyword"
     ],
@@ -5357,7 +5366,7 @@
   },
   {
     "name": "scroll-padding",
-    "syntax": "[ auto | <length-percentage> ]{1,4}",
+    "syntax": "[ auto | <length-percentage [0,∞]> ]{1,4}",
     "computed": [
       "scroll-padding-bottom",
       "scroll-padding-left",
@@ -5374,7 +5383,7 @@
   },
   {
     "name": "scroll-padding-block",
-    "syntax": "[ auto | <length-percentage> ]{1,2}",
+    "syntax": "[ auto | <length-percentage [0,∞]> ]{1,2}",
     "computed": [
       "scroll-padding-block-start",
       "scroll-padding-block-end"
@@ -5387,7 +5396,7 @@
   },
   {
     "name": "scroll-padding-block-end",
-    "syntax": "auto | <length-percentage>",
+    "syntax": "auto | <length-percentage [0,∞]>",
     "computed": [
       "asSpecified"
     ],
@@ -5396,7 +5405,7 @@
   },
   {
     "name": "scroll-padding-block-start",
-    "syntax": "auto | <length-percentage>",
+    "syntax": "auto | <length-percentage [0,∞]>",
     "computed": [
       "asSpecified"
     ],
@@ -5405,7 +5414,7 @@
   },
   {
     "name": "scroll-padding-bottom",
-    "syntax": "auto | <length-percentage>",
+    "syntax": "auto | <length-percentage [0,∞]>",
     "computed": [
       "asSpecified"
     ],
@@ -5414,7 +5423,7 @@
   },
   {
     "name": "scroll-padding-inline",
-    "syntax": "[ auto | <length-percentage> ]{1,2}",
+    "syntax": "[ auto | <length-percentage [0,∞]> ]{1,2}",
     "computed": [
       "scroll-padding-inline-start",
       "scroll-padding-inline-end"
@@ -5427,7 +5436,7 @@
   },
   {
     "name": "scroll-padding-inline-end",
-    "syntax": "auto | <length-percentage>",
+    "syntax": "auto | <length-percentage [0,∞]>",
     "computed": [
       "asSpecified"
     ],
@@ -5436,7 +5445,7 @@
   },
   {
     "name": "scroll-padding-inline-start",
-    "syntax": "auto | <length-percentage>",
+    "syntax": "auto | <length-percentage [0,∞]>",
     "computed": [
       "asSpecified"
     ],
@@ -5445,7 +5454,7 @@
   },
   {
     "name": "scroll-padding-left",
-    "syntax": "auto | <length-percentage>",
+    "syntax": "auto | <length-percentage [0,∞]>",
     "computed": [
       "asSpecified"
     ],
@@ -5454,7 +5463,7 @@
   },
   {
     "name": "scroll-padding-right",
-    "syntax": "auto | <length-percentage>",
+    "syntax": "auto | <length-percentage [0,∞]>",
     "computed": [
       "asSpecified"
     ],
@@ -5463,7 +5472,7 @@
   },
   {
     "name": "scroll-padding-top",
-    "syntax": "auto | <length-percentage>",
+    "syntax": "auto | <length-percentage [0,∞]>",
     "computed": [
       "asSpecified"
     ],
@@ -5629,7 +5638,7 @@
   },
   {
     "name": "shape-margin",
-    "syntax": "<length-percentage>",
+    "syntax": "<length-percentage [0,∞]>",
     "computed": [
       "asSpecifiedRelativeToAbsoluteLengths"
     ],
@@ -5638,7 +5647,7 @@
   },
   {
     "name": "shape-outside",
-    "syntax": "none | [ <shape-box> || <basic-shape> ] | <image>",
+    "syntax": "none | [ <basic-shape> || <shape-box> ] | <image>",
     "computed": [
       "asDefinedForBasicShapeWithAbsoluteURIOtherwiseAsSpecified"
     ],
@@ -5700,7 +5709,7 @@
   },
   {
     "name": "stroke-color",
-    "syntax": "<color>",
+    "syntax": "<color>#",
     "computed": [
       "computedColor"
     ],
@@ -5709,7 +5718,7 @@
   },
   {
     "name": "stroke-dasharray",
-    "syntax": "none | <dasharray>",
+    "syntax": "none | [<length-percentage> | <number>]+#",
     "computed": [
       "listEachItemConsistingOfAbsoluteLengthPercentageOrKeyword"
     ],
@@ -5736,7 +5745,7 @@
   },
   {
     "name": "stroke-linejoin",
-    "syntax": "miter | miter-clip | round | bevel | arcs",
+    "syntax": "[ crop | arcs | miter ] || [ bevel | round | fallback ]",
     "computed": [
       "asSpecified"
     ],
@@ -5763,7 +5772,7 @@
   },
   {
     "name": "stroke-width",
-    "syntax": "<length-percentage> | <number>",
+    "syntax": "[ <length-percentage> | <line-width> | <number> ]#",
     "computed": [
       "absoluteLengthOrPercentageNumbersConverted"
     ],
@@ -5772,7 +5781,7 @@
   },
   {
     "name": "tab-size",
-    "syntax": "<integer> | <length>",
+    "syntax": "<number [0,∞]> | <length [0,∞]>",
     "computed": [
       "specifiedIntegerOrAbsoluteLength"
     ],
@@ -5790,7 +5799,7 @@
   },
   {
     "name": "text-align",
-    "syntax": "start | end | left | right | center | justify | match-parent",
+    "syntax": "start | end | left | right | center | justify | match-parent | justify-all",
     "computed": [
       "asSpecifiedExceptMatchParent"
     ],
@@ -5799,7 +5808,7 @@
   },
   {
     "name": "text-align-last",
-    "syntax": "auto | start | end | left | right | center | justify",
+    "syntax": "auto | start | end | left | right | center | justify | match-parent",
     "computed": [
       "asSpecified"
     ],
@@ -5853,7 +5862,7 @@
   },
   {
     "name": "text-combine-upright",
-    "syntax": "none | all | [ digits <integer>? ]",
+    "syntax": "none | all | [ digits <integer [2,4]>? ]",
     "computed": [
       "keywordPlusIntegerIfDigits"
     ],
@@ -5862,7 +5871,7 @@
   },
   {
     "name": "text-decoration",
-    "syntax": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'> || <'text-decoration-thickness'>",
+    "syntax": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'>",
     "computed": [
       "text-decoration-line",
       "text-decoration-style",
@@ -5896,7 +5905,7 @@
   },
   {
     "name": "text-decoration-line",
-    "syntax": "none | [ underline || overline || line-through || blink ] | spelling-error | grammar-error",
+    "syntax": "none | [ underline || overline || line-through || blink ]",
     "computed": [
       "asSpecified"
     ],
@@ -5963,7 +5972,7 @@
   },
   {
     "name": "text-emphasis-position",
-    "syntax": "auto | [ over | under ] && [ right | left ]?",
+    "syntax": "[ over | under ] && [ right | left ]?",
     "computed": [
       "asSpecified"
     ],
@@ -5981,7 +5990,7 @@
   },
   {
     "name": "text-indent",
-    "syntax": "<length-percentage> && hanging? && each-line?",
+    "syntax": "[ <length-percentage> ] && hanging? && each-line?",
     "computed": [
       "percentageOrAbsoluteLengthPlusKeywords"
     ],
@@ -5990,7 +5999,7 @@
   },
   {
     "name": "text-justify",
-    "syntax": "auto | inter-character | inter-word | none",
+    "syntax": "auto | none | inter-word | inter-character",
     "computed": [
       "asSpecified"
     ],
@@ -6008,7 +6017,7 @@
   },
   {
     "name": "text-overflow",
-    "syntax": "[ clip | ellipsis | <string> ]{1,2}",
+    "syntax": "clip | ellipsis",
     "computed": [
       "asSpecified"
     ],
@@ -6026,7 +6035,7 @@
   },
   {
     "name": "text-shadow",
-    "syntax": "none | <shadow-t>#",
+    "syntax": "none | [ <color>? && [ <length>{2} <length [0,∞]>? ] ]#",
     "computed": [
       "colorPlusThreeAbsoluteLengths"
     ],
@@ -6035,7 +6044,7 @@
   },
   {
     "name": "text-size-adjust",
-    "syntax": "none | auto | <percentage>",
+    "syntax": "auto | none | <percentage [0,∞]>",
     "computed": [
       "asSpecified"
     ],
@@ -6053,7 +6062,7 @@
   },
   {
     "name": "text-transform",
-    "syntax": "none | [ capitalize | uppercase | lowercase ] || full-width || full-size-kana | math-auto",
+    "syntax": "none | [capitalize | uppercase | lowercase ] || full-width || full-size-kana",
     "computed": [
       "asSpecified"
     ],
@@ -6071,7 +6080,7 @@
   },
   {
     "name": "text-underline-position",
-    "syntax": "auto | from-font | [ under || [ left | right ] ]",
+    "syntax": "auto | [ under || [ left | right ] ]",
     "computed": [
       "asSpecified"
     ],
@@ -6108,7 +6117,7 @@
   },
   {
     "name": "timeline-scope",
-    "syntax": "none | <dashed-ident>#",
+    "syntax": "none | all | <dashed-ident>#",
     "computed": [
       "noneOrOrderedListOfIdentifiers"
     ],
@@ -6117,7 +6126,7 @@
   },
   {
     "name": "timeline-trigger",
-    "syntax": "none | [ <'timeline-trigger-name'> <'timeline-trigger-source'> <'timeline-trigger-activation-range'> [ '/' <'timeline-trigger-active-range'> ]? ]#",
+    "syntax": "none | [ <'timeline-trigger-name'> <'timeline-trigger-source'> <'timeline-trigger-activation-range'> [ / <'timeline-trigger-active-range'> ]? ]#",
     "computed": [
       "timeline-trigger-name",
       "timeline-trigger-source",
@@ -6250,7 +6259,7 @@
   },
   {
     "name": "transform-origin",
-    "syntax": "[ <length-percentage> | left | center | right | top | bottom ] | [ [ <length-percentage> | left | center | right ] && [ <length-percentage> | top | center | bottom ] ] <length>?",
+    "syntax": "[ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] <length>? | [ [ center | left | right ] && [ center | top | bottom ] ] <length>?",
     "computed": [
       "forLengthAbsoluteValueOtherwisePercentage"
     ],
@@ -6305,7 +6314,7 @@
   },
   {
     "name": "transition-duration",
-    "syntax": "<time>#",
+    "syntax": "<time [0s,∞]>#",
     "computed": [
       "asSpecified"
     ],
@@ -6359,7 +6368,7 @@
   },
   {
     "name": "user-select",
-    "syntax": "auto | text | none | all",
+    "syntax": "auto | text | none | contain | all",
     "computed": [
       "asSpecified"
     ],
@@ -6377,7 +6386,7 @@
   },
   {
     "name": "vertical-align",
-    "syntax": "baseline | sub | super | text-top | text-bottom | middle | top | bottom | <percentage> | <length>",
+    "syntax": "[ first | last] || <'alignment-baseline'> || <'baseline-shift'>",
     "computed": [
       "asLonghands"
     ],
@@ -6435,7 +6444,16 @@
   },
   {
     "name": "view-transition-name",
-    "syntax": "none | <custom-ident> | match-element",
+    "syntax": "none | <custom-ident>",
+    "computed": [
+      "asSpecified"
+    ],
+    "initial": "none",
+    "inherited": false
+  },
+  {
+    "name": "view-transition-scope",
+    "syntax": "none | all",
     "computed": [
       "asSpecified"
     ],
@@ -6444,7 +6462,7 @@
   },
   {
     "name": "visibility",
-    "syntax": "visible | hidden | collapse",
+    "syntax": "visible | hidden | force-hidden | collapse",
     "computed": [
       "asSpecified"
     ],
@@ -6453,7 +6471,7 @@
   },
   {
     "name": "white-space",
-    "syntax": "normal | pre | pre-wrap | pre-line | <'white-space-collapse'> || <'text-wrap-mode'>",
+    "syntax": "normal | pre | nowrap | pre-wrap | break-spaces | pre-line",
     "computed": [
       "asSpecified"
     ],
@@ -6471,7 +6489,7 @@
   },
   {
     "name": "widows",
-    "syntax": "<integer>",
+    "syntax": "<integer [1,∞]>",
     "computed": [
       "asSpecified"
     ],
@@ -6480,7 +6498,7 @@
   },
   {
     "name": "width",
-    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "computed": [
       "percentageAutoOrAbsoluteLength"
     ],
@@ -6498,7 +6516,7 @@
   },
   {
     "name": "word-break",
-    "syntax": "normal | break-all | keep-all | break-word | auto-phrase",
+    "syntax": "normal | keep-all | break-all | break-word",
     "computed": [
       "asSpecified"
     ],
@@ -6516,7 +6534,7 @@
   },
   {
     "name": "word-wrap",
-    "syntax": "normal | break-word",
+    "syntax": "normal | break-word | anywhere",
     "computed": [
       "asSpecified"
     ],
@@ -6534,7 +6552,7 @@
   },
   {
     "name": "x",
-    "syntax": "<length> | <percentage>",
+    "syntax": "<length-percentage>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -6543,7 +6561,7 @@
   },
   {
     "name": "y",
-    "syntax": "<length> | <percentage>",
+    "syntax": "<length-percentage>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -6552,7 +6570,7 @@
   },
   {
     "name": "z-index",
-    "syntax": "auto | <integer>",
+    "syntax": "auto | <integer> | inherit",
     "computed": [
       "asSpecified"
     ],
@@ -6561,7 +6579,7 @@
   },
   {
     "name": "zoom",
-    "syntax": "normal | reset | <number [0,∞]> || <percentage [0,∞]>",
+    "syntax": "<number [0,∞]> | <percentage [0,∞]>",
     "computed": [
       "asSpecifiedButWithPercentageConvertedToTheEquivalentNumber"
     ],

--- a/crates/gosub_css3/resources/definitions/definitions_properties.json
+++ b/crates/gosub_css3/resources/definitions/definitions_properties.json
@@ -1398,7 +1398,7 @@
   },
   {
     "name": "background-clip",
-    "syntax": "<visual-box>#",
+    "syntax": "<bg-clip>#",
     "computed": [
       "asSpecified"
     ],
@@ -2392,7 +2392,7 @@
   },
   {
     "name": "clip",
-    "syntax": "<rect()> | auto",
+    "syntax": "<shape> | <rect()> | auto",
     "computed": [
       "autoOrRectangle"
     ],
@@ -2533,7 +2533,7 @@
   },
   {
     "name": "column-width",
-    "syntax": "auto | <length [0,∞]> | min-content | max-content | fit-content(<length-percentage>)",
+    "syntax": "auto | <length [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage>)",
     "computed": [
       "autoOrAbsoluteLength"
     ],
@@ -3633,7 +3633,7 @@
   },
   {
     "name": "height",
-    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "computed": [
       "percentageAutoOrAbsoluteLength"
     ],
@@ -4400,7 +4400,7 @@
   },
   {
     "name": "max-height",
-    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "computed": [
       "percentageAsSpecifiedAbsoluteLengthOrNone"
     ],
@@ -4427,7 +4427,7 @@
   },
   {
     "name": "max-width",
-    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "computed": [
       "percentageAsSpecifiedAbsoluteLengthOrNone"
     ],
@@ -4445,7 +4445,7 @@
   },
   {
     "name": "min-height",
-    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -4463,7 +4463,7 @@
   },
   {
     "name": "min-width",
-    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "computed": [
       "percentageAsSpecifiedOrAbsoluteLength"
     ],
@@ -6498,7 +6498,7 @@
   },
   {
     "name": "width",
-    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
     "computed": [
       "percentageAutoOrAbsoluteLength"
     ],

--- a/crates/gosub_css3/resources/definitions/definitions_properties.json
+++ b/crates/gosub_css3/resources/definitions/definitions_properties.json
@@ -1355,7 +1355,7 @@
   },
   {
     "name": "background",
-    "syntax": "<bg-layer>#? , <final-bg-layer>",
+    "syntax": "[ <bg-layer> , ]* <final-bg-layer>",
     "computed": [
       "background-image",
       "background-position",

--- a/crates/gosub_css3/resources/definitions/definitions_selectors.json
+++ b/crates/gosub_css3/resources/definitions/definitions_selectors.json
@@ -1,84 +1,27 @@
 [
   {
-    "name": "::-moz-progress-bar"
+    "name": "&"
   },
   {
-    "name": "::-moz-range-progress"
-  },
-  {
-    "name": "::-moz-range-thumb"
-  },
-  {
-    "name": "::-moz-range-track"
-  },
-  {
-    "name": "::-ms-browse"
-  },
-  {
-    "name": "::-ms-check"
-  },
-  {
-    "name": "::-ms-clear"
-  },
-  {
-    "name": "::-ms-expand"
-  },
-  {
-    "name": "::-ms-fill"
-  },
-  {
-    "name": "::-ms-fill-lower"
-  },
-  {
-    "name": "::-ms-fill-upper"
-  },
-  {
-    "name": "::-ms-reveal"
-  },
-  {
-    "name": "::-ms-thumb"
-  },
-  {
-    "name": "::-ms-ticks-after"
-  },
-  {
-    "name": "::-ms-ticks-before"
-  },
-  {
-    "name": "::-ms-tooltip"
-  },
-  {
-    "name": "::-ms-track"
-  },
-  {
-    "name": "::-ms-value"
-  },
-  {
-    "name": "::-webkit-progress-bar"
-  },
-  {
-    "name": "::-webkit-progress-inner-value"
-  },
-  {
-    "name": "::-webkit-progress-value"
-  },
-  {
-    "name": "::-webkit-slider-runnable-track"
-  },
-  {
-    "name": "::-webkit-slider-thumb"
+    "name": "+"
   },
   {
     "name": "::after"
-  },
-  {
-    "name": "::backdrop"
   },
   {
     "name": "::before"
   },
   {
     "name": "::checkmark"
+  },
+  {
+    "name": "::clear-icon"
+  },
+  {
+    "name": "::color-swatch"
+  },
+  {
+    "name": "::column"
   },
   {
     "name": "::cue"
@@ -94,6 +37,15 @@
   },
   {
     "name": "::details-content"
+  },
+  {
+    "name": "::field-component"
+  },
+  {
+    "name": "::field-separator"
+  },
+  {
+    "name": "::field-text"
   },
   {
     "name": "::file-selector-button"
@@ -126,19 +78,37 @@
     "name": "::placeholder"
   },
   {
-    "name": "::scroll-marker"
+    "name": "::reveal-icon"
   },
   {
-    "name": "::scroll-marker-group"
+    "name": "::search-text"
   },
   {
     "name": "::selection"
+  },
+  {
+    "name": "::slider-fill"
+  },
+  {
+    "name": "::slider-thumb"
+  },
+  {
+    "name": "::slider-track"
   },
   {
     "name": "::slotted()"
   },
   {
     "name": "::spelling-error"
+  },
+  {
+    "name": "::step-control"
+  },
+  {
+    "name": "::step-down"
+  },
+  {
+    "name": "::step-up"
   },
   {
     "name": "::target-text"
@@ -148,6 +118,9 @@
   },
   {
     "name": "::view-transition-group()"
+  },
+  {
+    "name": "::view-transition-group-children()"
   },
   {
     "name": "::view-transition-image-pair()"
@@ -168,22 +141,25 @@
     "name": ":active-view-transition-type()"
   },
   {
+    "name": ":after"
+  },
+  {
+    "name": ":animated-image"
+  },
+  {
     "name": ":any-link"
   },
   {
     "name": ":autofill"
   },
   {
-    "name": ":blank"
+    "name": ":before"
   },
   {
     "name": ":buffering"
   },
   {
     "name": ":checked"
-  },
-  {
-    "name": ":current"
   },
   {
     "name": ":default"
@@ -210,6 +186,12 @@
     "name": ":first-child"
   },
   {
+    "name": ":first-letter"
+  },
+  {
+    "name": ":first-line"
+  },
+  {
     "name": ":first-of-type"
   },
   {
@@ -225,13 +207,13 @@
     "name": ":fullscreen"
   },
   {
-    "name": ":future"
-  },
-  {
     "name": ":has()"
   },
   {
     "name": ":has-slotted"
+  },
+  {
+    "name": ":high-value"
   },
   {
     "name": ":host"
@@ -273,7 +255,13 @@
     "name": ":link"
   },
   {
-    "name": ":local-link"
+    "name": ":link-to()"
+  },
+  {
+    "name": ":low-value"
+  },
+  {
+    "name": ":matches()"
   },
   {
     "name": ":modal"
@@ -282,7 +270,13 @@
     "name": ":muted"
   },
   {
+    "name": ":nav-source"
+  },
+  {
     "name": ":not()"
+  },
+  {
+    "name": ":nth()"
   },
   {
     "name": ":nth-child()"
@@ -306,13 +300,13 @@
     "name": ":open"
   },
   {
+    "name": ":optimal-value"
+  },
+  {
     "name": ":optional"
   },
   {
     "name": ":out-of-range"
-  },
-  {
-    "name": ":past"
   },
   {
     "name": ":paused"
@@ -354,16 +348,10 @@
     "name": ":stalled"
   },
   {
-    "name": ":state()"
-  },
-  {
     "name": ":target"
   },
   {
-    "name": ":target-current"
-  },
-  {
-    "name": ":target-within"
+    "name": ":unchecked"
   },
   {
     "name": ":user-invalid"
@@ -385,5 +373,11 @@
   },
   {
     "name": ":xr-overlay"
+  },
+  {
+    "name": ">"
+  },
+  {
+    "name": "~"
   }
 ]

--- a/crates/gosub_css3/resources/definitions/definitions_values.json
+++ b/crates/gosub_css3/resources/definitions/definitions_values.json
@@ -1,7 +1,19 @@
 [
   {
+    "name": "<a-n-plus-b>",
+    "syntax": "odd | even | <integer> | <n-dimension> | '+'? n | -n | <ndashdigit-dimension> | '+'? <ndashdigit-ident> | <dashndashdigit-ident> | <n-dimension> <signed-integer> | '+'? n <signed-integer> | -n <signed-integer> | <ndash-dimension> <signless-integer> | '+'? n- <signless-integer> | -n- <signless-integer> | <n-dimension> ['+' | '-'] <signless-integer> | '+'? n ['+' | '-'] <signless-integer> | -n ['+' | '-'] <signless-integer>"
+  },
+  {
+    "name": "<abs()>",
+    "syntax": "abs( <calc-sum> )"
+  },
+  {
     "name": "<absolute-size>",
-    "syntax": "xx-small | x-small | small | medium | large | x-large | xx-large | xxx-large"
+    "syntax": "[ xx-small | x-small | small | medium | large | x-large | xx-large | xxx-large ]"
+  },
+  {
+    "name": "<acos()>",
+    "syntax": "acos( <calc-sum> )"
   },
   {
     "name": "<alpha-value>",
@@ -9,7 +21,11 @@
   },
   {
     "name": "<an+b>",
-    "syntax": "odd | even | <integer> | <n-dimension> | '+'? n | -n | <ndashdigit-dimension> | '+'? <ndashdigit-ident> | <dashndashdigit-ident> | <n-dimension> <signed-integer> | '+'? n <signed-integer> | -n <signed-integer> | <ndash-dimension> <signless-integer> | '+'? n- <signless-integer> | -n- <signless-integer> | <n-dimension> ['+' | '-'] <signless-integer> | '+'? n ['+' | '-'] <signless-integer> | -n ['+' | '-'] <signless-integer>"
+    "syntax": "odd | even | <integer> | <n-dimension> | '+'?† n | -n | <ndashdigit-dimension> | '+'?† <ndashdigit-ident> | <dashndashdigit-ident> | <n-dimension> <signed-integer> | '+'?† n <signed-integer> | -n <signed-integer> | <ndash-dimension> <signless-integer> | '+'?† n- <signless-integer> | -n- <signless-integer> | <n-dimension> ['+' | '-'] <signless-integer> | '+'?† n ['+' | '-'] <signless-integer> | -n ['+' | '-'] <signless-integer>"
+  },
+  {
+    "name": "<anchor()>",
+    "syntax": "anchor( <anchor-name>? && <anchor-side>, <length-percentage>? )"
   },
   {
     "name": "<anchor-name>",
@@ -20,16 +36,16 @@
     "syntax": "inside | outside | top | left | right | bottom | start | end | self-start | self-end | <percentage> | center"
   },
   {
+    "name": "<anchor-size()>",
+    "syntax": "anchor-size( [ <anchor-name> || <anchor-size> ]? , <length-percentage>? )"
+  },
+  {
     "name": "<anchor-size>",
     "syntax": "width | height | block | inline | self-block | self-inline"
   },
   {
     "name": "<angle-percentage>",
-    "syntax": "<angle> | <percentage>"
-  },
-  {
-    "name": "<angle>",
-    "syntax": ""
+    "syntax": "[ <angle> | <percentage> ]"
   },
   {
     "name": "<angular-color-hint>",
@@ -52,8 +68,36 @@
     "syntax": "none | play | play-once | play-forwards | play-backwards | pause | reset | replay"
   },
   {
+    "name": "<arc-command>",
+    "syntax": "arc <command-end-point> [ [ of <length-percentage>{1,2} ] && <arc-sweep>? && <arc-size>? && [rotate <angle>]? ]"
+  },
+  {
+    "name": "<arc-size>",
+    "syntax": "large | small"
+  },
+  {
+    "name": "<arc-sweep>",
+    "syntax": "cw | ccw"
+  },
+  {
+    "name": "<asin()>",
+    "syntax": "asin( <calc-sum> )"
+  },
+  {
+    "name": "<atan()>",
+    "syntax": "atan( <calc-sum> )"
+  },
+  {
+    "name": "<atan2()>",
+    "syntax": "atan2( <calc-sum>, <calc-sum> )"
+  },
+  {
     "name": "<attachment>",
     "syntax": "scroll | fixed | local"
+  },
+  {
+    "name": "<attr()>",
+    "syntax": "attr( <attr-name> <attr-type>? , <declaration-value>? )"
   },
   {
     "name": "<attr-matcher>",
@@ -72,20 +116,52 @@
     "syntax": "'[' <wq-name> ']' | '[' <wq-name> <attr-matcher> [ <string-token> | <ident-token> ] <attr-modifier>? ']'"
   },
   {
+    "name": "<auto-line-color-list>",
+    "syntax": "<line-color-or-repeat>#? ',' <auto-repeat-line-color> ',' <line-color-or-repeat>#?"
+  },
+  {
+    "name": "<auto-line-style-list>",
+    "syntax": "<line-style-or-repeat>#? ',' <auto-repeat-line-style> ',' <line-style-or-repeat>#?"
+  },
+  {
+    "name": "<auto-line-width-list>",
+    "syntax": "<line-width-or-repeat>#? ',' <auto-repeat-line-width> ',' <line-width-or-repeat>#?"
+  },
+  {
+    "name": "<auto-repeat-line-color>",
+    "syntax": "repeat( auto ',' [ <color> ]# )"
+  },
+  {
+    "name": "<auto-repeat-line-style>",
+    "syntax": "repeat( auto ',' [ <line-style> ]# )"
+  },
+  {
+    "name": "<auto-repeat-line-width>",
+    "syntax": "repeat( auto ',' [ <line-width> ]# )"
+  },
+  {
     "name": "<auto-repeat>",
-    "syntax": "repeat( [ auto-fill | auto-fit ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
+    "syntax": "repeat( [ auto-fill | auto-fit ] ',' [ <line-names>? <fixed-size> ]+ <line-names>? )"
   },
   {
     "name": "<auto-track-list>",
-    "syntax": "[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>? <auto-repeat>\n[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>?"
+    "syntax": "[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>? <auto-repeat> [ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>?"
   },
   {
     "name": "<axis>",
     "syntax": "block | inline | x | y"
   },
   {
+    "name": "<base-descriptor>",
+    "syntax": "base-url ':' stylesheet | document | <url>"
+  },
+  {
+    "name": "<baseline-metric>",
+    "syntax": "text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top"
+  },
+  {
     "name": "<baseline-position>",
-    "syntax": "[ first | last ]? baseline"
+    "syntax": "[ first | last ]? && baseline"
   },
   {
     "name": "<basic-shape-rect>",
@@ -93,7 +169,7 @@
   },
   {
     "name": "<basic-shape>",
-    "syntax": "<inset()> | <xywh()> | <rect()> | <circle()> | <ellipse()> | <polygon()> | <path()> | shape()"
+    "syntax": "<basic-shape-rect> | <circle()> | <ellipse()> | <polygon()> | <path()> | <shape()>"
   },
   {
     "name": "<bg-clip>",
@@ -117,15 +193,55 @@
   },
   {
     "name": "<blend-mode>",
-    "syntax": "normal | multiply | screen | overlay | darken | lighten | color-dodge | color-burn | hard-light | soft-light | difference | exclusion | hue | saturation | color | luminosity"
+    "syntax": "normal | darken | multiply | color-burn | lighten | screen | color-dodge | overlay | soft-light | hard-light | difference | exclusion | hue | saturation | color | luminosity"
+  },
+  {
+    "name": "<blur()>",
+    "syntax": "blur( <length>? )"
+  },
+  {
+    "name": "<border-radius>",
+    "syntax": "<slash-separated-border-radius-syntax> | <legacy-border-radius-syntax>"
+  },
+  {
+    "name": "<box-shadow-blur>",
+    "syntax": "<length [0,∞]>#"
+  },
+  {
+    "name": "<box-shadow-color>",
+    "syntax": "<color>#"
+  },
+  {
+    "name": "<box-shadow-position>",
+    "syntax": "[ outset | inset ]#"
+  },
+  {
+    "name": "<box-shadow-spread>",
+    "syntax": "<length>#"
+  },
+  {
+    "name": "<brightness()>",
+    "syntax": "brightness( [ <number> | <percentage> ]? )"
+  },
+  {
+    "name": "<calc()>",
+    "syntax": "calc( <calc-sum> )"
   },
   {
     "name": "<calc-constant>",
     "syntax": "e | pi | infinity | -infinity | NaN"
   },
   {
+    "name": "<calc-keyword>",
+    "syntax": "e | pi | infinity | -infinity | NaN"
+  },
+  {
     "name": "<calc-product>",
-    "syntax": "<calc-value> [ '*' <calc-value> | '/' <number> ]*"
+    "syntax": "<calc-value> [ [ '*' | / ] <calc-value> ]*"
+  },
+  {
+    "name": "<calc-size()>",
+    "syntax": "calc-size( <calc-size-basis>, <calc-sum> )"
   },
   {
     "name": "<calc-size-basis>",
@@ -137,7 +253,7 @@
   },
   {
     "name": "<calc-value>",
-    "syntax": "<number> | <dimension> | <percentage> | <calc-constant> | ( <calc-sum> )"
+    "syntax": "<number> | <dimension> | <percentage> | <calc-keyword> | '(' <calc-sum> ')'"
   },
   {
     "name": "<cf-final-image>",
@@ -148,6 +264,14 @@
     "syntax": "<percentage>? && <image>"
   },
   {
+    "name": "<circle()>",
+    "syntax": "circle( <radial-size>? [ at <position> ]? )"
+  },
+  {
+    "name": "<clamp()>",
+    "syntax": "clamp( <calc-sum>#{3} )"
+  },
+  {
     "name": "<class-selector>",
     "syntax": "'.' <ident-token>"
   },
@@ -156,16 +280,32 @@
     "syntax": "<url>"
   },
   {
+    "name": "<color()>",
+    "syntax": "color( [ from <color> ]? <colorspace-params> [ / [ <alpha-value> | none ] ]? )"
+  },
+  {
     "name": "<color-base>",
-    "syntax": "<hex-color> | <color-function> | <named-color> | <color-mix()> | transparent"
+    "syntax": "<hex-color> | <color-function> | <named-color> | transparent"
+  },
+  {
+    "name": "<color-font-tech>",
+    "syntax": "[ color-COLRv0 | color-COLRv1 | color-SVG | color-sbix | color-CBDT ]"
   },
   {
     "name": "<color-function>",
-    "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <oklab()> | <oklch()> | <color()>"
+    "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <oklab()> | <oklch()> | <ictcp()> | <jzazbz()> | <jzczhz()> | <alpha()> | <color()> | <hdr-color()>"
   },
   {
     "name": "<color-interpolation-method>",
-    "syntax": "in [ <rectangular-color-space> | <polar-color-space> <hue-interpolation-method>? | <custom-color-space> ]"
+    "syntax": "in [ <rectangular-color-space> | <polar-color-space> <hue-interpolation-method>? ]"
+  },
+  {
+    "name": "<color-mix()>",
+    "syntax": "color-mix( <color-interpolation-method> , [ <color> && <percentage [0,100]>? ]#{2})"
+  },
+  {
+    "name": "<color-space>",
+    "syntax": "<rectangular-color-space> | <polar-color-space>"
   },
   {
     "name": "<color-stop-angle>",
@@ -177,7 +317,7 @@
   },
   {
     "name": "<color-stop-list>",
-    "syntax": "<linear-color-stop> , [ <linear-color-hint>? , <linear-color-stop> ]#?"
+    "syntax": "<linear-color-stop> ',' [ <linear-color-hint>? ',' <linear-color-stop> ]#?"
   },
   {
     "name": "<color-stop>",
@@ -185,15 +325,19 @@
   },
   {
     "name": "<color>",
-    "syntax": "<color-base> | currentColor | <system-color> | <light-dark()> | <deprecated-system-color>"
+    "syntax": "<color-base> | currentColor | <system-color>"
   },
   {
     "name": "<colorspace-params>",
-    "syntax": "[<custom-params> | <predefined-rgb-params> | <xyz-params>]"
+    "syntax": "[ <predefined-rgb-params> | <xyz-params>]"
   },
   {
     "name": "<combinator>",
-    "syntax": "'>' | '+' | '~' | [ '||' ]"
+    "syntax": "'>' | '+' | '~'"
+  },
+  {
+    "name": "<command-end-point>",
+    "syntax": "[ to <position> | by <coordinate-pair> ]"
   },
   {
     "name": "<common-lig-values>",
@@ -208,12 +352,28 @@
     "syntax": "textfield | menulist-button"
   },
   {
+    "name": "<complex-real-selector-list>",
+    "syntax": "<complex-real-selector>#"
+  },
+  {
+    "name": "<complex-real-selector>",
+    "syntax": "<compound-selector> [ <combinator>? <compound-selector> ]*"
+  },
+  {
     "name": "<complex-selector-list>",
     "syntax": "<complex-selector>#"
   },
   {
+    "name": "<complex-selector-unit>",
+    "syntax": "[ <compound-selector>? <pseudo-compound-selector>* ]!"
+  },
+  {
     "name": "<complex-selector>",
-    "syntax": "<compound-selector> [ <combinator>? <compound-selector> ]*"
+    "syntax": "<complex-selector-unit> [ <combinator>? <complex-selector-unit> ]*"
+  },
+  {
+    "name": "<composite-mode>",
+    "syntax": "clear | copy | source-over | destination-over | source-in | destination-in | source-out | destination-out | source-atop | destination-atop | xor | lighter | plus-darker | plus-lighter"
   },
   {
     "name": "<composite-style>",
@@ -229,7 +389,11 @@
   },
   {
     "name": "<compound-selector>",
-    "syntax": "[ <type-selector>? <subclass-selector>* [ <pseudo-element-selector> <pseudo-class-selector>* ]* ]!"
+    "syntax": "[ <type-selector>? <subclass-selector>* ]!"
+  },
+  {
+    "name": "<conic-gradient()>",
+    "syntax": "conic-gradient( [ <conic-gradient-syntax> ] )"
   },
   {
     "name": "<conic-gradient-syntax>",
@@ -253,7 +417,7 @@
   },
   {
     "name": "<content-list>",
-    "syntax": "[ <string> | <image> | <attr()> | <quote> | <counter> ]+"
+    "syntax": "[ <string> | <image> | <attr()> | contents | <quote> | <leader()> | <target> | <string()> | <content()> | <counter> ]+"
   },
   {
     "name": "<content-position>",
@@ -268,12 +432,32 @@
     "syntax": "[ contextual | no-contextual ]"
   },
   {
+    "name": "<contrast()>",
+    "syntax": "contrast( [ <number> | <percentage> ]? )"
+  },
+  {
+    "name": "<control-point>",
+    "syntax": "[ <position> | <relative-control-point> ]"
+  },
+  {
     "name": "<coord-box>",
     "syntax": "<paint-box> | view-box"
   },
   {
+    "name": "<coordinate-pair>",
+    "syntax": "<length-percentage>{2}"
+  },
+  {
     "name": "<corner-shape-value>",
     "syntax": "round | scoop | bevel | notch | square | squircle | <superellipse()>"
+  },
+  {
+    "name": "<cos()>",
+    "syntax": "cos( <calc-sum> )"
+  },
+  {
+    "name": "<counter()>",
+    "syntax": "counter( <counter-name>, <counter-style>? )"
   },
   {
     "name": "<counter-name>",
@@ -285,51 +469,79 @@
   },
   {
     "name": "<counter-style>",
-    "syntax": "<counter-style-name> | symbols()"
+    "syntax": "<counter-style-name> | <symbols()>"
   },
   {
     "name": "<counter>",
     "syntax": "<counter()> | <counters()>"
   },
   {
+    "name": "<counters()>",
+    "syntax": "counters( <counter-name>, <string>, <counter-style>? )"
+  },
+  {
+    "name": "<cross-fade()>",
+    "syntax": "cross-fade( <cf-mixing-image> , <cf-final-image>? )"
+  },
+  {
+    "name": "<css-type>",
+    "syntax": "<syntax-component> | <type()>"
+  },
+  {
+    "name": "<cubic-bezier()>",
+    "syntax": "cubic-bezier( [ <number [0,1]>, <number> ]#{2} )"
+  },
+  {
     "name": "<cubic-bezier-easing-function>",
     "syntax": "ease | ease-in | ease-out | ease-in-out | <cubic-bezier()>"
   },
   {
+    "name": "<cursor-image>",
+    "syntax": "[ <url> | <url-set> ] <number>{2}?"
+  },
+  {
     "name": "<cursor-predefined>",
-    "syntax": "auto | default | none | context-menu | help | pointer | progress | wait | cell | crosshair | text | vertical-text | alias | copy | move | no-drop | not-allowed | e-resize | n-resize | ne-resize | nw-resize | s-resize | se-resize | sw-resize | w-resize | ew-resize | ns-resize | nesw-resize | nwse-resize | col-resize | row-resize | all-scroll | zoom-in | zoom-out | grab | grabbing"
+    "syntax": "auto | default | none | context-menu | help | pointer | progress | wait | cell | crosshair | text | vertical-text | alias | copy | move | no-drop | not-allowed | grab | grabbing | e-resize | n-resize | ne-resize | nw-resize | s-resize | se-resize | sw-resize | w-resize | ew-resize | ns-resize | nesw-resize | nwse-resize | col-resize | row-resize | all-scroll | zoom-in | zoom-out"
+  },
+  {
+    "name": "<curve-command>",
+    "syntax": "curve [ [ to <position> with <control-point> [ / <control-point> ]? ] | [ by <coordinate-pair> with <relative-control-point> [ / <relative-control-point> ]? ] ]"
+  },
+  {
+    "name": "<custom-arg>",
+    "syntax": "'$' <ident-token>"
   },
   {
     "name": "<custom-color-space>",
     "syntax": "<dashed-ident>"
   },
   {
-    "name": "<custom-ident>",
-    "syntax": ""
-  },
-  {
     "name": "<custom-params>",
     "syntax": "<dashed-ident> [ <number> | <percentage> | none ]+"
+  },
+  {
+    "name": "<custom-selector>",
+    "syntax": "<custom-arg>? ':' <extension-name> [ '(' <custom-arg>+#? ')' ]?"
   },
   {
     "name": "<dasharray>",
     "syntax": "[ [ <length-percentage> | <number> ]+ ]#"
   },
   {
-    "name": "<dashed-ident>",
-    "syntax": ""
-  },
-  {
     "name": "<dashndashdigit-ident>",
     "syntax": "<ident-token>"
   },
   {
-    "name": "<deprecated-system-color>",
+    "name": "<default-value>",
+    "syntax": "<declaration-value>"
+  },
+  {
+    "name": "<deprecated-color>",
     "syntax": "ActiveBorder | ActiveCaption | AppWorkspace | Background | ButtonHighlight | ButtonShadow | CaptionText | InactiveBorder | InactiveCaption | InactiveCaptionText | InfoBackground | InfoText | Menu | MenuText | Scrollbar | ThreeDDarkShadow | ThreeDFace | ThreeDHighlight | ThreeDLightShadow | ThreeDShadow | Window | WindowFrame | WindowText"
   },
   {
-    "name": "<dimension>",
-    "syntax": ""
+    "name": "<deprecated-system-color>",
+    "syntax": "ActiveBorder | ActiveCaption | AppWorkspace | Background | ButtonHighlight | ButtonShadow | CaptionText | InactiveBorder | InactiveCaption | InactiveCaptionText | InfoBackground | InfoText | Menu | MenuText | Scrollbar | ThreeDDarkShadow | ThreeDFace | ThreeDHighlight | ThreeDLightShadow | ThreeDShadow | Window | WindowFrame | WindowText"
   },
   {
     "name": "<discretionary-lig-values>",
@@ -349,7 +561,7 @@
   },
   {
     "name": "<display-legacy>",
-    "syntax": "inline-block | inline-list-item | inline-table | inline-flex | inline-grid"
+    "syntax": "inline-block | inline-table | inline-flex | inline-grid"
   },
   {
     "name": "<display-listitem>",
@@ -358,6 +570,14 @@
   {
     "name": "<display-outside>",
     "syntax": "block | inline | run-in"
+  },
+  {
+    "name": "<drop-shadow()>",
+    "syntax": "drop-shadow( [ <color>? && <length>{2,3} ] )"
+  },
+  {
+    "name": "<dynamic-range-limit-mix()>",
+    "syntax": "dynamic-range-limit-mix( [ <'dynamic-range-limit'> && <percentage [0,100]> ]#{2,} )"
   },
   {
     "name": "<easing-function>",
@@ -372,6 +592,30 @@
     "syntax": "[ full-width | proportional-width ]"
   },
   {
+    "name": "<element()>",
+    "syntax": "element( <id-selector> )"
+  },
+  {
+    "name": "<ellipse()>",
+    "syntax": "ellipse( <radial-size>? [ at <position> ]? )"
+  },
+  {
+    "name": "<env()>",
+    "syntax": "env( <custom-ident> , <declaration-value>? )"
+  },
+  {
+    "name": "<env-args>",
+    "syntax": "env( <declaration-value>, <declaration-value>? )"
+  },
+  {
+    "name": "<event-trigger-event>",
+    "syntax": "activate | interest | click | touch | dblclick | keypress(<string>) | ..."
+  },
+  {
+    "name": "<exp()>",
+    "syntax": "exp( <calc-sum> )"
+  },
+  {
     "name": "<explicit-track-list>",
     "syntax": "[ <line-names>? <track-size> ]+ <line-names>?"
   },
@@ -381,7 +625,7 @@
   },
   {
     "name": "<feature-tag-value>",
-    "syntax": "<string> [ <integer> | on | off ]?"
+    "syntax": "<opentype-tag> [ <integer [0,∞]> | on | off ]?"
   },
   {
     "name": "<feature-type>",
@@ -409,7 +653,7 @@
   },
   {
     "name": "<filter-function>",
-    "syntax": "<blur()> | <brightness()> | <contrast()> | <drop-shadow()> | <grayscale()> | <hue-rotate()> | <invert()> | <opacity()> | <saturate()> | <sepia()>"
+    "syntax": "<blur()> | <brightness()> | <contrast()> | <drop-shadow()> | <grayscale()> | <hue-rotate()> | <invert()> | <opacity()> | <sepia()> | <saturate()>"
   },
   {
     "name": "<filter-value-list>",
@@ -420,24 +664,52 @@
     "syntax": "<bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <visual-box> || <visual-box> || <'background-color'>"
   },
   {
+    "name": "<fit-content()>",
+    "syntax": "fit-content( <length-percentage [0,∞]> )"
+  },
+  {
     "name": "<fixed-breadth>",
-    "syntax": "<length-percentage>"
+    "syntax": "<length-percentage [0,∞]>"
   },
   {
     "name": "<fixed-repeat>",
-    "syntax": "repeat( [ <integer [1,∞]> ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
+    "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-names>? <fixed-size> ]+ <line-names>? )"
   },
   {
     "name": "<fixed-size>",
-    "syntax": "<fixed-breadth> | minmax( <fixed-breadth> , <track-breadth> ) | minmax( <inflexible-breadth> , <fixed-breadth> )"
+    "syntax": "<fixed-breadth> | minmax( <fixed-breadth> ',' <track-breadth> ) | minmax( <inflexible-breadth> ',' <fixed-breadth> )"
   },
   {
-    "name": "<flex>",
-    "syntax": ""
+    "name": "<font-family-name>",
+    "syntax": "<string> | <custom-ident>+"
+  },
+  {
+    "name": "<font-feature-index>",
+    "syntax": "<integer>"
+  },
+  {
+    "name": "<font-feature-value-name>",
+    "syntax": "<ident>"
+  },
+  {
+    "name": "<font-features-tech>",
+    "syntax": "[ features-opentype | features-aat | features-graphite ]"
+  },
+  {
+    "name": "<font-format>",
+    "syntax": "[ <string> | collection | embedded-opentype | opentype | svg | truetype | woff | woff2 ]"
+  },
+  {
+    "name": "<font-src>",
+    "syntax": "<url> [ format( <font-format> ) ]? [ tech( <font-tech># ) ]? | local( <font-family-name> )"
   },
   {
     "name": "<font-stretch-absolute>",
     "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded | <percentage>"
+  },
+  {
+    "name": "<font-tech>",
+    "syntax": "[ <font-features-tech> | <color-font-tech> | variations | palettes | incremental ]"
   },
   {
     "name": "<font-variant-css2>",
@@ -445,7 +717,7 @@
   },
   {
     "name": "<font-weight-absolute>",
-    "syntax": "normal | bold | <number [1,1000]>"
+    "syntax": "[ normal | bold | <number [1,1000]> ]"
   },
   {
     "name": "<font-width-css3>",
@@ -457,15 +729,39 @@
   },
   {
     "name": "<frequency-percentage>",
-    "syntax": "<frequency> | <percentage>"
+    "syntax": "[ <frequency> | <percentage> ]"
   },
   {
-    "name": "<frequency>",
-    "syntax": ""
+    "name": "<function-parameter>",
+    "syntax": "<custom-property-name> <css-type>? [ ':' <default-value> ]?"
+  },
+  {
+    "name": "<gap-auto-repeat-rule>",
+    "syntax": "repeat( auto ',' <gap-rule># )"
+  },
+  {
+    "name": "<gap-auto-rule-list>",
+    "syntax": "<gap-rule-or-repeat>#? ',' <gap-auto-repeat-rule> ',' <gap-rule-or-repeat>#?"
+  },
+  {
+    "name": "<gap-repeat-rule>",
+    "syntax": "repeat( <integer [1,∞]> ',' <gap-rule># )"
+  },
+  {
+    "name": "<gap-rule-list>",
+    "syntax": "<gap-rule-or-repeat>#"
+  },
+  {
+    "name": "<gap-rule-or-repeat>",
+    "syntax": "<gap-rule> | <gap-repeat-rule>"
+  },
+  {
+    "name": "<gap-rule>",
+    "syntax": "<line-width> || <line-style> || <color>"
   },
   {
     "name": "<general-enclosed>",
-    "syntax": "[ <function-token> <any-value> ) ] | ( <ident> <any-value> )"
+    "syntax": "[ <function-token> <any-value>? ')' ] | [ '(' <any-value>? ')' ]"
   },
   {
     "name": "<generic-complete>",
@@ -476,8 +772,28 @@
     "syntax": "<generic-complete> | <generic-incomplete> | emoji | fangsong"
   },
   {
+    "name": "<generic-font-complete>",
+    "syntax": "serif | sans-serif | system-ui | cursive | fantasy | math | monospace"
+  },
+  {
+    "name": "<generic-font-family>",
+    "syntax": "<generic-font-script-specific>| <generic-font-complete> | <generic-font-incomplete>"
+  },
+  {
+    "name": "<generic-font-incomplete>",
+    "syntax": "ui-serif | ui-sans-serif | ui-monospace | ui-rounded"
+  },
+  {
+    "name": "<generic-font-script-specific>",
+    "syntax": "generic(fangsong) | generic(kai) | generic(khmer-mul) | generic(nastaliq)"
+  },
+  {
     "name": "<generic-incomplete>",
     "syntax": "ui-serif | ui-sans-serif | ui-monospace | ui-rounded"
+  },
+  {
+    "name": "<generic-voice>",
+    "syntax": "<age>? <gender> <integer [1,∞]>?"
   },
   {
     "name": "<geometry-box>",
@@ -485,31 +801,63 @@
   },
   {
     "name": "<gradient>",
-    "syntax": "<linear-gradient()> | <repeating-linear-gradient()> | <radial-gradient()> | <repeating-radial-gradient()> | <conic-gradient()> | <repeating-conic-gradient()>"
+    "syntax": "<linear-gradient()> | <repeating-linear-gradient()> | <radial-gradient()> | <repeating-radial-gradient()>"
+  },
+  {
+    "name": "<grayscale()>",
+    "syntax": "grayscale( [ <number> | <percentage> ]? )"
   },
   {
     "name": "<grid-line>",
-    "syntax": "auto | <custom-ident> | [ <integer> && <custom-ident>? ] | [ span && [ <integer> || <custom-ident> ] ]"
+    "syntax": "auto | <custom-ident> | [ [ <integer [-∞,-1]> | <integer [1,∞]> ] && <custom-ident>? ] | [ span && [ <integer [1,∞]> || <custom-ident> ] ]"
   },
   {
     "name": "<historical-lig-values>",
     "syntax": "[ historical-ligatures | no-historical-ligatures ]"
   },
   {
+    "name": "<horizontal-line-command>",
+    "syntax": "hline [ to [ <length-percentage> | left | center | right | x-start | x-end ] | by <length-percentage> ]"
+  },
+  {
+    "name": "<hsl()>",
+    "syntax": "hsl( <hue>, <percentage>, <percentage>, <alpha-value>? ) | hsl( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
+  },
+  {
+    "name": "<hsla()>",
+    "syntax": "hsla( <hue>, <percentage>, <percentage>, <alpha-value>? ) | hsla( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
+  },
+  {
     "name": "<hue-interpolation-method>",
     "syntax": "[ shorter | longer | increasing | decreasing ] hue"
+  },
+  {
+    "name": "<hue-rotate()>",
+    "syntax": "hue-rotate( [ <angle> | <zero> ]? )"
   },
   {
     "name": "<hue>",
     "syntax": "<number> | <angle>"
   },
   {
+    "name": "<hwb()>",
+    "syntax": "hwb( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
+  },
+  {
+    "name": "<hypot()>",
+    "syntax": "hypot( <calc-sum># )"
+  },
+  {
     "name": "<id-selector>",
     "syntax": "<hash-token>"
   },
   {
-    "name": "<ident>",
-    "syntax": ""
+    "name": "<image()>",
+    "syntax": "image( <image-tags>? [ <image-src>? , <color>? ]! )"
+  },
+  {
+    "name": "<image-set()>",
+    "syntax": "image-set( <image-set-option># )"
   },
   {
     "name": "<image-set-option>",
@@ -525,43 +873,127 @@
   },
   {
     "name": "<image>",
-    "syntax": "<url> | <image()> | <image-set()> | <element()> | <paint()> | <cross-fade()> | <gradient>"
+    "syntax": "<url> | <gradient>"
+  },
+  {
+    "name": "<import-conditions>",
+    "syntax": "[ supports( [ <supports-condition> | <declaration> ] ) ]? <media-query-list>?"
   },
   {
     "name": "<inflexible-breadth>",
-    "syntax": "<length-percentage> | min-content | max-content | auto"
+    "syntax": "<length-percentage [0,∞]> | min-content | max-content | auto"
+  },
+  {
+    "name": "<init-descriptor-name>",
+    "syntax": "protocol | hostname | port | pathname | search | hash"
+  },
+  {
+    "name": "<init-descriptor>",
+    "syntax": "<init-descriptor-name> ':' <string>"
+  },
+  {
+    "name": "<inset()>",
+    "syntax": "inset( <length-percentage>{1,4} [ round <'border-radius'> ]? )"
+  },
+  {
+    "name": "<inset-value>",
+    "syntax": "<length-percentage> | overlap-join"
   },
   {
     "name": "<integer>",
     "syntax": "<number-token>"
   },
   {
+    "name": "<invert()>",
+    "syntax": "invert( [ <number> | <percentage> ]? )"
+  },
+  {
+    "name": "<isolation-mode>",
+    "syntax": "auto | isolate"
+  },
+  {
     "name": "<keyframe-block>",
-    "syntax": "<keyframe-selector># {\n  <declaration-list>\n}"
+    "syntax": "<keyframe-selector># '{' <declaration-list> '}'"
   },
   {
     "name": "<keyframe-selector>",
-    "syntax": "from | to | <percentage [0,100]> | <timeline-range-name> <percentage>"
+    "syntax": "from | to | <percentage [0,100]>"
   },
   {
     "name": "<keyframes-name>",
     "syntax": "<custom-ident> | <string>"
   },
   {
+    "name": "<lab()>",
+    "syntax": "lab( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "<layer()>",
+    "syntax": "layer( <layer-name> )"
+  },
+  {
     "name": "<layer-name>",
     "syntax": "<ident> [ '.' <ident> ]*"
+  },
+  {
+    "name": "<layout-box>",
+    "syntax": "<visual-box> | margin-box"
+  },
+  {
+    "name": "<lch()>",
+    "syntax": "lch( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "<leader()>",
+    "syntax": "leader( <leader-type> )"
   },
   {
     "name": "<leader-type>",
     "syntax": "dotted | solid | space | <string>"
   },
   {
-    "name": "<length-percentage>",
-    "syntax": "<length> | <percentage>"
+    "name": "<legacy-border-radius-syntax>",
+    "syntax": "<length-percentage [0,∞]>{1,2}"
   },
   {
-    "name": "<length>",
-    "syntax": ""
+    "name": "<legacy-hsl-syntax>",
+    "syntax": "hsl( <hue>, <percentage>, <percentage>, <alpha-value>? )"
+  },
+  {
+    "name": "<legacy-hsla-syntax>",
+    "syntax": "hsla( <hue>, <percentage>, <percentage>, <alpha-value>? )"
+  },
+  {
+    "name": "<legacy-pseudo-element-selector>",
+    "syntax": "':' [before | after | first-line | first-letter]"
+  },
+  {
+    "name": "<legacy-rgb-syntax>",
+    "syntax": "rgb( <percentage>#{3} ',' <alpha-value>? ) | rgb( <number>#{3} ',' <alpha-value>? )"
+  },
+  {
+    "name": "<legacy-rgba-syntax>",
+    "syntax": "rgba( <percentage>#{3} ',' <alpha-value>? ) | rgba( <number>#{3} ',' <alpha-value>? )"
+  },
+  {
+    "name": "<length-percentage>",
+    "syntax": "[ <length> | <percentage> ]"
+  },
+  {
+    "name": "<light-dark()>",
+    "syntax": "light-dark( <color>, <color> )"
+  },
+  {
+    "name": "<line-color-list>",
+    "syntax": "<line-color-or-repeat>#"
+  },
+  {
+    "name": "<line-color-or-repeat>",
+    "syntax": "[ <color> | <repeat-line-color> ]"
+  },
+  {
+    "name": "<line-command>",
+    "syntax": "line <command-end-point>"
   },
   {
     "name": "<line-name-list>",
@@ -572,12 +1004,32 @@
     "syntax": "'[' <custom-ident>* ']'"
   },
   {
+    "name": "<line-style-list>",
+    "syntax": "<line-style-or-repeat>#"
+  },
+  {
+    "name": "<line-style-or-repeat>",
+    "syntax": "[ <line-style> | <repeat-line-style> ]"
+  },
+  {
     "name": "<line-style>",
     "syntax": "none | hidden | dotted | dashed | solid | double | groove | ridge | inset | outset"
   },
   {
+    "name": "<line-width-list>",
+    "syntax": "<line-width-or-repeat>#"
+  },
+  {
+    "name": "<line-width-or-repeat>",
+    "syntax": "[ <line-width> | <repeat-line-width> ]"
+  },
+  {
     "name": "<line-width>",
-    "syntax": "<length> | thin | medium | thick"
+    "syntax": "<length [0,∞]> | hairline | thin | medium | thick"
+  },
+  {
+    "name": "<linear()>",
+    "syntax": "linear( [ <number> && <percentage>{0,2} ]# )"
   },
   {
     "name": "<linear-color-hint>",
@@ -585,15 +1037,27 @@
   },
   {
     "name": "<linear-color-stop>",
-    "syntax": "<color> <color-stop-length>?"
+    "syntax": "<color> <length-percentage>?"
   },
   {
     "name": "<linear-easing-function>",
     "syntax": "linear | <linear()>"
   },
   {
+    "name": "<linear-gradient()>",
+    "syntax": "linear-gradient( [ <linear-gradient-syntax> ] )"
+  },
+  {
     "name": "<linear-gradient-syntax>",
-    "syntax": "[ [ <angle> | <zero> | to <side-or-corner> ] || <color-interpolation-method> ]? , <color-stop-list>"
+    "syntax": "[ <angle> | <zero> | to <side-or-corner> ]? ',' <color-stop-list>"
+  },
+  {
+    "name": "<log()>",
+    "syntax": "log( <calc-sum>, <calc-sum>? )"
+  },
+  {
+    "name": "<marker-ref>",
+    "syntax": "<url>"
   },
   {
     "name": "<mask-layer>",
@@ -616,24 +1080,36 @@
     "syntax": "alpha | luminance | match-source"
   },
   {
+    "name": "<matrix()>",
+    "syntax": "matrix( <number>#{6} )"
+  },
+  {
+    "name": "<matrix3d()>",
+    "syntax": "matrix3d( <number>#{16} )"
+  },
+  {
+    "name": "<max()>",
+    "syntax": "max( <calc-sum># )"
+  },
+  {
     "name": "<media-and>",
-    "syntax": "<media-in-parens> [ and <media-in-parens> ]+"
+    "syntax": "and <media-in-parens>"
   },
   {
     "name": "<media-condition-without-or>",
-    "syntax": "<media-not> | <media-and> | <media-in-parens>"
+    "syntax": "<media-not> | <media-in-parens> <media-and>*"
   },
   {
     "name": "<media-condition>",
-    "syntax": "<media-not> | <media-and> | <media-or> | <media-in-parens>"
+    "syntax": "<media-not> | <media-in-parens> [ <media-and>* | <media-or>* ]"
   },
   {
     "name": "<media-feature>",
-    "syntax": "( [ <mf-plain> | <mf-boolean> | <mf-range> ] )"
+    "syntax": "[ <mf-plain> | <mf-boolean> | <mf-range> ]"
   },
   {
     "name": "<media-in-parens>",
-    "syntax": "( <media-condition> ) | <media-feature> | <general-enclosed>"
+    "syntax": "'(' <media-condition> ')' | '(' <media-feature> ')' | <general-enclosed>"
   },
   {
     "name": "<media-not>",
@@ -641,7 +1117,7 @@
   },
   {
     "name": "<media-or>",
-    "syntax": "<media-in-parens> [ or <media-in-parens> ]+"
+    "syntax": "or <media-in-parens>"
   },
   {
     "name": "<media-query-list>",
@@ -660,20 +1136,72 @@
     "syntax": "<mf-name>"
   },
   {
+    "name": "<mf-comparison>",
+    "syntax": "<mf-lt> | <mf-gt> | <mf-eq>"
+  },
+  {
+    "name": "<mf-eq>",
+    "syntax": "'='"
+  },
+  {
+    "name": "<mf-gt>",
+    "syntax": "'>' '='?"
+  },
+  {
+    "name": "<mf-lt>",
+    "syntax": "'<' '='?"
+  },
+  {
     "name": "<mf-name>",
     "syntax": "<ident>"
   },
   {
     "name": "<mf-plain>",
-    "syntax": "<mf-name> : <mf-value>"
+    "syntax": "<mf-name> ':' <mf-value>"
   },
   {
     "name": "<mf-range>",
-    "syntax": "<mf-name> [ '<' | '>' ]? '='? <mf-value>\n| <mf-value> [ '<' | '>' ]? '='? <mf-name>\n| <mf-value> '<' '='? <mf-name> '<' '='? <mf-value>\n| <mf-value> '>' '='? <mf-name> '>' '='? <mf-value>"
+    "syntax": "<mf-name> <mf-comparison> <mf-value> | <mf-value> <mf-comparison> <mf-name> | <mf-value> <mf-lt> <mf-name> <mf-lt> <mf-value> | <mf-value> <mf-gt> <mf-name> <mf-gt> <mf-value>"
   },
   {
     "name": "<mf-value>",
     "syntax": "<number> | <dimension> | <ident> | <ratio>"
+  },
+  {
+    "name": "<min()>",
+    "syntax": "min( <calc-sum># )"
+  },
+  {
+    "name": "<minmax()>",
+    "syntax": "minmax( [ <length-percentage> | min-content | max-content | auto ] , [ <length-percentage> | <flex> | min-content | max-content | auto ] )"
+  },
+  {
+    "name": "<mod()>",
+    "syntax": "mod( <calc-sum>, <calc-sum> )"
+  },
+  {
+    "name": "<modern-hsl-syntax>",
+    "syntax": "hsl( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "<modern-hsla-syntax>",
+    "syntax": "hsla( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "<modern-rgb-syntax>",
+    "syntax": "rgb( [ <number> | <percentage> | none]{3} [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "<modern-rgba-syntax>",
+    "syntax": "rgba( [ <number> | <percentage> | none]{3} [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "<move-command>",
+    "syntax": "move <command-end-point>"
+  },
+  {
+    "name": "<mq-boolean>",
+    "syntax": "<integer [0,1]>"
   },
   {
     "name": "<n-dimension>",
@@ -681,15 +1209,55 @@
   },
   {
     "name": "<name-repeat>",
-    "syntax": "repeat( [ <integer [1,∞]> | auto-fill ], <line-names>+ )"
+    "syntax": "repeat( [ <integer [1,∞]> | auto-fill ], <line-names>+)"
   },
   {
     "name": "<named-color>",
-    "syntax": "aliceblue | antiquewhite | aqua | aquamarine | azure | beige | bisque | black | blanchedalmond | blue | blueviolet | brown | burlywood | cadetblue | chartreuse | chocolate | coral | cornflowerblue | cornsilk | crimson | cyan | darkblue | darkcyan | darkgoldenrod | darkgray | darkgreen | darkgrey | darkkhaki | darkmagenta | darkolivegreen | darkorange | darkorchid | darkred | darksalmon | darkseagreen | darkslateblue | darkslategray | darkslategrey | darkturquoise | darkviolet | deeppink | deepskyblue | dimgray | dimgrey | dodgerblue | firebrick | floralwhite | forestgreen | fuchsia | gainsboro | ghostwhite | gold | goldenrod | gray | green | greenyellow | grey | honeydew | hotpink | indianred | indigo | ivory | khaki | lavender | lavenderblush | lawngreen | lemonchiffon | lightblue | lightcoral | lightcyan | lightgoldenrodyellow | lightgray | lightgreen | lightgrey | lightpink | lightsalmon | lightseagreen | lightskyblue | lightslategray | lightslategrey | lightsteelblue | lightyellow | lime | limegreen | linen | magenta | maroon | mediumaquamarine | mediumblue | mediumorchid | mediumpurple | mediumseagreen | mediumslateblue | mediumspringgreen | mediumturquoise | mediumvioletred | midnightblue | mintcream | mistyrose | moccasin | navajowhite | navy | oldlace | olive | olivedrab | orange | orangered | orchid | palegoldenrod | palegreen | paleturquoise | palevioletred | papayawhip | peachpuff | peru | pink | plum | powderblue | purple | rebeccapurple | red | rosybrown | royalblue | saddlebrown | salmon | sandybrown | seagreen | seashell | sienna | silver | skyblue | slateblue | slategray | slategrey | snow | springgreen | steelblue | tan | teal | thistle | tomato | turquoise | violet | wheat | white | whitesmoke | yellow | yellowgreen"
+    "syntax": "aliceblue | antiquewhite | aqua | aquamarine | azure | beige | bisque | black | blanchedalmond | blue | blueviolet | brown | burlywood | cadetblue | chartreuse | chocolate | coral | cornflowerblue | cornsilk | crimson | cyan | darkblue | darkcyan | darkgoldenrod | darkgray | darkgreen | darkgrey | darkkhaki | darkmagenta | darkolivegreen | darkorange | darkorchid | darkred | darksalmon | darkseagreen | darkslateblue | darkslategray | darkslategrey | darkturquoise | darkviolet | deeppink | deepskyblue | dimgray | dimgrey | dodgerblue | firebrick | floralwhite | forestgreen | fuchsia | gainsboro | ghostwhite | gold | goldenrod | gray | green | greenyellow | grey | honeydew | hotpink | indianred | indigo | ivory | khaki | lavender | lavenderblush | lawngreen | lemonchiffon | lightblue | lightcoral | lightcyan | lightgoldenrodyellow | lightgray | lightgreen | lightgrey | lightpink | lightsalmon | lightseagreen | lightskyblue | lightslategray | lightslategrey | lightsteelblue | lightyellow | lime | limegreen | linen | magenta | maroon | mediumaquamarine | mediumblue | mediumorchid | mediumpurple | mediumseagreen | mediumslateblue | mediumspringgreen | mediumturquoise | mediumvioletred | midnightblue | mintcream | mistyrose | moccasin | navajowhite | navy | oldlace | olive | olivedrab | orange | orangered | orchid | palegoldenrod | palegreen | paleturquoise | palevioletred | papayawhip | peachpuff | peru | pink | plum | powderblue | purple | rebeccapurple | red | rosybrown | royalblue | saddlebrown | salmon | sandybrown | seagreen | seashell | sienna | silver | skyblue | slateblue | slategray | slategrey | snow | springgreen | steelblue | tan | teal | thistle | tomato | turquoise | violet | wheat | white | whitesmoke | yellow | yellowgreen | transparent"
   },
   {
     "name": "<namespace-prefix>",
     "syntax": "<ident>"
+  },
+  {
+    "name": "<navigation-condition>",
+    "syntax": "not <navigation-in-parens> | <navigation-in-parens> [ and <navigation-in-parens> ]* | <navigation-in-parens> [ or <navigation-in-parens> ]*"
+  },
+  {
+    "name": "<navigation-in-parens>",
+    "syntax": "'(' <navigation-condition> ')' | '(' <navigation-test> ')' | <general-enclosed>"
+  },
+  {
+    "name": "<navigation-location-between-test>",
+    "syntax": "between ':' <route-location> and <route-location>"
+  },
+  {
+    "name": "<navigation-location-test>",
+    "syntax": "<navigation-relation> ':' <route-location>"
+  },
+  {
+    "name": "<navigation-phase-keyword>",
+    "syntax": "loading | ready | committed"
+  },
+  {
+    "name": "<navigation-phase-test>",
+    "syntax": "phase ':' <navigation-phase-keyword>"
+  },
+  {
+    "name": "<navigation-relation>",
+    "syntax": "at | with | from | to"
+  },
+  {
+    "name": "<navigation-test>",
+    "syntax": "<navigation-location-test> | <navigation-location-between-test> | <navigation-type-test> | <navigation-phase-test>"
+  },
+  {
+    "name": "<navigation-type-keyword>",
+    "syntax": "traverse | back | forward | reload"
+  },
+  {
+    "name": "<navigation-type-test>",
+    "syntax": "history ':' <navigation-type-keyword>"
   },
   {
     "name": "<ndash-dimension>",
@@ -708,12 +1276,12 @@
     "syntax": "[ <ident-token> | '*' ]? '|'"
   },
   {
-    "name": "<number-percentage>",
-    "syntax": "<number> | <percentage>"
+    "name": "<number-optional-number>",
+    "syntax": "<number> <number>?"
   },
   {
-    "name": "<number>",
-    "syntax": ""
+    "name": "<number-percentage>",
+    "syntax": "<number> | <percentage>"
   },
   {
     "name": "<numeric-figure-values>",
@@ -732,12 +1300,28 @@
     "syntax": "<ray()> | <url> | <basic-shape>"
   },
   {
+    "name": "<oklab()>",
+    "syntax": "oklab( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "<oklch()>",
+    "syntax": "oklch( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "<opacity()>",
+    "syntax": "opacity( [ <number> | <percentage> ]? )"
+  },
+  {
     "name": "<opacity-value>",
     "syntax": "<number> | <percentage>"
   },
   {
+    "name": "<opentype-tag>",
+    "syntax": "<string>"
+  },
+  {
     "name": "<outline-line-style>",
-    "syntax": "none | dotted | dashed | solid | double | groove | ridge | inset | outset"
+    "syntax": "none | auto | dotted | dashed | solid | double | groove | ridge | inset | outset"
   },
   {
     "name": "<outline-radius>",
@@ -746,10 +1330,6 @@
   {
     "name": "<overflow-position>",
     "syntax": "unsafe | safe"
-  },
-  {
-    "name": "<overflow>",
-    "syntax": ""
   },
   {
     "name": "<page-body>",
@@ -765,15 +1345,19 @@
   },
   {
     "name": "<page-selector-list>",
-    "syntax": "[ <page-selector># ]?"
+    "syntax": "<page-selector>#"
   },
   {
     "name": "<page-selector>",
-    "syntax": "<pseudo-page>+ | <ident> <pseudo-page>*"
+    "syntax": "[ <ident-token>? <pseudo-page>* ]!"
   },
   {
     "name": "<page-size>",
     "syntax": "A5 | A4 | A3 | B5 | B4 | JIS-B5 | JIS-B4 | letter | legal | ledger"
+  },
+  {
+    "name": "<paint()>",
+    "syntax": "paint( <ident>, <declaration-value>? )"
   },
   {
     "name": "<paint-box>",
@@ -781,27 +1365,59 @@
   },
   {
     "name": "<paint>",
-    "syntax": "none | <color> | <url> [none | <color>]? | context-fill | context-stroke"
+    "syntax": "none | <image> | <svg-paint>"
   },
   {
     "name": "<palette-identifier>",
     "syntax": "<dashed-ident>"
   },
   {
-    "name": "<percentage>",
-    "syntax": ""
+    "name": "<palette-mix()>",
+    "syntax": "palette-mix(<color-interpolation-method> , [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})"
+  },
+  {
+    "name": "<path()>",
+    "syntax": "path( <'fill-rule'>? , <string> )"
+  },
+  {
+    "name": "<pattern-descriptor>",
+    "syntax": "pattern ':' <url-pattern()>"
+  },
+  {
+    "name": "<perspective()>",
+    "syntax": "perspective( [ <length [0,∞]> | none ] )"
+  },
+  {
+    "name": "<pointer-axis>",
+    "syntax": "block | inline | x | y"
+  },
+  {
+    "name": "<pointer-source>",
+    "syntax": "root | nearest | self"
+  },
+  {
+    "name": "<points>",
+    "syntax": "[ <number>+ ]#"
   },
   {
     "name": "<polar-color-space>",
     "syntax": "hsl | hwb | lch | oklch"
   },
   {
+    "name": "<polygon()>",
+    "syntax": "polygon( <'fill-rule'>? , [ <length-percentage> <length-percentage> ]# )"
+  },
+  {
     "name": "<position-area>",
-    "syntax": "[ left | center | right | span-left | span-right | x-start | x-end | span-x-start | span-x-end | x-self-start | x-self-end | span-x-self-start | span-x-self-end | span-all ] || [ top | center | bottom | span-top | span-bottom | y-start | y-end | span-y-start | span-y-end | y-self-start | y-self-end | span-y-self-start | span-y-self-end | span-all ] | [ block-start | center | block-end | span-block-start | span-block-end | span-all ] || [ inline-start | center | inline-end | span-inline-start | span-inline-end | span-all ] | [ self-block-start | center | self-block-end | span-self-block-start | span-self-block-end | span-all ] || [ self-inline-start | center | self-inline-end | span-self-inline-start | span-self-inline-end | span-all ] | [ start | center | end | span-start | span-end | span-all ]{1,2} | [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2}"
+    "syntax": "[ [ left | center | right | span-left | span-right | x-start | x-end | span-x-start | span-x-end | self-x-start | self-x-end | span-self-x-start | span-self-x-end | span-all ] || [ top | center | bottom | span-top | span-bottom | y-start | y-end | span-y-start | span-y-end | self-y-start | self-y-end | span-self-y-start | span-self-y-end | span-all ] | [ block-start | center | block-end | span-block-start | span-block-end | span-all ] || [ inline-start | center | inline-end | span-inline-start | span-inline-end | span-all ] | [ self-block-start | center | self-block-end | span-self-block-start | span-self-block-end | span-all ] || [ self-inline-start | center | self-inline-end | span-self-inline-start | span-self-inline-end | span-all ] | [ start | center | end | span-start | span-end | span-all ]{1,2} | [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2} ]"
   },
   {
     "name": "<position>",
-    "syntax": "[ [ left | center | right ] || [ top | center | bottom ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ]? | [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ] ]"
+    "syntax": "[ [ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right ] && [ top | center | bottom ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ] ]"
+  },
+  {
+    "name": "<pow()>",
+    "syntax": "pow( <calc-sum>, <calc-sum> )"
   },
   {
     "name": "<predefined-rgb-params>",
@@ -809,19 +1425,35 @@
   },
   {
     "name": "<predefined-rgb>",
-    "syntax": "srgb | srgb-linear | display-p3 | display-p3-linear | a98-rgb | prophoto-rgb | rec2020"
+    "syntax": "srgb | srgb-linear | display-p3 | display-p3-linear | a98-rgb | prophoto-rgb | rec2020 | rec2100-pq | rec2100-hlg | rec2100-linear"
   },
   {
     "name": "<pseudo-class-selector>",
     "syntax": "':' <ident-token> | ':' <function-token> <any-value> ')'"
   },
   {
+    "name": "<pseudo-compound-selector>",
+    "syntax": "<pseudo-element-selector> <pseudo-class-selector>*"
+  },
+  {
     "name": "<pseudo-element-selector>",
-    "syntax": "':' <pseudo-class-selector>"
+    "syntax": "':' <pseudo-class-selector> | <legacy-pseudo-element-selector>"
   },
   {
     "name": "<pseudo-page>",
-    "syntax": ": [ left | right | first | blank ]"
+    "syntax": "':' [ left | right | first | blank ]"
+  },
+  {
+    "name": "<pt-class-selector>",
+    "syntax": "['.' <custom-ident>]+"
+  },
+  {
+    "name": "<pt-name-and-class-selector>",
+    "syntax": "<pt-name-selector> <pt-class-selector>? | <pt-class-selector>"
+  },
+  {
+    "name": "<pt-name-selector>",
+    "syntax": "'*' | <custom-ident>"
   },
   {
     "name": "<query-in-parens>",
@@ -836,8 +1468,12 @@
     "syntax": "closest-corner | closest-side | farthest-corner | farthest-side"
   },
   {
+    "name": "<radial-gradient()>",
+    "syntax": "radial-gradient( [ <radial-gradient-syntax> ] )"
+  },
+  {
     "name": "<radial-gradient-syntax>",
-    "syntax": "[ [ [ <radial-shape> || <radial-size> ]? [ at <position> ]? ] || <color-interpolation-method> ]? , <color-stop-list>"
+    "syntax": "[ <radial-shape> || <radial-size> ]? [ at <position> ]? ',' <color-stop-list>"
   },
   {
     "name": "<radial-shape>",
@@ -852,12 +1488,32 @@
     "syntax": "<number [0,∞]> [ / <number [0,∞]> ]?"
   },
   {
+    "name": "<ray()>",
+    "syntax": "ray( <angle> && <ray-size>? && contain? && [at <position>]? )"
+  },
+  {
     "name": "<ray-size>",
-    "syntax": "closest-side | closest-corner | farthest-side | farthest-corner | sides"
+    "syntax": "<radial-extent> | sides"
+  },
+  {
+    "name": "<rect()>",
+    "syntax": "rect( [ <length-percentage> | auto ]{4} [ round <'border-radius'> ]? )"
   },
   {
     "name": "<rectangular-color-space>",
-    "syntax": "srgb | srgb-linear | display-p3 | display-p3-linear | a98-rgb | prophoto-rgb | rec2020 | lab | oklab | xyz | xyz-d50 | xyz-d65"
+    "syntax": "srgb | srgb-linear | display-p3 | display-p3-linear | a98-rgb | prophoto-rgb | rec2020 | lab | oklab | <xyz-space>"
+  },
+  {
+    "name": "<relative-control-point>",
+    "syntax": "<coordinate-pair> [ from [ start | end | origin ] ]?"
+  },
+  {
+    "name": "<relative-real-selector-list>",
+    "syntax": "<relative-real-selector>#"
+  },
+  {
+    "name": "<relative-real-selector>",
+    "syntax": "<combinator>? <complex-real-selector>"
   },
   {
     "name": "<relative-selector-list>",
@@ -869,23 +1525,119 @@
   },
   {
     "name": "<relative-size>",
-    "syntax": "larger | smaller"
+    "syntax": "[ larger | smaller ]"
+  },
+  {
+    "name": "<rem()>",
+    "syntax": "rem( <calc-sum>, <calc-sum> )"
+  },
+  {
+    "name": "<repeat-line-color>",
+    "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <color> ]# )"
+  },
+  {
+    "name": "<repeat-line-style>",
+    "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-style> ]# )"
+  },
+  {
+    "name": "<repeat-line-width>",
+    "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-width> ]# )"
   },
   {
     "name": "<repeat-style>",
-    "syntax": "repeat-x | repeat-y | [ repeat | space | round | no-repeat ]{1,2}"
+    "syntax": "repeat-x | repeat-y | [repeat | space | round | no-repeat]{1,2}"
   },
   {
-    "name": "<resolution>",
-    "syntax": ""
+    "name": "<repeating-conic-gradient()>",
+    "syntax": "repeating-conic-gradient( [ <conic-gradient-syntax> ] )"
+  },
+  {
+    "name": "<repeating-linear-gradient()>",
+    "syntax": "repeating-linear-gradient( [ <linear-gradient-syntax> ] )"
+  },
+  {
+    "name": "<repeating-radial-gradient()>",
+    "syntax": "repeating-radial-gradient( [ <radial-gradient-syntax> ] )"
   },
   {
     "name": "<reversed-counter-name>",
     "syntax": "reversed( <counter-name> )"
   },
   {
+    "name": "<rgb()>",
+    "syntax": "rgb( <percentage>#{3} , <alpha-value>? ) | rgb( <number>#{3} , <alpha-value>? ) | rgb( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )"
+  },
+  {
+    "name": "<rgba()>",
+    "syntax": "rgba( <percentage>#{3} , <alpha-value>? ) | rgba( <number>#{3} , <alpha-value>? ) | rgba( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )"
+  },
+  {
+    "name": "<rotate()>",
+    "syntax": "rotate( [ <angle> | <zero> ] )"
+  },
+  {
+    "name": "<rotate3d()>",
+    "syntax": "rotate3d( <number> , <number> , <number> , [ <angle> | <zero> ] )"
+  },
+  {
+    "name": "<rotateX()>",
+    "syntax": "rotateX( [ <angle> | <zero> ] )"
+  },
+  {
+    "name": "<rotateY()>",
+    "syntax": "rotateY( [ <angle> | <zero> ] )"
+  },
+  {
+    "name": "<rotateZ()>",
+    "syntax": "rotateZ( [ <angle> | <zero> ] )"
+  },
+  {
+    "name": "<round()>",
+    "syntax": "round( <rounding-strategy>?, <calc-sum>, <calc-sum> )"
+  },
+  {
     "name": "<rounding-strategy>",
-    "syntax": "nearest | up | down | to-zero"
+    "syntax": "nearest | up | down | to-zero | line-width"
+  },
+  {
+    "name": "<route-descriptor>",
+    "syntax": "<pattern-descriptor> | <init-descriptor> | <base-descriptor>"
+  },
+  {
+    "name": "<route-location>",
+    "syntax": "<url> | [ <route-name> | <url-pattern()> ]"
+  },
+  {
+    "name": "<route-name>",
+    "syntax": "<dashed-ident>"
+  },
+  {
+    "name": "<route-rule>",
+    "syntax": "@route <dashed-ident> '{' <declaration-list> '}'"
+  },
+  {
+    "name": "<saturate()>",
+    "syntax": "saturate( [ <number> | <percentage> ]? )"
+  },
+  {
+    "name": "<scale()>",
+    "syntax": "scale( [ <number> | <percentage> ]#{1,2} )"
+  },
+  {
+    "name": "<scale3d()>",
+    "syntax": "scale3d( [ <number> | <percentage> ]#{3} )"
+  },
+  {
+    "name": "<scaleX()>",
+    "syntax": "scaleX( [ <number> | <percentage> ] )"
+  },
+  {
+    "name": "<scaleY()>",
+    "syntax": "scaleY( [ <number> | <percentage> ] )"
+  },
+  {
+    "name": "<scaleZ()>",
+    "syntax": "scaleZ( [ <number> | <percentage> ] )"
   },
   {
     "name": "<scope-end>",
@@ -894,6 +1646,10 @@
   {
     "name": "<scope-start>",
     "syntax": "<selector-list>"
+  },
+  {
+    "name": "<scroll()>",
+    "syntax": "scroll( [ <scroller> || <axis> ]? )"
   },
   {
     "name": "<scroll-state-feature>",
@@ -920,16 +1676,24 @@
     "syntax": "center | start | end | self-start | self-end | flex-start | flex-end"
   },
   {
+    "name": "<sepia()>",
+    "syntax": "sepia( [ <number> | <percentage> ]? )"
+  },
+  {
     "name": "<shadow-t>",
     "syntax": "[ <length>{2,3} && <color>? ]"
   },
   {
     "name": "<shadow>",
-    "syntax": "inset? && <length>{2,4} && <color>?"
+    "syntax": "<color>? && [ <length>{2} [ <length [0,∞]> <length>? ]? ] && inset?"
   },
   {
     "name": "<shape-box>",
-    "syntax": "<visual-box> | margin-box"
+    "syntax": "<visual-box> | margin-box | half-border-box"
+  },
+  {
+    "name": "<shape-command>",
+    "syntax": "<move-command> | <line-command> | close | <horizontal-line-command> | <vertical-line-command> | <curve-command> | <smooth-command> | <arc-command>"
   },
   {
     "name": "<shape>",
@@ -937,7 +1701,11 @@
   },
   {
     "name": "<side-or-corner>",
-    "syntax": "[ left | right ] || [ top | bottom ]"
+    "syntax": "[left | right] || [top | bottom]"
+  },
+  {
+    "name": "<sign()>",
+    "syntax": "sign( <calc-sum> )"
   },
   {
     "name": "<signed-integer>",
@@ -946,6 +1714,18 @@
   {
     "name": "<signless-integer>",
     "syntax": "<number-token>"
+  },
+  {
+    "name": "<simple-selector-list>",
+    "syntax": "<simple-selector>#"
+  },
+  {
+    "name": "<simple-selector>",
+    "syntax": "<type-selector> | <subclass-selector>"
+  },
+  {
+    "name": "<sin()>",
+    "syntax": "sin( <calc-sum> )"
   },
   {
     "name": "<single-animation-composition>",
@@ -961,7 +1741,7 @@
   },
   {
     "name": "<single-animation-iteration-count>",
-    "syntax": "infinite | <number>"
+    "syntax": "infinite | <number [0,∞]>"
   },
   {
     "name": "<single-animation-play-state>",
@@ -973,7 +1753,7 @@
   },
   {
     "name": "<single-animation>",
-    "syntax": "<'animation-duration'> || <easing-function> || <'animation-delay'> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ] || <single-animation-timeline>"
+    "syntax": "<time [0s,∞]> || <easing-function> || <time> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ]"
   },
   {
     "name": "<single-transition-property>",
@@ -981,7 +1761,7 @@
   },
   {
     "name": "<single-transition>",
-    "syntax": "[ none | <single-transition-property> ] || <time> || <easing-function> || <time> || <transition-behavior-value>"
+    "syntax": "[ none | <single-transition-property> ] || <time> || <easing-function> || <time>"
   },
   {
     "name": "<size-feature>",
@@ -992,6 +1772,46 @@
     "syntax": "closest-side | farthest-side | closest-corner | farthest-corner | <length> | <length-percentage>{2}"
   },
   {
+    "name": "<skew()>",
+    "syntax": "skew( [ <angle> | <zero> ] , [ <angle> | <zero> ]? )"
+  },
+  {
+    "name": "<skewX()>",
+    "syntax": "skewX( [ <angle> | <zero> ] )"
+  },
+  {
+    "name": "<skewY()>",
+    "syntax": "skewY( [ <angle> | <zero> ] )"
+  },
+  {
+    "name": "<slash-separated-border-radius-syntax>",
+    "syntax": "<length-percentage [0,∞]> [ / <length-percentage [0,∞]> ]?"
+  },
+  {
+    "name": "<smooth-command>",
+    "syntax": "smooth [ [ to <position> [ with <control-point> ]? ] | [ by <coordinate-pair> [ with <relative-control-point> ]? ] ]"
+  },
+  {
+    "name": "<source-size-list>",
+    "syntax": "<source-size>#? ',' <source-size-value>"
+  },
+  {
+    "name": "<source-size-value>",
+    "syntax": "<length> | auto"
+  },
+  {
+    "name": "<source-size>",
+    "syntax": "<media-condition> <source-size-value> | auto"
+  },
+  {
+    "name": "<spread-shadow>",
+    "syntax": "<'box-shadow-color'>? && [ [ none | <length>{2} ] [ <'box-shadow-blur'> <'box-shadow-spread'>? ]? ] && <'box-shadow-position'>?"
+  },
+  {
+    "name": "<sqrt()>",
+    "syntax": "sqrt( <calc-sum> )"
+  },
+  {
     "name": "<step-easing-function>",
     "syntax": "step-start | step-end | <steps()>"
   },
@@ -1000,8 +1820,8 @@
     "syntax": "jump-start | jump-end | jump-none | jump-both | start | end"
   },
   {
-    "name": "<string>",
-    "syntax": ""
+    "name": "<steps()>",
+    "syntax": "steps( <integer>, <step-position>? )"
   },
   {
     "name": "<style-feature>",
@@ -1020,28 +1840,40 @@
     "syntax": "<id-selector> | <class-selector> | <attribute-selector> | <pseudo-class-selector>"
   },
   {
+    "name": "<superellipse()>",
+    "syntax": "superellipse( [ <number> | infinity | -infinity ] )"
+  },
+  {
     "name": "<supports-condition>",
     "syntax": "not <supports-in-parens> | <supports-in-parens> [ and <supports-in-parens> ]* | <supports-in-parens> [ or <supports-in-parens> ]*"
   },
   {
     "name": "<supports-decl>",
-    "syntax": "( <declaration> )"
+    "syntax": "'(' <declaration> ')'"
   },
   {
     "name": "<supports-feature>",
-    "syntax": "<supports-decl> | <supports-selector-fn>"
+    "syntax": "<supports-decl>"
   },
   {
     "name": "<supports-in-parens>",
-    "syntax": "( <supports-condition> ) | <supports-feature> | <general-enclosed>"
+    "syntax": "'(' <supports-condition> ')' | <supports-feature> | <general-enclosed>"
   },
   {
     "name": "<supports-selector-fn>",
     "syntax": "selector( <complex-selector> )"
   },
   {
+    "name": "<svg-paint>",
+    "syntax": "child | child( <integer> )"
+  },
+  {
     "name": "<symbol>",
     "syntax": "<string> | <image> | <custom-ident>"
+  },
+  {
+    "name": "<symbols()>",
+    "syntax": "symbols( <symbols-type>? [ <string> | <image> ]+ )"
   },
   {
     "name": "<symbols-type>",
@@ -1049,11 +1881,31 @@
   },
   {
     "name": "<system-color>",
-    "syntax": "AccentColor | AccentColorText | ActiveText | ButtonBorder | ButtonFace | ButtonText | Canvas | CanvasText | Field | FieldText | GrayText | Highlight | HighlightText | LinkText | Mark | MarkText | SelectedItem | SelectedItemText | VisitedText"
+    "syntax": "AccentColor | AccentColorText | ActiveText | ButtonBorder | ButtonFace | ButtonText | Canvas | CanvasText | Field | FieldText | GrayText | Highlight | HighlightText | LinkText | Mark | MarkText | SelectedItem | SelectedItemText | VisitedText | <deprecated-color>"
   },
   {
     "name": "<system-family-name>",
     "syntax": "caption | icon | menu | message-box | small-caption | status-bar"
+  },
+  {
+    "name": "<system-font-family-name>",
+    "syntax": "caption | icon | menu | message-box | small-caption | status-bar"
+  },
+  {
+    "name": "<tan()>",
+    "syntax": "tan( <calc-sum> )"
+  },
+  {
+    "name": "<target-counter()>",
+    "syntax": "target-counter( [ <string> | <url> ] , <custom-ident> , <counter-style>? )"
+  },
+  {
+    "name": "<target-counters()>",
+    "syntax": "target-counters( [ <string> | <url> ] , <custom-ident> , <string> , <counter-style>? )"
+  },
+  {
+    "name": "<target-text()>",
+    "syntax": "target-text( [ <string> | <url> ] , [ content | before | after | first-letter ]? )"
   },
   {
     "name": "<target>",
@@ -1061,15 +1913,11 @@
   },
   {
     "name": "<text-edge>",
-    "syntax": "[ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]?"
+    "syntax": "[ text | ideographic | ideographic-ink ] | [ text | ideographic | ideographic-ink | cap | ex ] [ text | ideographic | ideographic-ink | alphabetic ]"
   },
   {
     "name": "<time-percentage>",
-    "syntax": "<time> | <percentage>"
-  },
-  {
-    "name": "<time>",
-    "syntax": ""
+    "syntax": "[ <time> | <percentage> ]"
   },
   {
     "name": "<timeline-range-name>",
@@ -1077,7 +1925,7 @@
   },
   {
     "name": "<track-breadth>",
-    "syntax": "<length-percentage> | <flex> | min-content | max-content | auto"
+    "syntax": "<length-percentage [0,∞]> | <flex [0,∞]> | min-content | max-content | auto"
   },
   {
     "name": "<track-list>",
@@ -1085,11 +1933,11 @@
   },
   {
     "name": "<track-repeat>",
-    "syntax": "repeat( [ <integer [1,∞]> ] , [ <line-names>? <track-size> ]+ <line-names>? )"
+    "syntax": "repeat( [ <integer [1,∞]> ] ',' [ <line-names>? <track-size> ]+ <line-names>? )"
   },
   {
     "name": "<track-size>",
-    "syntax": "<track-breadth> | minmax( <inflexible-breadth> , <track-breadth> ) | fit-content( <length-percentage> )"
+    "syntax": "<track-breadth> | minmax( <inflexible-breadth> ',' <track-breadth> ) | fit-content( <length-percentage [0,∞]> )"
   },
   {
     "name": "<transform-function>",
@@ -1104,12 +1952,32 @@
     "syntax": "normal | allow-discrete"
   },
   {
+    "name": "<translate()>",
+    "syntax": "translate( <length-percentage> , <length-percentage>? )"
+  },
+  {
+    "name": "<translate3d()>",
+    "syntax": "translate3d( <length-percentage> , <length-percentage> , <length> )"
+  },
+  {
+    "name": "<translateX()>",
+    "syntax": "translateX( <length-percentage> )"
+  },
+  {
+    "name": "<translateY()>",
+    "syntax": "translateY( <length-percentage> )"
+  },
+  {
+    "name": "<translateZ()>",
+    "syntax": "translateZ( <length> )"
+  },
+  {
     "name": "<try-size>",
     "syntax": "most-width | most-height | most-block-size | most-inline-size"
   },
   {
     "name": "<try-tactic>",
-    "syntax": "flip-block || flip-inline || flip-start"
+    "syntax": "flip-block || flip-inline || flip-start || flip-x || flip-y"
   },
   {
     "name": "<type-or-unit>",
@@ -1120,8 +1988,28 @@
     "syntax": "<wq-name> | <ns-prefix>? '*'"
   },
   {
+    "name": "<type>",
+    "syntax": "'<' [ number | string ] '>'"
+  },
+  {
     "name": "<url>",
-    "syntax": ""
+    "syntax": "<url()> | <src()>"
+  },
+  {
+    "name": "<var()>",
+    "syntax": "var( <custom-property-name> , <declaration-value>? )"
+  },
+  {
+    "name": "<var-args>",
+    "syntax": "var( <declaration-value> ',' <declaration-value>? )"
+  },
+  {
+    "name": "<vertical-line-command>",
+    "syntax": "vline [ to [ <length-percentage> | top | center | bottom | y-start | y-end ] | by <length-percentage> ]"
+  },
+  {
+    "name": "<view()>",
+    "syntax": "view([<axis> || <'view-timeline-inset'>]?)"
   },
   {
     "name": "<viewport-length>",
@@ -1136,8 +2024,16 @@
     "syntax": "<ns-prefix>? <ident-token>"
   },
   {
+    "name": "<xywh()>",
+    "syntax": "xywh( <length-percentage>{2} <length-percentage [0,∞]>{2} [ round <'border-radius'> ]? )"
+  },
+  {
     "name": "<xyz-params>",
-    "syntax": "<xyz> [ <number> | <percentage> | none ]{3}"
+    "syntax": "<xyz-space> [ <number> | <percentage> | none ]{3}"
+  },
+  {
+    "name": "<xyz-space>",
+    "syntax": "xyz | xyz-d50 | xyz-d65"
   },
   {
     "name": "<xyz>",
@@ -1157,7 +2053,7 @@
   },
   {
     "name": "anchor-size()",
-    "syntax": "anchor-size( [ <anchor-name> || <anchor-size> ]? , <length-percentage>? )"
+    "syntax": "anchor-size( [ <anchor-name> || <anchor-size> ]? ',' <length-percentage>? )"
   },
   {
     "name": "asin()",
@@ -1172,10 +2068,6 @@
     "syntax": "atan2( <calc-sum>, <calc-sum> )"
   },
   {
-    "name": "attr()",
-    "syntax": "attr( <attr-name> <attr-type>? , <declaration-value>? )"
-  },
-  {
     "name": "blur()",
     "syntax": "blur( <length>? )"
   },
@@ -1188,32 +2080,28 @@
     "syntax": "calc( <calc-sum> )"
   },
   {
-    "name": "calc-size()",
-    "syntax": "calc-size( <calc-size-basis>, <calc-sum> )"
-  },
-  {
     "name": "circle()",
     "syntax": "circle( <radial-size>? [ at <position> ]? )"
   },
   {
     "name": "clamp()",
-    "syntax": "clamp( <calc-sum>#{3} )"
+    "syntax": "clamp( [ <calc-sum> | none ], <calc-sum>, [ <calc-sum> | none ] )"
   },
   {
     "name": "color()",
-    "syntax": "color( [ from <color> ]? <colorspace-params> [ / [ <alpha-value> | none ] ]? )"
+    "syntax": "color( <colorspace-params> [ / [ <alpha-value> | none ] ]? )"
   },
   {
-    "name": "color-mix()",
-    "syntax": "color-mix( <color-interpolation-method> , [ <color> && <percentage [0,100]>? ]#{2})"
-  },
-  {
-    "name": "conic-gradient()",
-    "syntax": "conic-gradient( [ <conic-gradient-syntax> ] )"
+    "name": "content()",
+    "syntax": "content( [ text | before | after | first-letter | marker ]? )"
   },
   {
     "name": "contrast()",
     "syntax": "contrast( [ <number> | <percentage> ]? )"
+  },
+  {
+    "name": "control-value()",
+    "syntax": "control-value( <type>? )"
   },
   {
     "name": "cos()",
@@ -1228,10 +2116,6 @@
     "syntax": "counters( <counter-name>, <string>, <counter-style>? )"
   },
   {
-    "name": "cross-fade()",
-    "syntax": "cross-fade( <cf-mixing-image> , <cf-final-image>? )"
-  },
-  {
     "name": "cubic-bezier()",
     "syntax": "cubic-bezier( [ <number [0,1]>, <number> ]#{2} )"
   },
@@ -1244,36 +2128,40 @@
     "syntax": "dynamic-range-limit-mix( [ <'dynamic-range-limit'> && <percentage [0,100]> ]#{2,} )"
   },
   {
-    "name": "element()",
-    "syntax": "element( <id-selector> )"
-  },
-  {
     "name": "ellipse()",
     "syntax": "ellipse( <radial-size>? [ at <position> ]? )"
   },
   {
     "name": "env()",
-    "syntax": "env( <custom-ident> , <declaration-value>? )"
+    "syntax": "env( <custom-ident> <integer [0,∞]>*, <declaration-value>? )"
   },
   {
     "name": "exp()",
     "syntax": "exp( <calc-sum> )"
   },
   {
+    "name": "filter()",
+    "syntax": "filter( [ <image> | <string> ], <filter-value-list> )"
+  },
+  {
     "name": "fit-content()",
-    "syntax": "fit-content( <length-percentage [0,∞]> )"
+    "syntax": "fit-content(<length-percentage [0,∞]>)"
   },
   {
     "name": "grayscale()",
     "syntax": "grayscale( [ <number> | <percentage> ]? )"
   },
   {
+    "name": "hdr-color()",
+    "syntax": "color-hdr([ <color> && <number [0,∞]>? ]#{2})"
+  },
+  {
     "name": "hsl()",
-    "syntax": "hsl( <hue>, <percentage>, <percentage>, <alpha-value>? ) | hsl( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
+    "syntax": "[ <legacy-hsl-syntax> | <modern-hsl-syntax> ]"
   },
   {
     "name": "hsla()",
-    "syntax": "hsla( <hue>, <percentage>, <percentage>, <alpha-value>? ) | hsla( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
+    "syntax": "[ <legacy-hsla-syntax> | <modern-hsla-syntax> ]"
   },
   {
     "name": "hue-rotate()",
@@ -1281,19 +2169,15 @@
   },
   {
     "name": "hwb()",
-    "syntax": "hwb( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
+    "syntax": "hwb( [<hue> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
   },
   {
     "name": "hypot()",
     "syntax": "hypot( <calc-sum># )"
   },
   {
-    "name": "image()",
-    "syntax": "image( <image-tags>? [ <image-src>? , <color>? ]! )"
-  },
-  {
-    "name": "image-set()",
-    "syntax": "image-set( <image-set-option># )"
+    "name": "ictcp()",
+    "syntax": "ictcp([from <color>]? [<percentage> | <number> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
   },
   {
     "name": "inset()",
@@ -1304,12 +2188,16 @@
     "syntax": "invert( [ <number> | <percentage> ]? )"
   },
   {
-    "name": "lab()",
-    "syntax": "lab( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+    "name": "jzazbz()",
+    "syntax": "jzazbz([from <color>]? [<percentage> | <number> | none] [<percentage> | <number> | none] [<percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
   },
   {
-    "name": "layer()",
-    "syntax": "layer( <layer-name> )"
+    "name": "jzczhz()",
+    "syntax": "jzczhz([from <color>]? [<percentage> | <number> | none] [<percentage> | <number> | none] [<hue> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  {
+    "name": "lab()",
+    "syntax": "lab( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
   },
   {
     "name": "lch()",
@@ -1318,10 +2206,6 @@
   {
     "name": "leader()",
     "syntax": "leader( <leader-type> )"
-  },
-  {
-    "name": "light-dark()",
-    "syntax": "light-dark( <color>, <color> )"
   },
   {
     "name": "linear()",
@@ -1340,10 +2224,6 @@
     "syntax": "matrix( <number>#{6} )"
   },
   {
-    "name": "matrix3d()",
-    "syntax": "matrix3d( <number>#{16} )"
-  },
-  {
     "name": "max()",
     "syntax": "max( <calc-sum># )"
   },
@@ -1353,7 +2233,7 @@
   },
   {
     "name": "minmax()",
-    "syntax": "minmax( [ <length-percentage> | min-content | max-content | auto ] , [ <length-percentage> | <flex> | min-content | max-content | auto ] )"
+    "syntax": "minmax(min, max)"
   },
   {
     "name": "mod()",
@@ -1377,19 +2257,23 @@
   },
   {
     "name": "palette-mix()",
-    "syntax": "palette-mix(<color-interpolation-method> , [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})"
+    "syntax": "palette-mix(<color-interpolation-method> ',' [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})"
+  },
+  {
+    "name": "param()",
+    "syntax": "param( <dashed-ident> ',' <declaration-value>? )"
   },
   {
     "name": "path()",
-    "syntax": "path( <'fill-rule'>? , <string> )"
+    "syntax": "path( <'fill-rule'>? ',' <string> )"
   },
   {
-    "name": "perspective()",
-    "syntax": "perspective( [ <length [0,∞]> | none ] )"
+    "name": "pointer()",
+    "syntax": "pointer( [ <pointer-source> || <pointer-axis> ]? )"
   },
   {
     "name": "polygon()",
-    "syntax": "polygon( <'fill-rule'>? , [ <length-percentage> <length-percentage> ]# )"
+    "syntax": "polygon( <'fill-rule'>? [ round <length> ]? ',' [<length-percentage> <length-percentage>]# )"
   },
   {
     "name": "pow()",
@@ -1412,10 +2296,6 @@
     "syntax": "rem( <calc-sum>, <calc-sum> )"
   },
   {
-    "name": "repeating-conic-gradient()",
-    "syntax": "repeating-conic-gradient( [ <conic-gradient-syntax> ] )"
-  },
-  {
     "name": "repeating-linear-gradient()",
     "syntax": "repeating-linear-gradient( [ <linear-gradient-syntax> ] )"
   },
@@ -1425,35 +2305,23 @@
   },
   {
     "name": "rgb()",
-    "syntax": "rgb( <percentage>#{3} , <alpha-value>? ) | rgb( <number>#{3} , <alpha-value>? ) | rgb( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )"
+    "syntax": "[ <legacy-rgb-syntax> | <modern-rgb-syntax> ]"
   },
   {
     "name": "rgba()",
-    "syntax": "rgba( <percentage>#{3} , <alpha-value>? ) | rgba( <number>#{3} , <alpha-value>? ) | rgba( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )"
+    "syntax": "[ <legacy-rgba-syntax> | <modern-rgba-syntax> ]"
   },
   {
     "name": "rotate()",
     "syntax": "rotate( [ <angle> | <zero> ] )"
   },
   {
-    "name": "rotate3d()",
-    "syntax": "rotate3d( <number> , <number> , <number> , [ <angle> | <zero> ] )"
-  },
-  {
-    "name": "rotateX()",
-    "syntax": "rotateX( [ <angle> | <zero> ] )"
-  },
-  {
-    "name": "rotateY()",
-    "syntax": "rotateY( [ <angle> | <zero> ] )"
-  },
-  {
-    "name": "rotateZ()",
-    "syntax": "rotateZ( [ <angle> | <zero> ] )"
-  },
-  {
     "name": "round()",
-    "syntax": "round( <rounding-strategy>?, <calc-sum>, <calc-sum> )"
+    "syntax": "round( <rounding-strategy>?, <calc-sum>, <calc-sum>? )"
+  },
+  {
+    "name": "running()",
+    "syntax": "running( <custom-ident> )"
   },
   {
     "name": "saturate()",
@@ -1461,23 +2329,15 @@
   },
   {
     "name": "scale()",
-    "syntax": "scale( [ <number> | <percentage> ]#{1,2} )"
-  },
-  {
-    "name": "scale3d()",
-    "syntax": "scale3d( [ <number> | <percentage> ]#{3} )"
+    "syntax": "scale( <number> ',' <number>? )"
   },
   {
     "name": "scaleX()",
-    "syntax": "scaleX( [ <number> | <percentage> ] )"
+    "syntax": "scaleX( <number> )"
   },
   {
     "name": "scaleY()",
-    "syntax": "scaleY( [ <number> | <percentage> ] )"
-  },
-  {
-    "name": "scaleZ()",
-    "syntax": "scaleZ( [ <number> | <percentage> ] )"
+    "syntax": "scaleY( <number> )"
   },
   {
     "name": "scroll()",
@@ -1486,6 +2346,10 @@
   {
     "name": "sepia()",
     "syntax": "sepia( [ <number> | <percentage> ]? )"
+  },
+  {
+    "name": "shape()",
+    "syntax": "shape( <'fill-rule'>? from <position> ',' <shape-command># )"
   },
   {
     "name": "sign()",
@@ -1497,7 +2361,7 @@
   },
   {
     "name": "skew()",
-    "syntax": "skew( [ <angle> | <zero> ] , [ <angle> | <zero> ]? )"
+    "syntax": "skew( [ <angle> | <zero> ] ',' [ <angle> | <zero> ]? )"
   },
   {
     "name": "skewX()",
@@ -1508,16 +2372,32 @@
     "syntax": "skewY( [ <angle> | <zero> ] )"
   },
   {
+    "name": "snap-block()",
+    "syntax": "snap-block( <length> ',' [ start | end | near ]? )"
+  },
+  {
+    "name": "snap-inline()",
+    "syntax": "snap-inline( <length> ',' [ left | right | near ]? )"
+  },
+  {
     "name": "sqrt()",
     "syntax": "sqrt( <calc-sum> )"
   },
   {
+    "name": "src()",
+    "syntax": "src( <string> <url-modifier>* )"
+  },
+  {
     "name": "steps()",
-    "syntax": "steps( <integer>, <step-position>? )"
+    "syntax": "steps( <integer>, <step-position>?)"
+  },
+  {
+    "name": "string()",
+    "syntax": "string( <custom-ident> ',' [ first | start | last | first-except ]? )"
   },
   {
     "name": "superellipse()",
-    "syntax": "superellipse( [ <number> | infinity | -infinity ] )"
+    "syntax": "superellipse(<number> | infinity | -infinity)"
   },
   {
     "name": "symbols()",
@@ -1529,23 +2409,19 @@
   },
   {
     "name": "target-counter()",
-    "syntax": "target-counter( [ <string> | <url> ] , <custom-ident> , <counter-style>? )"
+    "syntax": "target-counter( [ <string> | <url> ] ',' <custom-ident> ',' <counter-style>? )"
   },
   {
     "name": "target-counters()",
-    "syntax": "target-counters( [ <string> | <url> ] , <custom-ident> , <string> , <counter-style>? )"
+    "syntax": "target-counters( [ <string> | <url> ] ',' <custom-ident> ',' <string> ',' <counter-style>? )"
   },
   {
     "name": "target-text()",
-    "syntax": "target-text( [ <string> | <url> ] , [ content | before | after | first-letter ]? )"
+    "syntax": "target-text( [ <string> | <url> ] ',' [ content | before | after | first-letter ]? )"
   },
   {
     "name": "translate()",
-    "syntax": "translate( <length-percentage> , <length-percentage>? )"
-  },
-  {
-    "name": "translate3d()",
-    "syntax": "translate3d( <length-percentage> , <length-percentage> , <length> )"
+    "syntax": "translate( <length-percentage> ',' <length-percentage>? )"
   },
   {
     "name": "translateX()",
@@ -1556,16 +2432,20 @@
     "syntax": "translateY( <length-percentage> )"
   },
   {
-    "name": "translateZ()",
-    "syntax": "translateZ( <length> )"
+    "name": "url()",
+    "syntax": "url( <string> <url-modifier>* ) | <url-token>"
+  },
+  {
+    "name": "url-pattern()",
+    "syntax": "url-pattern( <string> )"
   },
   {
     "name": "var()",
-    "syntax": "var( <custom-property-name> , <declaration-value>? )"
+    "syntax": "var( <custom-property-name> ',' <declaration-value>? )"
   },
   {
     "name": "view()",
-    "syntax": "view([<axis> || <'view-timeline-inset'>]?)"
+    "syntax": "view( [ <axis> || <'view-timeline-inset'> ]? )"
   },
   {
     "name": "xywh()",

--- a/crates/gosub_css3/resources/definitions/definitions_values.json
+++ b/crates/gosub_css3/resources/definitions/definitions_values.json
@@ -204,6 +204,10 @@
     "syntax": "<slash-separated-border-radius-syntax> | <legacy-border-radius-syntax>"
   },
   {
+    "name": "<bottom>",
+    "syntax": "<length> | auto"
+  },
+  {
     "name": "<box-shadow-blur>",
     "syntax": "<length [0,∞]>"
   },
@@ -952,6 +956,10 @@
     "syntax": "dotted | solid | space | <string>"
   },
   {
+    "name": "<left>",
+    "syntax": "<length> | auto"
+  },
+  {
     "name": "<legacy-border-radius-syntax>",
     "syntax": "<length-percentage [0,∞]>{1,2}"
   },
@@ -1572,6 +1580,10 @@
     "syntax": "rgba( <percentage>#{3} , <alpha-value>? ) | rgba( <number>#{3} , <alpha-value>? ) | rgba( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )"
   },
   {
+    "name": "<right>",
+    "syntax": "<length> | auto"
+  },
+  {
     "name": "<rotate()>",
     "syntax": "rotate( [ <angle> | <zero> ] )"
   },
@@ -1922,6 +1934,10 @@
   {
     "name": "<timeline-range-name>",
     "syntax": "cover | contain | entry | exit | entry-crossing | exit-crossing"
+  },
+  {
+    "name": "<top>",
+    "syntax": "<length> | auto"
   },
   {
     "name": "<track-breadth>",

--- a/crates/gosub_css3/resources/definitions/definitions_values.json
+++ b/crates/gosub_css3/resources/definitions/definitions_values.json
@@ -205,19 +205,19 @@
   },
   {
     "name": "<box-shadow-blur>",
-    "syntax": "<length [0,∞]>#"
+    "syntax": "<length [0,∞]>"
   },
   {
     "name": "<box-shadow-color>",
-    "syntax": "<color>#"
+    "syntax": "<color>"
   },
   {
     "name": "<box-shadow-position>",
-    "syntax": "[ outset | inset ]#"
+    "syntax": "[ outset | inset ]"
   },
   {
     "name": "<box-shadow-spread>",
-    "syntax": "<length>#"
+    "syntax": "<length>"
   },
   {
     "name": "<brightness()>",

--- a/crates/gosub_css3/src/colors.rs
+++ b/crates/gosub_css3/src/colors.rs
@@ -930,10 +930,12 @@ lazy_static! {
     ];
 }
 
+// CSS keywords are ASCII case-insensitive, so `graytext` and `RED` are as valid as
+// `GrayText` and `red`.
 #[must_use]
 pub fn is_system_color(name: &str) -> bool {
     for entry in &CSS_SYSTEM_COLOR_NAMES {
-        if entry == &name {
+        if entry.eq_ignore_ascii_case(name) {
             return true;
         }
     }
@@ -943,7 +945,7 @@ pub fn is_system_color(name: &str) -> bool {
 #[must_use]
 pub fn is_named_color(name: &str) -> bool {
     for entry in *CSS_COLORNAMES {
-        if entry.name == name {
+        if entry.name.eq_ignore_ascii_case(name) {
             return true;
         }
     }

--- a/crates/gosub_css3/src/matcher/property_definitions.rs
+++ b/crates/gosub_css3/src/matcher/property_definitions.rs
@@ -277,14 +277,55 @@ impl CssDefinitions {
     }
 
     /// Resolve a syntax component
+    /// Resolves a datatype against the property definitions (for property references and
+    /// property-named datatypes). Returns None when no such property exists.
+    fn resolve_property_reference(
+        &mut self,
+        datatype: &str,
+        multipliers: &[crate::matcher::syntax::SyntaxComponentMultiplier],
+    ) -> Option<SyntaxComponent> {
+        // This datatype is not resolved yet.
+        if !self.resolved_properties.contains_key(datatype) {
+            if let Some(property_element) = self.properties.get(datatype) {
+                let name = property_element.name.clone();
+                self.resolve_property(name.as_str());
+            }
+        }
+
+        let resolved_prop = self.resolved_properties.get(datatype)?;
+        // If the resolved syntax is just a single element (be it a group, or a single
+        // element), return that component.
+        if resolved_prop.syntax.components.len() == 1 {
+            let mut component = resolved_prop.syntax.components[0].clone();
+            component.update_multipliers(multipliers.to_vec());
+            return Some(component);
+        }
+        // Otherwise, we return a group with the components
+        Some(SyntaxComponent::Group {
+            components: resolved_prop.syntax.components.clone(),
+            combinator: Juxtaposition,
+            multipliers: multipliers.to_vec(),
+        })
+    }
+
     pub fn resolve_component(&mut self, component: &SyntaxComponent, prop_name: &str) -> SyntaxComponent {
         match component {
             SyntaxComponent::Definition {
                 datatype,
+                quoted,
                 range,
                 multipliers,
-                ..
             } => {
+                // A quoted reference (`<'name'>`) denotes a PROPERTY per the CSS value
+                // definition syntax, so resolve it from the property grammar before
+                // anything else — a same-named value type (e.g. the `<top>` used by
+                // `<shape>`) must not shadow the property reference in `inset: <'top'>{1,4}`.
+                if *quoted && datatype != prop_name {
+                    if let Some(resolved) = self.resolve_property_reference(datatype, multipliers) {
+                        return resolved;
+                    }
+                }
+
                 // First step: Resolve by looking the definition up in the syntax defintions.
                 if let Some(syntax_element) = self.syntax.get(datatype) {
                     // Cycle guard: if this datatype is already being resolved further up
@@ -343,30 +384,8 @@ impl CssDefinitions {
                 // Don't resolve in properties when the datatype is the same as the
                 // property name (for instance: inset-area)
                 if datatype != prop_name {
-                    // This datatype is not resolved yet.
-                    if !self.resolved_properties.contains_key(datatype) {
-                        if let Some(property_element) = self.properties.get(datatype) {
-                            let name = property_element.name.clone();
-                            self.resolve_property(name.as_str());
-                        }
-                    }
-
-                    if let Some(resolved_prop) = self.resolved_properties.get(datatype) {
-                        // If the resolved syntax is just a single element (be it a group, or a single element),
-                        // return that component.
-                        if resolved_prop.syntax.components.len() == 1 {
-                            let mut component = resolved_prop.syntax.components[0].clone();
-
-                            component.update_multipliers(multipliers.clone());
-
-                            return component;
-                        }
-                        // Otherwise, we return a group with the components
-                        return SyntaxComponent::Group {
-                            components: resolved_prop.syntax.components.clone(),
-                            combinator: Juxtaposition,
-                            multipliers: multipliers.clone(),
-                        };
+                    if let Some(resolved) = self.resolve_property_reference(datatype, multipliers) {
+                        return resolved;
                     }
                 }
 
@@ -494,6 +513,8 @@ trait Map<K, V> {
     fn new() -> Self;
 
     fn insert(&mut self, key: K, value: V);
+
+    fn get(&self, key: &K) -> Option<&V>;
 }
 
 impl<K: Eq + Hash, V> Map<K, V> for HashMap<K, V> {
@@ -503,6 +524,10 @@ impl<K: Eq + Hash, V> Map<K, V> for HashMap<K, V> {
 
     fn insert(&mut self, key: K, value: V) {
         self.insert(key, value);
+    }
+
+    fn get(&self, key: &K) -> Option<&V> {
+        HashMap::get(self, key)
     }
 }
 
@@ -514,6 +539,10 @@ impl<K: Eq + Hash, V> Map<K, V> for indexmap::IndexMap<K, V> {
 
     fn insert(&mut self, key: K, value: V) {
         self.insert(key, value);
+    }
+
+    fn get(&self, key: &K) -> Option<&V> {
+        indexmap::IndexMap::get(self, key)
     }
 }
 
@@ -557,6 +586,21 @@ fn parse_syntax_file<M: Map<String, SyntaxDefinition>>(json: serde_json::Value) 
                 // `<integer>` accept any token and defeat validation.
                 if BUILTIN_DATA_TYPES.contains(&name.as_str()) {
                     continue;
+                }
+
+                // The definitions carry many names in BOTH forms: a bracketed value type
+                // `<scale()>` (the modern spec grammar, from webref value types / MDN
+                // syntaxes) and a bare `scale()` (a legacy per-property grammar fragment
+                // from webref). Both strip to the same key, and the bare form sorts
+                // last, so it silently shadowed the modern grammar (e.g. scale() lost
+                // its css-transforms-2 percentage form). Prefer the bracketed
+                // Definition-typed entry over any other form.
+                if ty != SyntaxType::Definition {
+                    if let Some(existing) = syntaxes.get(&name) {
+                        if existing.ty == SyntaxType::Definition {
+                            continue;
+                        }
+                    }
                 }
 
                 syntaxes.insert(
@@ -1076,6 +1120,304 @@ mod tests {
         assert!(!ok("margin", "inherit inherit"));
         assert!(!ok("color", "inherit red"));
         assert!(!ok("color", "banana"));
+    }
+
+    /// The `/` separating two `<grid-line>`s (and font-size/line-height etc.) is a
+    /// structural delimiter. The `<custom-ident>` catch-all used to consume it — the
+    /// optional ident tail in `[ <integer> && <custom-ident>? ]` ate the slash, so any
+    /// `grid-column` with a numeric or span left side and a second grid-line failed.
+    /// calc() bodies are preserved as raw text (the old stream-slice approach returned
+    /// an empty string because the tokenizer pre-buffers tokens ahead of the stream
+    /// position), and math functions substitute for numeric datatypes (CSS Values §10).
+    /// Long-tail gaps found by the real-world corpus: the bare css-sizing-4
+    /// `fit-content` keyword, any-order operand assignment that needs a different
+    /// order than greedy first-fit (background-position keyword pairs, transition with
+    /// the easing before the property name), and vendor-prefixed math functions.
+    /// Micro-gaps surfaced by the 66k-file external corpus: `background-clip: text`
+    /// (webref's <visual-box> misses it; use MDN's <bg-clip>), case-insensitive color
+    /// keywords, and percentage scale() — the bare legacy `scale()` value def shadowed
+    /// the modern bracketed `<scale()>` under one loader key (Definition-typed entries
+    /// now win). The corpus's `margin-top: 0 \9` rejections are the IE hack, whose whole
+    /// point is that modern parsers reject it — correct behavior, not a gap.
+    #[test]
+    fn test_external_corpus_micro_gaps() {
+        let defs = get_css_definitions();
+        let ok = |prop: &str, v: &str| {
+            defs.find_property(prop)
+                .unwrap_or_else(|| panic!("no def for {prop}"))
+                .clone()
+                .matches(&parse_decl_values(prop, v))
+        };
+
+        // css-backgrounds-4 background-clip values.
+        assert!(ok("background-clip", "text"));
+        assert!(ok("background-clip", "border-box"));
+        assert!(ok("background-clip", "padding-box, border-box"));
+        // CSS keywords are ASCII case-insensitive.
+        assert!(ok("color", "graytext"));
+        assert!(ok("color", "GrayText"));
+        assert!(ok("color", "RED"));
+        assert!(!ok("color", "not-a-color"));
+        // css-transforms-2 percentage scales (bracketed defs win over bare legacy ones).
+        assert!(ok("transform", "scale(70.71068%)"));
+        assert!(ok("transform", "scaleY(80%)"));
+        assert!(ok("transform", "scale(1.5)"));
+        // The `\9` IE hack must keep failing: the escape decodes to a tab inside an
+        // ident, which is not part of any grammar.
+        assert!(!ok("margin-top", "0 \\9"));
+    }
+
+    #[test]
+    fn test_corpus_long_tail() {
+        let defs = get_css_definitions();
+        let ok = |prop: &str, v: &str| {
+            defs.find_property(prop)
+                .unwrap_or_else(|| panic!("no def for {prop}"))
+                .clone()
+                .matches(&parse_decl_values(prop, v))
+        };
+
+        // css-sizing-4 bare fit-content keyword (webref only carries the function form).
+        assert!(ok("width", "fit-content"));
+        assert!(ok("height", "fit-content"));
+        assert!(ok("max-width", "fit-content"));
+        // Bare fit-content stays invalid where only the function form is allowed.
+        assert!(!ok("grid-template-columns", "fit-content"));
+
+        // Any-order (&&/||) groups retry rotated operand orders: greedy first-fit gave
+        // `center` to the horizontal operand and left `left` homeless.
+        assert!(ok("background-position", "center left"));
+        assert!(ok("background-position", "center right 7px"));
+        assert!(ok("background-position", "left center"));
+        assert!(!ok("background-position", "left left"));
+        assert!(ok("transition", "0.2s ease left"));
+        assert!(ok("transition", "ease all 300ms"));
+
+        // Vendor-prefixed math functions predate the unprefixed forms.
+        assert!(ok("max-width", "-webkit-calc(100% - 44px)"));
+        assert!(ok("width", "-moz-calc(50% + 10px)"));
+        assert!(!ok("width", "-webkit-banana(1)"));
+    }
+
+    /// POLICY: a lone vendor-prefixed keyword is accepted for every property (cascade
+    /// fallbacks like `display: -webkit-box; display: flex`). Vendor keywords inside
+    /// larger values and unprefixed legacy keywords stay rejected.
+    #[test]
+    fn test_vendor_prefixed_values() {
+        let defs = get_css_definitions();
+        let ok = |prop: &str, v: &str| {
+            defs.find_property(prop)
+                .unwrap_or_else(|| panic!("no def for {prop}"))
+                .clone()
+                .matches(&parse_decl_values(prop, v))
+        };
+
+        assert!(ok("display", "-webkit-box"));
+        assert!(ok("display", "-moz-box"));
+        assert!(ok("position", "-webkit-sticky"));
+        assert!(ok("cursor", "-webkit-grab"));
+        assert!(ok("width", "-webkit-fit-content"));
+        assert!(ok("width", "-moz-fit-content"));
+        // Unprefixed legacy keywords are NOT covered by the policy.
+        assert!(!ok("display", "box"));
+        // A lone dash or non-keyword stays rejected.
+        assert!(!ok("display", "-webkit-"));
+        // The policy covers only a single bare identifier, not compound values.
+        assert!(!ok("margin", "-webkit-foo 10px"));
+    }
+
+    /// `clip` accepts both rect() forms: the legacy comma-separated CSS2 shape (MDN's
+    /// `<shape>`, dominant in real-world CSS) and the modern space-separated basic-shape
+    /// `<rect()>`. Also guards the quoted-reference resolution order: `<'top'>` in
+    /// `inset` must resolve to the top PROPERTY, not the `<top>` value type that
+    /// `<shape>` uses.
+    #[test]
+    fn test_clip_rect_forms() {
+        let defs = get_css_definitions();
+        let ok = |prop: &str, v: &str| {
+            defs.find_property(prop)
+                .unwrap_or_else(|| panic!("no def for {prop}"))
+                .clone()
+                .matches(&parse_decl_values(prop, v))
+        };
+
+        assert!(ok("clip", "rect(0, 0, 0, 0)"));
+        assert!(ok("clip", "rect(1px, 2px, 3px, 4px)"));
+        assert!(ok("clip", "rect(auto, auto, auto, auto)"));
+        assert!(ok("clip", "rect(0 0 0 0)"));
+        assert!(ok("clip", "auto"));
+        assert!(!ok("clip", "banana"));
+        // <'top'> property references keep resolving to the property grammar, which
+        // accepts percentages — the <top> value type (`<length> | auto`) does not.
+        assert!(ok("inset", "10% 20%"));
+        assert!(ok("inset", "auto"));
+    }
+
+    #[test]
+    fn test_calc_and_math_functions() {
+        let defs = get_css_definitions();
+        let ok = |prop: &str, v: &str| {
+            defs.find_property(prop)
+                .unwrap_or_else(|| panic!("no def for {prop}"))
+                .clone()
+                .matches(&parse_decl_values(prop, v))
+        };
+
+        // The parsed calc body must be the raw expression, not empty.
+        let values = parse_decl_values("width", "calc(100% - 20px)");
+        assert_eq!(
+            values,
+            vec![CssValue::Function("calc".to_string(), vec![CssValue::String("100% - 20px".to_string())])]
+        );
+
+        // Math functions match wherever a numeric datatype is expected.
+        assert!(ok("width", "calc(100% - 20px)"));
+        assert!(ok("width", "calc((100% - 10px) * 2)"));
+        assert!(ok("height", "calc(100vh - 4rem)"));
+        assert!(ok("margin-left", "calc(-1 * var(--gap))"));
+        assert!(ok("top", "calc(50% + 10px)"));
+        assert!(ok("font-size", "min(4vw, 2rem)"));
+        assert!(ok("width", "clamp(10px, 50%, 100px)"));
+        assert!(ok("z-index", "calc(1 + 1)"));
+        // Non-math functions still do not match numeric contexts.
+        assert!(!ok("width", "banana(1)"));
+    }
+
+    #[test]
+    fn test_grid_line_slash() {
+        let defs = get_css_definitions();
+        let ok = |prop: &str, v: &str| {
+            defs.find_property(prop)
+                .unwrap_or_else(|| panic!("no def for {prop}"))
+                .clone()
+                .matches(&parse_decl_values(prop, v))
+        };
+
+        for v in [
+            "1",
+            "auto",
+            "span 2",
+            "1 / 3",
+            "1 / span 1",
+            "span 2 / 4",
+            "main-start",
+            "1 / -1",
+            "auto / auto",
+            "2 main-end",
+        ] {
+            assert!(ok("grid-column", v), "grid-column: {v} should match");
+        }
+        assert!(ok("grid-row", "1 / span 2"));
+        assert!(ok("grid-area", "1 / 1 / 2 / 2"));
+        // A slash needs a grammar-level `/` to be valid: no bare slash spam.
+        assert!(!ok("grid-column", "/"));
+        assert!(!ok("grid-column", "1 / / 2"));
+    }
+
+    /// The grammar parser's numeric literal path used nom's `float`, which accepts the
+    /// textual forms "inf"/"infinity"/"nan". That made it eat the front of grammar
+    /// KEYWORDS: `infinite` (in `<single-animation-iteration-count>`) compiled to the
+    /// unmatchable `Unit(inf, "inite")`, so `animation: shine 3s infinite` never matched.
+    #[test]
+    fn test_infinite_keyword() {
+        let defs = get_css_definitions();
+        let ok = |prop: &str, v: &str| {
+            defs.find_property(prop)
+                .unwrap_or_else(|| panic!("no def for {prop}"))
+                .clone()
+                .matches(&parse_decl_values(prop, v))
+        };
+
+        assert!(ok("animation-iteration-count", "infinite"));
+        assert!(ok("animation-iteration-count", "3"));
+        assert!(ok("animation", "shine 3s infinite"));
+        assert!(ok("animation", "spin 2s linear infinite"));
+        assert!(ok("animation", "fade-in 1s ease-out both"));
+        assert!(ok("animation", "none"));
+        // Numeric literals in grammars still work (`0` in e.g. flex-basis contexts).
+        assert!(ok("flex", "1 1 0%"));
+    }
+
+    /// `<alpha()>` in `<color-function>` denotes a function named `alpha`, not a bare
+    /// numeric. When its builtin arm matched Zero/Number/Percentage, any bare `0` matched
+    /// `<color>` — so box-shadow's `&&` group let a leading `0` offset claim the
+    /// shadow-color slot, rejecting every zero-offset shadow.
+    #[test]
+    fn test_zero_offset_shadows_and_alpha_function() {
+        let defs = get_css_definitions();
+        let ok = |prop: &str, v: &str| {
+            defs.find_property(prop)
+                .unwrap_or_else(|| panic!("no def for {prop}"))
+                .clone()
+                .matches(&parse_decl_values(prop, v))
+        };
+
+        // Zero-offset shadows, in every slot a bare 0 can occupy.
+        assert!(ok("box-shadow", "0 0"));
+        assert!(ok("box-shadow", "0 2px"));
+        assert!(ok("box-shadow", "0 2px 5px"));
+        assert!(ok("box-shadow", "0 2px 5px red"));
+        assert!(ok("box-shadow", "0 2px 5px #00000026"));
+        assert!(ok("box-shadow", "0 0.25em 0.5em 0 #00000019"));
+        assert!(ok("box-shadow", "0 1px 2px 0 rgba(0,0,0,0.05)"));
+        assert!(ok("box-shadow", "0 0 0 1px #fff"));
+        // A bare numeric is NOT a color.
+        assert!(!ok("color", "0"));
+        assert!(!ok("background-color", "1"));
+        // The alpha() FUNCTION still matches as a color-function alternative.
+        assert!(ok("color", "alpha(50%)"));
+        // Colors themselves are unaffected, including 8-digit hex.
+        assert!(ok("color", "#00000026"));
+        assert!(ok("background-color", "#00000026"));
+    }
+
+    /// Grammar commas adjacent to an omitted optional component are elided (CSS Values &
+    /// Units §2.2). webref's transform grammars use the css-transforms-1 forms with a
+    /// literal comma before an optional argument (`scale( <number> , <number>? )`), so
+    /// without elision every single-argument `scale()`/`translate()`/`skew()` failed.
+    #[test]
+    fn test_comma_elision() {
+        fn m(grammar: &str, vals: &[CssValue]) -> bool {
+            CssSyntax::new(grammar).compile().expect("compile").matches(vals)
+        }
+        let (a, b, comma) = (|| str!("a"), || str!("b"), || CssValue::Comma);
+
+        // Trailing: `a , b?` accepts a lone `a`, and still accepts the full form.
+        assert!(m("a , b?", &[a()]));
+        assert!(m("a , b?", &[a(), comma(), b()]));
+        // Leading: `a? , b` accepts a lone `b`.
+        assert!(m("a? , b", &[b()]));
+        assert!(m("a? , b", &[a(), comma(), b()]));
+        // Elision only applies to omitted components: two present components still
+        // require their separating comma, and a mandatory component can't be skipped.
+        assert!(!m("a , b?", &[a(), b()]));
+        assert!(!m("a? , b", &[a(), b()]));
+        assert!(!m("a , b", &[a()]));
+
+        let defs = get_css_definitions();
+        let ok = |v: &str| {
+            defs.find_property("transform")
+                .unwrap()
+                .clone()
+                .matches(&parse_decl_values("transform", v))
+        };
+        for v in [
+            "none",
+            "scale(1)",
+            "scale(1, 2)",
+            "scaleX(1)",
+            "rotate(45deg)",
+            "translate(10px)",
+            "translate(10px, 20px)",
+            "matrix(1, 0, 0, 1, 0, 0)",
+            "skewX(10deg)",
+            "scale(1) rotate(45deg)",
+        ] {
+            assert!(ok(v), "transform: {v} should match");
+        }
+        // The elided comma must not legalize a missing separator.
+        assert!(!ok("scale(1 2)"));
+        assert!(!ok("banana(1)"));
     }
 
     /// A value containing a `var()`/`env()` substitution is valid at parse time for any

--- a/crates/gosub_css3/src/matcher/property_definitions.rs
+++ b/crates/gosub_css3/src/matcher/property_definitions.rs
@@ -861,6 +861,10 @@ mod tests {
                     ("all 0.3s ease", true),
                     ("opacity 0.3s", true),
                     ("0.3s", true),
+                    // Comma-separated list where each item has multiple components: the
+                    // separating comma must not be swallowed by a component's matcher.
+                    ("opacity 0.3s, transform 0.5s", true),
+                    ("opacity 0.3s ease, transform 0.5s 0.1s", true),
                     ("banana", true),
                 ],
             ),
@@ -943,12 +947,6 @@ mod tests {
         // treats the bounded datatype as its unbounded base, so a negative length for a
         // non-negative property still matches.
         assert!(ok("width", "-5px"));
-
-        // A comma-separated list of a value type that itself contains a `||` group does
-        // not split on the separating comma (same family as the box-shadow `#` gap):
-        // a single transition matches, but a multi-transition list does not.
-        assert!(ok("transition", "opacity 0.3s"));
-        assert!(!ok("transition", "opacity 0.3s, transform 0.5s"));
 
         // The `fr` flex unit (`<flex>`) is not matched, so a track list using it fails
         // even though a length/keyword track list matches.

--- a/crates/gosub_css3/src/matcher/property_definitions.rs
+++ b/crates/gosub_css3/src/matcher/property_definitions.rs
@@ -850,17 +850,19 @@ mod tests {
                     ("banana", false),
                 ],
             ),
-            (
-                "opacity",
-                &[("0.5", true), ("1", true), ("0", true), ("banana", false)],
-            ),
+            ("opacity", &[("0.5", true), ("1", true), ("0", true), ("banana", false)]),
             (
                 "z-index",
                 &[("10", true), ("auto", true), ("banana", false), ("1.5", false)],
             ),
             (
                 "position",
-                &[("absolute", true), ("relative", true), ("static", true), ("banana", false)],
+                &[
+                    ("absolute", true),
+                    ("relative", true),
+                    ("static", true),
+                    ("banana", false),
+                ],
             ),
             (
                 "text-align",
@@ -956,7 +958,11 @@ mod tests {
                 // `[ ... <'font-size'> [ / <'line-height'> ]? <'font-family'># ] | ...`
                 // — exercises the `/` line-height separator inside a shorthand.
                 "font",
-                &[("12px serif", true), ("italic bold 12px/1.5 serif", true), ("banana", false)],
+                &[
+                    ("12px serif", true),
+                    ("italic bold 12px/1.5 serif", true),
+                    ("banana", false),
+                ],
             ),
             (
                 // Track sizing exercises the `<flex>` (`fr`) value type, including inside
@@ -1110,7 +1116,14 @@ mod tests {
                 .matches(&parse_decl_values(prop, v))
         };
 
-        for prop in ["color", "display", "margin", "width", "grid-template-columns", "box-shadow"] {
+        for prop in [
+            "color",
+            "display",
+            "margin",
+            "width",
+            "grid-template-columns",
+            "box-shadow",
+        ] {
             for kw in ["inherit", "initial", "unset", "revert", "revert-layer"] {
                 assert!(ok(prop, kw), "{prop}: {kw} should match");
             }
@@ -1267,7 +1280,10 @@ mod tests {
         let values = parse_decl_values("width", "calc(100% - 20px)");
         assert_eq!(
             values,
-            vec![CssValue::Function("calc".to_string(), vec![CssValue::String("100% - 20px".to_string())])]
+            vec![CssValue::Function(
+                "calc".to_string(),
+                vec![CssValue::String("100% - 20px".to_string())]
+            )]
         );
 
         // Math functions match wherever a numeric datatype is expected.

--- a/crates/gosub_css3/src/matcher/property_definitions.rs
+++ b/crates/gosub_css3/src/matcher/property_definitions.rs
@@ -6,7 +6,7 @@ use log::warn;
 
 use crate::matcher::shorthands::{FixList, Shorthands};
 use crate::matcher::syntax::GroupCombinators::Juxtaposition;
-use crate::matcher::syntax::{CssSyntax, SyntaxComponent};
+use crate::matcher::syntax::{CssSyntax, RangeType, SyntaxComponent};
 use crate::matcher::syntax_matcher::CssSyntaxTree;
 use crate::stylesheet::CssValue;
 
@@ -66,6 +66,27 @@ const BUILTIN_DATA_TYPES: [&str; 41] = [
     "syntax",
     "zero",
 ];
+
+/// Pushes `range` onto the numeric builtin leaves of `component` that do not already
+/// carry a range. Used to propagate a range written on a value-type reference (e.g.
+/// `<length-percentage [0,∞]>`) into the leaves of its resolved grammar, which have no
+/// range of their own. Nested functions are left alone: a range on the reference does
+/// not constrain arbitrary arguments of a function inside the resolved grammar.
+fn apply_range(component: &mut SyntaxComponent, range: RangeType) {
+    match component {
+        SyntaxComponent::Builtin { range: existing, .. } => {
+            if existing.is_empty() {
+                *existing = range;
+            }
+        }
+        SyntaxComponent::Group { components, .. } => {
+            for inner in components {
+                apply_range(inner, range);
+            }
+        }
+        _ => {}
+    }
+}
 
 /// A CSS property definition including its type and initial value and optional expanded values if it's a shorthand property
 #[derive(Debug, Clone)]
@@ -259,7 +280,10 @@ impl CssDefinitions {
     pub fn resolve_component(&mut self, component: &SyntaxComponent, prop_name: &str) -> SyntaxComponent {
         match component {
             SyntaxComponent::Definition {
-                datatype, multipliers, ..
+                datatype,
+                range,
+                multipliers,
+                ..
             } => {
                 // First step: Resolve by looking the definition up in the syntax defintions.
                 if let Some(syntax_element) = self.syntax.get(datatype) {
@@ -283,8 +307,18 @@ impl CssDefinitions {
                         self.syntax.insert(datatype.clone(), syntax_element.clone());
                     }
 
+                    let mut components = syntax_element.syntax.components.clone();
+                    // A range written on the reference (e.g. `<length-percentage [0,∞]>`)
+                    // constrains the numeric leaves of the resolved value type, which have
+                    // no range of their own. Push it down so the leaves enforce it.
+                    if !range.is_empty() {
+                        for component in &mut components {
+                            apply_range(component, *range);
+                        }
+                    }
+
                     return SyntaxComponent::Group {
-                        components: syntax_element.syntax.components.clone(),
+                        components,
                         combinator: Juxtaposition,
                         multipliers: multipliers.clone(),
                     };
@@ -299,6 +333,7 @@ impl CssDefinitions {
                 if BUILTIN_DATA_TYPES.contains(&datatype.as_str()) {
                     return SyntaxComponent::Builtin {
                         datatype: datatype.clone(),
+                        range: *range,
                         multipliers: multipliers.clone(),
                     };
                 }
@@ -961,12 +996,12 @@ mod tests {
         assert!(!m("a{1,3}", &[a(), a(), a(), a()]));
     }
 
-    /// Documents the matcher's currently-accepted limitations so the behavior is
-    /// pinned and the divergence from spec-correct matching is discoverable. Each
-    /// assertion encodes CURRENT behavior; flipping one when the underlying gap is
-    /// fixed is the intended maintenance signal.
+    /// Numeric range constraints (`<length [0,∞]>`, `<integer [1,∞]>`, ...) are enforced:
+    /// a magnitude outside the declared range does not match. Covers both a range written
+    /// directly on a builtin and one written on a value-type reference (`<length-percentage
+    /// [0,∞]>`) that must be pushed into the resolved grammar's numeric leaves.
     #[test]
-    fn test_matcher_known_limitations() {
+    fn test_range_enforcement() {
         let defs = get_css_definitions();
         let ok = |prop: &str, v: &str| {
             defs.find_property(prop)
@@ -975,10 +1010,25 @@ mod tests {
                 .matches(&parse_decl_values(prop, v))
         };
 
-        // Numeric range constraints (`<length [0,∞]>`) are NOT enforced: the matcher
-        // treats the bounded datatype as its unbounded base, so a negative length for a
-        // non-negative property still matches.
-        assert!(ok("width", "-5px"));
+        // `<length-percentage [0,∞]>` reference: the range reaches <length> and <percentage>.
+        assert!(ok("width", "5px"));
+        assert!(ok("width", "0"));
+        assert!(!ok("width", "-5px"));
+        assert!(!ok("width", "-5%"));
+        // `<length-percentage [0,∞]>{1,4}` box shorthand.
+        assert!(ok("padding", "5px"));
+        assert!(!ok("padding", "-5px"));
+        // `<number [0,∞]>` directly on a builtin.
+        assert!(ok("flex-grow", "1"));
+        assert!(!ok("flex-grow", "-1"));
+        // `<integer [1,∞]>`: the lower bound excludes 0.
+        assert!(ok("column-count", "1"));
+        assert!(!ok("column-count", "0"));
+        // `<time [0s,∞]>#`.
+        assert!(ok("animation-duration", "1s"));
+        assert!(!ok("animation-duration", "-1s"));
+        // A datatype with no range constraint is unaffected (angle accepts negatives).
+        assert!(ok("rotate", "-45deg"));
     }
 
     /// Regression tests for combinator/multiplier matching bugs fixed alongside

--- a/crates/gosub_css3/src/matcher/property_definitions.rs
+++ b/crates/gosub_css3/src/matcher/property_definitions.rs
@@ -1054,6 +1054,30 @@ mod tests {
         assert!(m("a? && b{2}", &[str!("b"), str!("b"), str!("a")]));
     }
 
+    /// The CSS-wide keywords are valid as the sole value of every property (none of which
+    /// list them in their grammar), but only when they stand alone.
+    #[test]
+    fn test_css_wide_keywords() {
+        let defs = get_css_definitions();
+        let ok = |prop: &str, v: &str| {
+            defs.find_property(prop)
+                .unwrap_or_else(|| panic!("no def for {prop}"))
+                .clone()
+                .matches(&parse_decl_values(prop, v))
+        };
+
+        for prop in ["color", "display", "margin", "width", "grid-template-columns", "box-shadow"] {
+            for kw in ["inherit", "initial", "unset", "revert", "revert-layer"] {
+                assert!(ok(prop, kw), "{prop}: {kw} should match");
+            }
+        }
+        // Must stand alone: a CSS-wide keyword combined with anything else is invalid,
+        // and it must not leak into a property that would otherwise reject the token.
+        assert!(!ok("margin", "inherit inherit"));
+        assert!(!ok("color", "inherit red"));
+        assert!(!ok("color", "banana"));
+    }
+
     #[test]
     fn test_box_shadow_matching() {
         let defs = get_css_definitions();

--- a/crates/gosub_css3/src/matcher/property_definitions.rs
+++ b/crates/gosub_css3/src/matcher/property_definitions.rs
@@ -893,6 +893,19 @@ mod tests {
                     ("banana", false),
                 ],
             ),
+            (
+                // `[ <bg-layer> , ]* <final-bg-layer>` — a single layer needs no comma, and
+                // additional layers are comma-separated. The generator rewrites the
+                // linearized `<bg-layer>#? , <final-bg-layer>` idiom into this spec form.
+                "background",
+                &[
+                    ("red", true),
+                    ("url(a.png)", true),
+                    ("url(a.png) no-repeat", true),
+                    ("url(a.png), red", true),
+                    ("url(a.png) no-repeat, url(b.png), blue", true),
+                ],
+            ),
         ];
 
         let defs = get_css_definitions();
@@ -966,10 +979,6 @@ mod tests {
         // treats the bounded datatype as its unbounded base, so a negative length for a
         // non-negative property still matches.
         assert!(ok("width", "-5px"));
-
-        // webref types `background` as `<bg-layer>#? , <final-bg-layer>`, which makes the
-        // separating comma mandatory, so a bare single-layer background does not match.
-        assert!(!ok("background", "red"));
     }
 
     /// Regression tests for combinator/multiplier matching bugs fixed alongside

--- a/crates/gosub_css3/src/matcher/property_definitions.rs
+++ b/crates/gosub_css3/src/matcher/property_definitions.rs
@@ -819,6 +819,57 @@ mod tests {
                     ("banana", false),
                 ],
             ),
+            (
+                // `<'margin-top'>{1,4}` — the 1-to-4 value box shorthand (ranged multiplier).
+                "margin",
+                &[
+                    ("10px", true),
+                    ("10px 20px", true),
+                    ("1px 2px 3px", true),
+                    ("1px 2px 3px 4px", true),
+                    ("auto", true),
+                    ("0 auto", true),
+                    // A fifth value exceeds the {1,4} range.
+                    ("1px 2px 3px 4px 5px", false),
+                    ("banana", false),
+                ],
+            ),
+            (
+                // Same {1,4} shorthand shape, length-percentage only (no `auto`).
+                "padding",
+                &[("10px", true), ("1px 2px 3px 4px", true), ("auto", false)],
+            ),
+            (
+                // `none | [ <'flex-grow'> <'flex-shrink'>? || <'flex-basis'> ]` — a `||`
+                // any-order group with an embedded optional operand.
+                "flex",
+                &[
+                    ("1", true),
+                    ("1 1", true),
+                    ("1 1 0%", true),
+                    ("auto", true),
+                    ("none", true),
+                    ("banana", false),
+                ],
+            ),
+            (
+                // `<single-transition>#`. A single transition uses a `||` group of
+                // property/time/easing. ("banana" is a valid <custom-ident>
+                // transition-property, so it legitimately matches.)
+                "transition",
+                &[
+                    ("all 0.3s ease", true),
+                    ("opacity 0.3s", true),
+                    ("0.3s", true),
+                    ("banana", true),
+                ],
+            ),
+            (
+                // `[ ... <'font-size'> [ / <'line-height'> ]? <'font-family'># ] | ...`
+                // — exercises the `/` line-height separator inside a shorthand.
+                "font",
+                &[("12px serif", true), ("italic bold 12px/1.5 serif", true), ("banana", false)],
+            ),
         ];
 
         let defs = get_css_definitions();
@@ -843,6 +894,70 @@ mod tests {
             eprintln!("  MISMATCH {m}");
         }
         assert!(mismatches.is_empty(), "{} matcher mismatches", mismatches.len());
+    }
+
+    /// Coverage for the multipliers not exercised by the combinator regression test
+    /// (`*` zero-or-more, `!` at-least-one-in-group, and the ranged `{min,max}` form —
+    /// as opposed to the fixed `{2}` count tested elsewhere).
+    #[test]
+    fn test_multiplier_coverage() {
+        fn m(grammar: &str, vals: &[CssValue]) -> bool {
+            CssSyntax::new(grammar).compile().expect("compile").matches(vals)
+        }
+        let (a, b) = (|| str!("a"), || str!("b"));
+
+        // `*` — zero or more, so the empty input is valid.
+        assert!(m("a*", &[]));
+        assert!(m("a*", &[a()]));
+        assert!(m("a*", &[a(), a(), a()]));
+
+        // `!` — the group must produce at least one value even though every operand
+        // inside it is individually optional.
+        assert!(!m("[ a? b? ]!", &[]));
+        assert!(m("[ a? b? ]!", &[a()]));
+        assert!(m("[ a? b? ]!", &[b()]));
+        assert!(m("[ a? b? ]!", &[a(), b()]));
+
+        // `{min,max}` — a genuine range (not the fixed `{2}` count): 1..=3 here.
+        assert!(!m("a{1,3}", &[]));
+        assert!(m("a{1,3}", &[a()]));
+        assert!(m("a{1,3}", &[a(), a(), a()]));
+        assert!(!m("a{1,3}", &[a(), a(), a(), a()]));
+    }
+
+    /// Documents the matcher's currently-accepted limitations so the behavior is
+    /// pinned and the divergence from spec-correct matching is discoverable. Each
+    /// assertion encodes CURRENT behavior; flipping one when the underlying gap is
+    /// fixed is the intended maintenance signal.
+    #[test]
+    fn test_matcher_known_limitations() {
+        let defs = get_css_definitions();
+        let ok = |prop: &str, v: &str| {
+            defs.find_property(prop)
+                .unwrap_or_else(|| panic!("no def for {prop}"))
+                .clone()
+                .matches(&parse_decl_values(prop, v))
+        };
+
+        // Numeric range constraints (`<length [0,∞]>`) are NOT enforced: the matcher
+        // treats the bounded datatype as its unbounded base, so a negative length for a
+        // non-negative property still matches.
+        assert!(ok("width", "-5px"));
+
+        // A comma-separated list of a value type that itself contains a `||` group does
+        // not split on the separating comma (same family as the box-shadow `#` gap):
+        // a single transition matches, but a multi-transition list does not.
+        assert!(ok("transition", "opacity 0.3s"));
+        assert!(!ok("transition", "opacity 0.3s, transform 0.5s"));
+
+        // The `fr` flex unit (`<flex>`) is not matched, so a track list using it fails
+        // even though a length/keyword track list matches.
+        assert!(ok("grid-template-columns", "100px auto"));
+        assert!(!ok("grid-template-columns", "1fr 1fr"));
+
+        // webref types `background` as `<bg-layer>#? , <final-bg-layer>`, which makes the
+        // separating comma mandatory, so a bare single-layer background does not match.
+        assert!(!ok("background", "red"));
     }
 
     /// Regression tests for combinator/multiplier matching bugs fixed alongside

--- a/crates/gosub_css3/src/matcher/property_definitions.rs
+++ b/crates/gosub_css3/src/matcher/property_definitions.rs
@@ -290,7 +290,20 @@ impl CssDefinitions {
                     };
                 }
 
-                // Second step: Resolve by looking the definition up in the properties
+                // Second step: check if the data type is a built-in datatype. Built-ins are
+                // terminal value types (e.g. `<flex>` = an `fr` value) and must take
+                // precedence over a same-named property: the property-reference form is the
+                // quoted `<'flex'>`, whereas bare `<flex>` is the value type. Without this
+                // ordering `<flex>` would resolve to the `flex` shorthand's grammar and an
+                // `fr` track size (`grid-template-columns: 1fr`) would never match.
+                if BUILTIN_DATA_TYPES.contains(&datatype.as_str()) {
+                    return SyntaxComponent::Builtin {
+                        datatype: datatype.clone(),
+                        multipliers: multipliers.clone(),
+                    };
+                }
+
+                // Third step: Resolve by looking the definition up in the properties
 
                 // Don't resolve in properties when the datatype is the same as the
                 // property name (for instance: inset-area)
@@ -320,14 +333,6 @@ impl CssDefinitions {
                             multipliers: multipliers.clone(),
                         };
                     }
-                }
-
-                // Last step: check if the data type is a built-in datatype
-                if BUILTIN_DATA_TYPES.contains(&datatype.as_str()) {
-                    return SyntaxComponent::Builtin {
-                        datatype: datatype.clone(),
-                        multipliers: multipliers.clone(),
-                    };
                 }
 
                 #[allow(clippy::panic)]
@@ -874,6 +879,20 @@ mod tests {
                 "font",
                 &[("12px serif", true), ("italic bold 12px/1.5 serif", true), ("banana", false)],
             ),
+            (
+                // Track sizing exercises the `<flex>` (`fr`) value type, including inside
+                // `minmax()`. `<flex>` is a builtin value type that must not be shadowed by
+                // the same-named `flex` property.
+                "grid-template-columns",
+                &[
+                    ("none", true),
+                    ("1fr", true),
+                    ("1fr 1fr", true),
+                    ("100px auto", true),
+                    ("minmax(100px, 1fr)", true),
+                    ("banana", false),
+                ],
+            ),
         ];
 
         let defs = get_css_definitions();
@@ -947,11 +966,6 @@ mod tests {
         // treats the bounded datatype as its unbounded base, so a negative length for a
         // non-negative property still matches.
         assert!(ok("width", "-5px"));
-
-        // The `fr` flex unit (`<flex>`) is not matched, so a track list using it fails
-        // even though a length/keyword track list matches.
-        assert!(ok("grid-template-columns", "100px auto"));
-        assert!(!ok("grid-template-columns", "1fr 1fr"));
 
         // webref types `background` as `<bg-layer>#? , <final-bg-layer>`, which makes the
         // separating comma mandatory, so a bare single-layer background does not match.

--- a/crates/gosub_css3/src/matcher/property_definitions.rs
+++ b/crates/gosub_css3/src/matcher/property_definitions.rs
@@ -17,7 +17,7 @@ use crate::stylesheet::CssValue;
 /// and a few legacy/niche types no data source defines. Every value type that *does*
 /// have a grammar is resolved from the definitions (webref / MDN `syntaxes.json`), so
 /// it must NOT be listed here.
-const BUILTIN_DATA_TYPES: [&str; 34] = [
+const BUILTIN_DATA_TYPES: [&str; 41] = [
     "age",
     "angle",
     "custom-ident",
@@ -55,6 +55,16 @@ const BUILTIN_DATA_TYPES: [&str; 34] = [
     // expandable grammar; matched explicitly in syntax_matcher so it can't act as
     // a wildcard inside `<color-function>`.
     "alpha()",
+    // Leaf datatypes that only appear inside function-argument grammars (attr(),
+    // element(), calc-size(), dynamic-range-limit-mix(), @property `<syntax>`). No
+    // data source (webref/MDN) defines them, so they are matched opaquely.
+    "attr-name",
+    "attr-unit",
+    "dynamic-range-limit",
+    "hash-token",
+    "intrinsic-size-keyword",
+    "syntax",
+    "zero",
 ];
 
 /// A CSS property definition including its type and initial value and optional expanded values if it's a shorthand property
@@ -157,6 +167,9 @@ pub struct CssDefinitions {
     pub properties: HashMap<String, PropertyDefinition>,
     /// List of syntax elements for resolving the properties
     pub syntax: HashMap<String, SyntaxDefinition>,
+    /// Datatypes currently being resolved, used to break reference cycles in
+    /// self-referential grammars (e.g. the calc() family). Transient during `resolve`.
+    resolving: std::collections::HashSet<String>,
 }
 
 impl Default for CssDefinitions {
@@ -172,6 +185,7 @@ impl CssDefinitions {
             resolved_properties: HashMap::new(),
             properties: HashMap::new(),
             syntax: HashMap::new(),
+            resolving: std::collections::HashSet::new(),
         }
     }
 
@@ -249,10 +263,23 @@ impl CssDefinitions {
             } => {
                 // First step: Resolve by looking the definition up in the syntax defintions.
                 if let Some(syntax_element) = self.syntax.get(datatype) {
+                    // Cycle guard: if this datatype is already being resolved further up
+                    // the stack, don't recurse into it again. Self-referential grammars
+                    // (notably the calc() family, now reachable because function arguments
+                    // are resolved) would otherwise recurse forever. Leaving the reference
+                    // as an unresolved Definition is harmless: it only occurs at the
+                    // recursive position of such grammars (e.g. calc(), whose arguments are
+                    // kept as an opaque string and never matched against this grammar).
+                    if self.resolving.contains(datatype) {
+                        return component.clone();
+                    }
+
                     let mut syntax_element = syntax_element.clone();
                     if !syntax_element.resolved {
+                        self.resolving.insert(datatype.clone());
                         syntax_element.syntax = self.resolve_syntax(&syntax_element.syntax, prop_name);
                         syntax_element.resolved = true;
+                        self.resolving.remove(datatype);
                         self.syntax.insert(datatype.clone(), syntax_element.clone());
                     }
 
@@ -326,6 +353,21 @@ impl CssDefinitions {
                     multipliers: multipliers.clone(),
                 }
             }
+            SyntaxComponent::Function {
+                name,
+                arguments,
+                multipliers,
+            } => {
+                // Resolve the argument grammar too, otherwise it keeps unresolved
+                // `<datatype>` definitions that the matcher cannot match against.
+                SyntaxComponent::Function {
+                    name: name.clone(),
+                    arguments: arguments
+                        .as_ref()
+                        .map(|arg| Box::new(self.resolve_component(arg, prop_name))),
+                    multipliers: multipliers.clone(),
+                }
+            }
             _ => {
                 // This component does not need any resolving
                 component.clone()
@@ -382,6 +424,7 @@ fn parse_definition_files() -> CssDefinitions {
         resolved_properties: HashMap::new(),
         properties,
         syntax,
+        resolving: std::collections::HashSet::new(),
     };
 
     definitions.index_shorthands();
@@ -466,6 +509,14 @@ fn parse_syntax_file<M: Map<String, SyntaxDefinition>>(json: serde_json::Value) 
 
                 if name.ends_with('>') {
                     name.pop();
+                }
+
+                // Genuine token primitives are matched directly by the syntax matcher.
+                // Don't let a value definition of the same name shadow the builtin: MDN,
+                // for instance, defines `integer` as `<number-token>`, which would make
+                // `<integer>` accept any token and defeat validation.
+                if BUILTIN_DATA_TYPES.contains(&name.as_str()) {
+                    continue;
                 }
 
                 syntaxes.insert(
@@ -628,6 +679,220 @@ mod tests {
         assert_true!(prop.clone().matches(&[str!("solid")]));
         assert_false!(prop.clone().matches(&[str!("not-solid")]));
         assert_false!(prop.clone().matches(&[str!("solid"), str!("solid"), unit!(1.0, "px"),]));
+    }
+
+    /// Parse a real declaration `prop: value` and return its value list, exactly as
+    /// the cascade would see it (functions like `rgb(0,0,0)` collapse to `Color`).
+    fn parse_decl_values(prop: &str, value: &str) -> Vec<CssValue> {
+        use crate::Css3;
+        use gosub_interface::css3::CssOrigin;
+        use gosub_shared::config::ParserConfig;
+
+        let css = format!("x {{ {prop}: {value}; }}");
+        let config = ParserConfig {
+            match_values: false,
+            ignore_errors: true,
+            ..Default::default()
+        };
+        let sheet = Css3::parse_str(&css, config, CssOrigin::Author, "corpus-test").expect("parse");
+        let Some(decl) = sheet.rules.first().and_then(|r| r.declarations.first()) else {
+            return vec![];
+        };
+        match &decl.value {
+            CssValue::List(v) => v.clone(),
+            other => vec![other.clone()],
+        }
+    }
+
+    /// A broad corpus exercising the matcher across many property/value combinations,
+    /// including the newly data-driven value types. Prints every mismatch, then fails
+    /// if any case disagrees with its expectation.
+    /// Run with: cargo test -p gosub_css3 test_matcher_corpus --lib -- --nocapture
+    #[test]
+    fn test_matcher_corpus() {
+        // property -> list of (value, should-match)
+        let corpus: &[(&str, &[(&str, bool)])] = &[
+            (
+                "width",
+                &[
+                    ("10px", true),
+                    ("0", true),
+                    ("5em", true),
+                    ("10.42%", true),
+                    ("auto", true),
+                    ("min-content", true),
+                    ("fit-content(10px)", true),
+                    ("fit-content(50%)", true),
+                    // argument is validated: a color is not a <length-percentage>
+                    ("fit-content(red)", false),
+                    ("banana", false),
+                    ("rgb(0,0,0)", false),
+                    ("red", false),
+                ],
+            ),
+            (
+                "color",
+                &[
+                    ("red", true),
+                    ("rebeccapurple", true),
+                    ("#ff0000", true),
+                    ("rgb(0,0,0)", true),
+                    ("rgba(0,0,0,0.5)", true),
+                    ("hsl(0,0%,0%)", true),
+                    ("transparent", true),
+                    ("banana", false),
+                    ("10px", false),
+                ],
+            ),
+            (
+                "display",
+                &[
+                    ("block", true),
+                    ("inline-block", true),
+                    ("flex", true),
+                    ("grid", true),
+                    ("none", true),
+                    ("banana", false),
+                    ("10px", false),
+                ],
+            ),
+            (
+                "font-size",
+                &[
+                    ("12px", true),
+                    ("1.5em", true),
+                    ("large", true),
+                    ("120%", true),
+                    ("banana", false),
+                ],
+            ),
+            (
+                "opacity",
+                &[("0.5", true), ("1", true), ("0", true), ("banana", false)],
+            ),
+            (
+                "z-index",
+                &[("10", true), ("auto", true), ("banana", false), ("1.5", false)],
+            ),
+            (
+                "position",
+                &[("absolute", true), ("relative", true), ("static", true), ("banana", false)],
+            ),
+            (
+                "text-align",
+                &[("center", true), ("left", true), ("justify", true), ("banana", false)],
+            ),
+            (
+                "overflow",
+                &[("hidden", true), ("scroll", true), ("auto", true), ("banana", false)],
+            ),
+            (
+                "line-height",
+                &[("1.5", true), ("normal", true), ("20px", true), ("150%", true)],
+            ),
+            (
+                "aspect-ratio",
+                &[("auto", true), ("16 / 9", true), ("1", true), ("banana", false)],
+            ),
+            (
+                "rotate",
+                &[("45deg", true), ("none", true), ("1turn", true), ("banana", false)],
+            ),
+            (
+                "transition-timing-function",
+                &[
+                    ("ease", true),
+                    ("linear", true),
+                    // multi-argument functions: comma-separated arguments must match
+                    ("cubic-bezier(0.1, 0.7, 1, 0.1)", true),
+                    ("steps(4, end)", true),
+                    ("banana", false),
+                ],
+            ),
+            (
+                "box-shadow",
+                &[
+                    ("2px 2px", true),
+                    ("2px 2px 4px red", true),
+                    ("inset 2px 2px 4px red", true),
+                    ("banana", false),
+                ],
+            ),
+        ];
+
+        let defs = get_css_definitions();
+        let (mut total, mut mismatches) = (0usize, Vec::new());
+        for (prop, cases) in corpus {
+            let Some(def) = defs.find_property(prop) else {
+                mismatches.push(format!("NO-DEF for {prop}"));
+                continue;
+            };
+            for (value, expected) in *cases {
+                total += 1;
+                let values = parse_decl_values(prop, value);
+                let got = def.clone().matches(&values);
+                if got != *expected {
+                    mismatches.push(format!("{prop}: {value:?} -> match={got} (want {expected})"));
+                }
+            }
+        }
+
+        eprintln!("test_matcher_corpus: {}/{} passed", total - mismatches.len(), total);
+        for m in &mismatches {
+            eprintln!("  MISMATCH {m}");
+        }
+        assert!(mismatches.is_empty(), "{} matcher mismatches", mismatches.len());
+    }
+
+    /// Regression tests for combinator/multiplier matching bugs fixed alongside
+    /// box-shadow support.
+    #[test]
+    fn test_combinator_and_multiplier_matching() {
+        fn m(grammar: &str, vals: &[CssValue]) -> bool {
+            CssSyntax::new(grammar).compile().expect("compile").matches(vals)
+        }
+        // `&&` with an absent trailing optional operand.
+        assert!(m("a && b?", &[str!("a")]));
+        // `&&` where optional operands surround a multi-value operand.
+        assert!(m("a? && [ b{2} ] && c?", &[str!("b"), str!("b")]));
+        // A single-element group must keep its inner multiplier (`[ b{2} ]` == `b{2}`).
+        assert!(m("[ b{2} ]", &[str!("b"), str!("b")]));
+        assert!(!m("[ b{2} ]", &[str!("b")]));
+        // `#` list stops at a non-comma and yields the rest to the next component.
+        assert!(m("b# c?", &[str!("b"), str!("c")]));
+        assert!(m("b# c", &[str!("b"), str!("c")]));
+        // A bounded multiplier must not greedily consume beyond its maximum.
+        assert!(m("a{2} b", &[str!("a"), str!("a"), str!("b")]));
+        // `&&` with an optional operand whose real value appears after other operands.
+        assert!(m("a? && b{2}", &[str!("b"), str!("b"), str!("a")]));
+    }
+
+    #[test]
+    fn test_box_shadow_matching() {
+        let defs = get_css_definitions();
+        let def = defs.find_property("box-shadow").unwrap();
+        let ok = |v: &str| def.clone().matches(&parse_decl_values("box-shadow", v));
+
+        // Single shadow, all component combinations (offset / blur / spread / color /
+        // position, in any order).
+        assert!(ok("2px 2px"));
+        assert!(ok("2px 2px 4px"));
+        assert!(ok("2px 2px 4px 5px"));
+        assert!(ok("2px 2px 4px red"));
+        assert!(ok("red 2px 2px"));
+        assert!(ok("inset 2px 2px"));
+        assert!(ok("inset 2px 2px 4px red"));
+        // Comma-separated list of shadows (without per-shadow colors).
+        assert!(ok("2px 2px, 3px 3px"));
+        // Invalid.
+        assert!(!ok("banana"));
+
+        // KNOWN GAP: a comma-separated list where shadows carry colors does not match.
+        // webref decomposes box-shadow into sub-properties typed as comma-lists
+        // (`box-shadow-color = <color>#`); embedded in one <spread-shadow> that `#`
+        // greedily consumes the shadow-separating comma. Fixing this needs the generator
+        // to drop the `#` from those sub-property definitions.
+        assert!(!ok("2px 2px red, 3px 3px blue"));
     }
 
     #[test]

--- a/crates/gosub_css3/src/matcher/property_definitions.rs
+++ b/crates/gosub_css3/src/matcher/property_definitions.rs
@@ -10,20 +10,19 @@ use crate::matcher::syntax::{CssSyntax, SyntaxComponent};
 use crate::matcher::syntax_matcher::CssSyntaxTree;
 use crate::stylesheet::CssValue;
 
-/// List of elements that are built-in data types in the CSS specification. These will be handled
-/// by the syntax matcher as built-in types.
-const BUILTIN_DATA_TYPES: [&str; 49] = [
-    "absolute-size",
+/// Terminal data types that have no expandable grammar and are matched directly by
+/// the syntax matcher rather than resolved from a value definition. This holds only:
+/// genuine token primitives (`length`, `number`, `angle`, …), types with dedicated
+/// match logic (`named-color`, `system-color`, `color()`, `hex-color`, `alpha()`),
+/// and a few legacy/niche types no data source defines. Every value type that *does*
+/// have a grammar is resolved from the definitions (webref / MDN `syntaxes.json`), so
+/// it must NOT be listed here.
+const BUILTIN_DATA_TYPES: [&str; 34] = [
     "age",
     "angle",
-    "basic-shape",
-    "calc-size()",
-    "counter-name",
-    "counter-style-name",
     "custom-ident",
     "dashed-ident",
     "decibel",
-    "feature-tag-value",
     "flex",
     "frequency",
     "gender",
@@ -37,31 +36,25 @@ const BUILTIN_DATA_TYPES: [&str; 49] = [
     "named-color",
     "semitones",
     "system-color",
-    "outline-line-style",
-    "palette-identifier",
     "percentage",
-    "relative-size",
     "string",
     "target-name",
     "time",
-    "timeline-range-name",
-    "transform-function",
     "uri",
     "url-set",
     "url-token",
     "x",
     "y",
-    "color()",
-    "attr()",    //TODO: this is not a builtin!
-    "element()", //TODO: this is not a builtin!
-    "dynamic-range-limit-mix()",
-    "palette-mix()",
     "declaration-value",
     "number-token",
     "autospace",
     "dimension",
     "resolution",
     "url",
+    // An alpha value is a numeric leaf (`<number> | <percentage>`) with no
+    // expandable grammar; matched explicitly in syntax_matcher so it can't act as
+    // a wildcard inside `<color-function>`.
+    "alpha()",
 ];
 
 /// A CSS property definition including its type and initial value and optional expanded values if it's a shorthand property
@@ -601,7 +594,7 @@ mod tests {
             .with_level(log::LevelFilter::Warn)
             .init()
             .unwrap();
-        assert_eq!(CSS_DEFINITIONS.len(), 664);
+        assert_eq!(CSS_DEFINITIONS.len(), 666);
     }
 
     #[test]

--- a/crates/gosub_css3/src/matcher/property_definitions.rs
+++ b/crates/gosub_css3/src/matcher/property_definitions.rs
@@ -1078,6 +1078,35 @@ mod tests {
         assert!(!ok("color", "banana"));
     }
 
+    /// A value containing a `var()`/`env()` substitution is valid at parse time for any
+    /// property, wherever the substitution appears — its grammar cannot be checked until
+    /// substitution happens (CSS Variables L1 §3).
+    #[test]
+    fn test_var_substitution() {
+        let defs = get_css_definitions();
+        let ok = |prop: &str, v: &str| {
+            defs.find_property(prop)
+                .unwrap_or_else(|| panic!("no def for {prop}"))
+                .clone()
+                .matches(&parse_decl_values(prop, v))
+        };
+
+        // Standalone, with fallback, nested in a function, and as one token of a shorthand.
+        assert!(ok("color", "var(--tw-prose-body)"));
+        assert!(ok("background-color", "var(--btn-bg, #fff)"));
+        assert!(ok("width", "var(--layout-col-20)"));
+        assert!(ok("border", "1px solid var(--grey-border)"));
+        assert!(ok("color", "rgb(var(--r), 0, 0)"));
+        assert!(ok("transform", "translate(var(--x), var(--y))"));
+        assert!(ok("padding", "var(--pad-v) 0"));
+        assert!(ok("font-size", "var(--fs)"));
+        // env() defers the same way.
+        assert!(ok("padding-top", "env(safe-area-inset-top)"));
+        // No substitution present -> still validated normally.
+        assert!(!ok("color", "banana"));
+        assert!(!ok("color", "notavar(--x)"));
+    }
+
     #[test]
     fn test_box_shadow_matching() {
         let defs = get_css_definitions();

--- a/crates/gosub_css3/src/matcher/property_definitions.rs
+++ b/crates/gosub_css3/src/matcher/property_definitions.rs
@@ -815,6 +815,7 @@ mod tests {
                     ("2px 2px", true),
                     ("2px 2px 4px red", true),
                     ("inset 2px 2px 4px red", true),
+                    ("2px 2px red, 3px 3px blue", true),
                     ("banana", false),
                 ],
             ),
@@ -882,17 +883,15 @@ mod tests {
         assert!(ok("red 2px 2px"));
         assert!(ok("inset 2px 2px"));
         assert!(ok("inset 2px 2px 4px red"));
-        // Comma-separated list of shadows (without per-shadow colors).
+        // Comma-separated list of shadows, with and without per-shadow colors.
+        // webref decomposes box-shadow into sub-properties typed as comma-lists
+        // (`box-shadow-color = <color>#`); when embedded in one shadow, that inner `#`
+        // used to greedily consume the shadow-separating comma. The generator now strips
+        // the trailing `#` from those value-type definitions, so both cases match.
         assert!(ok("2px 2px, 3px 3px"));
+        assert!(ok("2px 2px red, 3px 3px blue"));
         // Invalid.
         assert!(!ok("banana"));
-
-        // KNOWN GAP: a comma-separated list where shadows carry colors does not match.
-        // webref decomposes box-shadow into sub-properties typed as comma-lists
-        // (`box-shadow-color = <color>#`); embedded in one <spread-shadow> that `#`
-        // greedily consumes the shadow-separating comma. Fixing this needs the generator
-        // to drop the `#` from those sub-property definitions.
-        assert!(!ok("2px 2px red, 3px 3px blue"));
     }
 
     #[test]

--- a/crates/gosub_css3/src/matcher/syntax.rs
+++ b/crates/gosub_css3/src/matcher/syntax.rs
@@ -834,9 +834,17 @@ fn parse_component(input: &str) -> IResult<&str, SyntaxComponent> {
         parse_generic_keyword, // This is more of a catch-all
     ))
     .parse(input)?;
-    let (input, multipliers) = parse_multipliers(input)?;
+    let (rest, multipliers) = parse_multipliers(input)?;
 
-    component.update_multipliers(multipliers.clone());
+    // Only apply an explicit multiplier suffix (one that actually consumed input).
+    // `parse_multipliers` returns a default `[Once]` when no suffix is present; applying
+    // that would clobber a component's own multipliers. This matters for single-element
+    // groups such as `[ b{2} ]`, which unwrap to their inner component (`b{2}`) — that
+    // inner multiplier must survive.
+    if rest.len() != input.len() {
+        component.update_multipliers(multipliers.clone());
+    }
+    let input = rest;
 
     debug_print!("<- Parsed component_type: {:#?} {:?}", component, multipliers);
 
@@ -2367,16 +2375,18 @@ mod tests {
             CssSyntaxTree::new(vec![SyntaxComponent::Group {
                 combinator: GroupCombinators::ExactlyOne,
                 components: vec![
+                    // `[ left+ ]` unwraps to its inner component and must keep the `+`.
                     SyntaxComponent::GenericKeyword {
                         keyword: "left".to_string(),
-                        multipliers: vec![SyntaxComponentMultiplier::Once],
+                        multipliers: vec![SyntaxComponentMultiplier::OneOrMore],
                     },
                     SyntaxComponent::Group {
                         combinator: GroupCombinators::Juxtaposition,
                         components: vec![
+                            // `[ center? ]` likewise keeps the `?`.
                             SyntaxComponent::GenericKeyword {
                                 keyword: "center".to_string(),
-                                multipliers: vec![SyntaxComponentMultiplier::Once],
+                                multipliers: vec![SyntaxComponentMultiplier::Optional],
                             },
                             SyntaxComponent::GenericKeyword {
                                 keyword: "top".to_string(),

--- a/crates/gosub_css3/src/matcher/syntax.rs
+++ b/crates/gosub_css3/src/matcher/syntax.rs
@@ -303,6 +303,15 @@ impl CssSyntax {
 /// Parse a unit input
 fn parse_unit(input: &str) -> IResult<&str, SyntaxComponent> {
     let (input, value) = float(input)?;
+
+    // nom's float parser accepts the textual forms "inf"/"infinity"/"nan", which makes it
+    // eat the front of grammar KEYWORDS: `infinite` parsed as Unit(inf, "inite") and could
+    // never match. A numeric literal in a grammar is always finite; reject the textual
+    // specials so keyword parsing gets these tokens instead.
+    if !value.is_finite() {
+        return Err(Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Float)));
+    }
+
     let (input, suffix) = opt(alpha1).parse(input)?;
 
     let Some(suffix) = suffix else {

--- a/crates/gosub_css3/src/matcher/syntax.rs
+++ b/crates/gosub_css3/src/matcher/syntax.rs
@@ -107,6 +107,27 @@ impl RangeType {
             max: NumberOrInfinity::None,
         }
     }
+
+    /// Returns true when neither bound is set (the range constrains nothing).
+    pub(crate) fn is_empty(&self) -> bool {
+        matches!(self.min, NumberOrInfinity::None) && matches!(self.max, NumberOrInfinity::None)
+    }
+
+    /// Returns true when `value` lies within the range. An unset or infinite bound is
+    /// treated as unbounded on that side, so an empty range accepts every value.
+    pub(crate) fn contains(&self, value: f32) -> bool {
+        let above_min = match self.min {
+            NumberOrInfinity::None | NumberOrInfinity::NegativeInfinity => true,
+            NumberOrInfinity::Infinity => false,
+            NumberOrInfinity::FiniteI64(n) => value >= n as f32,
+        };
+        let below_max = match self.max {
+            NumberOrInfinity::None | NumberOrInfinity::Infinity => true,
+            NumberOrInfinity::NegativeInfinity => false,
+            NumberOrInfinity::FiniteI64(n) => value <= n as f32,
+        };
+        above_min && below_max
+    }
 }
 
 /// Syntax components. These are the elements that make up the css declaration syntax.
@@ -173,6 +194,7 @@ pub enum SyntaxComponent {
     },
     Builtin {
         datatype: String,
+        range: RangeType,
         multipliers: Vec<SyntaxComponentMultiplier>,
     },
 }

--- a/crates/gosub_css3/src/matcher/syntax_matcher.rs
+++ b/crates/gosub_css3/src/matcher/syntax_matcher.rs
@@ -38,6 +38,12 @@ impl CssSyntaxTree {
             return false;
         }
 
+        // The CSS-wide keywords are valid as the sole value of every property, yet they
+        // appear in no property grammar, so accept them here at the top level.
+        if is_css_wide_keyword(input) {
+            return true;
+        }
+
         assert!(
             (self.components.len() == 1),
             "Syntax tree must have exactly one root component"
@@ -52,6 +58,10 @@ impl CssSyntaxTree {
             return false;
         }
 
+        if is_css_wide_keyword(input) {
+            return true;
+        }
+
         assert!(
             (self.components.len() == 1),
             "Syntax tree must have exactly one root component"
@@ -59,6 +69,24 @@ impl CssSyntaxTree {
 
         let res = match_component(input, &self.components[0], Some(resolver));
         res.matched && res.remainder.is_empty()
+    }
+}
+
+/// Returns true when `input` is exactly one CSS-wide keyword (`inherit`, `initial`,
+/// `unset`, `revert`, `revert-layer`). These are valid for any property but must stand
+/// alone — `margin: inherit inherit` is invalid — so a single value is required. The real
+/// parser lowers them to `CssValue::String`, but the dedicated `Inherit`/`Initial`
+/// variants are also accepted for callers that build values directly.
+fn is_css_wide_keyword(input: &[CssValue]) -> bool {
+    let [value] = input else {
+        return false;
+    };
+    match value {
+        CssValue::Inherit | CssValue::Initial => true,
+        CssValue::String(s) => ["inherit", "initial", "unset", "revert", "revert-layer"]
+            .iter()
+            .any(|kw| s.eq_ignore_ascii_case(kw)),
+        _ => false,
     }
 }
 

--- a/crates/gosub_css3/src/matcher/syntax_matcher.rs
+++ b/crates/gosub_css3/src/matcher/syntax_matcher.rs
@@ -266,38 +266,63 @@ fn match_component_single<'a>(input: &'a [CssValue], component: &SyntaxComponent
         SyntaxComponent::Definition { .. } => {
             return no_match(input);
         }
-        SyntaxComponent::Builtin { datatype, .. } => match datatype.as_str() {
+        SyntaxComponent::Builtin { datatype, range, .. } => match datatype.as_str() {
+            // For the numeric datatypes, an optional `[min,max]` range written on the
+            // reference (e.g. `<length [0,∞]>`) is enforced here: the magnitude must fall
+            // within it. An empty range accepts every value, so unranged uses are
+            // unaffected.
             "percentage" => {
-                if let CssValue::Percentage(_) = value {
-                    return first_match(input);
+                if let CssValue::Percentage(n) = value {
+                    if range.contains(*n) {
+                        return first_match(input);
+                    }
                 }
             }
             "angle" => match value {
-                CssValue::Zero => return first_match(input),
-                CssValue::Unit(_, u) if u.eq_ignore_ascii_case("deg") => return first_match(input),
-                CssValue::Unit(_, u) if u.eq_ignore_ascii_case("grad") => return first_match(input),
-                CssValue::Unit(_, u) if u.eq_ignore_ascii_case("rad") => return first_match(input),
-                CssValue::Unit(_, u) if u.eq_ignore_ascii_case("turn") => return first_match(input),
+                CssValue::Zero if range.contains(0.0) => return first_match(input),
+                CssValue::Unit(n, u)
+                    if range.contains(*n)
+                        && (u.eq_ignore_ascii_case("deg")
+                            || u.eq_ignore_ascii_case("grad")
+                            || u.eq_ignore_ascii_case("rad")
+                            || u.eq_ignore_ascii_case("turn")) =>
+                {
+                    return first_match(input)
+                }
                 _ => {}
             },
             "length" => match value {
-                CssValue::Zero => return first_match(input),
-                CssValue::Unit(_, u) if LENGTH_UNITS.contains(&u.as_str()) => return first_match(input),
+                CssValue::Zero if range.contains(0.0) => return first_match(input),
+                CssValue::Unit(n, u) if LENGTH_UNITS.contains(&u.as_str()) && range.contains(*n) => {
+                    return first_match(input)
+                }
+                _ => {}
+            },
+            "time" => match value {
+                CssValue::Zero if range.contains(0.0) => return first_match(input),
+                CssValue::Unit(n, u)
+                    if (u.eq_ignore_ascii_case("s") || u.eq_ignore_ascii_case("ms")) && range.contains(*n) =>
+                {
+                    return first_match(input)
+                }
                 _ => {}
             },
             // A flexible length is a `<number>` followed by the `fr` unit (grid track sizing).
             "flex" => match value {
-                CssValue::Zero => return first_match(input),
-                CssValue::Unit(_, u) if u.eq_ignore_ascii_case("fr") => return first_match(input),
+                CssValue::Zero if range.contains(0.0) => return first_match(input),
+                CssValue::Unit(n, u) if u.eq_ignore_ascii_case("fr") && range.contains(*n) => {
+                    return first_match(input)
+                }
                 _ => {}
             },
             "number" => match value {
-                CssValue::Zero | CssValue::Number(_) => return first_match(input),
+                CssValue::Zero if range.contains(0.0) => return first_match(input),
+                CssValue::Number(n) if range.contains(*n) => return first_match(input),
                 _ => {}
             },
             "integer" => match value {
-                CssValue::Zero => return first_match(input),
-                CssValue::Number(n) if n.fract() == 0.0 => return first_match(input),
+                CssValue::Zero if range.contains(0.0) => return first_match(input),
+                CssValue::Number(n) if n.fract() == 0.0 && range.contains(*n) => return first_match(input),
                 _ => {}
             },
             "system-color" => {

--- a/crates/gosub_css3/src/matcher/syntax_matcher.rs
+++ b/crates/gosub_css3/src/matcher/syntax_matcher.rs
@@ -41,8 +41,10 @@ impl CssSyntaxTree {
         // The CSS-wide keywords are valid as the sole value of every property, yet they
         // appear in no property grammar, so accept them here at the top level. A value that
         // contains a substitution function (var()/env()) is likewise deferred: its grammar
-        // cannot be checked until substitution, so it is valid at parse time for any property.
-        if is_css_wide_keyword(input) || contains_substitution(input) {
+        // cannot be checked until substitution, so it is valid at parse time for any
+        // property. A lone vendor-prefixed keyword is accepted by policy (see
+        // is_vendor_prefixed_keyword).
+        if is_css_wide_keyword(input) || contains_substitution(input) || is_vendor_prefixed_keyword(input) {
             return true;
         }
 
@@ -60,7 +62,7 @@ impl CssSyntaxTree {
             return false;
         }
 
-        if is_css_wide_keyword(input) || contains_substitution(input) {
+        if is_css_wide_keyword(input) || contains_substitution(input) || is_vendor_prefixed_keyword(input) {
             return true;
         }
 
@@ -90,6 +92,31 @@ fn is_css_wide_keyword(input: &[CssValue]) -> bool {
             .any(|kw| s.eq_ignore_ascii_case(kw)),
         _ => false,
     }
+}
+
+/// POLICY: a lone vendor-prefixed keyword (`display: -webkit-box`, `position:
+/// -webkit-sticky`, `cursor: -moz-grab`, …) is accepted for every property. Real-world
+/// CSS ships these as cascade fallbacks before the standard value; each browser accepts
+/// its own vendor's values, and rejecting them all would drop widely-deployed
+/// declarations. Accepting keeps cascade behavior identical (a later standard value
+/// still wins) without maintaining a per-value alias table. Only a single bare
+/// identifier is covered — vendor keywords inside larger values stay strict, and
+/// unprefixed legacy values (`display: box`) stay rejected, as in real browsers.
+const VENDOR_PREFIXES: [&str; 6] = ["-webkit-", "-moz-", "-ms-", "-o-", "-khtml-", "-apple-"];
+
+/// Returns the remainder of `s` after a known vendor prefix, or None.
+fn strip_vendor_prefix(s: &str) -> Option<&str> {
+    VENDOR_PREFIXES.iter().find_map(|p| {
+        (s.len() > p.len() && s.get(..p.len()).is_some_and(|head| head.eq_ignore_ascii_case(p)))
+            .then(|| &s[p.len()..])
+    })
+}
+
+fn is_vendor_prefixed_keyword(input: &[CssValue]) -> bool {
+    let [CssValue::String(s)] = input else {
+        return false;
+    };
+    strip_vendor_prefix(s).is_some()
 }
 
 /// Returns true when any value in the tree is a substitution function (`var()` or
@@ -311,7 +338,18 @@ fn match_component_single<'a>(input: &'a [CssValue], component: &SyntaxComponent
         SyntaxComponent::Definition { .. } => {
             return no_match(input);
         }
-        SyntaxComponent::Builtin { datatype, range, .. } => match datatype.as_str() {
+        SyntaxComponent::Builtin { datatype, range, .. } => {
+            // A math function may be used wherever a numeric datatype is allowed (CSS
+            // Values & Units §10), e.g. `width: calc(100% - 20px)`. The expression is
+            // accepted opaquely — calc bodies are stored as raw text for the layout
+            // engine to evaluate, so neither its type nor a `[min,max]` range can be
+            // checked here.
+            if let CssValue::Function(name, _) = value {
+                if is_math_function(name) && NUMERIC_DATATYPES.contains(&datatype.as_str()) {
+                    return first_match(input);
+                }
+            }
+            match datatype.as_str() {
             // For the numeric datatypes, an optional `[min,max]` range written on the
             // reference (e.g. `<length [0,∞]>`) is enforced here: the magnitude must fall
             // within it. An empty range accepts every value, so unranged uses are
@@ -389,24 +427,42 @@ fn match_component_single<'a>(input: &'a [CssValue], component: &SyntaxComponent
                 CssValue::String(v) if v.starts_with('#') => return first_match(input),
                 _ => {}
             },
-            // An alpha value is numeric (`<number> | <percentage>`). It must not fall
-            // through to the permissive catch-all below: `<alpha()>` is part of
-            // `<color-function>`, so accepting arbitrary strings here would make any
-            // string match `<color>` and defeat color validation.
+            // `<alpha()>` (css-color-hdr) is an alternative of `<color-function>`, so it
+            // denotes a FUNCTION named `alpha`, not a bare numeric. It must not fall
+            // through to the permissive catch-all below (any string would match <color>),
+            // and it must not match bare numerics either — that made `color: 0` valid and
+            // let a leading `0` offset in box-shadow claim the shadow-color slot. No data
+            // source carries its argument grammar, so arguments are accepted opaquely.
             "alpha()" => match value {
-                CssValue::Zero | CssValue::Number(_) | CssValue::Percentage(_) => return first_match(input),
+                CssValue::Function(name, _) if name.eq_ignore_ascii_case("alpha") => return first_match(input),
                 _ => {}
             },
-            // A comma is a structural separator (list items, function arguments), never a
-            // leaf datatype value. Without this guard the permissive catch-all would let a
-            // built-in such as `<time>` consume the comma that separates items in a `#`
-            // list (e.g. `transition: opacity 0.3s, transform 0.5s`), swallowing the
-            // separator and leaving the following item unmatched.
+            // Identifiers are ident-like tokens only: the parser lowers them to String.
+            // Matching them via the permissive catch-all let `<custom-ident>` swallow
+            // units and numbers, e.g. `transition: 0.2s ease left` had `0.2s` claimed as
+            // the transition-property name. Slashes are separators, not idents.
+            "custom-ident" | "ident" => match value {
+                CssValue::String(s) if s != "/" => return first_match(input),
+                _ => {}
+            },
+            "dashed-ident" => match value {
+                CssValue::String(s) if s.starts_with("--") => return first_match(input),
+                _ => {}
+            },
+            // Commas and slashes are structural separators (list items, function
+            // arguments, `<grid-line> / <grid-line>`, font-size/line-height), never leaf
+            // datatype values. Without this guard the permissive catch-all would let a
+            // built-in such as `<time>` consume the separator and leave the following
+            // part unmatched (e.g. `transition: opacity 0.3s, transform 0.5s`,
+            // `grid-column: 1 / span 2`). Grammar-level separators still match through
+            // the Literal arm.
             _ if matches!(value, CssValue::Comma) => {}
+            _ if matches!(value, CssValue::String(s) if s == "/") => {}
             _ => {
                 return first_match(input);
             } // _ => panic!("Unknown built-in datatype: {:?}", datatype),
-        },
+            }
+        }
         SyntaxComponent::Inherit { .. } => match value {
             CssValue::Inherit => return first_match(input),
             CssValue::String(v) if v.eq_ignore_ascii_case("inherit") => return first_match(input),
@@ -587,6 +643,16 @@ fn match_group_at_least_one_any_order<'a>(
     components: &[SyntaxComponent],
     mut shorthand_resolver: Option<ShorthandResolver>,
 ) -> MatchResult<'a> {
+    // Same rotation strategy as match_group_all_any_order: a single greedy pass can
+    // hand a value to the wrong operand (`transition: ease all 300ms` — the
+    // <custom-ident> transition-property grabs `ease` before the easing operand gets a
+    // chance). The shorthand-resolver path keeps the single pass (side effects).
+    if shorthand_resolver.is_none() {
+        return best_any_order_attempt(raw_input, components.len(), |order| {
+            at_least_one_any_order_pass(raw_input, components, order)
+        });
+    }
+
     let mut input = raw_input;
     let mut matched_values = vec![];
     let mut components_matched = vec![];
@@ -635,27 +701,50 @@ fn match_group_at_least_one_any_order<'a>(
                 }
             }
         } else {
-            let component = &components[c_idx];
+            unreachable!("resolver-less matching is handled by at_least_one_any_order_pass");
+        }
+    }
 
-            let res = match_component(input, component, None);
-            if res.matched {
-                matched_values.append(&mut res.matched_values.clone());
-                components_matched.push(c_idx);
+    if components_matched.is_empty() {
+        return no_match(input);
+    }
 
-                input = res.remainder;
+    MatchResult {
+        remainder: input,
+        matched: true,
+        matched_values,
+    }
+}
 
-                // Found a match, so loop around for new matches
-                c_idx = 0;
-                while components_matched.contains(&c_idx) {
-                    c_idx += 1;
-                }
-            } else {
-                // Element didn't match. That might be alright, and we continue with the next unmatched component
-                c_idx += 1;
-                while components_matched.contains(&c_idx) {
-                    c_idx += 1;
-                }
-            }
+/// One greedy `||` pass trying operands in `order` priority (see all_any_order_pass).
+fn at_least_one_any_order_pass<'a>(
+    raw_input: &'a [CssValue],
+    components: &[SyntaxComponent],
+    order: &[usize],
+) -> MatchResult<'a> {
+    let mut input = raw_input;
+    let mut matched_values = vec![];
+    let mut components_matched: Vec<usize> = vec![];
+
+    let mut pos = 0;
+    while pos < order.len() {
+        if input.is_empty() {
+            break;
+        }
+        let c_idx = order[pos];
+        if components_matched.contains(&c_idx) {
+            pos += 1;
+            continue;
+        }
+
+        let res = match_component(input, &components[c_idx], None);
+        if res.matched {
+            matched_values.append(&mut res.matched_values.clone());
+            components_matched.push(c_idx);
+            input = res.remainder;
+            pos = 0;
+        } else {
+            pos += 1;
         }
     }
 
@@ -675,6 +764,19 @@ fn match_group_all_any_order<'a>(
     components: &[SyntaxComponent],
     mut shorthand_resolver: Option<ShorthandResolver>,
 ) -> MatchResult<'a> {
+    // A single greedy pass can assign a value to the wrong operand: in
+    // `[ center | [left|right] <lp>? ] && [ center | [top|bottom] <lp>? ]` matching
+    // `center left`, the first operand grabs `center` and `left` has no home, even
+    // though the assignment left/center works. There is no full backtracking here, but
+    // trying every rotation of the operand priority order covers the practical
+    // ambiguities. The shorthand-resolver path keeps the single greedy pass: its
+    // completions have side effects that must not run once per attempt.
+    if shorthand_resolver.is_none() {
+        return best_any_order_attempt(raw_input, components.len(), |order| {
+            all_any_order_pass(raw_input, components, order)
+        });
+    }
+
     let mut input = raw_input;
     let mut matched_values = vec![];
     let mut components_matched = vec![];
@@ -733,38 +835,7 @@ fn match_group_all_any_order<'a>(
                 }
             }
         } else {
-            let component = &components[c_idx];
-
-            let res = match_component(input, component, None);
-            // Only claim this slot when the component actually consumed input, or when it
-            // is required. An *optional* component that matched emptily must not claim its
-            // slot: the real value it should match may appear later, once other operands
-            // consume the values in between (e.g. the trailing `<color>` in
-            // `box-shadow: 2px 2px 4px red`). Absent optionals are accepted by the
-            // end-of-function check instead.
-            let consumed = res.matched && res.remainder.len() < input.len();
-            let optional = matches!(
-                multiplier_fulfilled(component, 0),
-                Fulfillment::Fulfilled | Fulfillment::FulfilledButMoreAllowed
-            );
-            if res.matched && (consumed || !optional) {
-                matched_values.append(&mut res.matched_values.clone());
-                components_matched.push(c_idx);
-
-                input = res.remainder;
-
-                // Found a match, so loop around for new matches
-                c_idx = 0;
-                while components_matched.contains(&c_idx) {
-                    c_idx += 1;
-                }
-            } else {
-                // Element didn't match. That might be alright, and we continue with the next unmatched component
-                c_idx += 1;
-                while components_matched.contains(&c_idx) {
-                    c_idx += 1;
-                }
-            }
+            unreachable!("resolver-less matching is handled by all_any_order_pass");
         }
     }
 
@@ -789,6 +860,93 @@ fn match_group_all_any_order<'a>(
     }
 }
 
+/// Runs `attempt` once per rotation of the operand priority order and returns the best
+/// result: the first attempt that consumes all input wins outright, otherwise the
+/// matched attempt with the shortest remainder.
+fn best_any_order_attempt<'a>(
+    raw_input: &'a [CssValue],
+    component_count: usize,
+    attempt: impl Fn(&[usize]) -> MatchResult<'a>,
+) -> MatchResult<'a> {
+    let mut best: Option<MatchResult> = None;
+    for offset in 0..component_count.max(1) {
+        let order: Vec<usize> = (0..component_count).map(|i| (i + offset) % component_count.max(1)).collect();
+        let res = attempt(&order);
+        if !res.matched {
+            continue;
+        }
+        if res.remainder.is_empty() {
+            return res;
+        }
+        if best
+            .as_ref()
+            .is_none_or(|b| res.remainder.len() < b.remainder.len())
+        {
+            best = Some(res);
+        }
+    }
+    best.unwrap_or_else(|| no_match(raw_input))
+}
+
+/// One greedy `&&` pass trying operands in `order` priority: after every claim the scan
+/// restarts at the front of `order`; a failed operand moves the scan to the next one.
+fn all_any_order_pass<'a>(
+    raw_input: &'a [CssValue],
+    components: &[SyntaxComponent],
+    order: &[usize],
+) -> MatchResult<'a> {
+    let mut input = raw_input;
+    let mut matched_values = vec![];
+    let mut components_matched: Vec<usize> = vec![];
+
+    let mut pos = 0;
+    while pos < order.len() {
+        if input.is_empty() {
+            break;
+        }
+        let c_idx = order[pos];
+        if components_matched.contains(&c_idx) {
+            pos += 1;
+            continue;
+        }
+
+        let component = &components[c_idx];
+        let res = match_component(input, component, None);
+        // See match_group_all_any_order: only claim a slot on real consumption or for
+        // required operands; absent optionals are handled by the final check.
+        let consumed = res.matched && res.remainder.len() < input.len();
+        let optional = matches!(
+            multiplier_fulfilled(component, 0),
+            Fulfillment::Fulfilled | Fulfillment::FulfilledButMoreAllowed
+        );
+        if res.matched && (consumed || !optional) {
+            matched_values.append(&mut res.matched_values.clone());
+            components_matched.push(c_idx);
+            input = res.remainder;
+            pos = 0;
+        } else {
+            pos += 1;
+        }
+    }
+
+    // Every unmatched component must be omissible.
+    for (idx, component) in components.iter().enumerate() {
+        if components_matched.contains(&idx) {
+            continue;
+        }
+        match multiplier_fulfilled(component, 0) {
+            Fulfillment::Fulfilled | Fulfillment::FulfilledButMoreAllowed => {}
+            _ => return no_match(raw_input),
+        }
+    }
+
+    MatchResult {
+        remainder: input,
+        matched: true,
+        matched_values,
+    }
+}
+
 fn match_group_juxtaposition<'a>(
     raw_input: &'a [CssValue],
     components: &[SyntaxComponent],
@@ -796,10 +954,16 @@ fn match_group_juxtaposition<'a>(
 ) -> MatchResult<'a> {
     let mut input = raw_input;
     let mut matched_values = vec![];
+    // Whether the previously matched component consumed input. Grammar commas next to an
+    // OMITTED optional component are elided (CSS Values & Units §2.2), so a comma right
+    // after an omitted component may be skipped. The group start counts as "consumed".
+    let mut prev_consumed = true;
 
     let mut c_idx = 0;
     while c_idx < components.len() {
-        if let Some(mut resolver) = copy_resolver(&mut shorthand_resolver) {
+        let component = &components[c_idx];
+
+        let res = if let Some(mut resolver) = copy_resolver(&mut shorthand_resolver) {
             let step = resolver.step(c_idx);
 
             let mut complete = None;
@@ -810,29 +974,46 @@ fn match_group_juxtaposition<'a>(
                 Ok(None) => {}
                 Err(c) => complete = Some(c),
             }
-            let component = &components[c_idx];
 
             let res = match_component(input, component, resolver);
             if res.matched {
-                matched_values.append(&mut res.matched_values.clone());
-                input = res.remainder;
-
                 if let Some(complete) = complete {
-                    complete.complete(res.matched_values);
+                    complete.complete(res.matched_values.clone());
                 }
-            } else {
-                break;
             }
+            res
         } else {
-            let component = &components[c_idx];
+            match_component(input, component, None)
+        };
 
-            let res = match_component(input, component, None);
-            if res.matched {
-                matched_values.append(&mut res.matched_values.clone());
-                input = res.remainder;
-            } else {
-                break;
+        if res.matched {
+            let consumed = res.remainder.len() < input.len();
+            matched_values.append(&mut res.matched_values.clone());
+            input = res.remainder;
+            prev_consumed = consumed;
+        } else {
+            if is_comma_literal(component) {
+                // Elide a comma whose preceding optional component was omitted
+                // (`a? , b` matching just `b`), and keep matching after it.
+                if !prev_consumed {
+                    c_idx += 1;
+                    continue;
+                }
+                // Elide a comma when everything after it is omitted (`a , b?` matching
+                // just `a`): the group ends here, leaving the rest of the input untouched.
+                // There must BE an omitted component: a comma that is the group's last
+                // component separates against something outside the group (e.g. the
+                // repeat group in `[ <bg-layer> , ]* <final-bg-layer>`) and stays mandatory.
+                let rest = &components[c_idx + 1..];
+                if !rest.is_empty() && rest.iter().all(is_omissible) {
+                    return MatchResult {
+                        remainder: input,
+                        matched: true,
+                        matched_values,
+                    };
+                }
             }
+            break;
         }
 
         c_idx += 1;
@@ -847,6 +1028,65 @@ fn match_group_juxtaposition<'a>(
         matched: true,
         matched_values,
     }
+}
+
+/// Returns true when the component is the literal comma separator.
+/// Numeric datatypes a math function may substitute for (CSS Values & Units §10).
+const NUMERIC_DATATYPES: [&str; 9] = [
+    "length",
+    "percentage",
+    "number",
+    "integer",
+    "time",
+    "angle",
+    "flex",
+    "frequency",
+    "resolution",
+];
+
+/// Returns true when `name` is a CSS math function (CSS Values & Units §10). Vendor
+/// prefixed forms (`-webkit-calc()`, `-moz-calc()`) predate the unprefixed ones and are
+/// still common in shipped CSS, so a vendor prefix is stripped first.
+fn is_math_function(name: &str) -> bool {
+    let name = strip_vendor_prefix(name).unwrap_or(name);
+    [
+        "calc",
+        "calc-size",
+        "min",
+        "max",
+        "clamp",
+        "round",
+        "mod",
+        "rem",
+        "abs",
+        "sign",
+        "pow",
+        "sqrt",
+        "hypot",
+        "log",
+        "exp",
+        "sin",
+        "cos",
+        "tan",
+        "asin",
+        "acos",
+        "atan",
+        "atan2",
+    ]
+    .iter()
+    .any(|f| name.eq_ignore_ascii_case(f))
+}
+
+fn is_comma_literal(component: &SyntaxComponent) -> bool {
+    matches!(component, SyntaxComponent::Literal { literal, .. } if literal == ",")
+}
+
+/// Returns true when the component may match zero occurrences (`?`, `*`, `{0,n}`).
+fn is_omissible(component: &SyntaxComponent) -> bool {
+    matches!(
+        multiplier_fulfilled(component, 0),
+        Fulfillment::Fulfilled | Fulfillment::FulfilledButMoreAllowed
+    )
 }
 
 /// Fulfillment is a result returned by the `multiplier_fulfilled` function. This is used to determine

--- a/crates/gosub_css3/src/matcher/syntax_matcher.rs
+++ b/crates/gosub_css3/src/matcher/syntax_matcher.rs
@@ -39,8 +39,10 @@ impl CssSyntaxTree {
         }
 
         // The CSS-wide keywords are valid as the sole value of every property, yet they
-        // appear in no property grammar, so accept them here at the top level.
-        if is_css_wide_keyword(input) {
+        // appear in no property grammar, so accept them here at the top level. A value that
+        // contains a substitution function (var()/env()) is likewise deferred: its grammar
+        // cannot be checked until substitution, so it is valid at parse time for any property.
+        if is_css_wide_keyword(input) || contains_substitution(input) {
             return true;
         }
 
@@ -58,7 +60,7 @@ impl CssSyntaxTree {
             return false;
         }
 
-        if is_css_wide_keyword(input) {
+        if is_css_wide_keyword(input) || contains_substitution(input) {
             return true;
         }
 
@@ -88,6 +90,21 @@ fn is_css_wide_keyword(input: &[CssValue]) -> bool {
             .any(|kw| s.eq_ignore_ascii_case(kw)),
         _ => false,
     }
+}
+
+/// Returns true when any value in the tree is a substitution function (`var()` or
+/// `env()`), searching inside nested function arguments and lists. Such a value is
+/// "guaranteed-invalid" to grammar-check until the substitution happens (CSS Variables
+/// L1 §3), so a declaration containing one is valid at parse time for any property,
+/// wherever the function appears (e.g. `1px solid var(--c)`, `rgb(var(--r), 0, 0)`).
+fn contains_substitution(values: &[CssValue]) -> bool {
+    values.iter().any(|value| match value {
+        CssValue::Function(name, args) => {
+            name.eq_ignore_ascii_case("var") || name.eq_ignore_ascii_case("env") || contains_substitution(args)
+        }
+        CssValue::List(items) => contains_substitution(items),
+        _ => false,
+    })
 }
 
 fn match_component_inner<'a>(

--- a/crates/gosub_css3/src/matcher/syntax_matcher.rs
+++ b/crates/gosub_css3/src/matcher/syntax_matcher.rs
@@ -285,6 +285,12 @@ fn match_component_single<'a>(input: &'a [CssValue], component: &SyntaxComponent
                 CssValue::Unit(_, u) if LENGTH_UNITS.contains(&u.as_str()) => return first_match(input),
                 _ => {}
             },
+            // A flexible length is a `<number>` followed by the `fr` unit (grid track sizing).
+            "flex" => match value {
+                CssValue::Zero => return first_match(input),
+                CssValue::Unit(_, u) if u.eq_ignore_ascii_case("fr") => return first_match(input),
+                _ => {}
+            },
             "number" => match value {
                 CssValue::Zero | CssValue::Number(_) => return first_match(input),
                 _ => {}

--- a/crates/gosub_css3/src/matcher/syntax_matcher.rs
+++ b/crates/gosub_css3/src/matcher/syntax_matcher.rs
@@ -196,9 +196,12 @@ fn match_component<'a>(
             break;
         }
 
-        // Make sure the next value from input is a comma
+        // If the next value is not a comma, the comma-separated list ends here; the
+        // remaining input belongs to whatever component follows this one (e.g. the
+        // `<box-shadow-spread>` after `<box-shadow-blur>#`). Stop consuming and let the
+        // count check below decide whether enough items matched.
         if input.first() != Some(&CssValue::Comma) {
-            return no_match(raw_input);
+            break;
         }
 
         // Remove the comma, and continue matching
@@ -282,6 +285,15 @@ fn match_component_single<'a>(input: &'a [CssValue], component: &SyntaxComponent
                 CssValue::Unit(_, u) if LENGTH_UNITS.contains(&u.as_str()) => return first_match(input),
                 _ => {}
             },
+            "number" => match value {
+                CssValue::Zero | CssValue::Number(_) => return first_match(input),
+                _ => {}
+            },
+            "integer" => match value {
+                CssValue::Zero => return first_match(input),
+                CssValue::Number(n) if n.fract() == 0.0 => return first_match(input),
+                _ => {}
+            },
             "system-color" => {
                 if let CssValue::String(v) = value {
                     if is_system_color(v) {
@@ -350,9 +362,12 @@ fn match_component_single<'a>(input: &'a [CssValue], component: &SyntaxComponent
                 log::warn!("Case insensitive literal matched");
                 return first_match(input);
             }
+            // A comma token is parsed to its own value variant, so match it against a
+            // `,` literal (e.g. the argument separators in `cubic-bezier(a, b, c, d)`).
+            CssValue::Comma if literal == "," => return first_match(input),
             _ => {}
         },
-        SyntaxComponent::Function { name, .. } => {
+        SyntaxComponent::Function { name, arguments, .. } => {
             let CssValue::Function(c_name, c_args) = value else {
                 return no_match(input);
             };
@@ -361,11 +376,21 @@ fn match_component_single<'a>(input: &'a [CssValue], component: &SyntaxComponent
                 return no_match(input);
             }
 
-            if c_args.is_empty() {
-                return first_match(input);
+            match arguments {
+                // No argument grammar was declared for this function, so match on the
+                // function name alone (we have nothing to validate the arguments against).
+                None => return first_match(input),
+                Some(arg_syntax) => {
+                    // Match the function's actual arguments against its argument grammar.
+                    // An empty argument list is allowed only if the grammar is satisfiable
+                    // by no input (i.e. every argument is optional).
+                    let res = match_component(c_args, arg_syntax, None);
+                    if res.matched && res.remainder.is_empty() {
+                        return first_match(input);
+                    }
+                    return no_match(input);
+                }
             }
-
-            // @todo: function arguments are not matched against the syntax yet.
         }
         SyntaxComponent::Value { value: css_value, .. } => {
             if value == css_value {
@@ -592,7 +617,18 @@ fn match_group_all_any_order<'a>(
             let component = &components[c_idx];
 
             let res = match_component(input, component, resolver);
-            if res.matched {
+            // Only claim this slot when the component actually consumed input, or when it
+            // is required. An *optional* component that matched emptily must not claim its
+            // slot: the real value it should match may appear later, once other operands
+            // consume the values in between (e.g. the trailing `<color>` in
+            // `box-shadow: 2px 2px 4px red`). Absent optionals are accepted by the
+            // end-of-function check instead.
+            let consumed = res.matched && res.remainder.len() < input.len();
+            let optional = matches!(
+                multiplier_fulfilled(component, 0),
+                Fulfillment::Fulfilled | Fulfillment::FulfilledButMoreAllowed
+            );
+            if res.matched && (consumed || !optional) {
                 matched_values.append(&mut res.matched_values.clone());
                 components_matched.push(c_idx);
 
@@ -618,7 +654,18 @@ fn match_group_all_any_order<'a>(
             let component = &components[c_idx];
 
             let res = match_component(input, component, None);
-            if res.matched {
+            // Only claim this slot when the component actually consumed input, or when it
+            // is required. An *optional* component that matched emptily must not claim its
+            // slot: the real value it should match may appear later, once other operands
+            // consume the values in between (e.g. the trailing `<color>` in
+            // `box-shadow: 2px 2px 4px red`). Absent optionals are accepted by the
+            // end-of-function check instead.
+            let consumed = res.matched && res.remainder.len() < input.len();
+            let optional = matches!(
+                multiplier_fulfilled(component, 0),
+                Fulfillment::Fulfilled | Fulfillment::FulfilledButMoreAllowed
+            );
+            if res.matched && (consumed || !optional) {
                 matched_values.append(&mut res.matched_values.clone());
                 components_matched.push(c_idx);
 
@@ -639,8 +686,18 @@ fn match_group_all_any_order<'a>(
         }
     }
 
-    if components_matched.len() != components.len() {
-        return no_match(input);
+    // Every component must be accounted for. A component that never matched is only
+    // acceptable if it is optional (its multiplier is satisfied by zero occurrences,
+    // e.g. `a?` or `a*`). This matters when the input runs out before a trailing
+    // optional operand gets its turn, e.g. `<color>? && [ … ] && <position>?`.
+    for (idx, component) in components.iter().enumerate() {
+        if components_matched.contains(&idx) {
+            continue;
+        }
+        match multiplier_fulfilled(component, 0) {
+            Fulfillment::Fulfilled | Fulfillment::FulfilledButMoreAllowed => {}
+            _ => return no_match(raw_input),
+        }
     }
 
     MatchResult {
@@ -760,7 +817,11 @@ fn multiplier_fulfilled(component: &SyntaxComponent, cnt: usize) -> Fulfillment 
         },
         SyntaxComponentMultiplier::Between(from, to) => match cnt {
             _ if cnt < *from => Fulfillment::NotYetFulfilled,
-            _ if cnt >= *from && cnt <= *to => Fulfillment::FulfilledButMoreAllowed,
+            // At the maximum, the component is satisfied and must NOT consume more,
+            // otherwise `<length>{2}` would greedily grab a following value (e.g. the
+            // blur length after the two offset lengths in `box-shadow`).
+            _ if cnt == *to => Fulfillment::Fulfilled,
+            _ if cnt >= *from && cnt < *to => Fulfillment::FulfilledButMoreAllowed,
             _ => Fulfillment::NotFulfilled,
         },
         _ => Fulfillment::NotFulfilled,

--- a/crates/gosub_css3/src/matcher/syntax_matcher.rs
+++ b/crates/gosub_css3/src/matcher/syntax_matcher.rs
@@ -107,8 +107,7 @@ const VENDOR_PREFIXES: [&str; 6] = ["-webkit-", "-moz-", "-ms-", "-o-", "-khtml-
 /// Returns the remainder of `s` after a known vendor prefix, or None.
 fn strip_vendor_prefix(s: &str) -> Option<&str> {
     VENDOR_PREFIXES.iter().find_map(|p| {
-        (s.len() > p.len() && s.get(..p.len()).is_some_and(|head| head.eq_ignore_ascii_case(p)))
-            .then(|| &s[p.len()..])
+        (s.len() > p.len() && s.get(..p.len()).is_some_and(|head| head.eq_ignore_ascii_case(p))).then(|| &s[p.len()..])
     })
 }
 
@@ -350,117 +349,117 @@ fn match_component_single<'a>(input: &'a [CssValue], component: &SyntaxComponent
                 }
             }
             match datatype.as_str() {
-            // For the numeric datatypes, an optional `[min,max]` range written on the
-            // reference (e.g. `<length [0,∞]>`) is enforced here: the magnitude must fall
-            // within it. An empty range accepts every value, so unranged uses are
-            // unaffected.
-            "percentage" => {
-                if let CssValue::Percentage(n) = value {
-                    if range.contains(*n) {
-                        return first_match(input);
+                // For the numeric datatypes, an optional `[min,max]` range written on the
+                // reference (e.g. `<length [0,∞]>`) is enforced here: the magnitude must fall
+                // within it. An empty range accepts every value, so unranged uses are
+                // unaffected.
+                "percentage" => {
+                    if let CssValue::Percentage(n) = value {
+                        if range.contains(*n) {
+                            return first_match(input);
+                        }
                     }
                 }
-            }
-            "angle" => match value {
-                CssValue::Zero if range.contains(0.0) => return first_match(input),
-                CssValue::Unit(n, u)
-                    if range.contains(*n)
-                        && (u.eq_ignore_ascii_case("deg")
-                            || u.eq_ignore_ascii_case("grad")
-                            || u.eq_ignore_ascii_case("rad")
-                            || u.eq_ignore_ascii_case("turn")) =>
-                {
-                    return first_match(input)
-                }
-                _ => {}
-            },
-            "length" => match value {
-                CssValue::Zero if range.contains(0.0) => return first_match(input),
-                CssValue::Unit(n, u) if LENGTH_UNITS.contains(&u.as_str()) && range.contains(*n) => {
-                    return first_match(input)
-                }
-                _ => {}
-            },
-            "time" => match value {
-                CssValue::Zero if range.contains(0.0) => return first_match(input),
-                CssValue::Unit(n, u)
-                    if (u.eq_ignore_ascii_case("s") || u.eq_ignore_ascii_case("ms")) && range.contains(*n) =>
-                {
-                    return first_match(input)
-                }
-                _ => {}
-            },
-            // A flexible length is a `<number>` followed by the `fr` unit (grid track sizing).
-            "flex" => match value {
-                CssValue::Zero if range.contains(0.0) => return first_match(input),
-                CssValue::Unit(n, u) if u.eq_ignore_ascii_case("fr") && range.contains(*n) => {
-                    return first_match(input)
-                }
-                _ => {}
-            },
-            "number" => match value {
-                CssValue::Zero if range.contains(0.0) => return first_match(input),
-                CssValue::Number(n) if range.contains(*n) => return first_match(input),
-                _ => {}
-            },
-            "integer" => match value {
-                CssValue::Zero if range.contains(0.0) => return first_match(input),
-                CssValue::Number(n) if n.fract() == 0.0 && range.contains(*n) => return first_match(input),
-                _ => {}
-            },
-            "system-color" => {
-                if let CssValue::String(v) = value {
-                    if is_system_color(v) {
-                        return first_match(input);
+                "angle" => match value {
+                    CssValue::Zero if range.contains(0.0) => return first_match(input),
+                    CssValue::Unit(n, u)
+                        if range.contains(*n)
+                            && (u.eq_ignore_ascii_case("deg")
+                                || u.eq_ignore_ascii_case("grad")
+                                || u.eq_ignore_ascii_case("rad")
+                                || u.eq_ignore_ascii_case("turn")) =>
+                    {
+                        return first_match(input)
+                    }
+                    _ => {}
+                },
+                "length" => match value {
+                    CssValue::Zero if range.contains(0.0) => return first_match(input),
+                    CssValue::Unit(n, u) if LENGTH_UNITS.contains(&u.as_str()) && range.contains(*n) => {
+                        return first_match(input)
+                    }
+                    _ => {}
+                },
+                "time" => match value {
+                    CssValue::Zero if range.contains(0.0) => return first_match(input),
+                    CssValue::Unit(n, u)
+                        if (u.eq_ignore_ascii_case("s") || u.eq_ignore_ascii_case("ms")) && range.contains(*n) =>
+                    {
+                        return first_match(input)
+                    }
+                    _ => {}
+                },
+                // A flexible length is a `<number>` followed by the `fr` unit (grid track sizing).
+                "flex" => match value {
+                    CssValue::Zero if range.contains(0.0) => return first_match(input),
+                    CssValue::Unit(n, u) if u.eq_ignore_ascii_case("fr") && range.contains(*n) => {
+                        return first_match(input)
+                    }
+                    _ => {}
+                },
+                "number" => match value {
+                    CssValue::Zero if range.contains(0.0) => return first_match(input),
+                    CssValue::Number(n) if range.contains(*n) => return first_match(input),
+                    _ => {}
+                },
+                "integer" => match value {
+                    CssValue::Zero if range.contains(0.0) => return first_match(input),
+                    CssValue::Number(n) if n.fract() == 0.0 && range.contains(*n) => return first_match(input),
+                    _ => {}
+                },
+                "system-color" => {
+                    if let CssValue::String(v) = value {
+                        if is_system_color(v) {
+                            return first_match(input);
+                        }
                     }
                 }
-            }
-            "named-color" => {
-                if let CssValue::String(v) = value {
-                    if is_named_color(v) {
-                        return first_match(input);
+                "named-color" => {
+                    if let CssValue::String(v) = value {
+                        if is_named_color(v) {
+                            return first_match(input);
+                        }
                     }
                 }
-            }
-            "hex-color" => match value {
-                CssValue::Color(_) => return first_match(input),
-                CssValue::String(v) if v.starts_with('#') => return first_match(input),
-                _ => {}
-            },
-            // `<alpha()>` (css-color-hdr) is an alternative of `<color-function>`, so it
-            // denotes a FUNCTION named `alpha`, not a bare numeric. It must not fall
-            // through to the permissive catch-all below (any string would match <color>),
-            // and it must not match bare numerics either — that made `color: 0` valid and
-            // let a leading `0` offset in box-shadow claim the shadow-color slot. No data
-            // source carries its argument grammar, so arguments are accepted opaquely.
-            "alpha()" => match value {
-                CssValue::Function(name, _) if name.eq_ignore_ascii_case("alpha") => return first_match(input),
-                _ => {}
-            },
-            // Identifiers are ident-like tokens only: the parser lowers them to String.
-            // Matching them via the permissive catch-all let `<custom-ident>` swallow
-            // units and numbers, e.g. `transition: 0.2s ease left` had `0.2s` claimed as
-            // the transition-property name. Slashes are separators, not idents.
-            "custom-ident" | "ident" => match value {
-                CssValue::String(s) if s != "/" => return first_match(input),
-                _ => {}
-            },
-            "dashed-ident" => match value {
-                CssValue::String(s) if s.starts_with("--") => return first_match(input),
-                _ => {}
-            },
-            // Commas and slashes are structural separators (list items, function
-            // arguments, `<grid-line> / <grid-line>`, font-size/line-height), never leaf
-            // datatype values. Without this guard the permissive catch-all would let a
-            // built-in such as `<time>` consume the separator and leave the following
-            // part unmatched (e.g. `transition: opacity 0.3s, transform 0.5s`,
-            // `grid-column: 1 / span 2`). Grammar-level separators still match through
-            // the Literal arm.
-            _ if matches!(value, CssValue::Comma) => {}
-            _ if matches!(value, CssValue::String(s) if s == "/") => {}
-            _ => {
-                return first_match(input);
-            } // _ => panic!("Unknown built-in datatype: {:?}", datatype),
+                "hex-color" => match value {
+                    CssValue::Color(_) => return first_match(input),
+                    CssValue::String(v) if v.starts_with('#') => return first_match(input),
+                    _ => {}
+                },
+                // `<alpha()>` (css-color-hdr) is an alternative of `<color-function>`, so it
+                // denotes a FUNCTION named `alpha`, not a bare numeric. It must not fall
+                // through to the permissive catch-all below (any string would match <color>),
+                // and it must not match bare numerics either — that made `color: 0` valid and
+                // let a leading `0` offset in box-shadow claim the shadow-color slot. No data
+                // source carries its argument grammar, so arguments are accepted opaquely.
+                "alpha()" => match value {
+                    CssValue::Function(name, _) if name.eq_ignore_ascii_case("alpha") => return first_match(input),
+                    _ => {}
+                },
+                // Identifiers are ident-like tokens only: the parser lowers them to String.
+                // Matching them via the permissive catch-all let `<custom-ident>` swallow
+                // units and numbers, e.g. `transition: 0.2s ease left` had `0.2s` claimed as
+                // the transition-property name. Slashes are separators, not idents.
+                "custom-ident" | "ident" => match value {
+                    CssValue::String(s) if s != "/" => return first_match(input),
+                    _ => {}
+                },
+                "dashed-ident" => match value {
+                    CssValue::String(s) if s.starts_with("--") => return first_match(input),
+                    _ => {}
+                },
+                // Commas and slashes are structural separators (list items, function
+                // arguments, `<grid-line> / <grid-line>`, font-size/line-height), never leaf
+                // datatype values. Without this guard the permissive catch-all would let a
+                // built-in such as `<time>` consume the separator and leave the following
+                // part unmatched (e.g. `transition: opacity 0.3s, transform 0.5s`,
+                // `grid-column: 1 / span 2`). Grammar-level separators still match through
+                // the Literal arm.
+                _ if matches!(value, CssValue::Comma) => {}
+                _ if matches!(value, CssValue::String(s) if s == "/") => {}
+                _ => {
+                    return first_match(input);
+                } // _ => panic!("Unknown built-in datatype: {:?}", datatype),
             }
         }
         SyntaxComponent::Inherit { .. } => match value {
@@ -870,7 +869,9 @@ fn best_any_order_attempt<'a>(
 ) -> MatchResult<'a> {
     let mut best: Option<MatchResult> = None;
     for offset in 0..component_count.max(1) {
-        let order: Vec<usize> = (0..component_count).map(|i| (i + offset) % component_count.max(1)).collect();
+        let order: Vec<usize> = (0..component_count)
+            .map(|i| (i + offset) % component_count.max(1))
+            .collect();
         let res = attempt(&order);
         if !res.matched {
             continue;
@@ -878,10 +879,7 @@ fn best_any_order_attempt<'a>(
         if res.remainder.is_empty() {
             return res;
         }
-        if best
-            .as_ref()
-            .is_none_or(|b| res.remainder.len() < b.remainder.len())
-        {
+        if best.as_ref().is_none_or(|b| res.remainder.len() < b.remainder.len()) {
             best = Some(res);
         }
     }

--- a/crates/gosub_css3/src/matcher/syntax_matcher.rs
+++ b/crates/gosub_css3/src/matcher/syntax_matcher.rs
@@ -321,6 +321,12 @@ fn match_component_single<'a>(input: &'a [CssValue], component: &SyntaxComponent
                 CssValue::Zero | CssValue::Number(_) | CssValue::Percentage(_) => return first_match(input),
                 _ => {}
             },
+            // A comma is a structural separator (list items, function arguments), never a
+            // leaf datatype value. Without this guard the permissive catch-all would let a
+            // built-in such as `<time>` consume the comma that separates items in a `#`
+            // list (e.g. `transition: opacity 0.3s, transform 0.5s`), swallowing the
+            // separator and leaving the following item unmatched.
+            _ if matches!(value, CssValue::Comma) => {}
             _ => {
                 return first_match(input);
             } // _ => panic!("Unknown built-in datatype: {:?}", datatype),

--- a/crates/gosub_css3/src/matcher/syntax_matcher.rs
+++ b/crates/gosub_css3/src/matcher/syntax_matcher.rs
@@ -296,15 +296,17 @@ fn match_component_single<'a>(input: &'a [CssValue], component: &SyntaxComponent
                     }
                 }
             }
-            "color()" => match value {
-                // @TODO: fix this according to what the spec says
+            "hex-color" => match value {
                 CssValue::Color(_) => return first_match(input),
                 CssValue::String(v) if v.starts_with('#') => return first_match(input),
                 _ => {}
             },
-            "hex-color" => match value {
-                CssValue::Color(_) => return first_match(input),
-                CssValue::String(v) if v.starts_with('#') => return first_match(input),
+            // An alpha value is numeric (`<number> | <percentage>`). It must not fall
+            // through to the permissive catch-all below: `<alpha()>` is part of
+            // `<color-function>`, so accepting arbitrary strings here would make any
+            // string match `<color>` and defeat color validation.
+            "alpha()" => match value {
+                CssValue::Zero | CssValue::Number(_) | CssValue::Percentage(_) => return first_match(input),
                 _ => {}
             },
             _ => {

--- a/crates/gosub_css3/src/parser/calc.rs
+++ b/crates/gosub_css3/src/parser/calc.rs
@@ -19,28 +19,49 @@ impl Css3<'_> {
 
         let loc = self.tokenizer.current_location();
 
-        let start = self.tokenizer.tell();
+        // Rebuild the expression text from the consumed TOKENS. Slicing the raw stream
+        // does not work here: the tokenizer pre-tokenizes into a buffer, so the stream
+        // position runs ahead of the current token and the slice comes up empty.
+        let mut expr = String::new();
 
         loop {
             let t = self.consume_any()?;
             match t.token_type {
                 TokenType::Eof => break,
-                // A nested function or `(` opens a sub-expression, one recursion level deeper.
-                TokenType::Function(_) | TokenType::LParen => {
-                    self.recurse(Self::parse_calc_expr)?;
+                // A nested function or `(` opens a sub-expression, one recursion level
+                // deeper. The recursive call consumes through the matching `)`.
+                TokenType::Function(name) => {
+                    expr.push_str(&name);
+                    expr.push('(');
+                    let inner = self.recurse(Self::parse_calc_expr)?;
+                    if let NodeType::Raw { value } = *inner.node_type {
+                        expr.push_str(&value);
+                    }
+                    expr.push(')');
+                }
+                TokenType::LParen => {
+                    expr.push('(');
+                    let inner = self.recurse(Self::parse_calc_expr)?;
+                    if let NodeType::Raw { value } = *inner.node_type {
+                        expr.push_str(&value);
+                    }
+                    expr.push(')');
                 }
                 TokenType::RParen => break,
+                TokenType::Comment(_) => {}
                 _ => {
-                    // ignore
+                    // Token's Display form is its CSS serialization (whitespace -> " ").
+                    expr.push_str(&t.to_string());
                 }
             }
         }
 
-        let end = self.tokenizer.tell();
-
-        let expr = self.tokenizer.slice(start, end);
-
-        Ok(Node::new(NodeType::Raw { value: expr }, loc))
+        Ok(Node::new(
+            NodeType::Raw {
+                value: expr.trim().to_string(),
+            },
+            loc,
+        ))
     }
 }
 

--- a/crates/gosub_css3/src/stylesheet.rs
+++ b/crates/gosub_css3/src/stylesheet.rs
@@ -559,7 +559,10 @@ impl CssValue {
                 value.insert(0, '#');
                 Ok(CssValue::Color(RgbColor::from(value.as_str())))
             }
-            crate::node::NodeType::Operator(_) => Ok(CssValue::None),
+            // Keep the operator character (e.g. `/` in `16 / 9` or `font: 14px/1.5`)
+            // as a string so it can match a `/` literal in a value grammar. Discarding
+            // it (as `None`) makes `<ratio>` and other slash-delimited grammars unmatchable.
+            crate::node::NodeType::Operator(value) => Ok(CssValue::String(value)),
             crate::node::NodeType::Calc { expr } => {
                 // Preserve the raw body of calc(...) so the layout engine can evaluate it later.
                 let body = match *expr.node_type {

--- a/crates/gosub_css3/tools/generate_definitions/src/main.rs
+++ b/crates/gosub_css3/tools/generate_definitions/src/main.rs
@@ -23,6 +23,60 @@ fn strip_trailing_comma_multiplier(re: &Regex, syntax: &str) -> String {
     re.replace_all(syntax.trim_end_matches(' '), "").into_owned()
 }
 
+/// Overrides for upstream PROPERTY grammars where both sources are wrong or
+/// incomplete for real-world CSS.
+const PROPERTY_SYNTAX_PATCHES: [(&str, &str); 2] = [
+    // webref only carries the modern space-separated basic-shape <rect()>, but
+    // the dominant real-world clip syntax is the legacy comma-separated CSS2
+    // rect() (MDN's <shape>). Accept both.
+    ("clip", "<shape> | <rect()> | auto"),
+    // webref types background-clip as <visual-box># which misses `text` (and
+    // `border-area`) from css-backgrounds-4; gradient text via
+    // `background-clip: text` is widely deployed. MDN's <bg-clip> carries the
+    // full alternation.
+    ("background-clip", "<bg-clip>#"),
+];
+
+/// Value types that grammars reference but neither source defines: webref
+/// lists them with an EMPTY syntax (which the generator skips) and MDN
+/// references them from <shape> without defining them. Definitions per
+/// CSS2.1 §11.1.2.
+const MISSING_VALUE_PATCHES: [(&str, &str); 4] = [
+    ("<top>", "<length> | auto"),
+    ("<right>", "<length> | auto"),
+    ("<bottom>", "<length> | auto"),
+    ("<left>", "<length> | auto"),
+];
+
+/// Pins value definitions that multiple specs define differently, so the
+/// choice is explicit instead of an artifact of decode order (first spec
+/// wins).
+const VALUE_SYNTAX_PATCHES: [(&str, &str); 1] = [
+    // Defined by css-masking-1 (legacy `rect( <top>, <right>, <bottom>,
+    // <left> )`, only for `clip`) and css-shapes-1 (the modern basic-shape
+    // used by clip-path etc.). Pin the modern form; `clip` reaches the legacy
+    // form through <shape> instead.
+    (
+        "rect()",
+        "rect( [ <length-percentage> | auto ]{4} [ round <'border-radius'> ]? )",
+    ),
+];
+
+/// Adds the css-sizing-4 bare `fit-content` keyword alongside the functional
+/// form in PROPERTY grammars (width, height, min/max-*, ...). webref still
+/// carries only `fit-content(<length-percentage>)` while MDN lists both; since
+/// webref grammar is preferred, the keyword would otherwise be lost. Value
+/// definitions are left alone: a bare fit-content is not valid in e.g. grid
+/// track sizing.
+fn add_bare_fit_content(syntax: &str) -> String {
+    match syntax.find("fit-content(") {
+        Some(pos) if !syntax.contains("fit-content |") => {
+            format!("{}fit-content | {}", &syntax[..pos], &syntax[pos..])
+        }
+        _ => syntax.to_string(),
+    }
+}
+
 fn main() -> Result<()> {
     // A value-definition-syntax comma multiplier at the very end of a grammar.
     let trailing_comma_multiplier = Regex::new(r"#(\{[0-9]+(,[0-9]*)?\})?\s*$")?;
@@ -72,7 +126,12 @@ fn main() -> Result<()> {
             }
         }
 
+        if let Some((_, patched)) = PROPERTY_SYNTAX_PATCHES.iter().find(|(n, _)| n == name) {
+            syntax = (*patched).to_string();
+        }
+
         let syntax = comma_list_idiom.replace_all(&syntax, "[ ${1} , ]* ").into_owned();
+        let syntax = add_bare_fit_content(&syntax);
 
         let computed = if mdn_prop.computed.array.is_empty() {
             if !mdn_prop.computed.string.is_empty() {
@@ -156,6 +215,25 @@ fn main() -> Result<()> {
                 syntax: strip_trailing_comma_multiplier(&trailing_comma_multiplier, &wp.syntax),
             });
             defined_values.insert(key);
+        }
+    }
+
+    // Backfill 3: value types no source defines (see MISSING_VALUE_PATCHES).
+    for (name, syntax) in MISSING_VALUE_PATCHES {
+        if defined_values.contains(name) {
+            continue;
+        }
+        data.values.push(Value {
+            name: name.to_string(),
+            syntax: syntax.to_string(),
+        });
+        defined_values.insert(name.to_string());
+    }
+
+    // Pin value definitions that specs duplicate with conflicting grammars.
+    for value in &mut data.values {
+        if let Some((_, patched)) = VALUE_SYNTAX_PATCHES.iter().find(|(n, _)| *n == value.name) {
+            value.syntax = (*patched).to_string();
         }
     }
 


### PR DESCRIPTION
After testing the CSS parser and syntax matcher against real life data, there were a few smaller issues found that needed to be resolved.

At this moment, a corpus of 3GB (66k files) of real CSS (taken from google's BigQuery httparchive dataset) reveals that we can now parse correctly 99.85% of the CSS, with the remaining part being invalid CSS data that is correctly ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded CSS grammar coverage across properties, values, colors, gradients, transforms, at-rules, and selectors, including navigation/view-transition-related syntax.
  * Improved definition-generation to backfill missing grammar pieces and apply targeted syntax patches.

* **Bug Fixes**
  * Case-insensitive matching for system and named color keywords.
  * More accurate matcher behavior for CSS-wide keywords, vendor-prefixed keywords, substitutions, separators (comma/slash), literals, function arguments, and `&&`/`||`/`{from,to}` grouping.
  * Corrected operator token handling and improved nested `calc()` serialization; non-finite numeric literals are rejected.

* **Tests**
  * Added corpus-style validation across many parsed declarations to verify matcher outcomes and improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->