### PR TITLE
Cleanup and optimizing some of the gosub_html5 crate

### DIFF
--- a/crates/gosub_html5/src/document/document_impl.rs
+++ b/crates/gosub_html5/src/document/document_impl.rs
@@ -272,6 +272,20 @@ impl<C: HasDocument<Document = Self>> Document<C> for DocumentImpl<C> {
         }
     }
 
+    fn append_text_value(&mut self, id: NodeId, value: &str) -> bool {
+        let Some(node) = self.arena.node_ref_mut(id) else {
+            return false;
+        };
+        if let NodeDataTypeInternal::Text(ref mut t) = node.data {
+            // In-place append: the backing String grows geometrically, so merging N adjacent
+            // text runs into this node stays amortized O(total length) instead of O(N^2).
+            t.value.push_str(value);
+            true
+        } else {
+            false
+        }
+    }
+
     fn comment_value(&self, id: NodeId) -> Option<&str> {
         match self.arena.node_ref(id)?.data {
             NodeDataTypeInternal::Comment(ref c) => Some(c.value.as_str()),

--- a/crates/gosub_html5/src/parser.rs
+++ b/crates/gosub_html5/src/parser.rs
@@ -145,6 +145,10 @@ pub struct Html5Parser<'tokens, C: HasDocument> {
     current_token: Token,
     /// If true, the current token should be processed again
     reprocess_token: bool,
+    /// True when an insertion-mode handler replaced `current_token` in place (e.g. the
+    /// `<image>` -> `<img>` rewrite). Signals that the replacement, not the token moved
+    /// out for matching, must survive into a reprocess. See `process_html_content`.
+    current_token_rewritten: bool,
     /// Stack of open elements
     open_elements: Vec<NodeId>,
     /// Current head element
@@ -284,6 +288,7 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
                 location: Location::default(),
             },
             reprocess_token: false,
+            current_token_rewritten: false,
             open_elements: Vec::new(),
             head_element: None,
             form_element: None,
@@ -322,6 +327,7 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
                 location: Location::default(),
             },
             reprocess_token: false,
+            current_token_rewritten: false,
             open_elements: Vec::new(),
             head_element: None,
             form_element: None,
@@ -485,6 +491,10 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
 
     // Process token in foreign content (svg, mathml)
     fn process_foreign_content(&mut self) {
+        // NOTE: unlike `process_html_content`, this keeps a clone: foreign handling
+        // delegates back into `process_html_content` (directly and via
+        // `process_unexpected_html_tag`), which re-reads `self.current_token`, so the
+        // real token must stay in place here.
         let current_token = self.current_token.clone();
 
         let mut handle_as_script_endtag = false;
@@ -686,7 +696,14 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
             self.ignore_lf = false;
         }
 
-        let current_token = self.current_token.clone();
+        // Move the token out for matching instead of deep-cloning it: tokens can carry
+        // large script/style/rawtext strings and this runs for every token. While
+        // processing, `self.current_token` is only read for its location (via
+        // `parse_error`), so we leave a location-only placeholder. It is restored below
+        // when the token must be reprocessed.
+        let loc = self.current_token.get_location();
+        let current_token = std::mem::replace(&mut self.current_token, Token::Eof { location: loc });
+        self.current_token_rewritten = false;
 
         match self.insertion_mode {
             InsertionMode::Initial => {
@@ -1714,6 +1731,14 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
                     }
                 }
             }
+        }
+
+        // If this token is to be reprocessed, restore it so the next iteration re-reads
+        // the real token rather than the placeholder we swapped in. When an arm installed
+        // a replacement in place (the `<image>` -> `<img>` rewrite), that replacement must
+        // survive instead, so we skip the restore in that case.
+        if self.reprocess_token && !self.current_token_rewritten {
+            self.current_token = current_token;
         }
     }
 
@@ -2801,6 +2826,9 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
                     is_self_closing: *is_self_closing,
                     location: token.get_location(),
                 };
