### PR TITLE
Rasterize viewport first, extend on scrolling

### DIFF
--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -22,12 +22,21 @@ use crate::html::RenderConfiguration;
 use gosub_interface::css3::{CssSystem, HoverFingerprints};
 use gosub_interface::document::Document as _;
 use gosub_interface::node::NodeType;
+use gosub_render_pipeline::common::browser_state::{BrowserState, WireframeState};
+use gosub_render_pipeline::common::document::pipeline_doc::GosubDocumentAdapter;
+use gosub_render_pipeline::common::geo::{Dimension as PipelineDimension, Rect as PipelineRect};
+use gosub_render_pipeline::common::media::MediaStore;
 use gosub_render_pipeline::common::texture::TilePixels;
-use gosub_render_pipeline::layering::layer::LayerList;
-use gosub_render_pipeline::layouter::LayoutElementId;
+use gosub_render_pipeline::layering::layer::{LayerId, LayerList};
+use gosub_render_pipeline::layouter::taffy::TaffyLayouter;
+use gosub_render_pipeline::layouter::{CanLayout, LayoutElementId};
 use gosub_render_pipeline::painter::{PaintScene, Painter};
-use gosub_render_pipeline::render::backend::{CachedTile, ExternalHandle};
+use gosub_render_pipeline::render::backend::{anchored_tile_pos, CachedTile, ExternalHandle};
+use gosub_render_pipeline::rendertree_builder::RenderTree;
+use gosub_render_pipeline::tile_budget::defer_tiles_outside_window;
+use gosub_render_pipeline::tiler::{TileList, TileState};
 use gosub_shared::node::NodeId;
+use gosub_shared::{timing_start, timing_stop};
 use std::any::Any;
 use url::Url;
 
@@ -165,7 +174,7 @@ pub struct BrowsingContext<C: RenderConfiguration = crate::html::DefaultRenderCo
     /// Media store shared between the layout and rasterization stages. The layouter loads
     /// images/SVGs into it by id; the rasterizer resolves the same ids back. It persists
     /// across renders so paint-only repaints (e.g. hover) still find previously loaded media.
-    media_store: std::sync::Arc<gosub_render_pipeline::common::media::MediaStore>,
+    media_store: std::sync::Arc<MediaStore>,
 
     /// Per-engine settings store (cloned from the zone/engine). Read settings or subscribe to
     /// changes via [`HasConfig::config`].
@@ -206,7 +215,7 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
             hover_cursor: CursorShape::Default,
             rasterizer: None,
             raster_strategy: RasterStrategy::None,
-            media_store: std::sync::Arc::new(gosub_render_pipeline::common::media::MediaStore::new()),
+            media_store: std::sync::Arc::new(MediaStore::new()),
             config_store,
             tile_budget: TileBudget::new(),
         }