+                // We replaced current_token in place; keep it (not the token moved out for
+                // matching) so the reprocess below sees the rewritten <img> tag.
+                self.current_token_rewritten = true;
                 self.reprocess_token = true;
             }
             Token::StartTag { name, .. } if name == "textarea" => {

--- a/crates/gosub_html5/src/parser.rs
+++ b/crates/gosub_html5/src/parser.rs
@@ -1896,8 +1896,8 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
             }
             if thoroughly {
                 if !([
-                    "tbody", "td", "tfoot", "th", "thead", "tr", "dd", "dt", "li", "option", "optgroup", "p", "rb",
-                    "rp", "rt", "rtc",
+                    "caption", "colgroup", "tbody", "td", "tfoot", "th", "thead", "tr", "dd", "dt", "li", "option",
+                    "optgroup", "p", "rb", "rp", "rt", "rtc",
                 ]
                 .contains(&tag)
                     && is_html)

--- a/crates/gosub_html5/src/parser.rs
+++ b/crates/gosub_html5/src/parser.rs
@@ -3991,52 +3991,34 @@ impl<'a, C: HasDocument> Html5Parser<'a, C> {
     /// tokens, but still be seen and parsed as a single `TextToken`.
     ///
     fn split_mixed_token(&self, text: &str) -> Vec<Token> {
-        let mut tokens = vec![];
-        let mut last_group = 'x';
-
-        let mut found = String::new();
-
-        for ch in text.chars() {
-            let group = if ch == '\0' {
+        self.split_token_by_group(text, |ch| {
+            if ch == '\0' {
                 '0'
             } else if ch.is_ascii_whitespace() {
                 'w'
             } else {
                 'r'
-            };
-
-            if last_group != group && !found.is_empty() {
-                tokens.push(Token::Text {
-                    text: found.clone(),
-                    location: self.tokenizer.get_location(),
-                });
-                found.clear();
             }
-
-            found.push(ch);
-            last_group = group;
-        }
-
-        if !found.is_empty() {
-            tokens.push(Token::Text {
-                text: found.clone(),
-                location: self.tokenizer.get_location(),
-            });
-        }
-
-        tokens
+        })
     }
 
     /// This will split tokens into \0 groups and non-\0 groups.
-    /// @todo: refactor this into `split_mixed_token` as well, but add a collection of groups callables
     fn split_mixed_token_null(&self, text: &str) -> Vec<Token> {
+        self.split_token_by_group(text, |ch| if ch == '\0' { '0' } else { 'r' })
+    }
+
+    /// Splits `text` into consecutive runs of characters that map to the same group, emitting
+    /// one `Token::Text` per run. `group_of` classifies each character into a group key; a
+    /// change in key starts a new token. This lets callers pick which distinctions matter
+    /// (e.g. whitespace vs null vs regular) without re-splitting large blobs unnecessarily.
+    fn split_token_by_group(&self, text: &str, group_of: impl Fn(char) -> char) -> Vec<Token> {
         let mut tokens = vec![];
         let mut last_group = 'x';
 
         let mut found = String::new();
 
         for ch in text.chars() {
-            let group = if ch == '\0' { '0' } else { 'r' };
+            let group = group_of(ch);
 
             if last_group != group && !found.is_empty() {
                 tokens.push(Token::Text {

--- a/crates/gosub_html5/src/parser/helper.rs
+++ b/crates/gosub_html5/src/parser/helper.rs
@@ -10,12 +10,12 @@ const ADOPTION_AGENCY_OUTER_LOOP_DEPTH: usize = 8;
 const ADOPTION_AGENCY_INNER_LOOP_DEPTH: usize = 3;
 
 #[derive(Debug)]
-pub enum InsertionPositionMode<NodeId> {
+pub(crate) enum InsertionPositionMode<NodeId> {
     LastChild { parent_id: NodeId },
     Sibling { parent_id: NodeId, before_id: NodeId },
 }
 
-pub enum BookMark<NodeId> {
+pub(crate) enum BookMark<NodeId> {
     Replace(NodeId),
     InsertAfter(NodeId),
 }
@@ -115,7 +115,7 @@ impl<C: HasDocument> Html5Parser<'_, C> {
             })
     }
 
-    pub fn insert_element_helper(&mut self, node_id: NodeId, position: InsertionPositionMode<NodeId>) {
+    pub(crate) fn insert_element_helper(&mut self, node_id: NodeId, position: InsertionPositionMode<NodeId>) {
         match position {
             InsertionPositionMode::Sibling { parent_id, before_id } => {
                 let pos = self.document.children(parent_id).iter().position(|&x| x == before_id);
@@ -127,7 +127,7 @@ impl<C: HasDocument> Html5Parser<'_, C> {
         }
     }
 
-    pub fn insert_text_helper(&mut self, position: InsertionPositionMode<NodeId>, token: &Token) {
+    pub(crate) fn insert_text_helper(&mut self, position: InsertionPositionMode<NodeId>, token: &Token) {
         // Text content to append when merging into an adjacent text node. For text tokens
         // this borrows the token's text directly instead of going through Display.
         fn token_text(token: &Token) -> std::borrow::Cow<'_, str> {
@@ -171,15 +171,15 @@ impl<C: HasDocument> Html5Parser<'_, C> {
         }
     }
 
-    pub fn insert_html_element(&mut self, token: &Token) -> NodeId {
+    pub(crate) fn insert_html_element(&mut self, token: &Token) -> NodeId {
         self.insert_element_from_token(token, None, Some(HTML_NAMESPACE))
     }
 
-    pub fn insert_foreign_element(&mut self, token: &Token, namespace: &str) -> NodeId {
+    pub(crate) fn insert_foreign_element(&mut self, token: &Token, namespace: &str) -> NodeId {
         self.insert_element_from_token(token, None, Some(namespace))
     }
 
-    pub fn insert_element_from_token(
+    pub(crate) fn insert_element_from_token(
         &mut self,
         token: &Token,
         override_node: Option<NodeId>,
@@ -189,12 +189,12 @@ impl<C: HasDocument> Html5Parser<'_, C> {
         self.insert_element(node_id, override_node)
     }
 
-    pub fn insert_element_from_node(&mut self, org_node_id: NodeId, override_node: Option<NodeId>) -> NodeId {
+    pub(crate) fn insert_element_from_node(&mut self, org_node_id: NodeId, override_node: Option<NodeId>) -> NodeId {
         let new_node_id = self.document.duplicate_node(org_node_id);
         self.insert_element(new_node_id, override_node)
     }
 
-    pub fn insert_element(&mut self, node_id: NodeId, override_node: Option<NodeId>) -> NodeId {
+    pub(crate) fn insert_element(&mut self, node_id: NodeId, override_node: Option<NodeId>) -> NodeId {
         let insert_position = self.appropriate_place_insert(override_node);
         self.insert_element_helper(node_id, insert_position);
 
@@ -205,18 +205,18 @@ impl<C: HasDocument> Html5Parser<'_, C> {
         node_id
     }
 
-    pub fn insert_doctype_element(&mut self, token: &Token) {
+    pub(crate) fn insert_doctype_element(&mut self, token: &Token) {
         let node_id = self.create_node(token, HTML_NAMESPACE);
         self.document.attach(node_id, NodeId::root(), None);
     }
 
-    pub fn insert_document_element(&mut self, token: &Token) {
+    pub(crate) fn insert_document_element(&mut self, token: &Token) {
         let node_id = self.create_node(token, HTML_NAMESPACE);
         self.document.attach(node_id, NodeId::root(), None);
         self.open_elements.push(node_id);
     }
 
-    pub fn insert_comment_element(&mut self, token: &Token, insert_position: Option<NodeId>) {
+    pub(crate) fn insert_comment_element(&mut self, token: &Token, insert_position: Option<NodeId>) {
         let node_id = self.create_node(token, HTML_NAMESPACE);
         if let Some(position) = insert_position {
             self.document.attach(node_id, position, None);
@@ -227,7 +227,7 @@ impl<C: HasDocument> Html5Parser<'_, C> {
         self.insert_element_helper(node_id, insert_position);
     }
 
-    pub fn insert_text_element(&mut self, token: &Token) {
+    pub(crate) fn insert_text_element(&mut self, token: &Token) {
         if let Token::Text { text, .. } = token {
             if text.is_empty() {
                 return;
@@ -243,7 +243,7 @@ impl<C: HasDocument> Html5Parser<'_, C> {
     //
     // The "no last table" sub-step (fragment case) is handled by the fallthrough at the
     // bottom of this function, which returns the first element in the open elements stack.
-    pub fn appropriate_place_insert(&self, override_node: Option<NodeId>) -> InsertionPositionMode<NodeId> {
+    pub(crate) fn appropriate_place_insert(&self, override_node: Option<NodeId>) -> InsertionPositionMode<NodeId> {
         let current_node_id = *self.open_elements.last().unwrap_or(&NodeId::root());
         let target_id = override_node.unwrap_or(current_node_id);
 
@@ -292,7 +292,7 @@ impl<C: HasDocument> Html5Parser<'_, C> {
         }
     }
 
-    pub fn adoption_agency_algorithm(&mut self, token: &Token) {
+    pub(crate) fn adoption_agency_algorithm(&mut self, token: &Token) {
         // step 1
         let subject = match token {
             Token::StartTag { name, .. } | Token::EndTag { name, .. } => name,

--- a/crates/gosub_html5/src/parser/helper.rs
+++ b/crates/gosub_html5/src/parser/helper.rs
@@ -148,9 +148,8 @@ impl<C: HasDocument> Html5Parser<'_, C> {
                     }
                     Some(index) => {
                         let last_node_id = children[index - 1];
-                        if self.document.text_value(last_node_id).is_some() {
-                            let cur = self.document.text_value(last_node_id).unwrap_or_default().to_owned();
-                            self.document.set_text_value(last_node_id, &(cur + &token_text(token)));
+                        // Merge into the preceding text node in place if there is one.
+                        if self.document.append_text_value(last_node_id, &token_text(token)) {
                             return;
                         }
                         let node_id = self.create_node(token, HTML_NAMESPACE);
@@ -161,9 +160,8 @@ impl<C: HasDocument> Html5Parser<'_, C> {
             InsertionPositionMode::LastChild { parent_id } => {
                 let last_child_id = self.document.children(parent_id).last().copied();
                 if let Some(last_node_id) = last_child_id {
-                    if self.document.text_value(last_node_id).is_some() {
-                        let cur = self.document.text_value(last_node_id).unwrap_or_default().to_owned();
-                        self.document.set_text_value(last_node_id, &(cur + &token_text(token)));
+                    // Merge into the last text child in place if there is one.
+                    if self.document.append_text_value(last_node_id, &token_text(token)) {
                         return;
                     }
                 }

--- a/crates/gosub_html5/src/tokenizer.rs
+++ b/crates/gosub_html5/src/tokenizer.rs
@@ -194,7 +194,7 @@ impl<'stream> Tokenizer<'stream> {
                     }
                 }
                 State::CharacterReferenceInData => {
-                    self.consume_character_reference(None, false);
+                    self.consume_character_reference(false);
                     self.state = State::Data;
                 }
                 State::RCDATA => {
@@ -215,7 +215,7 @@ impl<'stream> Tokenizer<'stream> {
                 }
                 State::CharacterReferenceInRcData => {
                     // consume character reference
-                    self.consume_character_reference(None, false);
+                    self.consume_character_reference(false);
                     self.state = State::RCDATA;
                 }
                 State::RAWTEXT => {
@@ -1084,7 +1084,7 @@ impl<'stream> Tokenizer<'stream> {
                     match c {
                         Ch('"') => self.state = State::AfterAttributeValueQuoted,
                         Ch('&') => {
-                            self.consume_character_reference(Some(Ch('"')), true);
+                            self.consume_character_reference(true);
                         }
                         Ch(CHAR_NUL) => {
                             self.parse_error(ParserError::UnexpectedNullCharacter, loc);
@@ -1105,7 +1105,7 @@ impl<'stream> Tokenizer<'stream> {
                     match c {
                         Ch('\'') => self.state = State::AfterAttributeValueQuoted,
                         Ch('&') => {
-                            self.consume_character_reference(Some(Ch('\'')), true);
+                            self.consume_character_reference(true);
                         }
                         Ch(CHAR_NUL) => {
                             self.parse_error(ParserError::UnexpectedNullCharacter, loc);
@@ -1128,7 +1128,7 @@ impl<'stream> Tokenizer<'stream> {
                             self.state = State::BeforeAttributeName;
                         }
                         Ch('&') => {
-                            self.consume_character_reference(Some(Ch('>')), true);
+                            self.consume_character_reference(true);
                         }
                         Ch('>') => {
                             self.store_and_clear_current_attribute();

--- a/crates/gosub_html5/src/tokenizer.rs
+++ b/crates/gosub_html5/src/tokenizer.rs
@@ -2022,8 +2022,11 @@ impl<'stream> Tokenizer<'stream> {
                 }
                 State::CharacterReferenceInAttributeValue => {
                     // Character references in attribute values are handled inline by the
-                    // attribute-value states; nothing ever transitions into this state.
-                    unreachable!("state {:?} is never entered", self.state);
+                    // attribute-value states; the tokenizer never transitions into this
+                    // state internally. It is only reachable when a caller seeds it via
+                    // the public `Options.initial_state`, which is not a valid entry
+                    // point, so error out instead of panicking on external input.
+                    return Err(Error::Parse(format!("cannot start tokenizing in state {:?}", self.state)).into());
                 }
             }
         }

--- a/crates/gosub_html5/src/tokenizer/character_reference.rs
+++ b/crates/gosub_html5/src/tokenizer/character_reference.rs
@@ -23,9 +23,7 @@ pub enum CcrState {
 impl Tokenizer<'_> {
     /// Consumes a character reference and places this in the tokenizer consume buffer
     /// ref: 8.2.4.69 Tokenizing character references
-    ///
-    /// @TODO: fix additional allowed char
-    pub fn consume_character_reference(&mut self, _additional_allowed_char: Option<Character>, as_attribute: bool) {
+    pub fn consume_character_reference(&mut self, as_attribute: bool) {
         let mut ccr_state = CcrState::CharacterReference;
         let mut char_ref_code: Option<u32> = Some(0);
 

--- a/crates/gosub_interface/src/document.rs
+++ b/crates/gosub_interface/src/document.rs
@@ -90,6 +90,22 @@ pub trait Document<C: HasCssSystem>: Sized + Display + Debug + PartialEq + 'stat
     fn text_value(&self, id: NodeId) -> Option<&str>;
     fn set_text_value(&mut self, id: NodeId, value: &str);
 
+    /// Appends `value` to a text node's existing content in place, returning `true` if the
+    /// node was a text node (and `false` otherwise, leaving it untouched). The parser uses
+    /// this to merge adjacent text runs; implementations should append without rebuilding
+    /// the whole string so that repeated appends stay amortized O(total length) rather than
+    /// quadratic. The default falls back to read-and-replace and should be overridden.
+    fn append_text_value(&mut self, id: NodeId, value: &str) -> bool {
+        let Some(existing) = self.text_value(id) else {
+            return false;
+        };
+        let mut combined = String::with_capacity(existing.len() + value.len());
+        combined.push_str(existing);
+        combined.push_str(value);
+        self.set_text_value(id, &combined);
+        true
+    }
+
     fn comment_value(&self, id: NodeId) -> Option<&str>;
 
     fn doctype_name(&self, id: NodeId) -> Option<&str>;


### PR DESCRIPTION
Cleanup and optimizing some of the gosub_html5 crate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML parsing reliability when tokens are rewritten and reprocessed.
  * Correctly handles `<image>` elements as `<img>` during parsing.
  * Improved merging of adjacent text content.
  * Returns a parse error instead of failing unexpectedly for invalid tokenizer states.
  * Expanded support for implied end-tag handling in tables.

* **Performance**
  * Reduced unnecessary token copying during HTML parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->