@@ -915,15 +924,8 @@ fn pipeline_build_scene<C: RenderConfiguration>(
     doc: Arc<EngineDocument<C>>,
     viewport: &Viewport,
     rasterizer: Option<&(dyn Rasterable + Send + Sync)>,
-    media_store: Arc<gosub_render_pipeline::common::media::MediaStore>,
+    media_store: Arc<MediaStore>,
 ) -> SceneCache {
-    use gosub_render_pipeline::common::browser_state::{BrowserState, WireframeState};
-    use gosub_render_pipeline::common::document::pipeline_doc::GosubDocumentAdapter;
-    use gosub_render_pipeline::common::geo::{Dimension as PipelineDimension, Rect as PipelineRect};
-    use gosub_render_pipeline::layouter::taffy::TaffyLayouter;
-    use gosub_render_pipeline::layouter::CanLayout;
-    use gosub_render_pipeline::rendertree_builder::RenderTree;
-
     // Resolve viewport-relative CSS units (vw/vh/vmin/vmax, incl. inside clamp()) against the
     // real viewport. Must precede parse(), which computes styles for display:none filtering.
     gosub_css3::stylesheet::set_layout_viewport(viewport.width as f32, viewport.height as f32);
@@ -995,18 +997,9 @@ fn pipeline_build_cache<C: RenderConfiguration>(
     rasterizer: Option<&(dyn Rasterable + Send + Sync)>,
     strategy: RasterStrategy,
     prev_tile_cache: TilePixelCache,
-    media_store: Arc<gosub_render_pipeline::common::media::MediaStore>,
+    media_store: Arc<MediaStore>,
     tile_size: f64,
 ) -> PipelineCache {
-    use gosub_render_pipeline::common::document::pipeline_doc::GosubDocumentAdapter;
-    use gosub_render_pipeline::common::geo::{Dimension as PipelineDimension, Rect as PipelineRect};
-    use gosub_render_pipeline::layering::layer::LayerList;
-    use gosub_render_pipeline::layouter::taffy::TaffyLayouter;
-    use gosub_render_pipeline::layouter::CanLayout;
-    use gosub_render_pipeline::rendertree_builder::RenderTree;
-    use gosub_render_pipeline::tiler::TileList;
-    use gosub_shared::{timing_start, timing_stop};
-
     let ts_total = timing_start!("pipeline.total");
 
     // Resolve viewport-relative CSS units (vw/vh/vmin/vmax, incl. inside clamp()) against the
@@ -1059,7 +1052,7 @@ fn pipeline_build_cache<C: RenderConfiguration>(
 
     // Park the rest of the page: stages 5 and 6 below only touch dirty tiles.
     // Scrolling past the window's slack re-rasters around the new position.
-    gosub_render_pipeline::tile_budget::defer_tiles_outside_window(&mut tile_list, scroll_y, viewport.height as f64);
+    defer_tiles_outside_window(&mut tile_list, scroll_y, viewport.height as f64);
 
     let render_height = page_height;
     let ts5 = timing_start!("pipeline.painting");
@@ -1115,14 +1108,9 @@ fn pipeline_extend_raster(
     rasterizer: Option<&(dyn Rasterable + Send + Sync)>,
     strategy: RasterStrategy,
     prev_tile_cache: TilePixelCache,
-    media_store: Arc<gosub_render_pipeline::common::media::MediaStore>,
+    media_store: Arc<MediaStore>,
     tile_size: f64,
 ) -> PipelineCache {
-    use gosub_render_pipeline::common::geo::{Dimension as PipelineDimension, Rect as PipelineRect};
-    use gosub_render_pipeline::tile_budget::defer_tiles_outside_window;
-    use gosub_render_pipeline::tiler::{TileList, TileState};
-    use gosub_shared::{timing_start, timing_stop};
-
     // Stage 4: re-tile against the cached layout. No CSS, no layout.
     let ts4 = timing_start!("pipeline.extend.tiling");
     let mut tile_list = TileList::from_arc(Arc::clone(&layer_list), PipelineDimension::new(tile_size, tile_size));
@@ -1198,23 +1186,19 @@ fn pipeline_extend_raster(
 /// re-evaluation, no re-rasterization.
 #[allow(clippy::too_many_arguments)]
 fn pipeline_hover_repaint(
-    layer_list: Arc<gosub_render_pipeline::layering::layer::LayerList>,
+    layer_list: Arc<LayerList>,
     page_height: f64,
     prev_baked_tiles: Vec<BakedTile>,
     old_hover_lei: Option<LayoutElementId>,
     new_hover_lei: Option<LayoutElementId>,
     hover_dirty_nodes: &[NodeId],
-    viewport: &gosub_render_pipeline::render::Viewport,
+    viewport: &Viewport,
     rasterizer: Option<&(dyn Rasterable + Send + Sync)>,
     strategy: RasterStrategy,
     prev_tile_cache: TilePixelCache,
-    media_store: Arc<gosub_render_pipeline::common::media::MediaStore>,
+    media_store: Arc<MediaStore>,
     tile_size: f64,
 ) -> PipelineCache {
-    use gosub_render_pipeline::common::geo::{Dimension as PipelineDimension, Rect as PipelineRect};
-    use gosub_render_pipeline::tiler::{TileList, TileState};
-    use gosub_shared::{timing_start, timing_stop};
-
     // Stage 4: tiling — reuse existing LayerList, no layout work.
     let ts4 = timing_start!("pipeline.hover.tiling");
     let mut tile_list = TileList::from_arc(Arc::clone(&layer_list), PipelineDimension::new(tile_size, tile_size));
@@ -1350,14 +1334,11 @@ fn pipeline_hover_repaint(
 /// Stage 5: paint every dirty tile. Callers steer the work through tile state - carried-over
 /// (`Ready`) and out-of-window (`Deferred`) tiles are skipped.
 fn paint_dirty_tiles(
-    tile_list: &mut gosub_render_pipeline::tiler::TileList,
-    layer_ids: &[gosub_render_pipeline::layering::layer::LayerId],
-    full_page_rect: gosub_render_pipeline::common::geo::Rect,
+    tile_list: &mut TileList,
+    layer_ids: &[LayerId],
+    full_page_rect: PipelineRect,
     rasterizer: Option<&(dyn Rasterable + Send + Sync)>,
 ) {
-    use gosub_render_pipeline::common::browser_state::{BrowserState, WireframeState};
-    use gosub_render_pipeline::tiler::TileState;
-
     let paint_state = BrowserState {
         visible_layer_list: vec![true; layer_ids.len()],
         wireframed: WireframeState::None,
@@ -1393,9 +1374,9 @@ fn paint_dirty_tiles(
 /// `(page_x bits, page_y bits, layer_id)` → tile; positions with no baked tile (empty/transparent)
 /// are simply skipped.
 fn order_baked_tiles_by_layer(
-    tile_list: &gosub_render_pipeline::tiler::TileList,
-    layer_ids: &[gosub_render_pipeline::layering::layer::LayerId],
-    full_page_rect: gosub_render_pipeline::common::geo::Rect,
+    tile_list: &TileList,
+    layer_ids: &[LayerId],
+    full_page_rect: PipelineRect,
     mut by_key: std::collections::HashMap<(u64, u64, u64), BakedTile>,
 ) -> Vec<BakedTile> {
     let mut ordered = Vec::with_capacity(by_key.len());
@@ -1418,10 +1399,7 @@ fn order_baked_tiles_by_layer(
 /// Selects tiles that intersect `(scroll_x, scroll_y, vp_w, vp_h)` and blits them at
 /// screen-relative positions. This is the only work done on every scroll tick.
 fn pipeline_composite(cache: &PipelineCache, scroll_x: f64, scroll_y: f64, vp_w: f64, vp_h: f64, rl: &mut RenderList) {
-    use gosub_shared::{timing_start, timing_stop};
     let ts7 = timing_start!("pipeline.composite");
-
-    use gosub_render_pipeline::render::backend::anchored_tile_pos;
 
     for tile in &cache.tiles {
         // Resolve the tile's position in viewport space (fixed tiles ignore scroll), then cull
@@ -1591,7 +1569,6 @@ mod tests {
         use crate::html::DefaultRenderConfig;
         use gosub_config::settings::Setting;
         use gosub_css3::system::Css3System;
-        use gosub_render_pipeline::common::media::MediaStore;
         use gosub_render_pipeline::common::texture::TextureId;
         use gosub_render_pipeline::common::texture_store::TextureStore;
         use gosub_render_pipeline::render::backend::PixelFormat;

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -127,6 +127,9 @@ pub struct BrowsingContext<C: RenderConfiguration = crate::html::DefaultRenderCo
     scroll_y: f64,
     /// True when only the scroll offset changed (no full re-layout needed).
     scroll_dirty: bool,
+    /// True when the scroll moved far enough that the raster window must be extended.
+    /// Cheaper than `render_dirty`: extending re-uses the cached layout.
+    raster_dirty: bool,
 
     /// Cached rasterized tiles for the full page. Valid until render_dirty is set.
     pipeline_cache: Option<PipelineCache>,
@@ -189,6 +192,7 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
             scroll_x: 0.0,
             scroll_y: 0.0,
             scroll_dirty: false,
+            raster_dirty: false,
             pipeline_cache: None,
             scene_cache: None,
             hover_dirty: false,
@@ -241,6 +245,7 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
         self.pipeline_cache = None;
         self.scene_cache = None;
         self.tile_budget.reset();
+        self.raster_dirty = false;
         self.hover_dirty = false;
         self.hover_leaf = None;
         self.hover_layout_element = None;
@@ -263,6 +268,7 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
         self.pipeline_cache = None;
         self.scene_cache = None;
         self.tile_budget.reset();
+        self.raster_dirty = false;
     }
 
     /// Update the scroll offset without triggering a full re-layout.
@@ -280,10 +286,14 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
         self.scroll_x = x;
         self.scroll_y = y;
         self.scroll_dirty = true;
-        // Scrolling toward a region whose tiles were evicted by the cache budget: compositing
-        // alone cannot restore pixels, so schedule a full re-render to re-rasterize them.
-        if self.tile_budget.needs_rerender(y, self.viewport.height as f64) {
-            self.render_dirty = true;
+        // Compositing cannot conjure up tiles that were never rastered or were evicted, so ask
+        // for a window extension rather than a full (re-laying-out) render.
+        let page_height = self.active_page_height().unwrap_or(0.0);
+        if self
+            .tile_budget
+            .needs_rerender(y, self.viewport.height as f64, page_height)
+        {
+            self.raster_dirty = true;
         }
     }
 
@@ -334,6 +344,7 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
             self.pipeline_cache = Some(pipeline_build_cache(
                 doc.clone(),
                 &self.viewport,
+                self.scroll_y,
                 self.rasterizer.as_deref(),
                 self.raster_strategy,
                 prev_tile_cache,
@@ -341,7 +352,9 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
                 self.config_store.get_uint("renderer.tile.size") as f64,
             ));
         }
+        self.note_rastered_window();
         self.enforce_tile_budget(true);
+        self.raster_dirty = false;
         self.render_dirty = false;
         self.hover_dirty = false;
         self.dom_dirty = false;
@@ -349,9 +362,53 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
         self.layout_dirty = false;
     }
 
+    /// Extend the raster window around the current scroll position, re-using the cached layout.
+    /// Falls back to a full rebuild when there is no cache to extend.
+    fn extend_raster_window(&mut self) {
+        let Some(old_cache) = self.pipeline_cache.take() else {
+            self.rebuild_full_pipeline();
+            return;
+        };
+        let PipelineCache {
+            layer_list,
+            page_height,
+            tile_pixel_cache,
+            tiles,
+            ..
+        } = old_cache;
+
+        self.pipeline_cache = Some(pipeline_extend_raster(
+            layer_list,
+            page_height,
+            tiles,
+            &self.viewport,
+            self.scroll_y,
+            self.rasterizer.as_deref(),
+            self.raster_strategy,
+            tile_pixel_cache,
+            self.media_store.clone(),
+            self.config_store.get_uint("renderer.tile.size") as f64,
+        ));
+
+        self.note_rastered_window();
+        // Anything evicted that fell back inside the window has just been rastered again.
+        self.tile_budget.note_full_raster();
+        self.enforce_tile_budget(false);
+        self.raster_dirty = false;
+    }
+
+    /// Record the window now rastered, so scrolling can tell when it reaches unbaked content.
+    fn note_rastered_window(&self) {
+        let Some(cache) = self.pipeline_cache.as_ref() else {
+            return;
+        };
+        self.tile_budget
+            .note_rastered_window(self.scroll_y, self.viewport.height as f64, cache.page_height);
+    }
+
     /// Apply the `renderer.tile.cache_budget_mb` budget to the current pipeline cache, evicting
-    /// LRU tiles outside the near-viewport band. `full_raster` marks that every tile was just
-    /// re-rasterized, so previously evicted regions are live again.
+    /// LRU tiles outside the raster window. `full_raster` marks that every tile in the window was
+    /// just re-rasterized, so previously evicted regions are live again.
     fn enforce_tile_budget(&mut self, full_raster: bool) {
         if full_raster {
             self.tile_budget.note_full_raster();
@@ -383,11 +440,13 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
     /// - **Paint-only repaint** (`hover_dirty`): reuses the cached layout tree and repaints
     ///   only the affected tiles, skipping stages 1–2.
     pub fn rebuild_pipeline_cache_if_needed(&mut self) {
-        if !self.render_dirty && !self.hover_dirty && !self.scroll_dirty {
+        if !self.render_dirty && !self.hover_dirty && !self.scroll_dirty && !self.raster_dirty {
             return;
         }
         if self.render_dirty {
             self.rebuild_full_pipeline();
+        } else if self.raster_dirty {
+            self.extend_raster_window();
         } else if self.hover_dirty {
             // Paint-only repaint: reuse the cached layout tree, skip stages 1–2.
             if let Some(old_cache) = self.pipeline_cache.take() {
@@ -419,12 +478,14 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
                     self.pipeline_cache = Some(pipeline_build_cache(
                         doc.clone(),
                         &self.viewport,
+                        self.scroll_y,
                         self.rasterizer.as_deref(),
                         self.raster_strategy,
                         std::collections::HashMap::new(),
                         self.media_store.clone(),
                         self.config_store.get_uint("renderer.tile.size") as f64,
                     ));
+                    self.note_rastered_window();
                     self.enforce_tile_budget(true);
                 }
             }
@@ -442,12 +503,14 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
     /// - **Scroll composite** (`scroll_dirty`): re-composites visible tiles from the cache with
     ///   the new scroll offset. No layout or rasterization work.
     pub fn rebuild_render_list_if_needed(&mut self) {
-        if !self.render_dirty && !self.scroll_dirty {
+        if !self.render_dirty && !self.scroll_dirty && !self.raster_dirty {
             return;
         }
 
         if self.render_dirty {
             self.rebuild_full_pipeline();
+        } else if self.raster_dirty {
+            self.extend_raster_window();
         }
 
         let mut rl = RenderList::default();
@@ -555,7 +618,8 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
     ///
     /// Calling this consumes the scroll-dirty flag and advances the scene epoch.
     pub fn take_scroll_handle(&mut self, dpr: u32) -> Option<ExternalHandle> {
-        if !self.scroll_dirty || self.render_dirty || self.hover_dirty {
+        // With `raster_dirty` the cached tile list is missing tiles this frame needs.
+        if !self.scroll_dirty || self.render_dirty || self.hover_dirty || self.raster_dirty {
             return None;
         }
         let cache = self.pipeline_cache.as_ref()?;
@@ -917,29 +981,30 @@ fn pipeline_build_scene<C: RenderConfiguration>(
     }
 }
 
-/// Runs pipeline stages 1–6 for the **entire page** (all tiles, not just the viewport slice)
-/// and returns a `PipelineCache` of rasterized tiles ready for repeated compositing.
+/// Runs pipeline stages 1–6 and returns a `PipelineCache` of rasterized tiles ready for repeated
+/// compositing. Layout and tiling cover the whole page, but painting and rasterization cover only
+/// the raster window around `scroll_y`, so first paint never pays for content nobody scrolls to.
 ///
 /// Splitting the full pipeline from compositing lets scroll re-use the cached tiles without
 /// re-running layout or rasterization.
+#[allow(clippy::too_many_arguments)]
 fn pipeline_build_cache<C: RenderConfiguration>(
     doc: Arc<EngineDocument<C>>,
     viewport: &Viewport,
+    scroll_y: f64,
     rasterizer: Option<&(dyn Rasterable + Send + Sync)>,
     strategy: RasterStrategy,
     prev_tile_cache: TilePixelCache,
     media_store: Arc<gosub_render_pipeline::common::media::MediaStore>,
     tile_size: f64,
 ) -> PipelineCache {
-    use gosub_render_pipeline::common::browser_state::{BrowserState, WireframeState};
     use gosub_render_pipeline::common::document::pipeline_doc::GosubDocumentAdapter;
     use gosub_render_pipeline::common::geo::{Dimension as PipelineDimension, Rect as PipelineRect};
     use gosub_render_pipeline::layering::layer::LayerList;
     use gosub_render_pipeline::layouter::taffy::TaffyLayouter;
     use gosub_render_pipeline::layouter::CanLayout;
-    use gosub_render_pipeline::painter::Painter;
     use gosub_render_pipeline::rendertree_builder::RenderTree;
-    use gosub_render_pipeline::tiler::{TileList, TileState};
+    use gosub_render_pipeline::tiler::TileList;
     use gosub_shared::{timing_start, timing_stop};
 
     let ts_total = timing_start!("pipeline.total");
@@ -992,41 +1057,15 @@ fn pipeline_build_cache<C: RenderConfiguration>(
     tile_list.generate();
     timing_stop!(ts4);
 
-    // Stage 5: paint all tiles for the full page so that scrolling reveals pre-rendered
-    // content. We use the full page_height rather than capping to viewport.height; the
-    // compositor only ships the visible subset to the screen anyway, so no extra pixels
-    // are transferred. Memory is bounded by tile count: at 256×256×4B per tile, a 6 000 px
-    // page × 1 280 px wide = ~120 tiles × 256 KB each ≈ 30 MB, which is acceptable.
+    // Park the rest of the page: stages 5 and 6 below only touch dirty tiles.
+    // Scrolling past the window's slack re-rasters around the new position.
+    gosub_render_pipeline::tile_budget::defer_tiles_outside_window(&mut tile_list, scroll_y, viewport.height as f64);
+
     let render_height = page_height;
     let ts5 = timing_start!("pipeline.painting");
     let full_page_rect = PipelineRect::new(0.0, 0.0, viewport.width as f64, render_height.max(1.0));
     let layer_ids = tile_list.layer_list.layer_ids.read().clone();
-    let paint_state = BrowserState {
-        visible_layer_list: vec![true; layer_ids.len()],
-        wireframed: WireframeState::None,
-        debug_hover: false,
-        current_hovered_element: None,
-        show_tilegrid: false,
-        debug_table_cells: std::env::var("GOSUB_DEBUG_TABLE_CELLS").is_ok(),
-        viewport: full_page_rect,
-        tile_list: None,
-        dpi_scale_factor: 1.0,
-    };
-    let painter = Painter::new(tile_list.layer_list.clone(), rasterizer.and_then(|r| r.font_system()));
-    for &layer_id in &layer_ids {
-        let tile_ids = tile_list.get_intersecting_tiles(layer_id, full_page_rect);
-        for tile_id in tile_ids {
-            let Some(tile) = tile_list.get_tile_mut(tile_id) else {
-                continue;
-            };
-            if tile.state != TileState::Dirty {
-                continue;
-            }
-            for tiled_element in &mut tile.elements {
-                tiled_element.paint_commands = painter.paint(tiled_element, &paint_state);
-            }
-        }
-    }
+    paint_dirty_tiles(&mut tile_list, &layer_ids, full_page_rect, rasterizer);
     timing_stop!(ts5);
 
     // Stage 6: rasterize tiles using the active backend's rasterizer + strategy (chosen at
@@ -1063,6 +1102,96 @@ fn pipeline_build_cache<C: RenderConfiguration>(
     }
 }
 
+/// Extend the raster window after a scroll: reuse the cached `LayerList` (so stages 1–2 are
+/// skipped) and raster only the tiles that are newly inside the window. This is what keeps
+/// scrolling a long page off the layout path.
+#[allow(clippy::too_many_arguments)]
+fn pipeline_extend_raster(
+    layer_list: Arc<LayerList>,
+    page_height: f64,
+    prev_baked_tiles: Vec<BakedTile>,
+    viewport: &Viewport,
+    scroll_y: f64,
+    rasterizer: Option<&(dyn Rasterable + Send + Sync)>,
+    strategy: RasterStrategy,
+    prev_tile_cache: TilePixelCache,
+    media_store: Arc<gosub_render_pipeline::common::media::MediaStore>,
+    tile_size: f64,
+) -> PipelineCache {
+    use gosub_render_pipeline::common::geo::{Dimension as PipelineDimension, Rect as PipelineRect};
+    use gosub_render_pipeline::tile_budget::defer_tiles_outside_window;
+    use gosub_render_pipeline::tiler::{TileList, TileState};
+    use gosub_shared::{timing_start, timing_stop};
+
+    // Stage 4: re-tile against the cached layout. No CSS, no layout.
+    let ts4 = timing_start!("pipeline.extend.tiling");
+    let mut tile_list = TileList::from_arc(Arc::clone(&layer_list), PipelineDimension::new(tile_size, tile_size));
+    tile_list.generate();
+    timing_stop!(ts4);
+
+    // Already-baked tiles are carried over; the rest of the window is painted below.
+    let mut prev_by_pos: std::collections::HashMap<(u64, u64, u64), BakedTile> = prev_baked_tiles
+        .into_iter()
+        .map(|t| ((t.page_x.to_bits(), t.page_y.to_bits(), t.layer_id), t))
+        .collect();
+
+    let mut clean_baked: Vec<BakedTile> = Vec::with_capacity(prev_by_pos.len());
+    for tile in tile_list.arena.values_mut() {
+        let key = (tile.rect.x.to_bits(), tile.rect.y.to_bits(), tile.layer_id.as_u64());
+        let Some(baked) = prev_by_pos.remove(&key) else {
+            continue;
+        };
+        tile.state = TileState::Ready;
+        clean_baked.push(baked);
+    }
+    defer_tiles_outside_window(&mut tile_list, scroll_y, viewport.height as f64);
+
+    let full_page_rect = PipelineRect::new(0.0, 0.0, viewport.width as f64, page_height.max(1.0));
+    let layer_ids = tile_list.layer_list.layer_ids.read().clone();
+
+    // Stage 5: only the newly in-window tiles are still dirty.
+    let ts5 = timing_start!("pipeline.extend.painting");
+    paint_dirty_tiles(&mut tile_list, &layer_ids, full_page_rect, rasterizer);
+    timing_stop!(ts5);
+
+    // Stage 6: the pixel cache makes tiles that were merely evicted cheap to bring back.
+    let (baked_tiles, new_tile_cache) = match (strategy, rasterizer) {
+        (RasterStrategy::ParallelCached, Some(rasterizer)) => rasterize_parallel(
+            rasterizer,
+            &layer_ids,
+            &mut tile_list,
+            full_page_rect,
+            &media_store,
+            &prev_tile_cache,
+            "pipeline.extend.rasterize",
+        ),
+        (RasterStrategy::Sequential, Some(rasterizer)) => {
+            rasterize_sequential(rasterizer, &layer_ids, &mut tile_list, full_page_rect, &media_store)
+        }
+        _ => (Vec::new(), std::collections::HashMap::new()),
+    };
+
+    // Keep carried-over entries: dropping them re-rasters those tiles on the next pass over.
+    let mut merged_tile_cache = prev_tile_cache;
+    merged_tile_cache.extend(new_tile_cache);
+
+    let by_key: std::collections::HashMap<(u64, u64, u64), BakedTile> = baked_tiles
+        .into_iter()
+        .chain(clean_baked)
+        .map(|t| ((t.page_x.to_bits(), t.page_y.to_bits(), t.layer_id), t))
+        .collect();
+    let all_baked_tiles = order_baked_tiles_by_layer(&tile_list, &layer_ids, full_page_rect, by_key);
+    let cached_tiles = Arc::new(cpu_cached_tiles(&all_baked_tiles));
+
+    PipelineCache {
+        tiles: all_baked_tiles,
+        page_height,
+        cached_tiles,
+        layer_list,
+        tile_pixel_cache: merged_tile_cache,
+    }
+}
+
 /// Hover-only repaint: skip stages 1–2 (render-tree + layout), reuse the cached
 /// `LayerList`, and only repaint tiles that intersect the old or new hovered element.
 /// All other tiles are carried over from `prev_baked_tiles` unchanged - no CSS
@@ -1082,9 +1211,7 @@ fn pipeline_hover_repaint(
     media_store: Arc<gosub_render_pipeline::common::media::MediaStore>,
     tile_size: f64,
 ) -> PipelineCache {
-    use gosub_render_pipeline::common::browser_state::{BrowserState, WireframeState};
     use gosub_render_pipeline::common::geo::{Dimension as PipelineDimension, Rect as PipelineRect};
-    use gosub_render_pipeline::painter::Painter;
     use gosub_render_pipeline::tiler::{TileList, TileState};
     use gosub_shared::{timing_start, timing_stop};
 
@@ -1178,32 +1305,7 @@ fn pipeline_hover_repaint(
     // Stage 5: paint ONLY dirty (hover-affected) tiles. `full_page_rect` and `layer_ids` were
     // computed above (shared with the carry-over ordering).
     let ts5 = timing_start!("pipeline.hover.painting");
-    let paint_state = BrowserState {
-        visible_layer_list: vec![true; layer_ids.len()],
-        wireframed: WireframeState::None,
-        debug_hover: false,
-        current_hovered_element: None,
-        show_tilegrid: false,
-        debug_table_cells: std::env::var("GOSUB_DEBUG_TABLE_CELLS").is_ok(),
-        viewport: full_page_rect,
-        tile_list: None,
-        dpi_scale_factor: 1.0,
-    };
-    let painter = Painter::new(tile_list.layer_list.clone(), rasterizer.and_then(|r| r.font_system()));
-    for &layer_id in &layer_ids {
-        let tile_ids = tile_list.get_intersecting_tiles(layer_id, full_page_rect);
-        for tile_id in tile_ids {
-            let Some(tile) = tile_list.get_tile_mut(tile_id) else {
-                continue;
-            };
-            if tile.state != TileState::Dirty {
-                continue;
-            }
-            for tiled_element in &mut tile.elements {
-                tiled_element.paint_commands = painter.paint(tiled_element, &paint_state);
-            }
-        }
-    }
+    paint_dirty_tiles(&mut tile_list, &layer_ids, full_page_rect, rasterizer);
     timing_stop!(ts5);
 
     // Stage 6 (hover): rasterize the dirty tiles with the active backend's rasterizer + strategy.
@@ -1242,6 +1344,45 @@ fn pipeline_hover_repaint(
         cached_tiles,
         layer_list,
         tile_pixel_cache: new_tile_cache,
+    }
+}
+
+/// Stage 5: paint every dirty tile. Callers steer the work through tile state - carried-over
+/// (`Ready`) and out-of-window (`Deferred`) tiles are skipped.
+fn paint_dirty_tiles(
+    tile_list: &mut gosub_render_pipeline::tiler::TileList,
+    layer_ids: &[gosub_render_pipeline::layering::layer::LayerId],
+    full_page_rect: gosub_render_pipeline::common::geo::Rect,
+    rasterizer: Option<&(dyn Rasterable + Send + Sync)>,
+) {
+    use gosub_render_pipeline::common::browser_state::{BrowserState, WireframeState};
+    use gosub_render_pipeline::tiler::TileState;
+
+    let paint_state = BrowserState {
+        visible_layer_list: vec![true; layer_ids.len()],
+        wireframed: WireframeState::None,
+        debug_hover: false,
+        current_hovered_element: None,
+        show_tilegrid: false,
+        debug_table_cells: std::env::var("GOSUB_DEBUG_TABLE_CELLS").is_ok(),
+        viewport: full_page_rect,
+        tile_list: None,
+        dpi_scale_factor: 1.0,
+    };
+    let painter = Painter::new(tile_list.layer_list.clone(), rasterizer.and_then(|r| r.font_system()));
+
+    for &layer_id in layer_ids {
+        for tile_id in tile_list.get_intersecting_tiles(layer_id, full_page_rect) {
+            let Some(tile) = tile_list.get_tile_mut(tile_id) else {
+                continue;
+            };
+            if tile.state != TileState::Dirty {
+                continue;
+            }
+            for tiled_element in &mut tile.elements {
+                tiled_element.paint_commands = painter.paint(tiled_element, &paint_state);
+            }
+        }
     }
 }
 
@@ -1455,13 +1596,17 @@ mod tests {
         use gosub_render_pipeline::common::texture_store::TextureStore;
         use gosub_render_pipeline::render::backend::PixelFormat;
         use gosub_render_pipeline::tiler::Tile;
+        use std::sync::atomic::{AtomicUsize, Ordering};
 
-        /// Stub backend rasterizer: fills every tile with opaque pixels, so each baked tile
-        /// costs exactly width * height * 4 bytes.
-        struct SolidRasterizer;
+        /// Fills every tile with opaque pixels, so a baked tile costs exactly w * h * 4 bytes.
+        /// The shared counter lets tests assert how many tiles a pass actually rasterized.
+        struct SolidRasterizer {
+            calls: Arc<AtomicUsize>,
+        }
 
         impl Rasterable for SolidRasterizer {
             fn rasterize(&self, tile: &Tile, store: &mut TextureStore, _media: &MediaStore) -> Option<TextureId> {
+                self.calls.fetch_add(1, Ordering::Relaxed);
                 let (w, h) = (tile.rect.width as usize, tile.rect.height as usize);
                 Some(store.add(w, h, vec![0xFFu8; w * h * 4], PixelFormat::PreMulArgb32))
             }
@@ -1491,70 +1636,125 @@ mod tests {
             cache.tiles.iter().any(|t| (t.page_y - y).abs() <= within)
         }
 
-        #[test]
-        fn tall_page_cache_stays_under_budget_and_scroll_restores_evicted_tiles() {
-            const BUDGET_MB: usize = 4;
-            const BUDGET_BYTES: usize = BUDGET_MB * 1024 * 1024;
+        const VP_H: u32 = 256;
 
+        /// A context on a 10 000 px page: ~40 tile rows if fully rastered (~20 MiB), against a
+        /// raster window three viewports tall.
+        fn tall_page_context(budget_mb: usize) -> (BrowsingContext<DefaultRenderConfig>, Arc<AtomicUsize>) {
             let config = settings_store::default_config();
             assert!(config
-                .set("renderer.tile.cache_budget_mb", Setting::UInt(BUDGET_MB))
+                .set("renderer.tile.cache_budget_mb", Setting::UInt(budget_mb))
                 .is_ok());
 
             let mut ctx: BrowsingContext<DefaultRenderConfig> = BrowsingContext::new(config);
-            ctx.set_rasterizer(Box::new(SolidRasterizer), RasterStrategy::ParallelCached);
+            let calls = Arc::new(AtomicUsize::new(0));
+            ctx.set_rasterizer(
+                Box::new(SolidRasterizer {
+                    calls: Arc::clone(&calls),
+                }),
+                RasterStrategy::ParallelCached,
+            );
             ctx.set_viewport(Viewport {
                 x: 0,
                 y: 0,
                 width: 512,
-                height: 256,
+                height: VP_H,
             });
 
-            // ~10 000 px tall page: ~40 tile rows x 2 columns ~= 20 MiB unbudgeted.
             let html =
                 r#"<html><body style="margin:0"><div style="height:10000px;background:#ddd"></div></body></html>"#;
             let mut doc = gosub_html5::html_compile::<DefaultRenderConfig>(html);
             doc.add_stylesheet(Css3System::load_default_useragent_stylesheet());
             ctx.set_document(Arc::new(doc));
 
-            ctx.rebuild_pipeline_cache_if_needed();
-            {
-                let Some(cache) = ctx.pipeline_cache.as_ref() else {
-                    unreachable!("pipeline cache must exist after rebuild");
-                };
-                assert!(cache.page_height >= 10_000.0, "page must lay out tall");
-                assert!(
-                    resident_bytes(cache) <= BUDGET_BYTES,
-                    "cache must fit the budget: {} > {}",
-                    resident_bytes(cache),
-                    BUDGET_BYTES
-                );
-                assert!(has_tile_near(cache, 0.0, 0.5), "viewport tiles must survive");
-                assert!(
-                    !has_tile_near(cache, 9984.0, 256.0),
-                    "bottom of the page must be evicted"
-                );
-                assert_eq!(
-                    cache.cached_tiles.len(),
-                    cache.tiles.len(),
-                    "compositor list must not keep evicted pixels alive"
-                );
-            }
+            (ctx, calls)
+        }
 
-            // Scrolling toward an evicted region must schedule a full re-render...
-            ctx.set_scroll(0.0, 5000.0);
-            assert!(ctx.render_dirty, "scroll into an evicted region must set render_dirty");
+        #[test]
+        fn first_render_rasterizes_only_the_window_of_a_tall_page() {
+            let (mut ctx, raster_calls) = tall_page_context(128);
 
-            // ...which restores tiles around the new viewport while staying under budget.
             ctx.rebuild_pipeline_cache_if_needed();
+
+            let calls = raster_calls.swap(0, Ordering::Relaxed);
             let Some(cache) = ctx.pipeline_cache.as_ref() else {
                 unreachable!("pipeline cache must exist after rebuild");
             };
+            assert!(cache.page_height >= 10_000.0, "page must lay out tall");
+
+            // The window at scroll 0 spans 2 tile rows; the whole page would be ~40.
             assert!(
-                has_tile_near(cache, 5000.0, 256.0),
-                "tiles near the new viewport must be back"
+                (1..=12).contains(&calls),
+                "first paint rastered {calls} tiles, expected only the window"
             );
-            assert!(resident_bytes(cache) <= BUDGET_BYTES);
+            assert!(has_tile_near(cache, 0.0, 0.5), "the viewport itself must be baked");
+            assert!(
+                !has_tile_near(cache, 5000.0, 256.0),
+                "content far below the viewport must stay deferred"
+            );
+            assert_eq!(cache.cached_tiles.len(), cache.tiles.len());
+        }
+
+        #[test]
+        fn scrolling_extends_the_window_without_relaying_out() {
+            let (mut ctx, raster_calls) = tall_page_context(128);
+            ctx.rebuild_pipeline_cache_if_needed();
+            let first_pass = raster_calls.swap(0, Ordering::Relaxed);
+            let page_height = ctx.page_height();
+
+            // Inside the slack: composite-only.
+            ctx.set_scroll(0.0, 50.0);
+            assert!(!ctx.raster_dirty, "small scroll must not schedule rasterization");
+
+            // Past it: an extension, not a full re-render.
+            ctx.set_scroll(0.0, 5000.0);
+            assert!(ctx.raster_dirty, "scrolling to unbaked content must raster");
+            assert!(!ctx.render_dirty, "extending must not force a re-layout");
+            assert!(
+                ctx.take_scroll_handle(1).is_none(),
+                "the composite-only path must not serve a frame with unbaked tiles"
+            );
+
+            ctx.rebuild_pipeline_cache_if_needed();
+
+            let extend_pass = raster_calls.swap(0, Ordering::Relaxed);
+            let Some(cache) = ctx.pipeline_cache.as_ref() else {
+                unreachable!("pipeline cache must exist after extend");
+            };
+            assert!(has_tile_near(cache, 5000.0, 256.0), "the new viewport must be baked");
+            assert!(
+                extend_pass <= first_pass * 3,
+                "extending rastered {extend_pass} tiles, expected a window"
+            );
+            assert_eq!(ctx.page_height(), page_height, "extending must reuse the cached layout");
+            assert!(!ctx.raster_dirty, "the extension must satisfy the scroll");
+        }
+
+        #[test]
+        fn cache_stays_under_budget_while_scrolling_the_whole_page() {
+            const BUDGET_MB: usize = 4;
+            const BUDGET_BYTES: usize = BUDGET_MB * 1024 * 1024;
+
+            let (mut ctx, _calls) = tall_page_context(BUDGET_MB);
+            ctx.rebuild_pipeline_cache_if_needed();
+
+            // Doom-scroll the whole page in viewport-sized steps.
+            let mut y = 0.0;
+            while y < 10_000.0 {
+                ctx.set_scroll(0.0, y);
+                ctx.rebuild_pipeline_cache_if_needed();
+
+                let Some(cache) = ctx.pipeline_cache.as_ref() else {
+                    unreachable!("pipeline cache must exist while scrolling");
+                };
+                assert!(
+                    resident_bytes(cache) <= BUDGET_BYTES,
+                    "cache must stay within budget at scroll {y}: {} > {BUDGET_BYTES}",
+                    resident_bytes(cache)
+                );
+                assert!(has_tile_near(cache, y, VP_H as f64), "viewport not baked at scroll {y}");
+                y += VP_H as f64;
+            }
         }
     }
 

--- a/crates/gosub_render_pipeline/src/tile_budget.rs
+++ b/crates/gosub_render_pipeline/src/tile_budget.rs
@@ -1,14 +1,12 @@
-//! Tile-cache memory budget with LRU eviction.
+//! Tile raster window and cache memory budget with LRU eviction.
 //!
-//! The pipeline rasterizes every tile of the full page eagerly, so without a bound a very tall
-//! page holds hundreds of megabytes of pixels. [`TileBudget`] caps the bytes held by a page's
-//! [`BakedTile`]s and the cross-render [`TilePixelCache`], evicting least-recently-composited
-//! tiles first while never touching the near-viewport band.
+//! Both halves work off one [`raster_window`]: tiles inside it are rasterized and never evicted,
+//! tiles outside it are deferred ([`defer_tiles_outside_window`]) or evicted ([`TileBudget`]).
+//! Sharing the window is what stops generation from producing tiles eviction instantly discards.
 //!
-//! Eviction only removes pixels and records where they were - restoring an evicted tile is the
-//! caller's decision (per-tile re-rasterization is not always possible, e.g. remotely rendered
-//! caches). The caller polls [`TileBudget::needs_rerender`] on scroll and schedules a full
-//! re-render when an evicted region approaches the viewport.
+//! Eviction only removes pixels and records where they were - restoring them is the caller's
+//! decision, since per-tile re-rasterization is not always possible (e.g. remotely rendered
+//! caches). Callers poll [`TileBudget::needs_rerender`] on scroll.
 
 use std::collections::{HashMap, HashSet};
 
@@ -18,6 +16,7 @@ use crate::common::geo::Rect;
 use crate::common::texture::TilePixels;
 use crate::rasterizer::{BakedTile, TilePixelCache};
 use crate::render::backend::{anchored_tile_pos, TileAnchor};
+use crate::tiler::{TileList, TileState};
 
 /// A tile's position identity: (page_x bits, page_y bits, layer id). One eviction unit covers
 /// the baked tile at that position plus any pixel-cache entries for it.
@@ -45,6 +44,8 @@ struct BudgetState {
     last_used: HashMap<TilePosKey, u64>,
     /// Page-space rects whose tiles were evicted; scrolling near one requires a re-render.
     evicted: Vec<Rect>,
+    /// Page-space `(lo, hi)` band last rasterized, clamped to the page. `None` before first raster.
+    rastered: Option<(f64, f64)>,
 }
 
 /// LRU bookkeeping and budget enforcement for one browsing context's tile caches.
@@ -54,10 +55,54 @@ pub struct TileBudget {
     state: Mutex<BudgetState>,
 }
 
-/// The never-evict band in page space: the viewport plus one viewport height above and below.
-/// The band spans the full page width so horizontal scrolling cannot land on a hole.
-fn protection_band(scroll_y: f64, vp_h: f64) -> (f64, f64) {
-    (scroll_y - vp_h, scroll_y + 2.0 * vp_h)
+/// Viewport heights rasterized above and below the viewport, so scrolling reveals ready tiles.
+pub const RASTER_MARGIN_VIEWPORTS: f64 = 1.0;
+
+/// Viewport heights of slack before the window is re-rastered. Smaller than
+/// [`RASTER_MARGIN_VIEWPORTS`], so the re-raster is scheduled while ready tiles remain ahead.
+pub const REFRESH_MARGIN_VIEWPORTS: f64 = 0.5;
+
+/// The rasterized band in page space. It spans the full page width, so horizontal scrolling
+/// cannot land on a hole.
+pub fn raster_window(scroll_y: f64, vp_h: f64) -> (f64, f64) {
+    let margin = RASTER_MARGIN_VIEWPORTS * vp_h;
+    (scroll_y - margin, scroll_y + vp_h + margin)
+}
+
+/// The band that must be resident before the next frame; escaping it triggers a re-raster.
+fn refresh_window(scroll_y: f64, vp_h: f64) -> (f64, f64) {
+    let margin = REFRESH_MARGIN_VIEWPORTS * vp_h;
+    (scroll_y - margin, scroll_y + vp_h + margin)
+}
+
+fn clamp_to_page(window: (f64, f64), page_height: f64) -> (f64, f64) {
+    let page_bottom = page_height.max(0.0);
+    (window.0.max(0.0), window.1.min(page_bottom).max(0.0))
+}
+
+/// Park dirty tiles outside the raster window in [`TileState::Deferred`] so stages 5 and 6 skip
+/// them; returns how many were parked. Viewport-pinned layers are exempt: their page positions
+/// do not track scroll, so a page-space window says nothing about whether they are on screen.
+pub fn defer_tiles_outside_window(tile_list: &mut TileList, scroll_y: f64, vp_h: f64) -> usize {
+    let (lo, hi) = raster_window(scroll_y, vp_h);
+    let layer_list = std::sync::Arc::clone(&tile_list.layer_list);
+    let mut deferred = 0;
+
+    for tile in tile_list.arena.values_mut() {
+        if tile.state != TileState::Dirty {
+            continue;
+        }
+        if layer_list.layer_anchor(tile.layer_id) != TileAnchor::Scroll {
+            continue;
+        }
+        if tile.rect.y < hi && tile.rect.y + tile.rect.height > lo {
+            continue;
+        }
+        tile.state = TileState::Deferred;
+        deferred += 1;
+    }
+
+    deferred
 }
 
 impl TileBudget {
@@ -72,11 +117,18 @@ impl TileBudget {
         st.tick = 0;
         st.last_used.clear();
         st.evicted.clear();
+        st.rastered = None;
     }
 
     /// Every tile was just re-rasterized, so previously evicted regions are live again.
     pub fn note_full_raster(&self) {
         self.state.lock().evicted.clear();
+    }
+
+    /// Record the window that is now rasterized; [`Self::needs_rerender`] measures against it.
+    pub fn note_rastered_window(&self, scroll_y: f64, vp_h: f64, page_height: f64) {
+        let window = clamp_to_page(raster_window(scroll_y, vp_h), page_height);
+        self.state.lock().rastered = Some(window);
     }
 
     /// Stamp the tiles visible at the given scroll position as most-recently composited.
@@ -94,22 +146,29 @@ impl TileBudget {
         }
     }
 
-    /// True when the near-viewport band at the given scroll position overlaps an evicted region.
-    /// Compositing alone cannot restore evicted pixels; the caller must schedule a re-render.
-    pub fn needs_rerender(&self, scroll_y: f64, vp_h: f64) -> bool {
-        let (lo, hi) = protection_band(scroll_y, vp_h);
-        self.state
-            .lock()
-            .evicted
-            .iter()
-            .any(|r| r.y < hi && r.y + r.height > lo)
+    /// True when content the viewport is about to need was never rastered or has been evicted.
+    /// Compositing cannot conjure either back, so the caller must re-raster the window.
+    pub fn needs_rerender(&self, scroll_y: f64, vp_h: f64, page_height: f64) -> bool {
+        let (lo, hi) = clamp_to_page(refresh_window(scroll_y, vp_h), page_height);
+        let st = self.state.lock();
+
+        if st.evicted.iter().any(|r| r.y < hi && r.y + r.height > lo) {
+            return true;
+        }
+
+        // Tolerance keeps sub-pixel scroll jitter at a page edge from re-rastering every frame.
+        const EPS: f64 = 0.5;
+        match st.rastered {
+            None => false,
+            Some((rlo, rhi)) => lo < rlo - EPS || hi > rhi + EPS,
+        }
     }
 
     /// Evict least-recently-composited tile positions until resident pixel bytes fit
     /// `budget_bytes` (`0` disables enforcement).
     ///
-    /// Never evicted: tiles overlapping the protection band (viewport ± one viewport height),
-    /// fixed/sticky tiles (viewport-pinned regardless of scroll), and GPU-resident tiles
+    /// Never evicted: tiles overlapping the [`raster_window`], fixed/sticky tiles
+    /// (viewport-pinned regardless of scroll), and GPU-resident tiles
     /// (their memory lives in the backend's texture store, not here). Ties in LRU age evict
     /// the position farthest from the viewport first.
     pub fn enforce(
@@ -127,7 +186,7 @@ impl TileBudget {
         }
 
         let mut st = self.state.lock();
-        let (band_lo, band_hi) = protection_band(scroll_y, vp_h);
+        let (band_lo, band_hi) = raster_window(scroll_y, vp_h);
 
         // Aggregate resident bytes per tile position. Pixel buffers are `Bytes` and shared
         // between a BakedTile, its CachedTile and its pixel-cache entry, so identical buffers
@@ -374,21 +433,164 @@ mod tests {
 
     #[test]
     fn needs_rerender_tracks_evicted_regions() {
+        const PAGE: f64 = 8000.0;
         let budget = TileBudget::new();
         let mut tiles = column(2);
         tiles.push(tile(0.0, 4000.0, 0));
         let mut cache = TilePixelCache::new();
 
+        // Pretend the whole page was rastered, so only eviction can create a hole.
+        budget.note_rastered_window(PAGE / 2.0, PAGE, PAGE);
         budget.enforce(&mut tiles, &mut cache, 0.0, TILE, 2 * TILE_BYTES);
         assert!(!has_tile_at(&tiles, 4000.0));
 
-        assert!(!budget.needs_rerender(0.0, TILE), "evicted region is far away");
-        assert!(budget.needs_rerender(3800.0, TILE), "band reaches the evicted region");
+        assert!(!budget.needs_rerender(0.0, TILE, PAGE), "evicted region is far away");
+        assert!(
+            budget.needs_rerender(3900.0, TILE, PAGE),
+            "refresh window reaches the evicted region"
+        );
 
         budget.note_full_raster();
         assert!(
-            !budget.needs_rerender(3800.0, TILE),
+            !budget.needs_rerender(3900.0, TILE, PAGE),
             "full re-raster restores everything"
         );
+    }
+
+    #[test]
+    fn needs_rerender_follows_the_rastered_window() {
+        const PAGE: f64 = 10_000.0;
+        let budget = TileBudget::new();
+
+        // Nothing rastered yet: the caller is about to render anyway, so don't ask for another.
+        assert!(!budget.needs_rerender(0.0, TILE, PAGE));
+
+        // Rastered around the top: window [0, 512]; the refresh window at scroll 0 is [0, 384].
+        budget.note_rastered_window(0.0, TILE, PAGE);
+        assert!(!budget.needs_rerender(0.0, TILE, PAGE), "fresh window needs nothing");
+        assert!(
+            !budget.needs_rerender(100.0, TILE, PAGE),
+            "small scroll stays inside the slack"
+        );
+        assert!(
+            budget.needs_rerender(300.0, TILE, PAGE),
+            "scrolling past the slack must extend the window"
+        );
+
+        // Extending around the new position satisfies the demand again.
+        budget.note_rastered_window(300.0, TILE, PAGE);
+        assert!(!budget.needs_rerender(300.0, TILE, PAGE));
+    }
+
+    #[test]
+    fn page_edges_do_not_re_raster_forever() {
+        const PAGE: f64 = 1000.0;
+        let budget = TileBudget::new();
+
+        // At either page edge the windows run past the page; clamping both to the page is what
+        // stops a permanent "needs re-raster" there.
+        let bottom = PAGE - TILE;
+        budget.note_rastered_window(bottom, TILE, PAGE);
+        assert!(!budget.needs_rerender(bottom, TILE, PAGE));
+
+        budget.note_rastered_window(0.0, TILE, PAGE);
+        assert!(!budget.needs_rerender(0.0, TILE, PAGE));
+    }
+
+    /// Tiles a real 6 000 px layout, so the deferral policy is exercised against the actual
+    /// `TileList` the pipeline builds rather than a hand-made stand-in.
+    mod deferral {
+        use super::*;
+        use crate::common::document::pipeline_doc::GosubDocumentAdapter;
+        use crate::common::geo::Dimension;
+        use crate::layering::layer::LayerList;
+        use crate::layouter::taffy::TaffyLayouter;
+        use crate::layouter::CanLayout;
+        use crate::rendertree_builder::RenderTree;
+        use crate::tiler::TileList;
+        use gosub_css3::system::Css3System;
+        use gosub_html5::document::document_impl::DocumentImpl;
+        use gosub_html5::html_compile;
+        use gosub_html5::parser::Html5Parser;
+        use gosub_interface::config::ModuleConfiguration;
+        use gosub_interface::css3::CssSystem as _;
+        use gosub_interface::document::Document as _;
+        use std::sync::Arc;
+
+        #[derive(Clone, Debug, PartialEq)]
+        struct Config;
+
+        impl ModuleConfiguration for Config {
+            type CssSystem = Css3System;
+            type Document = DocumentImpl<Self>;
+            type HtmlParser = Html5Parser<'static, Self>;
+        }
+
+        fn tall_page_tiles() -> TileList {
+            let mut doc = html_compile::<Config>(
+                r#"<html><body style="margin:0"><div style="height:6000px;background:#ccc"></div></body></html>"#,
+            );
+            doc.add_stylesheet(Css3System::load_default_useragent_stylesheet());
+
+            let mut render_tree = RenderTree::new(Arc::new(GosubDocumentAdapter::<Config>::new(Arc::new(doc))));
+            let _ = render_tree.parse();
+
+            let layout_tree = TaffyLayouter::new().layout(render_tree, Some(Dimension::new(512.0, TILE)), 1.0);
+            let mut tile_list = TileList::new(LayerList::new(layout_tree), Dimension::new(TILE, TILE));
+            tile_list.generate();
+            tile_list
+        }
+
+        fn count(tile_list: &TileList, state: TileState) -> usize {
+            tile_list.arena.values().filter(|t| t.state == state).count()
+        }
+
+        #[test]
+        fn defers_tiles_outside_the_window_only() {
+            let mut tile_list = tall_page_tiles();
+            let total = tile_list.arena.len();
+            assert!(total > 20, "a 6 000 px page must produce many tiles, got {total}");
+
+            let deferred = defer_tiles_outside_window(&mut tile_list, 0.0, TILE);
+            let dirty = count(&tile_list, TileState::Dirty);
+
+            assert_eq!(deferred + dirty, total, "every tile is either deferred or paintable");
+            assert!(dirty > 0, "the window itself must stay paintable");
+            assert!(
+                deferred > dirty,
+                "far more of a tall page is out of window than in it ({deferred} vs {dirty})"
+            );
+
+            // Everything still dirty must intersect the window; everything deferred must not.
+            let (lo, hi) = raster_window(0.0, TILE);
+            for tile in tile_list.arena.values() {
+                let in_window = tile.rect.y < hi && tile.rect.y + tile.rect.height > lo;
+                match tile.state {
+                    TileState::Dirty => assert!(in_window, "kept an out-of-window tile at y={}", tile.rect.y),
+                    TileState::Deferred => assert!(!in_window, "deferred an in-window tile at y={}", tile.rect.y),
+                    _ => {}
+                }
+            }
+        }
+
+        #[test]
+        fn deferral_follows_the_scroll_position() {
+            let mut tile_list = tall_page_tiles();
+            defer_tiles_outside_window(&mut tile_list, 3000.0, TILE);
+
+            let (lo, hi) = raster_window(3000.0, TILE);
+            let dirty_ys: Vec<f64> = tile_list
+                .arena
+                .values()
+                .filter(|t| t.state == TileState::Dirty)
+                .map(|t| t.rect.y)
+                .collect();
+
+            assert!(!dirty_ys.is_empty(), "the window around y=3000 must hold tiles");
+            assert!(
+                dirty_ys.iter().all(|&y| y + TILE > lo && y < hi),
+                "only tiles around the scrolled viewport stay paintable: {dirty_ys:?}"
+            );
+        }
     }
 }

--- a/crates/gosub_render_pipeline/src/tiler.rs
+++ b/crates/gosub_render_pipeline/src/tiler.rs
@@ -84,6 +84,9 @@ pub enum TileState {
     Unrenderable,
     /// Tile is clean, but it does not contain anything (ie: no texture needed)
     Empty,
+    /// Outside the raster window: intentionally not painted or rasterized yet. Becomes `Dirty`
+    /// when the window moves over it (see `tile_budget::defer_tiles_outside_window`).
+    Deferred,
 }
 
 /// Single tile: the elements it covers plus the rendered texture that gets composited to screen.


### PR DESCRIPTION
When we have a large page, we do not need to create tiles for the whole page yet. We only need to make sure we generate the tiles for the viewport.

To speed things up with scrolling, we also create a few tiles after the viewport so we try to keep ahead of scrolling this way. Old tiles outside the viewport are stored in the cache and uses an LRU system to clear once the cache is full.

Stacked upon #1155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved scrolling through content that has not yet been rasterized.
  - Reuses cached tiles and pixel data for more efficient updates.
  - Defers off-screen rendering and rasterizes content as it enters view.
  - Added memory controls to limit rendering-cache usage while preserving visible content.
- **Bug Fixes**
  - Improved tile ordering and repaint behavior during scrolling and hover updates.
  - Prevented scroll-only updates until required content is ready for display.
  - Improved handling of cached content at page edges and during repeated scrolling.
- **Navigation & Interaction**
  - Added fragment-target navigation support.
  - Improved context-menu hit testing and cursor-shape updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->