### PR TITLE
Lattice: more table functionality and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,7 +1240,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2044,7 +2044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2826,7 +2826,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4687,7 +4687,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6304,7 +6304,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6361,7 +6361,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7096,7 +7096,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8508,7 +8508,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/bin/gosub-screenshot/main.rs
+++ b/bin/gosub-screenshot/main.rs
@@ -28,6 +28,10 @@ use tokio::runtime::{Builder, Runtime};
 use url::Url;
 use uuid::uuid;
 
+/// Cap on the composited RGBA buffer (1 GiB): keeps a runaway `--min-height` from
+/// wrapping the size arithmetic or exhausting memory.
+const MAX_CAPTURE_BYTES: usize = 1 << 30;
+
 const BUILD_VERSION: &str = concat!(
     env!("CARGO_PKG_VERSION"),
     " (",
@@ -309,7 +313,18 @@ fn main() {
     );
 
     // Fill with opaque white, then alpha-blend each tile (premultiplied).
-    let mut pixels = vec![255u8; (page_w * page_h * 4) as usize];
+    let Some(buf_len) = (page_w as usize)
+        .checked_mul(page_h as usize)
+        .and_then(|n| n.checked_mul(4))
+        .filter(|&n| n <= MAX_CAPTURE_BYTES)
+    else {
+        eprintln!(
+            "Capture of {page_w}x{page_h} px exceeds the supported size ({} MiB); lower the width or --min-height.",
+            MAX_CAPTURE_BYTES / (1024 * 1024)
+        );
+        std::process::exit(1);
+    };
+    let mut pixels = vec![255u8; buf_len];
 
     for tile in tiles.iter() {
         let tx = tile.page_x as u32;

--- a/bin/gosub-screenshot/main.rs
+++ b/bin/gosub-screenshot/main.rs
@@ -69,6 +69,11 @@ struct Args {
     /// Print the aggregated pipeline timing table (per stage) after the capture
     #[arg(long)]
     timings: bool,
+    /// Minimum capture height in CSS pixels. The image is normally cut at the page's flow
+    /// height; absolutely-positioned content below it (common in WPT reftest references)
+    /// would be lost, so reftest runners pass the comparison-canvas height here.
+    #[arg(long, default_value = "0")]
+    min_height: u32,
 }
 
 const DEFAULT_ZONE: uuid::Uuid = uuid!("f1234567-abcd-4000-8000-000000000003");
@@ -273,7 +278,7 @@ fn main() {
     };
 
     let page_w = viewport_w;
-    let page_h = (page_height_f.ceil() as u32).max(1);
+    let page_h = (page_height_f.ceil() as u32).max(1).max(args.min_height);
 
     eprintln!(
         "Page size: {}×{} px. Compositing {} tile(s)…",

--- a/bin/gosub-screenshot/main.rs
+++ b/bin/gosub-screenshot/main.rs
@@ -236,6 +236,27 @@ fn main() {
     if args.settle > 0 {
         std::thread::sleep(Duration::from_secs(args.settle));
         while rx_redraw.try_recv().is_ok() {}
+    } else {
+        // Quiescence wait: async media (images) decode after the first render and
+        // trigger reflows. Capturing between first render and that reflow races -
+        // e.g. an image-only table captures as zero-size. Wait until no redraw has
+        // arrived for a quiet window (capped, so pages that keep animating still
+        // capture promptly).
+        let quiet_window = Duration::from_millis(300);
+        let cap = Instant::now() + Duration::from_secs(3);
+        let mut last_redraw = Instant::now();
+        while Instant::now() < cap {
+            let mut saw = false;
+            while rx_redraw.try_recv().is_ok() {
+                saw = true;
+            }
+            if saw {
+                last_redraw = Instant::now();
+            } else if last_redraw.elapsed() >= quiet_window {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
     }
 
     let phase1_handle = compositor.frame_for(tab_id);

--- a/crates/gosub_css3/resources/useragent-quirks.css
+++ b/crates/gosub_css3/resources/useragent-quirks.css
@@ -1,0 +1,13 @@
+/* Applied after useragent.css, only for documents the parser put in quirks mode
+   (no or a legacy doctype). HTML Living Standard, Rendering § Tables: in quirks mode a
+   table does not inherit these from its ancestors, so a `<center>` or a font-styled
+   wrapper around a table leaves the cell text alone. */
+table {
+    font-weight: initial;
+    font-style: initial;
+    font-variant: initial;
+    font-size: initial;
+    line-height: initial;
+    white-space: initial;
+    text-align: initial;
+}

--- a/crates/gosub_css3/src/lib.rs
+++ b/crates/gosub_css3/src/lib.rs
@@ -149,6 +149,20 @@ pub fn load_default_useragent_stylesheet() -> CssStylesheet {
     Css3::parse_str(css_data, config, CssOrigin::UserAgent, url).expect("Could not parse useragent stylesheet")
 }
 
+/// The rules the HTML spec adds for documents in quirks mode; attached after the default sheet.
+#[must_use]
+pub fn load_quirks_useragent_stylesheet() -> CssStylesheet {
+    let config = ParserConfig {
+        ignore_errors: true,
+        match_values: true,
+        ..Default::default()
+    };
+    let css_data = include_str!("../resources/useragent-quirks.css");
+    #[allow(clippy::expect_used)] // PANIC-SAFE: compiled-in stylesheet, exercised by the parser tests
+    Css3::parse_str(css_data, config, CssOrigin::UserAgent, "gosub:useragent-quirks.css")
+        .expect("Could not parse quirks useragent stylesheet")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/gosub_css3/src/matcher/shorthands.rs
+++ b/crates/gosub_css3/src/matcher/shorthands.rs
@@ -470,6 +470,34 @@ impl CompleteStep<'_> {
     }
 }
 
+/// Reorder a 4-longhand box list into the [bottom, left, right, top] order QuadMulti's
+/// value->side mapping expects. Lists that are not four distinct sides (or already carry no
+/// side keywords) are returned unchanged - only the order is normalised, never the names.
+fn quad_side_order(computed: &[String]) -> Vec<String> {
+    if computed.len() != 4 {
+        return computed.to_vec();
+    }
+    let side_of = |name: &str| -> Option<usize> {
+        // Match the side as a hyphen-delimited segment so e.g. `border-top-color`
+        // and bare `top` both classify, but unrelated names never do.
+        for (i, side) in ["bottom", "left", "right", "top"].iter().enumerate() {
+            if name.split('-').any(|seg| seg == *side) {
+                return Some(i);
+            }
+        }
+        None
+    };
+    let mut ordered: [Option<&String>; 4] = [None; 4];
+    for name in computed {
+        match side_of(name) {
+            Some(i) if ordered[i].is_none() => ordered[i] = Some(name),
+            // Missing or duplicate side: not a box shorthand - keep the original order.
+            _ => return computed.to_vec(),
+        }
+    }
+    ordered.into_iter().flatten().cloned().collect()
+}
+
 /// Component paths for the `font` shorthand's longhands, validated against the inlined grammar
 /// `[ [ style || variant || weight || stretch ]? <font-size> [ / <line-height> ]? <font-family># ]
 /// | <system-font>`. The shape checks guard against a regenerated definitions file silently
@@ -581,31 +609,17 @@ impl CssDefinitions {
         if let Some(component) = syntax.components.first() {
             for m in component.multipliers() {
                 match m {
-                    SyntaxComponentMultiplier::Between(_, b) if *b == computed.len() => {
-                        for c in computed {
+                    SyntaxComponentMultiplier::Between(_, b) | SyntaxComponentMultiplier::CommaSeparatedRepeat(_, b)
+                        if *b == computed.len() =>
+                    {
+                        // QuadMulti's value->side mapping assumes the longhand list order
+                        // [bottom, left, right, top] (what margin/padding use in the
+                        // definitions data). Properties listing their longhands in natural
+                        // TRBL order (border-color/style/width) must be reordered, or
+                        // `border-color: a b c LEFT` lands its 4th value on the RIGHT.
+                        for c in quad_side_order(computed) {
                             shorthands.push(Shorthand {
-                                name: c.clone(),
-                                components: vec![],
-                            });
-                        }
-
-                        let multiplier = match computed.len() {
-                            2 => Multiplier::DuoMulti,
-                            4 => Multiplier::QuadMulti,
-                            _ => Multiplier::NextProp,
-                        };
-
-                        return Some(Shorthands {
-                            multiplier,
-                            shorthands,
-                            name: name.to_string(),
-                        });
-                    }
-
-                    SyntaxComponentMultiplier::CommaSeparatedRepeat(_, b) if *b == computed.len() => {
-                        for c in computed {
-                            shorthands.push(Shorthand {
-                                name: c.clone(),
+                                name: c,
                                 components: vec![],
                             });
                         }
@@ -833,6 +847,31 @@ mod tests {
             value_of(&expanded, "font-family"),
             Some(&CssValue::String("sans-serif".into()))
         );
+    }
+
+    /// `border-color`'s longhands are listed in TRBL order in the definitions data, but
+    /// QuadMulti maps values assuming [bottom, left, right, top] - without reordering,
+    /// `border-color: a b c LEFT` landed its 4th value on the RIGHT
+    /// (WPT border-conflict-element-001*).
+    #[test]
+    fn border_color_shorthand_assigns_sides_correctly() {
+        let definitions = get_css_definitions();
+        let prop = definitions.find_property("border-color").unwrap();
+
+        let mut fix_list = FixList::new();
+        assert!(prop.clone().matches_and_shorthands(
+            &[str!("green"), str!("green"), str!("green"), str!("red")],
+            &mut fix_list,
+        ));
+
+        let get = |name: &str| -> String {
+            let (_, v) = fix_list.list.iter().find(|(k, _)| k == name).expect("longhand present");
+            format!("{}", v.last().unwrap().value)
+        };
+        assert_eq!(get("border-top-color"), "green");
+        assert_eq!(get("border-right-color"), "green");
+        assert_eq!(get("border-bottom-color"), "green");
+        assert_eq!(get("border-left-color"), "red");
     }
 
     #[test]

--- a/crates/gosub_css3/src/matcher/shorthands.rs
+++ b/crates/gosub_css3/src/matcher/shorthands.rs
@@ -609,7 +609,8 @@ impl CssDefinitions {
         if let Some(component) = syntax.components.first() {
             for m in component.multipliers() {
                 match m {
-                    SyntaxComponentMultiplier::Between(_, b) | SyntaxComponentMultiplier::CommaSeparatedRepeat(_, b)
+                    SyntaxComponentMultiplier::Between(_, b)
+                    | SyntaxComponentMultiplier::CommaSeparatedRepeat(_, b)
                         if *b == computed.len() =>
                     {
                         // QuadMulti's value->side mapping assumes the longhand list order
@@ -823,25 +824,49 @@ mod tests {
     #[test]
     fn font_shorthand_expands_size_line_height_family() {
         let expanded = expand_font("1.25em/1.2 serif");
-        assert_eq!(value_of(&expanded, "font-size"), Some(&CssValue::Unit(1.25, "em".into())));
+        assert_eq!(
+            value_of(&expanded, "font-size"),
+            Some(&CssValue::Unit(1.25, "em".into()))
+        );
         assert_eq!(value_of(&expanded, "line-height"), Some(&CssValue::Number(1.2)));
-        assert_eq!(value_of(&expanded, "font-family"), Some(&CssValue::String("serif".into())));
+        assert_eq!(
+            value_of(&expanded, "font-family"),
+            Some(&CssValue::String("serif".into()))
+        );
     }
 
     #[test]
     fn font_shorthand_expands_prelude_and_px_line_height() {
         let expanded = expand_font("italic bold 12px/18px serif");
-        assert_eq!(value_of(&expanded, "font-style"), Some(&CssValue::String("italic".into())));
-        assert_eq!(value_of(&expanded, "font-weight"), Some(&CssValue::String("bold".into())));
-        assert_eq!(value_of(&expanded, "font-size"), Some(&CssValue::Unit(12.0, "px".into())));
-        assert_eq!(value_of(&expanded, "line-height"), Some(&CssValue::Unit(18.0, "px".into())));
-        assert_eq!(value_of(&expanded, "font-family"), Some(&CssValue::String("serif".into())));
+        assert_eq!(
+            value_of(&expanded, "font-style"),
+            Some(&CssValue::String("italic".into()))
+        );
+        assert_eq!(
+            value_of(&expanded, "font-weight"),
+            Some(&CssValue::String("bold".into()))
+        );
+        assert_eq!(
+            value_of(&expanded, "font-size"),
+            Some(&CssValue::Unit(12.0, "px".into()))
+        );
+        assert_eq!(
+            value_of(&expanded, "line-height"),
+            Some(&CssValue::Unit(18.0, "px".into()))
+        );
+        assert_eq!(
+            value_of(&expanded, "font-family"),
+            Some(&CssValue::String("serif".into()))
+        );
     }
 
     #[test]
     fn font_shorthand_without_line_height() {
         let expanded = expand_font("12px sans-serif");
-        assert_eq!(value_of(&expanded, "font-size"), Some(&CssValue::Unit(12.0, "px".into())));
+        assert_eq!(
+            value_of(&expanded, "font-size"),
+            Some(&CssValue::Unit(12.0, "px".into()))
+        );
         assert_eq!(value_of(&expanded, "line-height"), None);
         assert_eq!(
             value_of(&expanded, "font-family"),

--- a/crates/gosub_css3/src/matcher/shorthands.rs
+++ b/crates/gosub_css3/src/matcher/shorthands.rs
@@ -4,7 +4,7 @@ use std::collections::hash_map::Entry;
 
 use crate::matcher::property_definitions::CssDefinitions;
 use crate::matcher::styling::{CssProperties, CssProperty, DeclarationProperty};
-use crate::matcher::syntax::{SyntaxComponent, SyntaxComponentMultiplier};
+use crate::matcher::syntax::{GroupCombinators, SyntaxComponent, SyntaxComponentMultiplier};
 use crate::matcher::syntax_matcher::CssSyntaxTree;
 
 impl CssSyntaxTree {
@@ -470,6 +470,77 @@ impl CompleteStep<'_> {
     }
 }
 
+/// Component paths for the `font` shorthand's longhands, validated against the inlined grammar
+/// `[ [ style || variant || weight || stretch ]? <font-size> [ / <line-height> ]? <font-family># ]
+/// | <system-font>`. The shape checks guard against a regenerated definitions file silently
+/// changing the tree: on mismatch the shorthand expands to nothing again (and the unit test that
+/// asserts the expansion catches it).
+fn font_shorthands(syntax: &CssSyntaxTree, name: &str) -> Option<Shorthands> {
+    // Top level: `main-form | system-font` (ExactlyOne). The main form is component 0.
+    let SyntaxComponent::Group {
+        components: top,
+        combinator: GroupCombinators::ExactlyOne,
+        ..
+    } = syntax.components.first()?
+    else {
+        return None;
+    };
+    let SyntaxComponent::Group {
+        components: main,
+        combinator: GroupCombinators::Juxtaposition,
+        ..
+    } = top.first()?
+    else {
+        return None;
+    };
+    if main.len() != 4 {
+        return None;
+    }
+
+    // main[0]: the optional `||` prelude with exactly style/variant/weight/stretch operands.
+    let SyntaxComponent::Group {
+        components: prelude,
+        combinator: GroupCombinators::AtLeastOneAnyOrder,
+        ..
+    } = &main[0]
+    else {
+        return None;
+    };
+    if prelude.len() != 4 {
+        return None;
+    }
+
+    // main[2]: the `[ / <line-height> ]` group - a juxtaposition starting with the `/` literal.
+    let SyntaxComponent::Group { components: slash, .. } = &main[2] else {
+        return None;
+    };
+    if !matches!(slash.first(), Some(SyntaxComponent::Literal { literal, .. }) if literal == "/") {
+        return None;
+    }
+
+    let paths: &[(&str, &[usize])] = &[
+        ("font-style", &[0, 0, 0]),
+        ("font-variant", &[0, 0, 1]),
+        ("font-weight", &[0, 0, 2]),
+        ("font-stretch", &[0, 0, 3]),
+        ("font-size", &[0, 1]),
+        ("line-height", &[0, 2, 1]),
+        ("font-family", &[0, 3]),
+    ];
+
+    Some(Shorthands {
+        multiplier: Multiplier::None,
+        name: name.to_string(),
+        shorthands: paths
+            .iter()
+            .map(|(prop, path)| Shorthand {
+                name: (*prop).to_string(),
+                components: path.to_vec(),
+            })
+            .collect(),
+    })
+}
+
 impl CssDefinitions {
     pub fn index_shorthands(&mut self) {
         let mut shorthands = Vec::new();
@@ -495,6 +566,14 @@ impl CssDefinitions {
     pub fn resolve_shorthands(&self, computed: &[String], syntax: &CssSyntaxTree, name: &str) -> Option<Shorthands> {
         if computed.len() <= 1 || syntax.components.is_empty() {
             return None;
+        }
+
+        // `font` gets hand-built component paths: its longhand references (`<'font-size'>`,
+        // `<'line-height'>`, ...) are inlined into their value grammars at definition-load time,
+        // so the name-based property search below finds nothing and the whole shorthand would
+        // silently expand to nothing - dropping e.g. the line-height in `font: 12px/1.5 serif`.
+        if name == "font" {
+            return font_shorthands(syntax, name);
         }
 
         let mut shorthands: Vec<Shorthand> = Vec::with_capacity(computed.len());
@@ -684,6 +763,76 @@ mod tests {
         ($v:expr, $u:expr) => {
             CssValue::Unit($v, $u.to_string())
         };
+    }
+
+    /// Expand a `font:` declaration (parsed from real CSS) and return the resulting
+    /// (longhand, value) pairs.
+    fn expand_font(decl: &str) -> Vec<(String, CssValue)> {
+        use crate::Css3;
+        use gosub_interface::css3::CssOrigin;
+        use gosub_shared::config::ParserConfig;
+
+        let definitions = get_css_definitions();
+        let prop = definitions.find_property("font").unwrap();
+
+        let css = format!("x {{ font: {decl}; }}");
+        let config = ParserConfig {
+            match_values: false,
+            ignore_errors: true,
+            ..Default::default()
+        };
+        let sheet = Css3::parse_str(&css, config, CssOrigin::Author, "font-test").expect("parse");
+        let decl = &sheet.rules[0].declarations[0];
+        let values = match &decl.value {
+            CssValue::List(v) => v.clone(),
+            other => vec![other.clone()],
+        };
+
+        let mut fix_list = FixList::new();
+        assert!(
+            prop.clone().matches_and_shorthands(&values, &mut fix_list),
+            "font: declaration should match"
+        );
+        fix_list
+            .list
+            .iter()
+            .map(|(name, decls)| (name.clone(), decls.last().unwrap().value.clone()))
+            .collect()
+    }
+
+    fn value_of<'a>(expanded: &'a [(String, CssValue)], name: &str) -> Option<&'a CssValue> {
+        expanded.iter().find(|(n, _)| n == name).map(|(_, v)| v)
+    }
+
+    /// `font: <size>/<line-height> <family>` must expand line-height - it drives the line-box
+    /// height of every WPT table test using the `font:` shorthand.
+    #[test]
+    fn font_shorthand_expands_size_line_height_family() {
+        let expanded = expand_font("1.25em/1.2 serif");
+        assert_eq!(value_of(&expanded, "font-size"), Some(&CssValue::Unit(1.25, "em".into())));
+        assert_eq!(value_of(&expanded, "line-height"), Some(&CssValue::Number(1.2)));
+        assert_eq!(value_of(&expanded, "font-family"), Some(&CssValue::String("serif".into())));
+    }
+
+    #[test]
+    fn font_shorthand_expands_prelude_and_px_line_height() {
+        let expanded = expand_font("italic bold 12px/18px serif");
+        assert_eq!(value_of(&expanded, "font-style"), Some(&CssValue::String("italic".into())));
+        assert_eq!(value_of(&expanded, "font-weight"), Some(&CssValue::String("bold".into())));
+        assert_eq!(value_of(&expanded, "font-size"), Some(&CssValue::Unit(12.0, "px".into())));
+        assert_eq!(value_of(&expanded, "line-height"), Some(&CssValue::Unit(18.0, "px".into())));
+        assert_eq!(value_of(&expanded, "font-family"), Some(&CssValue::String("serif".into())));
+    }
+
+    #[test]
+    fn font_shorthand_without_line_height() {
+        let expanded = expand_font("12px sans-serif");
+        assert_eq!(value_of(&expanded, "font-size"), Some(&CssValue::Unit(12.0, "px".into())));
+        assert_eq!(value_of(&expanded, "line-height"), None);
+        assert_eq!(
+            value_of(&expanded, "font-family"),
+            Some(&CssValue::String("sans-serif".into()))
+        );
     }
 
     #[test]

--- a/crates/gosub_css3/src/matcher/shorthands.rs
+++ b/crates/gosub_css3/src/matcher/shorthands.rs
@@ -653,7 +653,7 @@ impl CssDefinitions {
             // value on the right side). Corner properties are listed naturally as
             // `[top-left, top-right, bottom-right, bottom-left]`, so feed the corners to the
             // resolver reordered to `[BR, BL, TR, TL]`; that makes `get_names` reproduce the CSS
-            // corner rules (1 value → all; 2 → TL·BR / TR·BL; 3 → TL / TR·BL / BR; 4 → TL TR BR BL).
+            // corner rules (1 value -> all; 2 -> TL+BR / TR+BL; 3 -> TL / TR+BL / BR; 4 -> TL TR BR BL).
             if computed.len() == 4 {
                 if let SyntaxComponent::Group { components: outer, .. } = component {
                     let nested_quad = outer.first().is_some_and(|first_child| {

--- a/crates/gosub_css3/src/matcher/styling.rs
+++ b/crates/gosub_css3/src/matcher/styling.rs
@@ -669,6 +669,10 @@ impl css3::CssProperty<Css3System> for CssProperty {
     fn is_none(&self) -> bool {
         matches!(self.actual, CssValue::None)
     }
+
+    fn winning_origin(&self) -> Option<CssOrigin> {
+        self.declared.iter().max().map(|d| d.origin)
+    }
 }
 
 /// Map of all declared values for a single node. Note that these are only the defined properties, not

--- a/crates/gosub_css3/src/matcher/syntax_matcher.rs
+++ b/crates/gosub_css3/src/matcher/syntax_matcher.rs
@@ -553,56 +553,21 @@ fn match_group_exactly_one<'a>(
     mut shorthand_resolver: Option<ShorthandResolver>,
 ) -> MatchResult<'a> {
     let input = raw_input;
-    let mut matched_values = vec![];
     let mut components_matched = vec![];
 
+    // Pass 1: find the winning alternative WITHOUT resolver side effects. `|` picks
+    // exactly one alternative, but a value can syntactically match several (e.g.
+    // `green` matches more than one arm of `<color>`); firing a shorthand-complete per
+    // match would over-advance the {1,4} value->side counter and scramble box
+    // shorthands like `border-color`.
     let mut c_idx = 0;
     while c_idx < components.len() {
         if input.is_empty() {
             break;
         }
-
-        if let Some(mut resolver) = copy_resolver(&mut shorthand_resolver) {
-            let step = resolver.step(c_idx);
-
-            let mut complete = None;
-            let mut resolver = None;
-
-            match step {
-                Ok(Some(r)) => resolver = Some(r),
-                Ok(None) => {}
-                Err(c) => complete = Some(c),
-            }
-
-            let component = &components[c_idx];
-
-            let res = match_component(input, component, resolver);
-            if res.matched {
-                matched_values.append(&mut res.matched_values.clone());
-
-                // input = res.remainder.clone();
-
-                components_matched.push((c_idx, res.matched_values.clone(), res.remainder));
-
-                if let Some(complete) = complete {
-                    complete.complete(res.matched_values);
-                }
-            } else {
-                // No match. That's all right.
-            }
-        } else {
-            let component = &components[c_idx];
-
-            let res = match_component(input, component, None);
-            if res.matched {
-                matched_values.append(&mut res.matched_values.clone());
-
-                // input = res.remainder.clone();
-
-                components_matched.push((c_idx, res.matched_values, res.remainder));
-            } else {
-                // No match. That's all right.
-            }
+        let res = match_component(input, &components[c_idx], None);
+        if res.matched {
+            components_matched.push((c_idx, res.matched_values, res.remainder));
         }
         c_idx += 1;
     }
@@ -611,28 +576,35 @@ fn match_group_exactly_one<'a>(
         return no_match(input);
     }
 
-    if components_matched.len() > 1 {
-        let mut shortest_remainder_idx = 0;
-        let mut shortest_remainder_len = usize::MAX;
-
-        for (idx, (_, _, remainder)) in components_matched.iter().enumerate() {
-            if remainder.len() < shortest_remainder_len {
-                shortest_remainder_len = remainder.len();
-                shortest_remainder_idx = idx;
-            }
+    let mut winner = 0;
+    let mut shortest_remainder_len = usize::MAX;
+    for (idx, (_, _, remainder)) in components_matched.iter().enumerate() {
+        if remainder.len() < shortest_remainder_len {
+            shortest_remainder_len = remainder.len();
+            winner = idx;
         }
+    }
+    let (winner_c_idx, winner_values, winner_remainder) = &components_matched[winner];
 
-        return MatchResult {
-            remainder: components_matched[shortest_remainder_idx].2,
-            matched: true,
-            matched_values: components_matched[shortest_remainder_idx].1.clone(),
-        };
+    // Pass 2: replay ONLY the winner against the resolver - completing it here, or
+    // descending with the stepped resolver when the shorthand path continues deeper.
+    if let Some(mut resolver) = copy_resolver(&mut shorthand_resolver) {
+        match resolver.step(*winner_c_idx) {
+            Ok(Some(sub)) => {
+                let res = match_component(input, &components[*winner_c_idx], Some(sub));
+                if res.matched {
+                    return res;
+                }
+            }
+            Ok(None) => {}
+            Err(complete) => complete.complete(winner_values.clone()),
+        }
     }
 
     MatchResult {
-        remainder: components_matched[0].2,
+        remainder: winner_remainder,
         matched: true,
-        matched_values: components_matched[0].1.clone(),
+        matched_values: winner_values.clone(),
     }
 }
 

--- a/crates/gosub_css3/src/system.rs
+++ b/crates/gosub_css3/src/system.rs
@@ -6,7 +6,7 @@ use crate::matcher::property_definitions::get_css_definitions;
 use crate::matcher::shorthands::{FixList, FixListInfo};
 use crate::matcher::styling::{cascade_rank, match_selector, CssProperties, CssProperty, DeclarationProperty};
 use crate::stylesheet::{CssDeclaration, CssStylesheet, CssValue, Specificity};
-use crate::{load_default_useragent_stylesheet, Css3};
+use crate::{load_default_useragent_stylesheet, load_quirks_useragent_stylesheet, Css3};
 use cow_utils::CowUtils;
 use gosub_interface::config::HasDocument;
 use gosub_interface::css3::{CssOrigin, CssPropertyMap, CssSystem, HoverFingerprints};
@@ -94,6 +94,10 @@ impl CssSystem for Css3System {
 
     fn load_default_useragent_stylesheet() -> Self::Stylesheet {
         load_default_useragent_stylesheet()
+    }
+
+    fn load_quirks_useragent_stylesheet() -> Option<Self::Stylesheet> {
+        Some(load_quirks_useragent_stylesheet())
     }
 
     fn hover_fingerprints(sheets: &[Self::Stylesheet]) -> HoverFingerprints {

--- a/crates/gosub_engine/src/html/parser.rs
+++ b/crates/gosub_engine/src/html/parser.rs
@@ -8,6 +8,7 @@ use gosub_html5::document::builder::DocumentBuilderImpl;
 use gosub_html5::parser::Html5Parser;
 use gosub_interface::css3::CssSystem;
 use gosub_interface::document::Document as _;
+use gosub_interface::node::QuirksMode;
 use gosub_shared::byte_stream::{ByteStream, Encoding};
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -152,6 +153,11 @@ where
     let _ = Html5Parser::<C>::parse_document(&mut stream, &mut doc, None);
     let ua = <C::CssSystem as CssSystem>::load_default_useragent_stylesheet();
     doc.add_stylesheet(ua);
+    if doc.quirks_mode() == QuirksMode::Quirks {
+        if let Some(quirks) = <C::CssSystem as CssSystem>::load_quirks_useragent_stylesheet() {
+            doc.add_stylesheet(quirks);
+        }
+    }
 
     Ok(doc)
 }
@@ -324,6 +330,40 @@ mod tests {
         assert!(hints
             .iter()
             .any(|h| h.kind == ResourceKind::Image && h.url.as_str() == "https://example.com/path/images/logo.png"));
+    }
+
+    /// HN-style markup: no doctype, `<center><table>`. The spec's quirks-mode table rules
+    /// keep the cells from inheriting the centering; a standards-mode document gets no such sheet.
+    #[tokio::test(flavor = "current_thread")]
+    async fn quirks_mode_documents_get_the_quirks_useragent_sheet() {
+        let body = "<center><table><tr><td>row</td></tr></table></center>";
+        let base = Url::parse("https://example.com/").unwrap();
+        let parse = |html: String| {
+            parse_main_document_stream::<DefaultRenderConfig, _, _>(
+                base.clone(),
+                reader_from_str(&html),
+                CancellationToken::new(),
+                HtmlParseConfig::default(),
+                |_| {},
+            )
+        };
+
+        let quirks = parse(format!("<html><body>{body}</body></html>")).await.unwrap();
+        assert_eq!(quirks.quirks_mode(), QuirksMode::Quirks);
+        let standards = parse(format!("<!DOCTYPE html><html><body>{body}</body></html>"))
+            .await
+            .unwrap();
+        assert_eq!(standards.quirks_mode(), QuirksMode::NoQuirks);
+
+        assert_eq!(
+            quirks.stylesheets().len(),
+            standards.stylesheets().len() + 1,
+            "quirks documents carry exactly one extra user-agent sheet"
+        );
+        assert!(
+            quirks.stylesheets().iter().any(|s| s.url.contains("useragent-quirks")),
+            "the extra sheet is the quirks sheet"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/gosub_fontmanager/src/pango_system.rs
+++ b/crates/gosub_fontmanager/src/pango_system.rs
@@ -408,11 +408,16 @@ impl PangoFontSystem {
         Some(layout)
     }
 
-    /// Measure `text` by reading the pixel size of its laid-out Pango layout.
+    /// Measure `text` by reading the pixel size of its laid-out Pango layout. An explicit CSS
+    /// line-height overrides the natural height: every line box is exactly that tall (CSS 2
+    /// §10.8 half-leading model), so the total is line-count x line-height.
     fn measure_inner(&self, text: &str, style: &TextStyle) -> Option<(f32, f32)> {
         let layout = self.build_layout(text, style)?;
         let (w, h) = layout.pixel_size();
-        Some((w as f32, h as f32))
+        match css_line_height(style) {
+            Some(lh) => Some((w as f32, lh * layout.line_count().max(1) as f32)),
+            None => Some((w as f32, h as f32)),
+        }
     }
 
     /// Walk a laid-out Pango layout and export its glyph runs in the neutral [`ShapedText`] form.
@@ -424,14 +429,45 @@ impl PangoFontSystem {
     fn runs_from_layout(&mut self, layout: &pango::Layout, style: &TextStyle) -> ShapedText {
         let scale = pango::SCALE as f32;
         let (px_w, px_h) = layout.pixel_size();
-        let ascent = layout.baseline() as f32 / scale;
+        let natural_ascent = layout.baseline() as f32 / scale;
         let line_count = layout.line_count().max(1) as f32;
+
+        // With an explicit CSS line-height, every line box is exactly that tall and the line's
+        // natural extent (ascent+descent) is centered inside it - the CSS 2 §10.8 half-leading
+        // model. Precompute per line: natural baseline (pango units) -> adjusted baseline (px);
+        // runs are then repositioned by looking up the line they sit on.
+        let css_lh = css_line_height(style);
+        let mut baseline_map: Vec<(i32, f32)> = Vec::new();
+        if let Some(lh) = css_lh {
+            let mut it = layout.iter();
+            let mut line_idx = 0usize;
+            loop {
+                let natural_baseline = it.baseline();
+                let (y0, y1) = it.line_yrange();
+                let natural_height = (y1 - y0) as f32 / scale;
+                let ascent_within_line = (natural_baseline - y0) as f32 / scale;
+                baseline_map.push((
+                    natural_baseline,
+                    line_idx as f32 * lh + (lh - natural_height) / 2.0 + ascent_within_line,
+                ));
+                line_idx += 1;
+                if !it.next_line() {
+                    break;
+                }
+            }
+        }
+        let adjust_baseline = |natural_units: i32| -> f32 {
+            baseline_map
+                .iter()
+                .find(|(n, _)| *n == natural_units)
+                .map_or(natural_units as f32 / scale, |(_, adjusted)| *adjusted)
+        };
 
         let mut runs: Vec<ShapedRun> = Vec::new();
         let mut iter = layout.iter();
         loop {
             if let Some(run) = iter.run_readonly() {
-                let baseline = iter.baseline() as f32 / scale;
+                let baseline = adjust_baseline(iter.baseline());
                 let (_, logical) = iter.run_extents();
                 let run_x = logical.x() as f32 / scale;
 
@@ -490,14 +526,32 @@ impl PangoFontSystem {
             }
         }
 
+        let (height, line_height, ascent) = match css_lh {
+            Some(lh) => (
+                lh * line_count,
+                lh,
+                baseline_map.first().map_or(natural_ascent, |(_, adjusted)| *adjusted),
+            ),
+            None => (px_h as f32, px_h as f32 / line_count, natural_ascent),
+        };
+
         ShapedText {
             runs,
             width: px_w as f32,
-            height: px_h as f32,
-            line_height: px_h as f32 / line_count,
+            height,
+            line_height,
             ascent,
         }
     }
+}
+
+/// The CSS line-height to apply, in device px, or `None` when the layout should keep Pango's
+/// natural line height (CSS `normal`).
+fn css_line_height(style: &TextStyle) -> Option<f32> {
+    style
+        .line_height
+        .filter(|lh| *lh > 0.0)
+        .map(|lh| lh * style.display_scale)
 }
 
 /// Pango as a swappable [`FontSystem`].
@@ -508,8 +562,10 @@ impl PangoFontSystem {
 /// pixel size. The Cairo rasterizer still draws through Pango natively; the glyph runs exist so
 /// any [`ShapedText`]-painting backend can consume this font system too.
 ///
-/// Note: Pango uses its own natural line height (matching how the Cairo rasterizer draws), so
-/// `TextStyle::line_height` is intentionally not applied during measurement or shaping.
+/// An explicit `TextStyle::line_height` is honoured exactly in both `measure` and `shape`
+/// (line boxes are line-height tall, glyphs centered via half-leading); `None` keeps Pango's
+/// natural per-font line height. Measurement and shaping apply the same rule, so layout boxes
+/// and painted glyph runs always agree.
 impl FontSystem for PangoFontSystem {
     fn register_font(&mut self, data: Vec<u8>, family_override: Option<&str>) -> Result<(), FontError> {
         register_font_via_fontconfig(&data, family_override)
@@ -703,6 +759,53 @@ mod tests {
             "measure ({w} x {h}) must agree with shape ({} x {})",
             shaped.width,
             shaped.height
+        );
+    }
+
+    /// An explicit CSS line-height must be EXACT: line boxes are line-height tall (measure and
+    /// shape agree), and glyph baselines sit at half-leading inside each line box - not at
+    /// Pango's natural positions.
+    #[test]
+    fn explicit_line_height_is_exact() {
+        let mut fs = PangoFontSystem::new();
+
+        let mut style = TextStyle::new("sans-serif", 16.0);
+        style.line_height = Some(24.0);
+
+        let (_, h) = fs.measure("Hello", &style);
+        assert_eq!(h, 24.0, "single line at line-height 24px must measure exactly 24px");
+
+        let shaped = fs.shape("Hello", &style);
+        assert_eq!(shaped.height, 24.0);
+        assert_eq!(shaped.line_height, 24.0);
+        // Natural extent centered in the 24px box: baseline = (24 - natural)/2 + natural_ascent,
+        // which for a 16px font (natural height ~18-19px) lands well inside (2, 24).
+        assert!(
+            shaped.ascent > 2.0 && shaped.ascent < 24.0,
+            "adjusted first baseline {} must sit inside the line box",
+            shaped.ascent
+        );
+        for run in &shaped.runs {
+            assert!(
+                (run.baseline - shaped.ascent).abs() < 0.01,
+                "single-line run baseline {} must match the adjusted ascent {}",
+                run.baseline,
+                shaped.ascent
+            );
+        }
+
+        // Two forced lines: exactly 2 x 24px, and the two baselines exactly 24px apart.
+        let (_, h2) = fs.measure("Hello\nWorld", &style);
+        assert_eq!(h2, 48.0, "two lines at line-height 24px must measure exactly 48px");
+        let shaped2 = fs.shape("Hello\nWorld", &style);
+        let mut baselines: Vec<f32> = shaped2.runs.iter().map(|r| r.baseline).collect();
+        baselines.dedup();
+        assert_eq!(baselines.len(), 2, "expected two distinct line baselines");
+        assert!(
+            (baselines[1] - baselines[0] - 24.0).abs() < 0.01,
+            "baselines must be exactly one line-height apart, got {} and {}",
+            baselines[0],
+            baselines[1]
         );
     }
 }

--- a/crates/gosub_interface/src/css3.rs
+++ b/crates/gosub_interface/src/css3.rs
@@ -143,6 +143,11 @@ pub trait CssProperty<S: CssSystem>: Debug + Display + Sized + From<S::Value> {
     fn as_function(&self) -> Option<(&str, &[S::Value])>;
 
     fn is_none(&self) -> bool;
+
+    /// Origin of the cascade-winning declaration for this property, if any was declared.
+    /// Lets consumers slot HTML presentational hints (`cellspacing`, `cellpadding`, ...)
+    /// between user-agent and author styles.
+    fn winning_origin(&self) -> Option<CssOrigin>;
 }
 
 pub trait CssValue: Sized {

--- a/crates/gosub_interface/src/css3.rs
+++ b/crates/gosub_interface/src/css3.rs
@@ -77,6 +77,13 @@ pub trait CssSystem: Clone + Debug + 'static {
 
     fn load_default_useragent_stylesheet() -> Self::Stylesheet;
 
+    /// The extra user-agent rules for a document in quirks mode (HTML spec, Rendering:
+    /// tables do not inherit font and alignment there). Attached after the default sheet;
+    /// `None` when this system has no quirks rules.
+    fn load_quirks_useragent_stylesheet() -> Option<Self::Stylesheet> {
+        None
+    }
+
     /// Scan `sheets` and collect the [`HoverFingerprints`] - the element types/classes/ids that
     /// are the subject of a `:hover` rule. Lets the engine cheaply decide whether a hover change
     /// can affect styling without re-running selector matching.

--- a/crates/gosub_lattice/src/bin/table_console.rs
+++ b/crates/gosub_lattice/src/bin/table_console.rs
@@ -8,7 +8,7 @@ use gosub_lattice::{compute_table_layout, TableRole};
 
 fn main() {
     eprintln!(
-        "{} v{} — console demos of the lattice table layout engine (colspan/rowspan/sections)",
+        "{} v{} - console demos of the lattice table layout engine (colspan/rowspan/sections)",
         env!("CARGO_BIN_NAME"),
         env!("CARGO_PKG_VERSION")
     );
@@ -29,7 +29,7 @@ fn main() {
     let out = MockTable::new(60.0)
         .header_row(vec![cell("Name"), cell("Info")])
         .body_row(vec![cell("Alice"), cell("Amsterdam")])
-        .body_row(vec![cell("Bob — long name that spans both columns").colspan(2)])
+        .body_row(vec![cell("Bob - long name that spans both columns").colspan(2)])
         .body_row(vec![cell("Carol"), cell("Brussels")])
         .render();
     println!("{out}");
@@ -45,11 +45,11 @@ fn main() {
         .render();
     println!("{out}");
 
-    // 4. rowspan that would cross thead→tbody boundary - must be clamped
+    // 4. rowspan that would cross thead->tbody boundary - must be clamped
     println!("=== rowspan clamped at section boundary ===");
     let out = MockTable::new(60.0)
         .header_row(vec![
-            cell("Header rowspan=99").rowspan(99), // only 1 row in thead → clamped to 1
+            cell("Header rowspan=99").rowspan(99), // only 1 row in thead -> clamped to 1
             cell("H2"),
         ])
         .body_row(vec![cell("Body A"), cell("Body B")])
@@ -110,8 +110,8 @@ fn main() {
     }
 
     // 9. Section order normalization (test 13): source order is tfoot, tbody,
-    //    thead - the layout renders header → body → footer regardless.
-    println!("=== source order tfoot/tbody/thead → renders head/body/foot ===");
+    //    thead - the layout renders header -> body -> footer regardless.
+    println!("=== source order tfoot/tbody/thead -> renders head/body/foot ===");
     let mut tree = MockTree::new(1.0, 0.0);
     let root = tree.alloc(TableRole::Table, None, 1, 1, None, None, 0.0, 0.0);
     for (role, label) in [

--- a/crates/gosub_lattice/src/compute.rs
+++ b/crates/gosub_lattice/src/compute.rs
@@ -55,7 +55,9 @@ pub fn compute_table_layout<T: TableTree>(
         .max()
         .unwrap_or(0);
 
-    if n_cols == 0 {
+    // A caption-only table still needs CAPMIN and the caption's own layout, so it
+    // takes the full path with an empty grid.
+    if n_cols == 0 && model.caption.is_none() {
         // No grid, but the element's specified size still applies (§17.5.2/3: the used
         // size is the greater of the specified size and the grid extent - zero here).
         // Extents are content-box; the caller wraps border and padding around them.

--- a/crates/gosub_lattice/src/compute.rs
+++ b/crates/gosub_lattice/src/compute.rs
@@ -112,6 +112,22 @@ pub fn compute_table_layout<T: TableTree>(
         HashMap::new()
     };
 
+    // CAPMIN: the caption's minimum border-box width. CSS 2 §17.5.2 floors the used
+    // table width at it in both layout modes (an empty table with a 100px caption is
+    // still 100px wide). Intrinsics are border-box; a specified width is content-box,
+    // so it gains the caption's own border and padding.
+    let capmin = match model.caption {
+        Some(cap) => {
+            let intrinsic_min = tree.cell_intrinsic_widths(cap).0;
+            let specified = match tree.css_length(cap, CssProp::Width) {
+                CssLength::Px(w) => w + read_border(tree, cap).horizontal() + read_padding(tree, cap).horizontal(),
+                _ => 0.0,
+            };
+            intrinsic_min.max(specified)
+        }
+        None => 0.0,
+    };
+
     let (col_widths, table_width) = compute_column_widths(
         tree,
         n_cols,
@@ -122,6 +138,7 @@ pub fn compute_table_layout<T: TableTree>(
         model.sizing,
         &col_specs,
         &collapsed_borders,
+        capmin,
     );
 
     if std::env::var_os("LATTICE_DEBUG").is_some() {

--- a/crates/gosub_lattice/src/compute.rs
+++ b/crates/gosub_lattice/src/compute.rs
@@ -249,6 +249,9 @@ pub fn compute_table_layout<T: TableTree>(
                 );
             }
 
+            // Positions are consumed relative to the DOM parent chain. An anonymous group has
+            // no node to carry `group_y`, so its offset folds into its rows/cells instead.
+            let group_base_y = if group.node.is_none() { group_y } else { 0.0 };
             place_rows(
                 tree,
                 group,
@@ -259,6 +262,7 @@ pub fn compute_table_layout<T: TableTree>(
                 &col_widths,
                 &content_heights,
                 &collapsed_borders,
+                group_base_y,
             );
 
             group_y += group_height + spacing_y;
@@ -293,6 +297,10 @@ pub fn compute_table_layout<T: TableTree>(
 }
 
 /// Write layouts for every row and cell within one section.
+///
+/// Positions are relative to the nearest ANCESTOR WITH A NODE (the consumer resolves them
+/// along the DOM parent chain): `group_base_y` carries an anonymous group's table-relative
+/// offset, and an anonymous row folds its own offset into its cells the same way.
 #[allow(clippy::too_many_arguments)]
 fn place_rows<T: TableTree>(
     tree: &mut T,
@@ -304,6 +312,7 @@ fn place_rows<T: TableTree>(
     col_widths: &[f32],
     content_heights: &HashMap<T::NodeId, f32>,
     collapsed_borders: &HashMap<T::NodeId, CollapsedBorders>,
+    group_base_y: f32,
 ) {
     let inner_width: f32 = match (col_x.last(), col_widths.last()) {
         (Some(&x), Some(&w)) => x + w - col_x.first().copied().unwrap_or(0.0),
@@ -318,7 +327,7 @@ fn place_rows<T: TableTree>(
             tree.set_layout(
                 node,
                 CellLayout {
-                    position: Point::new(0.0, ry),
+                    position: Point::new(0.0, group_base_y + ry),
                     size: Size::new(inner_width, rh),
                     border: BOX_EDGES_ZERO,
                     padding: BOX_EDGES_ZERO,
@@ -329,7 +338,9 @@ fn place_rows<T: TableTree>(
             );
         }
 
-        // Cells for this row.
+        // Cells of an anonymous row hang off the group (or table) in the DOM, so they
+        // carry the row's offset themselves.
+        let cell_base_y = if row.node.is_some() { 0.0 } else { group_base_y + ry };
         for cell in grid.cells_in_row(row_idx) {
             place_cell(
                 tree,
@@ -340,6 +351,7 @@ fn place_rows<T: TableTree>(
                 row_y,
                 content_heights,
                 collapsed_borders,
+                cell_base_y,
             );
         }
     }
@@ -356,6 +368,8 @@ fn place_cell<T: TableTree>(
     row_y: &[f32],
     content_heights: &HashMap<T::NodeId, f32>,
     collapsed_borders: &HashMap<T::NodeId, CollapsedBorders>,
+    // Offset of the cell's (anonymous) row relative to the cell's DOM parent; 0 in a real row.
+    base_y: f32,
 ) {
     // Extents come from the offset tables so gutters (separate borders) and
     // overlaps (collapsed borders) are both handled: a spanning cell runs from
@@ -369,8 +383,8 @@ fn place_cell<T: TableTree>(
     let cell_height =
         row_y.get(last_row).copied().unwrap_or(0.0) + row_heights.get(last_row).copied().unwrap_or(0.0) - cell_row_y;
 
-    // Cell y is relative to its own row's top.
-    let y_within_row = 0.0;
+    // Cell y is relative to its own row's top (plus that row's own offset when anonymous).
+    let y_within_row = base_y;
 
     let collapsed = collapsed_borders.get(&cell.node).copied();
     let border = effective_border(tree, cell.node, collapsed_borders);

--- a/crates/gosub_lattice/src/compute.rs
+++ b/crates/gosub_lattice/src/compute.rs
@@ -254,7 +254,7 @@ pub fn compute_table_layout<T: TableTree>(
 
     // Apply positions
     //
-    //    Per CSS: sections are rendered in the order header → body → footer,
+    //    Per CSS: sections are rendered in the order header -> body -> footer,
     //    regardless of their source position.  Each group is positioned
     //    relative to the table.  Each row is positioned relative to its group.
     //    Each cell is positioned relative to its row.

--- a/crates/gosub_lattice/src/compute.rs
+++ b/crates/gosub_lattice/src/compute.rs
@@ -575,10 +575,9 @@ fn resolve_border_conflicts<T: TableTree>(
     for grid in grids {
         for cell in grid.cells() {
             borders.entry(cell.node).or_insert_with(|| read_border(tree, cell.node));
+            let col_end = (cell.col + cell.colspan).min(n_cols);
             for r in cell.row..(cell.row + cell.rowspan).min(grid.n_rows) {
-                for c in cell.col..(cell.col + cell.colspan).min(n_cols) {
-                    slots[row_offset + r][c] = Some(cell.node);
-                }
+                slots[row_offset + r][cell.col..col_end].fill(Some(cell.node));
             }
         }
         row_offset += grid.n_rows;
@@ -686,7 +685,12 @@ fn resolve_border_conflicts<T: TableTree>(
     // half the resolved boundary in the layout, half painted as outset up to the
     // table's border-box edge.
     let table_border = read_border(tree, table_node);
-    let table_edge = [table_border.top, table_border.right, table_border.bottom, table_border.left];
+    let table_edge = [
+        table_border.top,
+        table_border.right,
+        table_border.bottom,
+        table_border.left,
+    ];
     let mut collapsed_map = HashMap::new();
     let mut owners_map = HashMap::new();
     for (&node, raw) in &borders {

--- a/crates/gosub_lattice/src/compute.rs
+++ b/crates/gosub_lattice/src/compute.rs
@@ -56,7 +56,19 @@ pub fn compute_table_layout<T: TableTree>(
         .unwrap_or(0);
 
     if n_cols == 0 {
-        return Ok((0.0, 0.0));
+        // No grid, but the element's specified size still applies (§17.5.2/3: the used
+        // size is the greater of the specified size and the grid extent - zero here).
+        // Extents are content-box; the caller wraps border and padding around them.
+        let w = match tree.css_length(table_node, CssProp::Width) {
+            CssLength::Px(w) => w.max(0.0),
+            CssLength::Percent(p) => (p / 100.0 * available_width).max(0.0),
+            _ => 0.0,
+        };
+        let h = match tree.css_length(table_node, CssProp::Height) {
+            CssLength::Px(h) => h.max(0.0),
+            _ => 0.0,
+        };
+        return Ok((w, h));
     }
 
     // Explicit widths from <colgroup>/<col> elements. Under fixed layout the

--- a/crates/gosub_lattice/src/compute.rs
+++ b/crates/gosub_lattice/src/compute.rs
@@ -95,15 +95,10 @@ pub fn compute_table_layout<T: TableTree>(
     );
 
     // Precompute cumulative column x-offsets (relative to the row's left edge).
-    // col_x[i] = x of the left edge of column i (within a row). Under collapse,
-    // adjacent columns overlap by their shared border width so the borders of
-    // neighbouring cells coincide.
-    let col_overlaps = if collapse {
-        column_border_overlaps(tree, n_cols, &all_grids)
-    } else {
-        vec![0.0; n_cols]
-    };
-    let col_x = col_x_offsets(&col_widths, spacing_x, &col_overlaps);
+    // col_x[i] = x of the left edge of column i (within a row). Under collapse
+    // the cells sit flush (spacing 0) and conflict resolution below decides
+    // which cell paints each shared border.
+    let col_x = col_x_offsets(&col_widths, spacing_x);
 
     // Row heights per section
     //
@@ -149,13 +144,13 @@ pub fn compute_table_layout<T: TableTree>(
         ));
     }
 
-    // Per-section vertical border overlaps (collapse only): rows within a
-    // section overlap by their shared border; the section edge borders are
-    // kept so adjacent sections can overlap too.
-    let all_row_overlaps: Vec<Vec<RowOverlaps>> = [&header_grids, &body_grids, &footer_grids]
-        .into_iter()
-        .map(|grids| grids.iter().map(|g| row_border_overlaps(tree, g, collapse)).collect())
-        .collect();
+    // Border-conflict resolution (collapse only): decide per shared boundary
+    // which cell paints it; the loser's edge is flagged for the host to skip.
+    let suppressed_borders: HashMap<T::NodeId, [bool; 4]> = if collapse {
+        resolve_border_conflicts(tree, n_cols, &all_grids)
+    } else {
+        HashMap::new()
+    };
 
     // Caption: measured like a cell spanning the full table width; placed
     // above (default) or below the grid per `caption-side`.
@@ -196,27 +191,15 @@ pub fn compute_table_layout<T: TableTree>(
     let mut group_y = if caption_bottom { 0.0 } else { caption_height } + spacing_y;
 
     #[allow(clippy::type_complexity)]
-    let section_data: &[(&[RowGroup<T::NodeId>], &[SectionGrid<T::NodeId>], &[Vec<f32>], &[RowOverlaps])] = &[
-        (&model.header_groups, &header_grids, &header_heights, &all_row_overlaps[0]),
-        (&model.row_groups, &body_grids, &body_heights, &all_row_overlaps[1]),
-        (&model.footer_groups, &footer_grids, &footer_heights, &all_row_overlaps[2]),
+    let section_data: &[(&[RowGroup<T::NodeId>], &[SectionGrid<T::NodeId>], &[Vec<f32>])] = &[
+        (&model.header_groups, &header_grids, &header_heights),
+        (&model.row_groups, &body_grids, &body_heights),
+        (&model.footer_groups, &footer_grids, &footer_heights),
     ];
 
-    // Bottom border of the previous non-empty section's last row, for
-    // collapsing the boundary between adjacent sections.
-    let mut prev_bottom: Option<f32> = None;
-
-    for (groups, grids, heights, overlapses) in section_data {
-        for (((group, grid), row_heights), overlaps) in
-            groups.iter().zip(grids.iter()).zip(heights.iter()).zip(overlapses.iter())
-        {
-            if collapse && grid.n_rows > 0 {
-                if let Some(prev) = prev_bottom {
-                    group_y -= prev.min(overlaps.first_top);
-                }
-            }
-
-            let row_y = row_y_offsets(row_heights, spacing_y, &overlaps.between);
+    for (groups, grids, heights) in section_data {
+        for ((group, grid), row_heights) in groups.iter().zip(grids.iter()).zip(heights.iter()) {
+            let row_y = row_y_offsets(row_heights, spacing_y);
             let group_height = section_height(row_heights, &row_y);
 
             if let Some(node) = group.node {
@@ -228,15 +211,23 @@ pub fn compute_table_layout<T: TableTree>(
                         border: BOX_EDGES_ZERO,
                         padding: BOX_EDGES_ZERO,
                         content_offset_y: 0.0,
+                        suppressed_borders: [false; 4],
                     },
                 );
             }
 
-            place_rows(tree, group, grid, row_heights, &row_y, &col_x, &col_widths, &content_heights);
+            place_rows(
+                tree,
+                group,
+                grid,
+                row_heights,
+                &row_y,
+                &col_x,
+                &col_widths,
+                &content_heights,
+                &suppressed_borders,
+            );
 
-            if grid.n_rows > 0 {
-                prev_bottom = Some(overlaps.last_bottom);
-            }
             group_y += group_height + spacing_y;
         }
     }
@@ -256,6 +247,7 @@ pub fn compute_table_layout<T: TableTree>(
                 border,
                 padding,
                 content_offset_y: 0.0,
+                suppressed_borders: [false; 4],
             },
         );
         if caption_bottom {
@@ -277,6 +269,7 @@ fn place_rows<T: TableTree>(
     col_x: &[f32],
     col_widths: &[f32],
     content_heights: &HashMap<T::NodeId, f32>,
+    suppressed_borders: &HashMap<T::NodeId, [bool; 4]>,
 ) {
     let inner_width: f32 = match (col_x.last(), col_widths.last()) {
         (Some(&x), Some(&w)) => x + w - col_x.first().copied().unwrap_or(0.0),
@@ -296,18 +289,29 @@ fn place_rows<T: TableTree>(
                     border: BOX_EDGES_ZERO,
                     padding: BOX_EDGES_ZERO,
                     content_offset_y: 0.0,
+                    suppressed_borders: [false; 4],
                 },
             );
         }
 
         // Cells for this row.
         for cell in grid.cells_in_row(row_idx) {
-            place_cell(tree, cell, row_heights, col_x, col_widths, row_y, content_heights);
+            place_cell(
+                tree,
+                cell,
+                row_heights,
+                col_x,
+                col_widths,
+                row_y,
+                content_heights,
+                suppressed_borders,
+            );
         }
     }
 }
 
 /// Write the layout for one placed cell.
+#[allow(clippy::too_many_arguments)]
 fn place_cell<T: TableTree>(
     tree: &mut T,
     cell: &PlacedCell<T::NodeId>,
@@ -316,6 +320,7 @@ fn place_cell<T: TableTree>(
     col_widths: &[f32],
     row_y: &[f32],
     content_heights: &HashMap<T::NodeId, f32>,
+    suppressed_borders: &HashMap<T::NodeId, [bool; 4]>,
 ) {
     // Extents come from the offset tables so gutters (separate borders) and
     // overlaps (collapsed borders) are both handled: a spanning cell runs from
@@ -354,32 +359,20 @@ fn place_cell<T: TableTree>(
             border,
             padding,
             content_offset_y,
+            suppressed_borders: suppressed_borders.get(&cell.node).copied().unwrap_or([false; 4]),
         },
     );
 }
 
 // Offset helpers
 
-/// Vertical border-overlap data for one section under `border-collapse`.
-struct RowOverlaps {
-    /// `between[r]` = overlap between row `r-1` and row `r` (index 0 unused).
-    between: Vec<f32>,
-    /// Max top border of the section's first row (for cross-section collapse).
-    first_top: f32,
-    /// Max bottom border of the section's last row.
-    last_bottom: f32,
-}
-
 /// `col_x[i]` = x of the left edge of column `i` within a row, in px.
 /// Accounts for the border-spacing gutter to the left of each column
-/// (separate borders) or the shared-border overlap (collapsed borders).
-fn col_x_offsets(col_widths: &[f32], spacing_x: f32, overlaps: &[f32]) -> Vec<f32> {
+/// (zero under `border-collapse`, where cells sit flush).
+fn col_x_offsets(col_widths: &[f32], spacing_x: f32) -> Vec<f32> {
     let mut offsets = Vec::with_capacity(col_widths.len());
     let mut x = spacing_x;
-    for (c, &w) in col_widths.iter().enumerate() {
-        if c > 0 {
-            x -= overlaps.get(c).copied().unwrap_or(0.0);
-        }
+    for &w in col_widths {
         offsets.push(x);
         x += w + spacing_x;
     }
@@ -389,13 +382,10 @@ fn col_x_offsets(col_widths: &[f32], spacing_x: f32, overlaps: &[f32]) -> Vec<f3
 /// `row_y[i]` = y of the top edge of row `i` within its group, in px.
 /// The first row starts at 0 - the gutter above it belongs to the table
 /// (or to the previous group's bottom boundary), not to this group.
-fn row_y_offsets(row_heights: &[f32], spacing_y: f32, overlaps: &[f32]) -> Vec<f32> {
+fn row_y_offsets(row_heights: &[f32], spacing_y: f32) -> Vec<f32> {
     let mut offsets = Vec::with_capacity(row_heights.len());
     let mut y = 0.0;
-    for (r, &h) in row_heights.iter().enumerate() {
-        if r > 0 {
-            y -= overlaps.get(r).copied().unwrap_or(0.0);
-        }
+    for &h in row_heights {
         offsets.push(y);
         y += h + spacing_y;
     }
@@ -403,9 +393,9 @@ fn row_y_offsets(row_heights: &[f32], spacing_y: f32, overlaps: &[f32]) -> Vec<f
 }
 
 /// Total height of a section: from the top of the first row to the bottom of
-/// the last (gutters and collapse overlaps are baked into `row_y`). Boundary
-/// gutters (above the first row / below the last) are added by the caller
-/// when stacking groups, so they are not counted here.
+/// the last (gutters are baked into `row_y`). Boundary gutters (above the
+/// first row / below the last) are added by the caller when stacking groups,
+/// so they are not counted here.
 fn section_height(row_heights: &[f32], row_y: &[f32]) -> f32 {
     match (row_y.last(), row_heights.last()) {
         (Some(&y), Some(&h)) => y + h,
@@ -413,62 +403,111 @@ fn section_height(row_heights: &[f32], row_y: &[f32]) -> f32 {
     }
 }
 
-/// Per-boundary horizontal overlap between adjacent columns under
-/// `border-collapse`: the shared border width, i.e. the smaller of the widest
-/// right border ending at the boundary and the widest left border starting
-/// there. Overlapping the cell boxes by this amount makes equal borders
-/// coincide exactly; unequal ones stack with the later-painted cell on top.
-fn column_border_overlaps<T: TableTree>(tree: &T, n_cols: usize, grids: &[&SectionGrid<T::NodeId>]) -> Vec<f32> {
-    let mut left = vec![0.0_f32; n_cols];
-    let mut right = vec![0.0_f32; n_cols];
+/// CSS border-conflict resolution for `border-collapse` (simplified): every
+/// boundary shared by two cells is painted by exactly one of them - the wider
+/// border wins; ties go to the left/top cell (matching CSS 2 §17.6.2.1 for
+/// same-style borders; the style-rank tiebreak is not implemented). A cell
+/// edge is suppressed when it loses against EVERY neighbouring segment along
+/// that edge; mixed outcomes keep the edge painted (overlap behaviour).
+///
+/// Grids must be in render order (header -> body -> footer) so cross-section
+/// adjacency is resolved too. Edge index order: `[top, right, bottom, left]`.
+fn resolve_border_conflicts<T: TableTree>(
+    tree: &T,
+    n_cols: usize,
+    grids: &[&SectionGrid<T::NodeId>],
+) -> HashMap<T::NodeId, [bool; 4]> {
+    // Flat slot occupancy across all sections, in render order.
+    let total_rows: usize = grids.iter().map(|g| g.n_rows).sum();
+    let mut slots: Vec<Vec<Option<T::NodeId>>> = vec![vec![None; n_cols]; total_rows];
+    let mut borders: HashMap<T::NodeId, crate::types::BoxEdges> = HashMap::new();
+
+    let mut row_offset = 0;
     for grid in grids {
         for cell in grid.cells() {
-            let b = read_border(tree, cell.node);
-            let first = cell.col;
-            let last = cell.col + cell.colspan - 1;
-            if first < n_cols {
-                left[first] = left[first].max(b.left);
+            borders.entry(cell.node).or_insert_with(|| read_border(tree, cell.node));
+            for r in cell.row..(cell.row + cell.rowspan).min(grid.n_rows) {
+                for c in cell.col..(cell.col + cell.colspan).min(n_cols) {
+                    slots[row_offset + r][c] = Some(cell.node);
+                }
             }
-            if last < n_cols {
-                right[last] = right[last].max(b.right);
+        }
+        row_offset += grid.n_rows;
+    }
+
+    // Per (cell, edge): whether it faced any neighbour and whether it lost
+    // every segment. `wins[edge]` flips to true as soon as one segment wins.
+    #[derive(Default, Clone, Copy)]
+    struct EdgeState {
+        has_seg: [bool; 4],
+        won_any: [bool; 4],
+    }
+    let mut states: HashMap<T::NodeId, EdgeState> = HashMap::new();
+    let zero = crate::types::BoxEdges::default();
+
+    const TOP: usize = 0;
+    const RIGHT: usize = 1;
+    const BOTTOM: usize = 2;
+    const LEFT: usize = 3;
+
+    for r in 0..total_rows {
+        for c in 0..n_cols {
+            let Some(cur) = slots[r][c] else { continue };
+
+            // Vertical boundary with the cell to the right.
+            if c + 1 < n_cols {
+                if let Some(next) = slots[r][c + 1] {
+                    if next != cur {
+                        let left_w = borders.get(&cur).unwrap_or(&zero).right;
+                        let right_w = borders.get(&next).unwrap_or(&zero).left;
+                        let left_wins = left_w >= right_w;
+                        let s = states.entry(cur).or_default();
+                        s.has_seg[RIGHT] = true;
+                        if left_wins {
+                            s.won_any[RIGHT] = true;
+                        }
+                        let s = states.entry(next).or_default();
+                        s.has_seg[LEFT] = true;
+                        if !left_wins {
+                            s.won_any[LEFT] = true;
+                        }
+                    }
+                }
+            }
+
+            // Horizontal boundary with the cell below.
+            if r + 1 < total_rows {
+                if let Some(below) = slots[r + 1][c] {
+                    if below != cur {
+                        let top_w = borders.get(&cur).unwrap_or(&zero).bottom;
+                        let bottom_w = borders.get(&below).unwrap_or(&zero).top;
+                        let top_wins = top_w >= bottom_w;
+                        let s = states.entry(cur).or_default();
+                        s.has_seg[BOTTOM] = true;
+                        if top_wins {
+                            s.won_any[BOTTOM] = true;
+                        }
+                        let s = states.entry(below).or_default();
+                        s.has_seg[TOP] = true;
+                        if !top_wins {
+                            s.won_any[TOP] = true;
+                        }
+                    }
+                }
             }
         }
     }
-    let mut overlaps = vec![0.0_f32; n_cols];
-    for c in 1..n_cols {
-        overlaps[c] = right[c - 1].min(left[c]);
-    }
-    overlaps
-}
 
-/// Row-boundary equivalent of [`column_border_overlaps`], for one section.
-/// Returns zeroed data when `collapse` is off.
-fn row_border_overlaps<T: TableTree>(tree: &T, grid: &SectionGrid<T::NodeId>, collapse: bool) -> RowOverlaps {
-    let n_rows = grid.n_rows;
-    if !collapse || n_rows == 0 {
-        return RowOverlaps {
-            between: vec![0.0; n_rows],
-            first_top: 0.0,
-            last_bottom: 0.0,
-        };
-    }
-    let mut top = vec![0.0_f32; n_rows];
-    let mut bottom = vec![0.0_f32; n_rows];
-    for cell in grid.cells() {
-        let b = read_border(tree, cell.node);
-        top[cell.row] = top[cell.row].max(b.top);
-        let last = (cell.row + cell.rowspan - 1).min(n_rows - 1);
-        bottom[last] = bottom[last].max(b.bottom);
-    }
-    let mut between = vec![0.0_f32; n_rows];
-    for r in 1..n_rows {
-        between[r] = bottom[r - 1].min(top[r]);
-    }
-    RowOverlaps {
-        between,
-        first_top: top.first().copied().unwrap_or(0.0),
-        last_bottom: bottom.last().copied().unwrap_or(0.0),
-    }
+    states
+        .into_iter()
+        .map(|(node, s)| {
+            let mut suppressed = [false; 4];
+            for e in 0..4 {
+                suppressed[e] = s.has_seg[e] && !s.won_any[e];
+            }
+            (node, suppressed)
+        })
+        .collect()
 }
 
 // Zero-value BoxEdges constant (avoids Default derive noise in call sites).

--- a/crates/gosub_lattice/src/compute.rs
+++ b/crates/gosub_lattice/src/compute.rs
@@ -65,11 +65,12 @@ pub fn compute_table_layout<T: TableTree>(
         n_cols
     };
 
-    // Resolve table width
-    let table_width = match tree.css_length(model.node, CssProp::Width) {
-        CssLength::Px(w) => w,
-        CssLength::Percent(p) => p / 100.0 * available_width,
-        _ => available_width,
+    // Resolve the explicit table width, if any; auto tables shrink-to-fit
+    // inside `compute_column_widths`.
+    let explicit_table_width = match tree.css_length(model.node, CssProp::Width) {
+        CssLength::Px(w) => Some(w),
+        CssLength::Percent(p) => Some(p / 100.0 * available_width),
+        _ => None,
     };
 
     // Column widths
@@ -79,7 +80,16 @@ pub fn compute_table_layout<T: TableTree>(
         .chain(footer_grids.iter())
         .collect();
 
-    let col_widths = compute_column_widths(tree, n_cols, table_width, spacing_x, &all_grids, model.sizing, &col_specs);
+    let (col_widths, table_width) = compute_column_widths(
+        tree,
+        n_cols,
+        explicit_table_width,
+        available_width,
+        spacing_x,
+        &all_grids,
+        model.sizing,
+        &col_specs,
+    );
 
     // Precompute cumulative column x-offsets (relative to the row's left edge).
     // col_x[i] = x of the left edge of column i (within a row).

--- a/crates/gosub_lattice/src/compute.rs
+++ b/crates/gosub_lattice/src/compute.rs
@@ -3,9 +3,9 @@ use anyhow::Result;
 
 use crate::grid::{build_section_grid, PlacedCell, SectionGrid};
 use crate::model::{build_model, RowGroup};
-use crate::sizing::columns::compute_column_widths;
+use crate::sizing::columns::{column_specs, compute_column_widths};
 use crate::sizing::rows::{compute_row_heights, read_border, read_padding};
-use crate::types::{CellLayout, CssLength, CssProp};
+use crate::types::{CellLayout, CssLength, CssProp, TableSizing};
 use crate::TableTree;
 
 /// Entry point for the CSS table layout algorithm.
@@ -55,6 +55,15 @@ pub fn compute_table_layout<T: TableTree>(
         return Ok((0.0, 0.0));
     }
 
+    // Explicit widths from <colgroup>/<col> elements. Under fixed layout the
+    // col elements can define columns beyond those implied by any cell.
+    let col_specs = column_specs(tree, &model);
+    let n_cols = if model.sizing == TableSizing::Fixed {
+        n_cols.max(col_specs.len())
+    } else {
+        n_cols
+    };
+
     // Resolve table width
     let table_width = match tree.css_length(model.node, CssProp::Width) {
         CssLength::Px(w) => w,
@@ -69,7 +78,7 @@ pub fn compute_table_layout<T: TableTree>(
         .chain(footer_grids.iter())
         .collect();
 
-    let col_widths = compute_column_widths(tree, n_cols, table_width, spacing_x, &all_grids);
+    let col_widths = compute_column_widths(tree, n_cols, table_width, spacing_x, &all_grids, model.sizing, &col_specs);
 
     // Precompute cumulative column x-offsets (relative to the row's left edge).
     // col_x[i] = x of the left edge of column i (within a row).

--- a/crates/gosub_lattice/src/compute.rs
+++ b/crates/gosub_lattice/src/compute.rs
@@ -6,7 +6,7 @@ use crate::grid::{build_section_grid, PlacedCell, SectionGrid};
 use crate::model::{build_model, RowGroup};
 use crate::sizing::columns::{column_specs, compute_column_widths};
 use crate::sizing::rows::{compute_row_heights, effective_border, read_border, read_padding};
-use crate::types::{BorderCollapse, CellLayout, CssLength, CssProp, TableSizing};
+use crate::types::{BorderCollapse, CellLayout, CollapsedBorders, CssLength, CssProp, TableSizing};
 use crate::TableTree;
 
 /// Entry point for the CSS table layout algorithm.
@@ -97,13 +97,15 @@ pub fn compute_table_layout<T: TableTree>(
         .collect();
 
     // Border-conflict resolution (collapse only) runs BEFORE any sizing:
-    // suppressed edges take no layout space, so intrinsic measurement, row
-    // heights and cell boxes must all use the effective (post-conflict)
-    // borders. The implementor is notified so its layout engine agrees.
-    let suppressed_borders: HashMap<T::NodeId, [bool; 4]> = if collapse {
-        let resolved = resolve_border_conflicts(tree, n_cols, &all_grids);
-        for (&node, &edges) in &resolved {
-            tree.suppress_cell_borders(node, edges);
+    // every cell's layout border becomes half the resolved boundary width, so
+    // intrinsic measurement, row heights and cell boxes must all use the
+    // collapse geometry. The implementor is notified so its layout engine
+    // agrees.
+    let collapsed_borders: HashMap<T::NodeId, CollapsedBorders> = if collapse {
+        let (resolved, owners) = resolve_border_conflicts(tree, n_cols, &all_grids);
+        for (&node, cb) in &resolved {
+            let edge_owners = owners.get(&node).copied().unwrap_or([None; 4]);
+            tree.set_collapsed_cell_borders(node, cb.layout, edge_owners);
         }
         resolved
     } else {
@@ -151,7 +153,7 @@ pub fn compute_table_layout<T: TableTree>(
             spacing_x,
             spacing_y,
             &mut content_heights,
-            &suppressed_borders,
+            &collapsed_borders,
         ));
     }
 
@@ -164,7 +166,7 @@ pub fn compute_table_layout<T: TableTree>(
             spacing_x,
             spacing_y,
             &mut content_heights,
-            &suppressed_borders,
+            &collapsed_borders,
         ));
     }
 
@@ -177,7 +179,7 @@ pub fn compute_table_layout<T: TableTree>(
             spacing_x,
             spacing_y,
             &mut content_heights,
-            &suppressed_borders,
+            &collapsed_borders,
         ));
     }
 
@@ -241,6 +243,7 @@ pub fn compute_table_layout<T: TableTree>(
                         padding: BOX_EDGES_ZERO,
                         content_offset_y: 0.0,
                         suppressed_borders: [false; 4],
+                        border_outsets: [0.0; 4],
                     },
                 );
             }
@@ -254,7 +257,7 @@ pub fn compute_table_layout<T: TableTree>(
                 &col_x,
                 &col_widths,
                 &content_heights,
-                &suppressed_borders,
+                &collapsed_borders,
             );
 
             group_y += group_height + spacing_y;
@@ -277,6 +280,7 @@ pub fn compute_table_layout<T: TableTree>(
                 padding,
                 content_offset_y: 0.0,
                 suppressed_borders: [false; 4],
+                border_outsets: [0.0; 4],
             },
         );
         if caption_bottom {
@@ -298,7 +302,7 @@ fn place_rows<T: TableTree>(
     col_x: &[f32],
     col_widths: &[f32],
     content_heights: &HashMap<T::NodeId, f32>,
-    suppressed_borders: &HashMap<T::NodeId, [bool; 4]>,
+    collapsed_borders: &HashMap<T::NodeId, CollapsedBorders>,
 ) {
     let inner_width: f32 = match (col_x.last(), col_widths.last()) {
         (Some(&x), Some(&w)) => x + w - col_x.first().copied().unwrap_or(0.0),
@@ -319,6 +323,7 @@ fn place_rows<T: TableTree>(
                     padding: BOX_EDGES_ZERO,
                     content_offset_y: 0.0,
                     suppressed_borders: [false; 4],
+                    border_outsets: [0.0; 4],
                 },
             );
         }
@@ -333,7 +338,7 @@ fn place_rows<T: TableTree>(
                 col_widths,
                 row_y,
                 content_heights,
-                suppressed_borders,
+                collapsed_borders,
             );
         }
     }
@@ -349,7 +354,7 @@ fn place_cell<T: TableTree>(
     col_widths: &[f32],
     row_y: &[f32],
     content_heights: &HashMap<T::NodeId, f32>,
-    suppressed_borders: &HashMap<T::NodeId, [bool; 4]>,
+    collapsed_borders: &HashMap<T::NodeId, CollapsedBorders>,
 ) {
     // Extents come from the offset tables so gutters (separate borders) and
     // overlaps (collapsed borders) are both handled: a spanning cell runs from
@@ -366,7 +371,8 @@ fn place_cell<T: TableTree>(
     // Cell y is relative to its own row's top.
     let y_within_row = 0.0;
 
-    let border = effective_border(tree, cell.node, suppressed_borders);
+    let collapsed = collapsed_borders.get(&cell.node).copied();
+    let border = effective_border(tree, cell.node, collapsed_borders);
     let padding = read_padding(tree, cell.node);
 
     // vertical-align: shift the cell's children down within the free space
@@ -388,7 +394,8 @@ fn place_cell<T: TableTree>(
             border,
             padding,
             content_offset_y,
-            suppressed_borders: suppressed_borders.get(&cell.node).copied().unwrap_or([false; 4]),
+            suppressed_borders: collapsed.map(|c| c.suppressed).unwrap_or([false; 4]),
+            border_outsets: collapsed.map(|c| c.outsets).unwrap_or([0.0; 4]),
         },
     );
 }
@@ -432,20 +439,33 @@ fn section_height(row_heights: &[f32], row_y: &[f32]) -> f32 {
     }
 }
 
-/// CSS border-conflict resolution for `border-collapse` (simplified): every
-/// boundary shared by two cells is painted by exactly one of them - the wider
-/// border wins; ties go to the left/top cell (matching CSS 2 §17.6.2.1 for
-/// same-style borders; the style-rank tiebreak is not implemented). A cell
-/// edge is suppressed when it loses against EVERY neighbouring segment along
-/// that edge; mixed outcomes keep the edge painted (overlap behaviour).
+/// CSS border-conflict resolution for `border-collapse`, per CSS 2 §17.6.2:
+/// collapsed borders are CENTERED on the grid lines. The wider border wins a
+/// boundary; ties go to the left/top cell (the style-rank tiebreak is not
+/// implemented). Both cells reserve half the resolved boundary width in their
+/// layout, and each paints ITS OWN half - the losing cell in the winner's
+/// style (see the returned owners map) - so the result does not depend on the
+/// order cells are painted in. Outer (perimeter) edges get a paint outset of
+/// half the cell's own border: the other half sticks out of the table box
+/// like in browsers, where nothing can overpaint it.
+///
+/// A cell edge is suppressed when it loses against EVERY neighbouring segment
+/// along that edge; mixed outcomes keep the edge painted in the cell's own
+/// style. Multi-segment edges (spanning cells) resolve to the widest
+/// segment's winner for the whole edge - per-segment painting is not
+/// implemented.
 ///
 /// Grids must be in render order (header -> body -> footer) so cross-section
 /// adjacency is resolved too. Edge index order: `[top, right, bottom, left]`.
+#[allow(clippy::type_complexity)]
 fn resolve_border_conflicts<T: TableTree>(
     tree: &T,
     n_cols: usize,
     grids: &[&SectionGrid<T::NodeId>],
-) -> HashMap<T::NodeId, [bool; 4]> {
+) -> (
+    HashMap<T::NodeId, CollapsedBorders>,
+    HashMap<T::NodeId, [Option<T::NodeId>; 4]>,
+) {
     // Flat slot occupancy across all sections, in render order.
     let total_rows: usize = grids.iter().map(|g| g.n_rows).sum();
     let mut slots: Vec<Vec<Option<T::NodeId>>> = vec![vec![None; n_cols]; total_rows];
@@ -464,14 +484,27 @@ fn resolve_border_conflicts<T: TableTree>(
         row_offset += grid.n_rows;
     }
 
-    // Per (cell, edge): whether it faced any neighbour and whether it lost
-    // every segment. `wins[edge]` flips to true as soon as one segment wins.
-    #[derive(Default, Clone, Copy)]
-    struct EdgeState {
+    // Per (cell, edge): whether it faced any neighbour, whether it won at
+    // least one segment, the widest resolved boundary along the edge, and the
+    // widest segment's winning cell.
+    #[derive(Clone, Copy)]
+    struct EdgeState<Id> {
         has_seg: [bool; 4],
         won_any: [bool; 4],
+        resolved: [f32; 4],
+        winner: [Option<Id>; 4],
     }
-    let mut states: HashMap<T::NodeId, EdgeState> = HashMap::new();
+    impl<Id> EdgeState<Id> {
+        fn new() -> Self {
+            EdgeState {
+                has_seg: [false; 4],
+                won_any: [false; 4],
+                resolved: [0.0; 4],
+                winner: [None, None, None, None],
+            }
+        }
+    }
+    let mut states: HashMap<T::NodeId, EdgeState<T::NodeId>> = HashMap::new();
     let zero = crate::types::BoxEdges::default();
 
     const TOP: usize = 0;
@@ -489,14 +522,24 @@ fn resolve_border_conflicts<T: TableTree>(
                     if next != cur {
                         let left_w = borders.get(&cur).unwrap_or(&zero).right;
                         let right_w = borders.get(&next).unwrap_or(&zero).left;
+                        let resolved = left_w.max(right_w);
                         let left_wins = left_w >= right_w;
-                        let s = states.entry(cur).or_default();
+                        let seg_winner = if left_wins { cur } else { next };
+                        let s = states.entry(cur).or_insert_with(EdgeState::new);
                         s.has_seg[RIGHT] = true;
+                        if resolved >= s.resolved[RIGHT] {
+                            s.resolved[RIGHT] = resolved;
+                            s.winner[RIGHT] = Some(seg_winner);
+                        }
                         if left_wins {
                             s.won_any[RIGHT] = true;
                         }
-                        let s = states.entry(next).or_default();
+                        let s = states.entry(next).or_insert_with(EdgeState::new);
                         s.has_seg[LEFT] = true;
+                        if resolved >= s.resolved[LEFT] {
+                            s.resolved[LEFT] = resolved;
+                            s.winner[LEFT] = Some(seg_winner);
+                        }
                         if !left_wins {
                             s.won_any[LEFT] = true;
                         }
@@ -510,14 +553,24 @@ fn resolve_border_conflicts<T: TableTree>(
                     if below != cur {
                         let top_w = borders.get(&cur).unwrap_or(&zero).bottom;
                         let bottom_w = borders.get(&below).unwrap_or(&zero).top;
+                        let resolved = top_w.max(bottom_w);
                         let top_wins = top_w >= bottom_w;
-                        let s = states.entry(cur).or_default();
+                        let seg_winner = if top_wins { cur } else { below };
+                        let s = states.entry(cur).or_insert_with(EdgeState::new);
                         s.has_seg[BOTTOM] = true;
+                        if resolved >= s.resolved[BOTTOM] {
+                            s.resolved[BOTTOM] = resolved;
+                            s.winner[BOTTOM] = Some(seg_winner);
+                        }
                         if top_wins {
                             s.won_any[BOTTOM] = true;
                         }
-                        let s = states.entry(below).or_default();
+                        let s = states.entry(below).or_insert_with(EdgeState::new);
                         s.has_seg[TOP] = true;
+                        if resolved >= s.resolved[TOP] {
+                            s.resolved[TOP] = resolved;
+                            s.winner[TOP] = Some(seg_winner);
+                        }
                         if !top_wins {
                             s.won_any[TOP] = true;
                         }
@@ -527,16 +580,44 @@ fn resolve_border_conflicts<T: TableTree>(
         }
     }
 
-    states
-        .into_iter()
-        .map(|(node, s)| {
-            let mut suppressed = [false; 4];
-            for e in 0..4 {
-                suppressed[e] = s.has_seg[e] && !s.won_any[e];
+    // Every cell of a collapsed table gets an entry: outer edges resolve to
+    // the cell's own border (half in the layout, half sticking out of the
+    // table box, like browsers).
+    let mut collapsed_map = HashMap::new();
+    let mut owners_map = HashMap::new();
+    for (&node, raw) in &borders {
+        let s = states.get(&node).copied().unwrap_or_else(EdgeState::new);
+        let own = [raw.top, raw.right, raw.bottom, raw.left];
+        let mut suppressed = [false; 4];
+        let mut resolved = [0.0_f32; 4];
+        let mut outsets = [0.0_f32; 4];
+        let mut owners = [None; 4];
+        for e in 0..4 {
+            suppressed[e] = s.has_seg[e] && !s.won_any[e];
+            resolved[e] = if s.has_seg[e] { s.resolved[e] } else { own[e] };
+            // Only perimeter edges paint outside the box; internal boundaries
+            // are covered half-and-half by the two adjacent cells.
+            outsets[e] = if s.has_seg[e] { 0.0 } else { own[e] / 2.0 };
+            if suppressed[e] {
+                owners[e] = s.winner[e];
             }
-            (node, suppressed)
-        })
-        .collect()
+        }
+        collapsed_map.insert(
+            node,
+            CollapsedBorders {
+                layout: crate::types::BoxEdges {
+                    top: resolved[0] / 2.0,
+                    right: resolved[1] / 2.0,
+                    bottom: resolved[2] / 2.0,
+                    left: resolved[3] / 2.0,
+                },
+                suppressed,
+                outsets,
+            },
+        );
+        owners_map.insert(node, owners);
+    }
+    (collapsed_map, owners_map)
 }
 
 // Zero-value BoxEdges constant (avoids Default derive noise in call sites).

--- a/crates/gosub_lattice/src/compute.rs
+++ b/crates/gosub_lattice/src/compute.rs
@@ -121,6 +121,7 @@ pub fn compute_table_layout<T: TableTree>(
         &all_grids,
         model.sizing,
         &col_specs,
+        &collapsed_borders,
     );
 
     if std::env::var_os("LATTICE_DEBUG").is_some() {

--- a/crates/gosub_lattice/src/compute.rs
+++ b/crates/gosub_lattice/src/compute.rs
@@ -175,6 +175,7 @@ pub fn compute_table_layout<T: TableTree>(
     // than iterator combinators because a closure can't hold `&mut tree` while
     // the model is also borrowed.
     let mut content_heights: HashMap<T::NodeId, f32> = HashMap::new();
+    let mut baseline_shifts: HashMap<T::NodeId, f32> = HashMap::new();
 
     let mut header_heights: Vec<Vec<f32>> = Vec::with_capacity(header_grids.len());
     for grid in &header_grids {
@@ -186,6 +187,7 @@ pub fn compute_table_layout<T: TableTree>(
             spacing_y,
             &mut content_heights,
             &collapsed_borders,
+            &mut baseline_shifts,
         ));
     }
 
@@ -199,6 +201,7 @@ pub fn compute_table_layout<T: TableTree>(
             spacing_y,
             &mut content_heights,
             &collapsed_borders,
+            &mut baseline_shifts,
         ));
     }
 
@@ -212,6 +215,7 @@ pub fn compute_table_layout<T: TableTree>(
             spacing_y,
             &mut content_heights,
             &collapsed_borders,
+            &mut baseline_shifts,
         ));
     }
 
@@ -293,6 +297,7 @@ pub fn compute_table_layout<T: TableTree>(
                 &col_widths,
                 &content_heights,
                 &collapsed_borders,
+                &baseline_shifts,
                 group_base_y,
             );
 
@@ -343,6 +348,7 @@ fn place_rows<T: TableTree>(
     col_widths: &[f32],
     content_heights: &HashMap<T::NodeId, f32>,
     collapsed_borders: &HashMap<T::NodeId, CollapsedBorders>,
+    baseline_shifts: &HashMap<T::NodeId, f32>,
     group_base_y: f32,
 ) {
     let inner_width: f32 = match (col_x.last(), col_widths.last()) {
@@ -382,6 +388,7 @@ fn place_rows<T: TableTree>(
                 row_y,
                 content_heights,
                 collapsed_borders,
+                baseline_shifts,
                 cell_base_y,
             );
         }
@@ -399,6 +406,7 @@ fn place_cell<T: TableTree>(
     row_y: &[f32],
     content_heights: &HashMap<T::NodeId, f32>,
     collapsed_borders: &HashMap<T::NodeId, CollapsedBorders>,
+    baseline_shifts: &HashMap<T::NodeId, f32>,
     // Offset of the cell's (anonymous) row relative to the cell's DOM parent; 0 in a real row.
     base_y: f32,
 ) {
@@ -430,6 +438,9 @@ fn place_cell<T: TableTree>(
         crate::types::VerticalAlign::Top => 0.0,
         crate::types::VerticalAlign::Middle => free / 2.0,
         crate::types::VerticalAlign::Bottom => free,
+        // Shift down so the first-line baseline meets the row baseline; a cell with
+        // no line box (no shift entry) stays at the top.
+        crate::types::VerticalAlign::Baseline => baseline_shifts.get(&cell.node).copied().unwrap_or(0.0),
     };
 
     tree.set_layout(

--- a/crates/gosub_lattice/src/compute.rs
+++ b/crates/gosub_lattice/src/compute.rs
@@ -6,7 +6,7 @@ use crate::grid::{build_section_grid, PlacedCell, SectionGrid};
 use crate::model::{build_model, RowGroup};
 use crate::sizing::columns::{column_specs, compute_column_widths};
 use crate::sizing::rows::{compute_row_heights, read_border, read_padding};
-use crate::types::{CellLayout, CssLength, CssProp, TableSizing};
+use crate::types::{BorderCollapse, CellLayout, CssLength, CssProp, TableSizing};
 use crate::TableTree;
 
 /// Entry point for the CSS table layout algorithm.
@@ -25,7 +25,10 @@ pub fn compute_table_layout<T: TableTree>(
     _available_height: Option<f32>,
 ) -> Result<(f32, f32)> {
     let model = build_model(tree, table_node);
-    let (spacing_x, spacing_y) = model.border_spacing;
+    let collapse = model.border_collapse == BorderCollapse::Collapse;
+    // Collapsed borders have no gutters; adjacent cells share their border
+    // instead (realized below by overlapping their boxes).
+    let (spacing_x, spacing_y) = if collapse { (0.0, 0.0) } else { model.border_spacing };
 
     // Build per-section grids
     let header_grids: Vec<SectionGrid<T::NodeId>> = model
@@ -92,8 +95,15 @@ pub fn compute_table_layout<T: TableTree>(
     );
 
     // Precompute cumulative column x-offsets (relative to the row's left edge).
-    // col_x[i] = x of the left edge of column i (within a row).
-    let col_x = col_x_offsets(&col_widths, spacing_x);
+    // col_x[i] = x of the left edge of column i (within a row). Under collapse,
+    // adjacent columns overlap by their shared border width so the borders of
+    // neighbouring cells coincide.
+    let col_overlaps = if collapse {
+        column_border_overlaps(tree, n_cols, &all_grids)
+    } else {
+        vec![0.0; n_cols]
+    };
+    let col_x = col_x_offsets(&col_widths, spacing_x, &col_overlaps);
 
     // Row heights per section
     //
@@ -139,30 +149,75 @@ pub fn compute_table_layout<T: TableTree>(
         ));
     }
 
+    // Per-section vertical border overlaps (collapse only): rows within a
+    // section overlap by their shared border; the section edge borders are
+    // kept so adjacent sections can overlap too.
+    let all_row_overlaps: Vec<Vec<RowOverlaps>> = [&header_grids, &body_grids, &footer_grids]
+        .into_iter()
+        .map(|grids| grids.iter().map(|g| row_border_overlaps(tree, g, collapse)).collect())
+        .collect();
+
+    // Caption: measured like a cell spanning the full table width; placed
+    // above (default) or below the grid per `caption-side`.
+    let caption_bottom = model
+        .caption
+        .map(|cap| matches!(tree.css_length(cap, CssProp::CaptionSide), CssLength::Px(v) if v == 1.0))
+        .unwrap_or(false);
+    let caption_height = match model.caption {
+        Some(cap) => {
+            let border = read_border(tree, cap);
+            let padding = read_padding(tree, cap);
+            let inner_w = (table_width - border.horizontal() - padding.horizontal()).max(0.0);
+            let content_h = tree.layout_cell(cap, inner_w);
+            let explicit_h = match tree.css_length(cap, CssProp::Height) {
+                CssLength::Px(px) => px,
+                _ => 0.0,
+            };
+            content_h.max(explicit_h) + border.vertical() + padding.vertical()
+        }
+        None => 0.0,
+    };
+
     // Apply positions
     //
     //    Per CSS: sections are rendered in the order header → body → footer,
     //    regardless of their source position.  Each group is positioned
     //    relative to the table.  Each row is positioned relative to its group.
     //    Each cell is positioned relative to its row.
-    let inner_width = col_widths.iter().sum::<f32>() + (n_cols as f32 + 1.0) * spacing_x;
+    let inner_width = match (col_x.last(), col_widths.last()) {
+        (Some(&x), Some(&w)) => x + w + spacing_x,
+        _ => 0.0,
+    };
 
     // Y offset of the next group, relative to the table. Vertically the table is one
     // flat stack of rows: one gutter above the first row, one between any two adjacent
     // rows (also across group boundaries), one below the last. Groups therefore carry
     // only the (n_rows - 1) *internal* gutters; the shared boundary gutters live here.
-    let mut group_y = spacing_y;
+    let mut group_y = if caption_bottom { 0.0 } else { caption_height } + spacing_y;
 
     #[allow(clippy::type_complexity)]
-    let section_data: &[(&[RowGroup<T::NodeId>], &[SectionGrid<T::NodeId>], &[Vec<f32>])] = &[
-        (&model.header_groups, &header_grids, &header_heights),
-        (&model.row_groups, &body_grids, &body_heights),
-        (&model.footer_groups, &footer_grids, &footer_heights),
+    let section_data: &[(&[RowGroup<T::NodeId>], &[SectionGrid<T::NodeId>], &[Vec<f32>], &[RowOverlaps])] = &[
+        (&model.header_groups, &header_grids, &header_heights, &all_row_overlaps[0]),
+        (&model.row_groups, &body_grids, &body_heights, &all_row_overlaps[1]),
+        (&model.footer_groups, &footer_grids, &footer_heights, &all_row_overlaps[2]),
     ];
 
-    for (groups, grids, heights) in section_data {
-        for ((group, grid), row_heights) in groups.iter().zip(grids.iter()).zip(heights.iter()) {
-            let group_height = section_height(row_heights, spacing_y);
+    // Bottom border of the previous non-empty section's last row, for
+    // collapsing the boundary between adjacent sections.
+    let mut prev_bottom: Option<f32> = None;
+
+    for (groups, grids, heights, overlapses) in section_data {
+        for (((group, grid), row_heights), overlaps) in
+            groups.iter().zip(grids.iter()).zip(heights.iter()).zip(overlapses.iter())
+        {
+            if collapse && grid.n_rows > 0 {
+                if let Some(prev) = prev_bottom {
+                    group_y -= prev.min(overlaps.first_top);
+                }
+            }
+
+            let row_y = row_y_offsets(row_heights, spacing_y, &overlaps.between);
+            let group_height = section_height(row_heights, &row_y);
 
             if let Some(node) = group.node {
                 tree.set_layout(
@@ -177,23 +232,36 @@ pub fn compute_table_layout<T: TableTree>(
                 );
             }
 
-            place_rows(
-                tree,
-                group,
-                grid,
-                row_heights,
-                &col_x,
-                &col_widths,
-                spacing_x,
-                spacing_y,
-                &content_heights,
-            );
+            place_rows(tree, group, grid, row_heights, &row_y, &col_x, &col_widths, &content_heights);
 
+            if grid.n_rows > 0 {
+                prev_bottom = Some(overlaps.last_bottom);
+            }
             group_y += group_height + spacing_y;
         }
     }
 
-    let total_height = group_y;
+    // A top caption's height is already part of group_y; a bottom caption
+    // extends the table below the grid.
+    let mut total_height = group_y;
+    if let Some(cap) = model.caption {
+        let y = if caption_bottom { total_height } else { 0.0 };
+        let border = read_border(tree, cap);
+        let padding = read_padding(tree, cap);
+        tree.set_layout(
+            cap,
+            CellLayout {
+                position: Point::new(0.0, y),
+                size: Size::new(table_width, caption_height),
+                border,
+                padding,
+                content_offset_y: 0.0,
+            },
+        );
+        if caption_bottom {
+            total_height += caption_height;
+        }
+    }
 
     Ok((table_width, total_height))
 }
@@ -205,15 +273,15 @@ fn place_rows<T: TableTree>(
     group: &RowGroup<T::NodeId>,
     grid: &SectionGrid<T::NodeId>,
     row_heights: &[f32],
+    row_y: &[f32],
     col_x: &[f32],
     col_widths: &[f32],
-    spacing_x: f32,
-    spacing_y: f32,
     content_heights: &HashMap<T::NodeId, f32>,
 ) {
-    // Precompute y offset of each row within the group.
-    let row_y = row_y_offsets(row_heights, spacing_y);
-    let inner_width: f32 = col_widths.iter().sum::<f32>();
+    let inner_width: f32 = match (col_x.last(), col_widths.last()) {
+        (Some(&x), Some(&w)) => x + w - col_x.first().copied().unwrap_or(0.0),
+        _ => 0.0,
+    };
 
     for (row_idx, row) in group.rows.iter().enumerate() {
         let ry = row_y[row_idx];
@@ -234,23 +302,12 @@ fn place_rows<T: TableTree>(
 
         // Cells for this row.
         for cell in grid.cells_in_row(row_idx) {
-            place_cell(
-                tree,
-                cell,
-                row_heights,
-                col_x,
-                col_widths,
-                &row_y,
-                spacing_x,
-                spacing_y,
-                content_heights,
-            );
+            place_cell(tree, cell, row_heights, col_x, col_widths, row_y, content_heights);
         }
     }
 }
 
 /// Write the layout for one placed cell.
-#[allow(clippy::too_many_arguments)]
 fn place_cell<T: TableTree>(
     tree: &mut T,
     cell: &PlacedCell<T::NodeId>,
@@ -258,26 +315,22 @@ fn place_cell<T: TableTree>(
     col_x: &[f32],
     col_widths: &[f32],
     row_y: &[f32],
-    spacing_x: f32,
-    spacing_y: f32,
     content_heights: &HashMap<T::NodeId, f32>,
 ) {
-    // Width = sum of spanned column widths, plus the border-spacing gutters the
-    // spanning cell covers (a colspan=2 cell runs across the gutter between its
-    // two columns). `col_widths` itself excludes spacing.
-    let spanned_cols = col_widths.get(cell.col..cell.col + cell.colspan).unwrap_or(&[]);
-    let cell_width: f32 = spanned_cols.iter().sum::<f32>() + spacing_x * spanned_cols.len().saturating_sub(1) as f32;
-
-    // Height = sum of spanned row heights, plus the gutters between them.
-    let spanned_rows = row_heights.get(cell.row..cell.row + cell.rowspan).unwrap_or(&[]);
-    let cell_height: f32 = spanned_rows.iter().sum::<f32>() + spacing_y * spanned_rows.len().saturating_sub(1) as f32;
-
+    // Extents come from the offset tables so gutters (separate borders) and
+    // overlaps (collapsed borders) are both handled: a spanning cell runs from
+    // its first column/row's start to its last column/row's end.
+    let last_col = (cell.col + cell.colspan - 1).min(col_widths.len().saturating_sub(1));
     let x = col_x.get(cell.col).copied().unwrap_or(0.0);
+    let cell_width = col_x.get(last_col).copied().unwrap_or(0.0) + col_widths.get(last_col).copied().unwrap_or(0.0) - x;
+
+    let last_row = (cell.row + cell.rowspan - 1).min(row_heights.len().saturating_sub(1));
+    let cell_row_y = row_y.get(cell.row).copied().unwrap_or(0.0);
+    let cell_height =
+        row_y.get(last_row).copied().unwrap_or(0.0) + row_heights.get(last_row).copied().unwrap_or(0.0) - cell_row_y;
 
     // Cell y is relative to its own row's top.
-    let cell_row_y = row_y.get(cell.row).copied().unwrap_or(0.0);
-    let start_row_y = row_y.get(cell.row).copied().unwrap_or(0.0);
-    let y_within_row = cell_row_y - start_row_y; // always 0.0 for row-relative coords
+    let y_within_row = 0.0;
 
     let border = read_border(tree, cell.node);
     let padding = read_padding(tree, cell.node);
@@ -307,12 +360,26 @@ fn place_cell<T: TableTree>(
 
 // Offset helpers
 
+/// Vertical border-overlap data for one section under `border-collapse`.
+struct RowOverlaps {
+    /// `between[r]` = overlap between row `r-1` and row `r` (index 0 unused).
+    between: Vec<f32>,
+    /// Max top border of the section's first row (for cross-section collapse).
+    first_top: f32,
+    /// Max bottom border of the section's last row.
+    last_bottom: f32,
+}
+
 /// `col_x[i]` = x of the left edge of column `i` within a row, in px.
-/// Accounts for the border-spacing gutter to the left of each column.
-fn col_x_offsets(col_widths: &[f32], spacing_x: f32) -> Vec<f32> {
+/// Accounts for the border-spacing gutter to the left of each column
+/// (separate borders) or the shared-border overlap (collapsed borders).
+fn col_x_offsets(col_widths: &[f32], spacing_x: f32, overlaps: &[f32]) -> Vec<f32> {
     let mut offsets = Vec::with_capacity(col_widths.len());
     let mut x = spacing_x;
-    for &w in col_widths {
+    for (c, &w) in col_widths.iter().enumerate() {
+        if c > 0 {
+            x -= overlaps.get(c).copied().unwrap_or(0.0);
+        }
         offsets.push(x);
         x += w + spacing_x;
     }
@@ -322,23 +389,86 @@ fn col_x_offsets(col_widths: &[f32], spacing_x: f32) -> Vec<f32> {
 /// `row_y[i]` = y of the top edge of row `i` within its group, in px.
 /// The first row starts at 0 - the gutter above it belongs to the table
 /// (or to the previous group's bottom boundary), not to this group.
-fn row_y_offsets(row_heights: &[f32], spacing_y: f32) -> Vec<f32> {
+fn row_y_offsets(row_heights: &[f32], spacing_y: f32, overlaps: &[f32]) -> Vec<f32> {
     let mut offsets = Vec::with_capacity(row_heights.len());
     let mut y = 0.0;
-    for &h in row_heights {
+    for (r, &h) in row_heights.iter().enumerate() {
+        if r > 0 {
+            y -= overlaps.get(r).copied().unwrap_or(0.0);
+        }
         offsets.push(y);
         y += h + spacing_y;
     }
     offsets
 }
 
-/// Total height of a section: its rows plus the gutters *between* them.
-/// Boundary gutters (above the first row / below the last) are added by the
-/// caller when stacking groups, so they are not counted here.
-fn section_height(row_heights: &[f32], spacing_y: f32) -> f32 {
-    let rows_h: f32 = row_heights.iter().sum();
-    let gaps = spacing_y * row_heights.len().saturating_sub(1) as f32;
-    rows_h + gaps
+/// Total height of a section: from the top of the first row to the bottom of
+/// the last (gutters and collapse overlaps are baked into `row_y`). Boundary
+/// gutters (above the first row / below the last) are added by the caller
+/// when stacking groups, so they are not counted here.
+fn section_height(row_heights: &[f32], row_y: &[f32]) -> f32 {
+    match (row_y.last(), row_heights.last()) {
+        (Some(&y), Some(&h)) => y + h,
+        _ => 0.0,
+    }
+}
+
+/// Per-boundary horizontal overlap between adjacent columns under
+/// `border-collapse`: the shared border width, i.e. the smaller of the widest
+/// right border ending at the boundary and the widest left border starting
+/// there. Overlapping the cell boxes by this amount makes equal borders
+/// coincide exactly; unequal ones stack with the later-painted cell on top.
+fn column_border_overlaps<T: TableTree>(tree: &T, n_cols: usize, grids: &[&SectionGrid<T::NodeId>]) -> Vec<f32> {
+    let mut left = vec![0.0_f32; n_cols];
+    let mut right = vec![0.0_f32; n_cols];
+    for grid in grids {
+        for cell in grid.cells() {
+            let b = read_border(tree, cell.node);
+            let first = cell.col;
+            let last = cell.col + cell.colspan - 1;
+            if first < n_cols {
+                left[first] = left[first].max(b.left);
+            }
+            if last < n_cols {
+                right[last] = right[last].max(b.right);
+            }
+        }
+    }
+    let mut overlaps = vec![0.0_f32; n_cols];
+    for c in 1..n_cols {
+        overlaps[c] = right[c - 1].min(left[c]);
+    }
+    overlaps
+}
+
+/// Row-boundary equivalent of [`column_border_overlaps`], for one section.
+/// Returns zeroed data when `collapse` is off.
+fn row_border_overlaps<T: TableTree>(tree: &T, grid: &SectionGrid<T::NodeId>, collapse: bool) -> RowOverlaps {
+    let n_rows = grid.n_rows;
+    if !collapse || n_rows == 0 {
+        return RowOverlaps {
+            between: vec![0.0; n_rows],
+            first_top: 0.0,
+            last_bottom: 0.0,
+        };
+    }
+    let mut top = vec![0.0_f32; n_rows];
+    let mut bottom = vec![0.0_f32; n_rows];
+    for cell in grid.cells() {
+        let b = read_border(tree, cell.node);
+        top[cell.row] = top[cell.row].max(b.top);
+        let last = (cell.row + cell.rowspan - 1).min(n_rows - 1);
+        bottom[last] = bottom[last].max(b.bottom);
+    }
+    let mut between = vec![0.0_f32; n_rows];
+    for r in 1..n_rows {
+        between[r] = bottom[r - 1].min(top[r]);
+    }
+    RowOverlaps {
+        between,
+        first_top: top.first().copied().unwrap_or(0.0),
+        last_bottom: bottom.last().copied().unwrap_or(0.0),
+    }
 }
 
 // Zero-value BoxEdges constant (avoids Default derive noise in call sites).

--- a/crates/gosub_lattice/src/compute.rs
+++ b/crates/gosub_lattice/src/compute.rs
@@ -102,7 +102,7 @@ pub fn compute_table_layout<T: TableTree>(
     // collapse geometry. The implementor is notified so its layout engine
     // agrees.
     let collapsed_borders: HashMap<T::NodeId, CollapsedBorders> = if collapse {
-        let (resolved, owners) = resolve_border_conflicts(tree, n_cols, &all_grids);
+        let (resolved, owners) = resolve_border_conflicts(tree, table_node, n_cols, &all_grids);
         for (&node, cb) in &resolved {
             let edge_owners = owners.get(&node).copied().unwrap_or([None; 4]);
             tree.set_collapsed_cell_borders(node, cb.layout, edge_owners);
@@ -148,11 +148,25 @@ pub fn compute_table_layout<T: TableTree>(
         );
     }
 
+    // Under collapse the table's border box spans OUTER border edge to outer border
+    // edge (matching browsers): the perimeter cells' outer border halves live inside
+    // the table box, not in its margin. Grow the box by the widest perimeter half on
+    // each side and shift the grid inward to make room.
+    let perimeter = if collapse {
+        perimeter_halves::<T>(&collapsed_borders, n_cols, &all_grids)
+    } else {
+        BOX_EDGES_ZERO
+    };
+    let table_width = table_width + perimeter.left + perimeter.right;
+
     // Precompute cumulative column x-offsets (relative to the row's left edge).
     // col_x[i] = x of the left edge of column i (within a row). Under collapse
     // the cells sit flush (spacing 0) and conflict resolution below decides
     // which cell paints each shared border.
-    let col_x = col_x_offsets(&col_widths, spacing_x);
+    let mut col_x = col_x_offsets(&col_widths, spacing_x);
+    for x in &mut col_x {
+        *x += perimeter.left;
+    }
 
     // Row heights per section
     //
@@ -237,7 +251,7 @@ pub fn compute_table_layout<T: TableTree>(
     // flat stack of rows: one gutter above the first row, one between any two adjacent
     // rows (also across group boundaries), one below the last. Groups therefore carry
     // only the (n_rows - 1) *internal* gutters; the shared boundary gutters live here.
-    let mut group_y = if caption_bottom { 0.0 } else { caption_height } + spacing_y;
+    let mut group_y = if caption_bottom { 0.0 } else { caption_height } + spacing_y + perimeter.top;
 
     #[allow(clippy::type_complexity)]
     let section_data: &[(&[RowGroup<T::NodeId>], &[SectionGrid<T::NodeId>], &[Vec<f32>])] = &[
@@ -288,7 +302,7 @@ pub fn compute_table_layout<T: TableTree>(
 
     // A top caption's height is already part of group_y; a bottom caption
     // extends the table below the grid.
-    let mut total_height = group_y;
+    let mut total_height = group_y + perimeter.bottom;
     if let Some(cap) = model.caption {
         let y = if caption_bottom { total_height } else { 0.0 };
         let border = read_border(tree, cap);
@@ -471,6 +485,36 @@ fn section_height(row_heights: &[f32], row_y: &[f32]) -> f32 {
     }
 }
 
+/// The widest outer border half on each side of a collapsed table: the halves that
+/// stick out beyond the grid and become part of the table's border box.
+fn perimeter_halves<T: TableTree>(
+    collapsed: &HashMap<T::NodeId, CollapsedBorders>,
+    n_cols: usize,
+    grids: &[&SectionGrid<T::NodeId>],
+) -> crate::types::BoxEdges {
+    let mut out = BOX_EDGES_ZERO;
+    let last_grid = grids.iter().rposition(|g| g.n_rows > 0);
+    let first_grid = grids.iter().position(|g| g.n_rows > 0);
+    for (gi, grid) in grids.iter().enumerate() {
+        for cell in grid.cells() {
+            let Some(cb) = collapsed.get(&cell.node) else { continue };
+            if cell.col == 0 {
+                out.left = out.left.max(cb.layout.left);
+            }
+            if cell.col + cell.colspan >= n_cols {
+                out.right = out.right.max(cb.layout.right);
+            }
+            if Some(gi) == first_grid && cell.row == 0 {
+                out.top = out.top.max(cb.layout.top);
+            }
+            if Some(gi) == last_grid && cell.row + cell.rowspan >= grid.n_rows {
+                out.bottom = out.bottom.max(cb.layout.bottom);
+            }
+        }
+    }
+    out
+}
+
 /// CSS border-conflict resolution for `border-collapse`, per CSS 2 §17.6.2:
 /// collapsed borders are CENTERED on the grid lines. The wider border wins a
 /// boundary; ties go to the left/top cell (the style-rank tiebreak is not
@@ -492,6 +536,7 @@ fn section_height(row_heights: &[f32], row_y: &[f32]) -> f32 {
 #[allow(clippy::type_complexity)]
 fn resolve_border_conflicts<T: TableTree>(
     tree: &T,
+    table_node: T::NodeId,
     n_cols: usize,
     grids: &[&SectionGrid<T::NodeId>],
 ) -> (
@@ -612,9 +657,13 @@ fn resolve_border_conflicts<T: TableTree>(
         }
     }
 
-    // Every cell of a collapsed table gets an entry: outer edges resolve to
-    // the cell's own border (half in the layout, half sticking out of the
-    // table box, like browsers).
+    // Every cell of a collapsed table gets an entry. Perimeter edges (no facing
+    // neighbour) conflict with the TABLE's own border instead (CSS 2 §17.6.2.1 -
+    // wider wins, tie -> the cell, per the style-source precedence cell > table):
+    // half the resolved boundary in the layout, half painted as outset up to the
+    // table's border-box edge.
+    let table_border = read_border(tree, table_node);
+    let table_edge = [table_border.top, table_border.right, table_border.bottom, table_border.left];
     let mut collapsed_map = HashMap::new();
     let mut owners_map = HashMap::new();
     for (&node, raw) in &borders {
@@ -626,12 +675,21 @@ fn resolve_border_conflicts<T: TableTree>(
         let mut owners = [None; 4];
         for e in 0..4 {
             suppressed[e] = s.has_seg[e] && !s.won_any[e];
-            resolved[e] = if s.has_seg[e] { s.resolved[e] } else { own[e] };
+            resolved[e] = if s.has_seg[e] {
+                s.resolved[e]
+            } else {
+                own[e].max(table_edge[e])
+            };
             // Only perimeter edges paint outside the box; internal boundaries
             // are covered half-and-half by the two adjacent cells.
-            outsets[e] = if s.has_seg[e] { 0.0 } else { own[e] / 2.0 };
+            outsets[e] = if s.has_seg[e] { 0.0 } else { resolved[e] / 2.0 };
             if suppressed[e] {
                 owners[e] = s.winner[e];
+            } else if !s.has_seg[e] && table_edge[e] > own[e] {
+                // The table's wider border wins the perimeter boundary: the cell
+                // paints its half in the table's edge style.
+                suppressed[e] = true;
+                owners[e] = Some(table_node);
             }
         }
         collapsed_map.insert(

--- a/crates/gosub_lattice/src/compute.rs
+++ b/crates/gosub_lattice/src/compute.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use crate::grid::{build_section_grid, PlacedCell, SectionGrid};
 use crate::model::{build_model, RowGroup};
 use crate::sizing::columns::{column_specs, compute_column_widths};
-use crate::sizing::rows::{compute_row_heights, read_border, read_padding};
+use crate::sizing::rows::{compute_row_heights, effective_border, read_border, read_padding};
 use crate::types::{BorderCollapse, CellLayout, CssLength, CssProp, TableSizing};
 use crate::TableTree;
 
@@ -68,6 +68,19 @@ pub fn compute_table_layout<T: TableTree>(
         n_cols
     };
 
+    // Colspans may reach into columns other sections define, but never past
+    // the table's last column (n_cols excludes phantom trailing columns).
+    let mut header_grids = header_grids;
+    let mut body_grids = body_grids;
+    let mut footer_grids = footer_grids;
+    for grid in header_grids
+        .iter_mut()
+        .chain(body_grids.iter_mut())
+        .chain(footer_grids.iter_mut())
+    {
+        grid.clamp_colspans(n_cols);
+    }
+
     // Resolve the explicit table width, if any; auto tables shrink-to-fit
     // inside `compute_column_widths`.
     let explicit_table_width = match tree.css_length(model.node, CssProp::Width) {
@@ -83,6 +96,20 @@ pub fn compute_table_layout<T: TableTree>(
         .chain(footer_grids.iter())
         .collect();
 
+    // Border-conflict resolution (collapse only) runs BEFORE any sizing:
+    // suppressed edges take no layout space, so intrinsic measurement, row
+    // heights and cell boxes must all use the effective (post-conflict)
+    // borders. The implementor is notified so its layout engine agrees.
+    let suppressed_borders: HashMap<T::NodeId, [bool; 4]> = if collapse {
+        let resolved = resolve_border_conflicts(tree, n_cols, &all_grids);
+        for (&node, &edges) in &resolved {
+            tree.suppress_cell_borders(node, edges);
+        }
+        resolved
+    } else {
+        HashMap::new()
+    };
+
     let (col_widths, table_width) = compute_column_widths(
         tree,
         n_cols,
@@ -93,6 +120,13 @@ pub fn compute_table_layout<T: TableTree>(
         model.sizing,
         &col_specs,
     );
+
+    if std::env::var_os("LATTICE_DEBUG").is_some() {
+        eprintln!(
+            "lattice: table {:?} n_cols={} table_width={} col_widths={:?}",
+            table_node, n_cols, table_width, col_widths
+        );
+    }
 
     // Precompute cumulative column x-offsets (relative to the row's left edge).
     // col_x[i] = x of the left edge of column i (within a row). Under collapse
@@ -117,6 +151,7 @@ pub fn compute_table_layout<T: TableTree>(
             spacing_x,
             spacing_y,
             &mut content_heights,
+            &suppressed_borders,
         ));
     }
 
@@ -129,6 +164,7 @@ pub fn compute_table_layout<T: TableTree>(
             spacing_x,
             spacing_y,
             &mut content_heights,
+            &suppressed_borders,
         ));
     }
 
@@ -141,16 +177,9 @@ pub fn compute_table_layout<T: TableTree>(
             spacing_x,
             spacing_y,
             &mut content_heights,
+            &suppressed_borders,
         ));
     }
-
-    // Border-conflict resolution (collapse only): decide per shared boundary
-    // which cell paints it; the loser's edge is flagged for the host to skip.
-    let suppressed_borders: HashMap<T::NodeId, [bool; 4]> = if collapse {
-        resolve_border_conflicts(tree, n_cols, &all_grids)
-    } else {
-        HashMap::new()
-    };
 
     // Caption: measured like a cell spanning the full table width; placed
     // above (default) or below the grid per `caption-side`.
@@ -337,7 +366,7 @@ fn place_cell<T: TableTree>(
     // Cell y is relative to its own row's top.
     let y_within_row = 0.0;
 
-    let border = read_border(tree, cell.node);
+    let border = effective_border(tree, cell.node, suppressed_borders);
     let padding = read_padding(tree, cell.node);
 
     // vertical-align: shift the cell's children down within the free space

--- a/crates/gosub_lattice/src/compute.rs
+++ b/crates/gosub_lattice/src/compute.rs
@@ -1,5 +1,6 @@
 use crate::geo::{Point, Size};
 use anyhow::Result;
+use std::collections::HashMap;
 
 use crate::grid::{build_section_grid, PlacedCell, SectionGrid};
 use crate::model::{build_model, RowGroup};
@@ -90,19 +91,42 @@ pub fn compute_table_layout<T: TableTree>(
     // run the normal layout engine inside each cell.  We use for-loops rather
     // than iterator combinators because a closure can't hold `&mut tree` while
     // the model is also borrowed.
+    let mut content_heights: HashMap<T::NodeId, f32> = HashMap::new();
+
     let mut header_heights: Vec<Vec<f32>> = Vec::with_capacity(header_grids.len());
     for grid in &header_grids {
-        header_heights.push(compute_row_heights(tree, grid, &col_widths));
+        header_heights.push(compute_row_heights(
+            tree,
+            grid,
+            &col_widths,
+            spacing_x,
+            spacing_y,
+            &mut content_heights,
+        ));
     }
 
     let mut body_heights: Vec<Vec<f32>> = Vec::with_capacity(body_grids.len());
     for grid in &body_grids {
-        body_heights.push(compute_row_heights(tree, grid, &col_widths));
+        body_heights.push(compute_row_heights(
+            tree,
+            grid,
+            &col_widths,
+            spacing_x,
+            spacing_y,
+            &mut content_heights,
+        ));
     }
 
     let mut footer_heights: Vec<Vec<f32>> = Vec::with_capacity(footer_grids.len());
     for grid in &footer_grids {
-        footer_heights.push(compute_row_heights(tree, grid, &col_widths));
+        footer_heights.push(compute_row_heights(
+            tree,
+            grid,
+            &col_widths,
+            spacing_x,
+            spacing_y,
+            &mut content_heights,
+        ));
     }
 
     // Apply positions
@@ -138,6 +162,7 @@ pub fn compute_table_layout<T: TableTree>(
                         size: Size::new(inner_width, group_height),
                         border: BOX_EDGES_ZERO,
                         padding: BOX_EDGES_ZERO,
+                        content_offset_y: 0.0,
                     },
                 );
             }
@@ -151,6 +176,7 @@ pub fn compute_table_layout<T: TableTree>(
                 &col_widths,
                 spacing_x,
                 spacing_y,
+                &content_heights,
             );
 
             group_y += group_height + spacing_y;
@@ -173,6 +199,7 @@ fn place_rows<T: TableTree>(
     col_widths: &[f32],
     spacing_x: f32,
     spacing_y: f32,
+    content_heights: &HashMap<T::NodeId, f32>,
 ) {
     // Precompute y offset of each row within the group.
     let row_y = row_y_offsets(row_heights, spacing_y);
@@ -190,13 +217,24 @@ fn place_rows<T: TableTree>(
                     size: Size::new(inner_width, rh),
                     border: BOX_EDGES_ZERO,
                     padding: BOX_EDGES_ZERO,
+                    content_offset_y: 0.0,
                 },
             );
         }
 
         // Cells for this row.
         for cell in grid.cells_in_row(row_idx) {
-            place_cell(tree, cell, row_heights, col_x, col_widths, &row_y, spacing_x, spacing_y);
+            place_cell(
+                tree,
+                cell,
+                row_heights,
+                col_x,
+                col_widths,
+                &row_y,
+                spacing_x,
+                spacing_y,
+                content_heights,
+            );
         }
     }
 }
@@ -212,6 +250,7 @@ fn place_cell<T: TableTree>(
     row_y: &[f32],
     spacing_x: f32,
     spacing_y: f32,
+    content_heights: &HashMap<T::NodeId, f32>,
 ) {
     // Width = sum of spanned column widths, plus the border-spacing gutters the
     // spanning cell covers (a colspan=2 cell runs across the gutter between its
@@ -233,6 +272,17 @@ fn place_cell<T: TableTree>(
     let border = read_border(tree, cell.node);
     let padding = read_padding(tree, cell.node);
 
+    // vertical-align: shift the cell's children down within the free space
+    // between its content and its (row-driven) height.
+    let inner_h = (cell_height - border.vertical() - padding.vertical()).max(0.0);
+    let content_h = content_heights.get(&cell.node).copied().unwrap_or(0.0);
+    let free = (inner_h - content_h).max(0.0);
+    let content_offset_y = match tree.vertical_align(cell.node) {
+        crate::types::VerticalAlign::Top => 0.0,
+        crate::types::VerticalAlign::Middle => free / 2.0,
+        crate::types::VerticalAlign::Bottom => free,
+    };
+
     tree.set_layout(
         cell.node,
         CellLayout {
@@ -240,6 +290,7 @@ fn place_cell<T: TableTree>(
             size: Size::new(cell_width, cell_height),
             border,
             padding,
+            content_offset_y,
         },
     );
 }

--- a/crates/gosub_lattice/src/grid.rs
+++ b/crates/gosub_lattice/src/grid.rs
@@ -205,7 +205,7 @@ mod tests {
 
     #[test]
     fn rowspan_clamped_at_section_boundary() {
-        // Section has 2 rows; a cell in row 0 claims rowspan=5 → clamped to 2.
+        // Section has 2 rows; a cell in row 0 claims rowspan=5 -> clamped to 2.
         let rows = vec![make_row(&[(1, 5), (1, 1)]), make_row(&[(1, 1)])];
         let grid = build_section_grid(&rows);
         let spanning = grid.cells_in_row(0).next().expect("first cell");
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn colspan_places_correctly() {
-        // Row 0: A (colspan=2), B (colspan=1)  → 3 columns
+        // Row 0: A (colspan=2), B (colspan=1)  -> 3 columns
         let rows = vec![make_row(&[(2, 1), (1, 1)])];
         let grid = build_section_grid(&rows);
         assert_eq!(grid.n_cols, 3);

--- a/crates/gosub_lattice/src/grid.rs
+++ b/crates/gosub_lattice/src/grid.rs
@@ -215,11 +215,7 @@ mod tests {
     #[test]
     fn rowspan_zero_spans_rest_of_section() {
         // HTML rowspan=0: the cell spans all remaining rows of the row group.
-        let rows = vec![
-            make_row(&[(1, 0), (1, 1)]),
-            make_row(&[(1, 1)]),
-            make_row(&[(1, 1)]),
-        ];
+        let rows = vec![make_row(&[(1, 0), (1, 1)]), make_row(&[(1, 1)]), make_row(&[(1, 1)])];
         let grid = build_section_grid(&rows);
         let spanning = grid.cells_in_row(0).next().expect("first cell");
         assert_eq!(spanning.rowspan, 3, "rowspan=0 covers every remaining section row");

--- a/crates/gosub_lattice/src/grid.rs
+++ b/crates/gosub_lattice/src/grid.rs
@@ -27,6 +27,14 @@ impl<N: Copy> SectionGrid<N> {
         &self.cells
     }
 
+    /// Clamp every cell's colspan to the table-wide column count, so spans
+    /// can't reach past the last column any cell (in any section) originates in.
+    pub fn clamp_colspans(&mut self, table_n_cols: usize) {
+        for cell in &mut self.cells {
+            cell.colspan = cell.colspan.min(table_n_cols.saturating_sub(cell.col)).max(1);
+        }
+    }
+
     /// Iterate over cells whose `row` field equals `row_idx`.
     pub fn cells_in_row(&self, row_idx: usize) -> impl Iterator<Item = &PlacedCell<N>> {
         self.cells.iter().filter(move |c| c.row == row_idx)
@@ -108,7 +116,13 @@ pub fn build_section_grid<N: Copy>(rows: &[TableRow<N>]) -> SectionGrid<N> {
         }
     }
 
-    let n_cols = slot_remaining.len();
+    // Trailing columns no cell *originates* in don't count (css-tables-3;
+    // matches browsers): a lone `colspan=9` in a 4-column grid must not create
+    // five phantom columns that would each drag in a border-spacing gutter.
+    // Colspans stay unclamped here - the table clamps them against the
+    // TABLE-wide column count (spans may reach into columns other sections
+    // define) via [`SectionGrid::clamp_colspans`].
+    let n_cols = cells.iter().map(|c| c.col + 1).max().unwrap_or(0);
     SectionGrid { cells, n_cols, n_rows }
 }
 

--- a/crates/gosub_lattice/src/grid.rs
+++ b/crates/gosub_lattice/src/grid.rs
@@ -92,9 +92,15 @@ pub fn build_section_grid<N: Copy>(rows: &[TableRow<N>]) -> SectionGrid<N> {
 
             let colspan = source_cell.colspan.max(1);
 
-            // Rowspan is clamped: a cell can only span within the current section.
+            // Rowspan is clamped: a cell can only span within the current
+            // section. HTML's rowspan=0 means "all remaining rows of the
+            // row group" (same clamp, taken literally).
             let rows_left = n_rows.saturating_sub(row_idx);
-            let rowspan = source_cell.rowspan.max(1).min(rows_left);
+            let rowspan = if source_cell.rowspan == 0 {
+                rows_left
+            } else {
+                source_cell.rowspan.min(rows_left)
+            };
 
             // Grow the slot tracker to cover all columns this cell occupies.
             grow_slots(&mut slot_remaining, col + colspan);
@@ -204,6 +210,21 @@ mod tests {
         let grid = build_section_grid(&rows);
         let spanning = grid.cells_in_row(0).next().expect("first cell");
         assert_eq!(spanning.rowspan, 2, "rowspan must be clamped to section size");
+    }
+
+    #[test]
+    fn rowspan_zero_spans_rest_of_section() {
+        // HTML rowspan=0: the cell spans all remaining rows of the row group.
+        let rows = vec![
+            make_row(&[(1, 0), (1, 1)]),
+            make_row(&[(1, 1)]),
+            make_row(&[(1, 1)]),
+        ];
+        let grid = build_section_grid(&rows);
+        let spanning = grid.cells_in_row(0).next().expect("first cell");
+        assert_eq!(spanning.rowspan, 3, "rowspan=0 covers every remaining section row");
+        // The spanned column stays occupied: later rows' cells land in col 1.
+        assert_eq!(grid.cells_in_row(2).next().expect("row 2 cell").col, 1);
     }
 
     #[test]

--- a/crates/gosub_lattice/src/lib.rs
+++ b/crates/gosub_lattice/src/lib.rs
@@ -8,7 +8,7 @@ mod tests;
 pub mod types;
 
 pub use compute::compute_table_layout;
-pub use types::{BorderCollapse, BoxEdges, CellLayout, CssLength, CssProp, TableRole, TableSizing};
+pub use types::{BorderCollapse, BoxEdges, CellLayout, CssLength, CssProp, TableRole, TableSizing, VerticalAlign};
 
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -53,5 +53,12 @@ pub trait TableTree {
     /// than equally.  Return `0.0` for mock/test trees.
     fn cell_content_width(&self, _id: Self::NodeId) -> f32 {
         0.0
+    }
+
+    /// `vertical-align` for cell `id`, resolved through the cascade (including
+    /// the HTML rendering-spec pattern of `inherit` on cells picking up
+    /// `middle` from the row/section) by the implementor.
+    fn vertical_align(&self, _id: Self::NodeId) -> types::VerticalAlign {
+        types::VerticalAlign::Top
     }
 }

--- a/crates/gosub_lattice/src/lib.rs
+++ b/crates/gosub_lattice/src/lib.rs
@@ -67,4 +67,11 @@ pub trait TableTree {
     fn vertical_align(&self, _id: Self::NodeId) -> types::VerticalAlign {
         types::VerticalAlign::Top
     }
+
+    /// Under `border-collapse`, tells the implementor which border edges of
+    /// cell `id` lost their boundary (`[top, right, bottom, left]`) BEFORE any
+    /// measurement happens. Losing edges take up no layout space and are not
+    /// painted - implementors backed by a layout engine should zero those
+    /// edges in the engine's style for the cell so content sits flush.
+    fn suppress_cell_borders(&mut self, _id: Self::NodeId, _edges: [bool; 4]) {}
 }

--- a/crates/gosub_lattice/src/lib.rs
+++ b/crates/gosub_lattice/src/lib.rs
@@ -51,8 +51,14 @@ pub trait TableTree {
     /// measured by the layout engine in a prior pass (e.g. Taffy).  Used to
     /// distribute auto column widths proportionally to content width rather
     /// than equally.  Return `0.0` for mock/test trees.
-    fn cell_content_width(&self, _id: Self::NodeId) -> f32 {
-        0.0
+    /// Intrinsic (content-driven) border-box widths of cell `id` as measured
+    /// by the layout engine: `(min_content, max_content)`. Min-content is the
+    /// narrowest the cell can get without overflowing (longest word, widest
+    /// replaced box); max-content is its width with no wrapping at all. Takes
+    /// `&mut self` because implementors typically have to run layout passes to
+    /// measure. Return `(0.0, 0.0)` for mock/test trees with no real content.
+    fn cell_intrinsic_widths(&mut self, _id: Self::NodeId) -> (f32, f32) {
+        (0.0, 0.0)
     }
 
     /// `vertical-align` for cell `id`, resolved through the cascade (including

--- a/crates/gosub_lattice/src/lib.rs
+++ b/crates/gosub_lattice/src/lib.rs
@@ -61,6 +61,15 @@ pub trait TableTree {
         (0.0, 0.0)
     }
 
+    /// Whether `cell_intrinsic_widths` returns REAL measurements. When true, an
+    /// all-zero result means the content genuinely has no width (empty cells) and the
+    /// table shrinks to fit per CSS 2 §17.5.2.2; when false (mock/test trees using the
+    /// default stub), zero means "no information" and auto tables fill the available
+    /// width instead of collapsing.
+    fn measures_intrinsics(&self) -> bool {
+        false
+    }
+
     /// `vertical-align` for cell `id`, resolved through the cascade (including
     /// the HTML rendering-spec pattern of `inherit` on cells picking up
     /// `middle` from the row/section) by the implementor.

--- a/crates/gosub_lattice/src/lib.rs
+++ b/crates/gosub_lattice/src/lib.rs
@@ -68,10 +68,24 @@ pub trait TableTree {
         types::VerticalAlign::Top
     }
 
-    /// Under `border-collapse`, tells the implementor which border edges of
-    /// cell `id` lost their boundary (`[top, right, bottom, left]`) BEFORE any
-    /// measurement happens. Losing edges take up no layout space and are not
-    /// painted - implementors backed by a layout engine should zero those
-    /// edges in the engine's style for the cell so content sits flush.
-    fn suppress_cell_borders(&mut self, _id: Self::NodeId, _edges: [bool; 4]) {}
+    /// Under `border-collapse`, gives the implementor cell `id`'s LAYOUT
+    /// border - half the resolved boundary width per edge, since collapsed
+    /// borders are centered on the grid lines - BEFORE any measurement
+    /// happens. Implementors backed by a layout engine should override the
+    /// cell's border widths in the engine's style so content sits where the
+    /// collapse geometry says.
+    ///
+    /// `edge_owners` (`[top, right, bottom, left]`) names, per edge, the cell
+    /// whose CSS border style/color must be used when painting this cell's
+    /// half of the boundary: `None` means the cell's own border (it won or the
+    /// edge is on the table perimeter), `Some(other)` means it lost the
+    /// conflict and paints its half in the winner's style. Painting each half
+    /// from its own cell keeps the result independent of cell paint order.
+    fn set_collapsed_cell_borders(
+        &mut self,
+        _id: Self::NodeId,
+        _layout: types::BoxEdges,
+        _edge_owners: [Option<Self::NodeId>; 4],
+    ) {
+    }
 }

--- a/crates/gosub_lattice/src/lib.rs
+++ b/crates/gosub_lattice/src/lib.rs
@@ -70,6 +70,13 @@ pub trait TableTree {
         false
     }
 
+    /// Distance from the top of cell `id`'s BORDER box to the baseline of its first
+    /// in-flow line box, measured after `layout_cell` has run for the cell. `None`
+    /// when the cell has no line box (empty cells align top).
+    fn cell_baseline(&mut self, _id: Self::NodeId) -> Option<f32> {
+        None
+    }
+
     /// `vertical-align` for cell `id`, resolved through the cascade (including
     /// the HTML rendering-spec pattern of `inherit` on cells picking up
     /// `middle` from the row/section) by the implementor.

--- a/crates/gosub_lattice/src/mock.rs
+++ b/crates/gosub_lattice/src/mock.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use crate::compute::compute_table_layout;
 use crate::grid::{build_section_grid, PlacedCell, SectionGrid};
 use crate::model::{build_model, RowGroup};
-use crate::types::{CellLayout, CssLength, CssProp, TableRole};
+use crate::types::{CellLayout, CssLength, CssProp, TableRole, VerticalAlign};
 use crate::TableTree;
 
 // MockCell - a single cell specification used by the builder
@@ -31,6 +31,8 @@ pub struct MockCell {
     pub content_width: f32,
     /// Content height reported by `layout_cell` (as if children were laid out).
     pub content_height: f32,
+    /// `vertical-align` for the cell.
+    pub valign: VerticalAlign,
 }
 
 impl MockCell {
@@ -45,6 +47,7 @@ impl MockCell {
             padding: 1.0,
             content_width: 0.0,
             content_height: 0.0,
+            valign: VerticalAlign::Top,
         }
     }
 
@@ -78,6 +81,10 @@ impl MockCell {
     }
     pub fn content_height(mut self, h: f32) -> Self {
         self.content_height = h;
+        self
+    }
+    pub fn valign(mut self, v: VerticalAlign) -> Self {
+        self.valign = v;
         self
     }
 }
@@ -226,6 +233,7 @@ struct MockNode {
     padding: f32,
     content_width: f32,
     content_height: f32,
+    valign: VerticalAlign,
 }
 
 pub struct MockTree {
@@ -277,6 +285,7 @@ impl MockTree {
                 padding,
                 content_width: 0.0,
                 content_height: 0.0,
+                valign: VerticalAlign::Top,
             },
         );
         id
@@ -297,6 +306,7 @@ impl MockTree {
         if let Some(node) = self.nodes.get_mut(&id) {
             node.content_width = mc.content_width;
             node.content_height = mc.content_height;
+            node.valign = mc.valign;
         }
         id
     }
@@ -385,6 +395,10 @@ impl TableTree for MockTree {
 
     fn cell_content_width(&self, id: u32) -> f32 {
         self.nodes.get(&id).map(|n| n.content_width).unwrap_or(0.0)
+    }
+
+    fn vertical_align(&self, id: u32) -> VerticalAlign {
+        self.nodes.get(&id).map(|n| n.valign).unwrap_or_default()
     }
 }
 

--- a/crates/gosub_lattice/src/mock.rs
+++ b/crates/gosub_lattice/src/mock.rs
@@ -21,6 +21,8 @@ pub struct MockCell {
     pub rowspan: usize,
     /// Explicit pixel width, if any.
     pub width: Option<f32>,
+    /// Explicit percentage width, if any (wins over `width`).
+    pub width_pct: Option<f32>,
     /// Explicit pixel height, if any.
     pub height: Option<f32>,
     /// Uniform border width on all sides.
@@ -44,6 +46,7 @@ impl MockCell {
             colspan: 1,
             rowspan: 1,
             width: None,
+            width_pct: None,
             height: None,
             border: 0.0,
             padding: 1.0,
@@ -64,6 +67,10 @@ impl MockCell {
     }
     pub fn width(mut self, w: f32) -> Self {
         self.width = Some(w);
+        self
+    }
+    pub fn width_pct(mut self, p: f32) -> Self {
+        self.width_pct = Some(p);
         self
     }
     pub fn height(mut self, h: f32) -> Self {
@@ -268,6 +275,7 @@ struct MockNode {
     children: Vec<u32>,
     layout: Option<CellLayout>,
     width: Option<f32>,
+    width_pct: Option<f32>,
     height: Option<f32>,
     border: f32,
     padding: f32,
@@ -327,6 +335,7 @@ impl MockTree {
                 children: Vec::new(),
                 layout: None,
                 width,
+                width_pct: None,
                 height,
                 border,
                 padding,
@@ -352,6 +361,7 @@ impl MockTree {
             mc.padding,
         );
         if let Some(node) = self.nodes.get_mut(&id) {
+            node.width_pct = mc.width_pct;
             node.content_width = mc.content_width;
             node.min_content_width = mc.min_content_width;
             node.content_height = mc.content_height;
@@ -403,7 +413,11 @@ impl TableTree for MockTree {
             return CssLength::Auto;
         };
         match prop {
-            CssProp::Width => node.width.map(CssLength::Px).unwrap_or(CssLength::Auto),
+            CssProp::Width => node
+                .width_pct
+                .map(CssLength::Percent)
+                .or(node.width.map(CssLength::Px))
+                .unwrap_or(CssLength::Auto),
             CssProp::Height => node.height.map(CssLength::Px).unwrap_or(CssLength::Auto),
             CssProp::BorderTopWidth
             | CssProp::BorderRightWidth

--- a/crates/gosub_lattice/src/mock.rs
+++ b/crates/gosub_lattice/src/mock.rs
@@ -640,7 +640,7 @@ fn h_border(
             // Rightmost edge - always a real corner
             '+'
         } else if left_spanned && right_spanned {
-            // Both neighbours are spanning cells → vertical wall between them
+            // Both neighbours are spanning cells -> vertical wall between them
             '|'
         } else if no_right_wall.get(pos - 1).copied().unwrap_or(false) {
             // Inside a colspan - suppress the junction
@@ -677,7 +677,7 @@ fn content_row(
     col_char_w: &[usize],
     n_cols: usize,
 ) -> String {
-    // Map col → placed cell for cells that START in this row.
+    // Map col -> placed cell for cells that START in this row.
     let mut cell_at: HashMap<usize, &PlacedCell<u32>> = HashMap::new();
     for cell in grid.cells_in_row(row_idx) {
         cell_at.insert(cell.col, cell);

--- a/crates/gosub_lattice/src/mock.rs
+++ b/crates/gosub_lattice/src/mock.rs
@@ -94,6 +94,9 @@ pub struct MockTable {
     available_width: f32,
     border_spacing_x: f32,
     border_spacing_y: f32,
+    fixed_layout: bool,
+    /// One entry per `<col>` element: its explicit width, or `None` for auto.
+    cols: Vec<Option<f32>>,
     header_rows: Vec<Vec<MockCell>>,
     body_rows: Vec<Vec<MockCell>>,
     footer_rows: Vec<Vec<MockCell>>,
@@ -112,6 +115,18 @@ impl MockTable {
     pub fn spacing(mut self, x: f32, y: f32) -> Self {
         self.border_spacing_x = x;
         self.border_spacing_y = y;
+        self
+    }
+
+    /// `table-layout: fixed`.
+    pub fn fixed(mut self) -> Self {
+        self.fixed_layout = true;
+        self
+    }
+
+    /// Append a `<col>` element with an optional explicit width.
+    pub fn col(mut self, width: Option<f32>) -> Self {
+        self.cols.push(width);
         self
     }
 
@@ -141,7 +156,17 @@ impl MockTable {
     /// Convert into a raw [`MockTree`] (root NodeId is returned alongside).
     pub fn into_tree(self) -> (MockTree, u32) {
         let mut tree = MockTree::new(self.border_spacing_x, self.border_spacing_y);
+        tree.fixed_layout = self.fixed_layout;
         let root = tree.alloc(TableRole::Table, None, 1, 1, None, None, 0.0, 0.0);
+
+        if !self.cols.is_empty() {
+            let cg = tree.alloc(TableRole::ColumnGroup, None, 1, 1, None, None, 0.0, 0.0);
+            tree.add_child(root, cg);
+            for width in self.cols {
+                let col = tree.alloc(TableRole::Column, None, 1, 1, width, None, 0.0, 0.0);
+                tree.add_child(cg, col);
+            }
+        }
 
         if !self.header_rows.is_empty() {
             let hg = tree.alloc(TableRole::HeaderGroup, None, 1, 1, None, None, 0.0, 0.0);
@@ -208,6 +233,8 @@ pub struct MockTree {
     next_id: u32,
     border_spacing_x: f32,
     border_spacing_y: f32,
+    /// `table-layout: fixed`, reported for the table node via the Px(1.0) sentinel.
+    pub fixed_layout: bool,
 }
 
 impl MockTree {
@@ -217,6 +244,7 @@ impl MockTree {
             next_id: 0,
             border_spacing_x,
             border_spacing_y,
+            fixed_layout: false,
         }
     }
 
@@ -327,6 +355,7 @@ impl TableTree for MockTree {
             }
             CssProp::BorderSpacingX => CssLength::Px(self.border_spacing_x),
             CssProp::BorderSpacingY => CssLength::Px(self.border_spacing_y),
+            CssProp::TableLayout if node.role == TableRole::Table && self.fixed_layout => CssLength::Px(1.0),
             _ => CssLength::Auto,
         }
     }

--- a/crates/gosub_lattice/src/mock.rs
+++ b/crates/gosub_lattice/src/mock.rs
@@ -111,6 +111,9 @@ pub struct MockTable {
     border_spacing_x: f32,
     border_spacing_y: f32,
     fixed_layout: bool,
+    collapse: bool,
+    /// Caption content height and whether it sits at the bottom.
+    caption: Option<(f32, bool)>,
     /// One entry per `<col>` element: its explicit width, or `None` for auto.
     cols: Vec<Option<f32>>,
     header_rows: Vec<Vec<MockCell>>,
@@ -143,6 +146,18 @@ impl MockTable {
     /// `table-layout: fixed`.
     pub fn fixed(mut self) -> Self {
         self.fixed_layout = true;
+        self
+    }
+
+    /// `border-collapse: collapse`.
+    pub fn collapse(mut self) -> Self {
+        self.collapse = true;
+        self
+    }
+
+    /// Add a caption with the given content height; `bottom` = `caption-side: bottom`.
+    pub fn caption(mut self, content_height: f32, bottom: bool) -> Self {
+        self.caption = Some((content_height, bottom));
         self
     }
 
@@ -179,7 +194,17 @@ impl MockTable {
     pub fn into_tree(self) -> (MockTree, u32) {
         let mut tree = MockTree::new(self.border_spacing_x, self.border_spacing_y);
         tree.fixed_layout = self.fixed_layout;
+        tree.collapse = self.collapse;
         let root = tree.alloc(TableRole::Table, None, 1, 1, self.table_width, None, 0.0, 0.0);
+
+        if let Some((content_height, bottom)) = self.caption {
+            let cap = tree.alloc(TableRole::Caption, Some("caption".into()), 1, 1, None, None, 0.0, 0.0);
+            if let Some(node) = tree.nodes.get_mut(&cap) {
+                node.content_height = content_height;
+            }
+            tree.caption_bottom = bottom;
+            tree.add_child(root, cap);
+        }
 
         if !self.cols.is_empty() {
             let cg = tree.alloc(TableRole::ColumnGroup, None, 1, 1, None, None, 0.0, 0.0);
@@ -259,6 +284,10 @@ pub struct MockTree {
     border_spacing_y: f32,
     /// `table-layout: fixed`, reported for the table node via the Px(1.0) sentinel.
     pub fixed_layout: bool,
+    /// `border-collapse: collapse`, reported via the Px(1.0) sentinel.
+    pub collapse: bool,
+    /// `caption-side: bottom` on the caption node, via the Px(1.0) sentinel.
+    pub caption_bottom: bool,
 }
 
 impl MockTree {
@@ -269,6 +298,8 @@ impl MockTree {
             border_spacing_x,
             border_spacing_y,
             fixed_layout: false,
+            collapse: false,
+            caption_bottom: false,
         }
     }
 
@@ -384,6 +415,8 @@ impl TableTree for MockTree {
             CssProp::BorderSpacingX => CssLength::Px(self.border_spacing_x),
             CssProp::BorderSpacingY => CssLength::Px(self.border_spacing_y),
             CssProp::TableLayout if node.role == TableRole::Table && self.fixed_layout => CssLength::Px(1.0),
+            CssProp::BorderCollapse if node.role == TableRole::Table && self.collapse => CssLength::Px(1.0),
+            CssProp::CaptionSide if node.role == TableRole::Caption && self.caption_bottom => CssLength::Px(1.0),
             _ => CssLength::Auto,
         }
     }

--- a/crates/gosub_lattice/src/mock.rs
+++ b/crates/gosub_lattice/src/mock.rs
@@ -27,8 +27,10 @@ pub struct MockCell {
     pub border: f32,
     /// Uniform padding on all sides.
     pub padding: f32,
-    /// Natural (pre-pass) border-box width reported via `cell_content_width`.
+    /// Max-content border-box width reported via `cell_intrinsic_widths`.
     pub content_width: f32,
+    /// Min-content border-box width reported via `cell_intrinsic_widths`.
+    pub min_content_width: f32,
     /// Content height reported by `layout_cell` (as if children were laid out).
     pub content_height: f32,
     /// `vertical-align` for the cell.
@@ -46,6 +48,7 @@ impl MockCell {
             border: 0.0,
             padding: 1.0,
             content_width: 0.0,
+            min_content_width: 0.0,
             content_height: 0.0,
             valign: VerticalAlign::Top,
         }
@@ -79,6 +82,10 @@ impl MockCell {
         self.content_width = w;
         self
     }
+    pub fn min_content_width(mut self, w: f32) -> Self {
+        self.min_content_width = w;
+        self
+    }
     pub fn content_height(mut self, h: f32) -> Self {
         self.content_height = h;
         self
@@ -99,6 +106,8 @@ pub fn cell(label: impl Into<String>) -> MockCell {
 #[derive(Default)]
 pub struct MockTable {
     available_width: f32,
+    /// Explicit CSS `width` on the table element; `None` = auto (shrink-to-fit).
+    table_width: Option<f32>,
     border_spacing_x: f32,
     border_spacing_y: f32,
     fixed_layout: bool,
@@ -122,6 +131,12 @@ impl MockTable {
     pub fn spacing(mut self, x: f32, y: f32) -> Self {
         self.border_spacing_x = x;
         self.border_spacing_y = y;
+        self
+    }
+
+    /// Explicit CSS `width` on the table element.
+    pub fn width(mut self, w: f32) -> Self {
+        self.table_width = Some(w);
         self
     }
 
@@ -164,7 +179,7 @@ impl MockTable {
     pub fn into_tree(self) -> (MockTree, u32) {
         let mut tree = MockTree::new(self.border_spacing_x, self.border_spacing_y);
         tree.fixed_layout = self.fixed_layout;
-        let root = tree.alloc(TableRole::Table, None, 1, 1, None, None, 0.0, 0.0);
+        let root = tree.alloc(TableRole::Table, None, 1, 1, self.table_width, None, 0.0, 0.0);
 
         if !self.cols.is_empty() {
             let cg = tree.alloc(TableRole::ColumnGroup, None, 1, 1, None, None, 0.0, 0.0);
@@ -232,6 +247,7 @@ struct MockNode {
     border: f32,
     padding: f32,
     content_width: f32,
+    min_content_width: f32,
     content_height: f32,
     valign: VerticalAlign,
 }
@@ -284,6 +300,7 @@ impl MockTree {
                 border,
                 padding,
                 content_width: 0.0,
+                min_content_width: 0.0,
                 content_height: 0.0,
                 valign: VerticalAlign::Top,
             },
@@ -305,6 +322,7 @@ impl MockTree {
         );
         if let Some(node) = self.nodes.get_mut(&id) {
             node.content_width = mc.content_width;
+            node.min_content_width = mc.min_content_width;
             node.content_height = mc.content_height;
             node.valign = mc.valign;
         }
@@ -393,8 +411,11 @@ impl TableTree for MockTree {
         self.nodes.get(&id).map(|n| n.content_height).unwrap_or(0.0)
     }
 
-    fn cell_content_width(&self, id: u32) -> f32 {
-        self.nodes.get(&id).map(|n| n.content_width).unwrap_or(0.0)
+    fn cell_intrinsic_widths(&mut self, id: u32) -> (f32, f32) {
+        self.nodes
+            .get(&id)
+            .map(|n| (n.min_content_width, n.content_width.max(n.min_content_width)))
+            .unwrap_or((0.0, 0.0))
     }
 
     fn vertical_align(&self, id: u32) -> VerticalAlign {

--- a/crates/gosub_lattice/src/mock.rs
+++ b/crates/gosub_lattice/src/mock.rs
@@ -31,6 +31,8 @@ pub struct MockCell {
     pub padding: f32,
     /// Max-content border-box width reported via `cell_intrinsic_widths`.
     pub content_width: f32,
+    /// First-line baseline offset reported via `cell_baseline`.
+    pub baseline: Option<f32>,
     /// Min-content border-box width reported via `cell_intrinsic_widths`.
     pub min_content_width: f32,
     /// Content height reported by `layout_cell` (as if children were laid out).
@@ -54,6 +56,7 @@ impl MockCell {
             min_content_width: 0.0,
             content_height: 0.0,
             valign: VerticalAlign::Top,
+            baseline: None,
         }
     }
 
@@ -97,6 +100,11 @@ impl MockCell {
         self.content_height = h;
         self
     }
+    pub fn baseline(mut self, b: f32) -> Self {
+        self.baseline = Some(b);
+        self
+    }
+
     pub fn valign(mut self, v: VerticalAlign) -> Self {
         self.valign = v;
         self
@@ -283,6 +291,7 @@ struct MockNode {
     min_content_width: f32,
     content_height: f32,
     valign: VerticalAlign,
+    baseline: Option<f32>,
 }
 
 pub struct MockTree {
@@ -343,6 +352,7 @@ impl MockTree {
                 min_content_width: 0.0,
                 content_height: 0.0,
                 valign: VerticalAlign::Top,
+                baseline: None,
             },
         );
         id
@@ -366,6 +376,7 @@ impl MockTree {
             node.min_content_width = mc.min_content_width;
             node.content_height = mc.content_height;
             node.valign = mc.valign;
+            node.baseline = mc.baseline;
         }
         id
     }
@@ -467,6 +478,10 @@ impl TableTree for MockTree {
 
     fn vertical_align(&self, id: u32) -> VerticalAlign {
         self.nodes.get(&id).map(|n| n.valign).unwrap_or_default()
+    }
+
+    fn cell_baseline(&mut self, id: u32) -> Option<f32> {
+        self.nodes.get(&id).and_then(|n| n.baseline)
     }
 }
 

--- a/crates/gosub_lattice/src/model.rs
+++ b/crates/gosub_lattice/src/model.rs
@@ -83,12 +83,12 @@ pub fn build_model<T: TableTree>(tree: &T, table_node: T::NodeId) -> TableModel<
             TableRole::FooterGroup => {
                 model.footer_groups.push(build_row_group(tree, child));
             }
-            // Bare row directly inside the table → anonymous tbody
+            // Bare row directly inside the table -> anonymous tbody
             TableRole::Row => {
                 let group = anon_body_group(&mut model.row_groups);
                 group.rows.push(build_row(tree, child));
             }
-            // Bare cell directly inside the table → anonymous row inside anonymous tbody
+            // Bare cell directly inside the table -> anonymous row inside anonymous tbody
             TableRole::Cell => {
                 let group = anon_body_group(&mut model.row_groups);
                 let row = anon_row(&mut group.rows);
@@ -123,7 +123,7 @@ fn build_row_group<T: TableTree>(tree: &T, node: T::NodeId) -> RowGroup<T::NodeI
     for child in tree.children(node) {
         match tree.table_role(child) {
             TableRole::Row => group.rows.push(build_row(tree, child)),
-            // Cell directly inside row group → anonymous row
+            // Cell directly inside row group -> anonymous row
             TableRole::Cell => {
                 let row = anon_row(&mut group.rows);
                 row.cells.push(build_source_cell(tree, child));

--- a/crates/gosub_lattice/src/model.rs
+++ b/crates/gosub_lattice/src/model.rs
@@ -40,7 +40,9 @@ pub struct SourceCell<N> {
     pub node: N,
     /// Effective colspan (always >= 1).
     pub colspan: usize,
-    /// Effective rowspan (always >= 1, clamped per section by the grid builder).
+    /// Rowspan as authored: `0` is the HTML sentinel for "span all remaining
+    /// rows of the row group". The grid builder resolves it and clamps every
+    /// span to the section boundary (spans never cross into another section).
     pub rowspan: usize,
 }
 
@@ -147,7 +149,8 @@ fn build_row<T: TableTree>(tree: &T, node: T::NodeId) -> TableRow<T::NodeId> {
 
 fn build_source_cell<T: TableTree>(tree: &T, node: T::NodeId) -> SourceCell<T::NodeId> {
     let colspan = tree.attr_usize(node, "colspan").unwrap_or(1).max(1);
-    let rowspan = tree.attr_usize(node, "rowspan").unwrap_or(1).max(1);
+    // rowspan=0 is kept as-is: HTML's "span all remaining rows of the group".
+    let rowspan = tree.attr_usize(node, "rowspan").unwrap_or(1);
     SourceCell { node, colspan, rowspan }
 }
 

--- a/crates/gosub_lattice/src/sizing/columns.rs
+++ b/crates/gosub_lattice/src/sizing/columns.rs
@@ -1,14 +1,43 @@
 use crate::grid::SectionGrid;
-use crate::types::{CssLength, CssProp};
+use crate::model::TableModel;
+use crate::types::{CssLength, CssProp, TableSizing};
 use crate::TableTree;
+
+/// Per-column width specs from `<colgroup>`/`<col>` elements, in document
+/// order, expanded by their `span` attributes. A `<colgroup>` without `<col>`
+/// children contributes its own width once per column it spans. Columns not
+/// covered by any col element are simply absent from the returned vec.
+pub fn column_specs<T: TableTree>(tree: &T, model: &TableModel<T::NodeId>) -> Vec<CssLength> {
+    let mut specs = Vec::new();
+    for group in &model.column_groups {
+        if group.columns.is_empty() {
+            let span = tree.attr_usize(group.node, "span").unwrap_or(1).max(1);
+            let w = tree.css_length(group.node, CssProp::Width);
+            specs.extend(std::iter::repeat(w).take(span));
+        } else {
+            for &col in &group.columns {
+                let span = tree.attr_usize(col, "span").unwrap_or(1).max(1);
+                let w = tree.css_length(col, CssProp::Width);
+                specs.extend(std::iter::repeat(w).take(span));
+            }
+        }
+    }
+    specs
+}
 
 /// Compute column widths for a table with `n_cols` columns.
 ///
-/// Algorithm:
+/// `table-layout: fixed` (CSS 2 §17.5.2.1): widths come from `<col>` elements
+/// first, then from the cells of the first row (a colspan cell's width divides
+/// evenly over its columns); content is never measured. Remaining space is
+/// split equally over the width-less columns.
+///
+/// `table-layout: auto` (heuristic, not the full CSS algorithm):
 /// 1. The available space is `table_width` minus the horizontal border-spacing
 ///    gutters (one between each pair of columns plus the outer two).
-/// 2. Scan the first non-empty row across all provided grids (header first,
-///    then body, then footer).  For each single-column cell in that row:
+/// 2. Seed explicit widths from `<col>` elements, then scan the first
+///    non-empty row across all provided grids (header first, then body, then
+///    footer).  For each single-column cell in that row:
 ///    - If it has an explicit CSS `width` in px or %, assign that to its column.
 ///    - Record its pre-pass natural width (from `cell_content_width`) for use
 ///      in step 3.
@@ -21,6 +50,8 @@ pub fn compute_column_widths<T: TableTree>(
     table_width: f32,
     border_spacing_x: f32,
     grids: &[&SectionGrid<T::NodeId>],
+    sizing: TableSizing,
+    col_specs: &[CssLength],
 ) -> Vec<f32> {
     if n_cols == 0 {
         return Vec::new();
@@ -30,8 +61,19 @@ pub fn compute_column_widths<T: TableTree>(
     let spacing_total = (n_cols as f32 + 1.0) * border_spacing_x;
     let available = (table_width - spacing_total).max(0.0);
 
+    if sizing == TableSizing::Fixed {
+        return fixed_column_widths(tree, n_cols, table_width, available, grids, col_specs);
+    }
+
     let mut explicit: Vec<Option<f32>> = vec![None; n_cols];
     let mut natural: Vec<f32> = vec![0.0; n_cols];
+
+    // Widths from <col>/<colgroup> elements claim their columns first.
+    for (i, spec) in col_specs.iter().take(n_cols).enumerate() {
+        if let Some(px) = spec.resolve(table_width) {
+            explicit[i] = Some(px);
+        }
+    }
 
     // Scan the first non-empty row for explicit widths and natural content widths.
     'outer: for grid in grids {
@@ -115,6 +157,71 @@ pub fn compute_column_widths<T: TableTree>(
             }
         }
     }
+
+    explicit.iter().map(|w| w.unwrap_or(0.0)).collect()
+}
+
+/// The fixed table layout algorithm: column widths are fully determined by
+/// `<col>` elements and the first row's cells - later rows and content play no
+/// part, which is what makes fixed layout single-pass and overflow-prone.
+fn fixed_column_widths<T: TableTree>(
+    tree: &T,
+    n_cols: usize,
+    table_width: f32,
+    available: f32,
+    grids: &[&SectionGrid<T::NodeId>],
+    col_specs: &[CssLength],
+) -> Vec<f32> {
+    let mut explicit: Vec<Option<f32>> = vec![None; n_cols];
+
+    for (i, spec) in col_specs.iter().take(n_cols).enumerate() {
+        if let Some(px) = spec.resolve(table_width) {
+            explicit[i] = Some(px);
+        }
+    }
+
+    // First non-empty row: cell widths claim any columns the col elements left
+    // open. A colspan cell's width divides evenly over its columns.
+    'outer: for grid in grids {
+        for row_idx in 0..grid.n_rows {
+            let mut found_any = false;
+            for cell in grid.cells_in_row(row_idx) {
+                found_any = true;
+                let Some(w) = tree.css_length(cell.node, CssProp::Width).resolve(table_width) else {
+                    continue;
+                };
+                let share = w / cell.colspan as f32;
+                for c in cell.col..(cell.col + cell.colspan).min(n_cols) {
+                    if explicit[c].is_none() {
+                        explicit[c] = Some(share);
+                    }
+                }
+            }
+            if found_any {
+                break 'outer;
+            }
+        }
+    }
+
+    let set_total: f32 = explicit.iter().flatten().sum();
+    let auto_cols: Vec<usize> = (0..n_cols).filter(|&c| explicit[c].is_none()).collect();
+
+    if !auto_cols.is_empty() {
+        // Remaining space divides EQUALLY over the auto columns (fixed layout
+        // has no content information to weight by).
+        let equal = (available - set_total).max(0.0) / auto_cols.len() as f32;
+        for c in auto_cols {
+            explicit[c] = Some(equal);
+        }
+    } else if set_total > 0.0 && set_total < available {
+        // Every column has a width but they under-fill the table: scale up
+        // pro-rata so the columns span the full table width.
+        let scale = available / set_total;
+        for w in explicit.iter_mut().flatten() {
+            *w *= scale;
+        }
+    }
+    // set_total > available: keep the specified widths; the table overflows.
 
     explicit.iter().map(|w| w.unwrap_or(0.0)).collect()
 }

--- a/crates/gosub_lattice/src/sizing/columns.rs
+++ b/crates/gosub_lattice/src/sizing/columns.rs
@@ -55,16 +55,20 @@ pub fn compute_column_widths<T: TableTree>(
     sizing: TableSizing,
     col_specs: &[CssLength],
     collapsed_borders: &HashMap<T::NodeId, CollapsedBorders>,
+    // CAPMIN: the caption's minimum border-box width. CSS 2 §17.5.2 makes the used
+    // table width the greater of the width the columns require and CAPMIN, in both
+    // layout modes. 0.0 when there is no caption.
+    capmin: f32,
 ) -> (Vec<f32>, f32) {
     if n_cols == 0 {
-        return (Vec::new(), 0.0);
+        return (Vec::new(), capmin.max(0.0));
     }
 
     // Total space consumed by border-spacing gutters.
     let spacing_total = (n_cols as f32 + 1.0) * border_spacing_x;
 
     if sizing == TableSizing::Fixed {
-        let table_width = explicit_table_width.unwrap_or(available_width);
+        let table_width = explicit_table_width.unwrap_or(available_width).max(capmin);
         let available = (table_width - spacing_total).max(0.0);
         let widths = fixed_column_widths(tree, n_cols, available, grids, col_specs, collapsed_borders);
         return (widths, table_width);
@@ -137,9 +141,13 @@ pub fn compute_column_widths<T: TableTree>(
     let cmin: f32 = contrib_min.iter().sum();
     let cmax: f32 = contrib_max.iter().sum();
 
-    // With no intrinsic information at all (mock trees, fully empty cells)
-    // shrink-to-fit would collapse the table - fill the available width instead.
-    let has_intrinsic = max.iter().any(|&m| m > 0.0) || min.iter().any(|&m| m > 0.0);
+    // With no intrinsic information at all shrink-to-fit would collapse the table -
+    // fill the available width instead. Only for mock trees using the intrinsics
+    // stub: a measuring implementor's all-zero result means genuinely empty cells,
+    // which DO shrink to fit (an empty auto table is CAPMIN/spacing wide, CSS 2
+    // §17.5.2.2).
+    let has_intrinsic =
+        tree.measures_intrinsics() || max.iter().any(|&m| m > 0.0) || min.iter().any(|&m| m > 0.0);
 
     let used_width = match explicit_table_width {
         Some(w) => w.max(cmin + spacing_total),
@@ -147,7 +155,8 @@ pub fn compute_column_widths<T: TableTree>(
         // Shrink-to-fit: as wide as the content wants, capped by the containing
         // block, but never below the min-content total.
         None => (cmax + spacing_total).min(available_width).max(cmin + spacing_total),
-    };
+    }
+    .max(capmin);
 
     // Distribute the inner width: start every column at its min contribution,
     // grow toward the max contributions, then hand any extra to auto columns.

--- a/crates/gosub_lattice/src/sizing/columns.rs
+++ b/crates/gosub_lattice/src/sizing/columns.rs
@@ -25,140 +25,183 @@ pub fn column_specs<T: TableTree>(tree: &T, model: &TableModel<T::NodeId>) -> Ve
     specs
 }
 
-/// Compute column widths for a table with `n_cols` columns.
+/// Compute column widths and the used table width.
 ///
 /// `table-layout: fixed` (CSS 2 §17.5.2.1): widths come from `<col>` elements
 /// first, then from the cells of the first row (a colspan cell's width divides
 /// evenly over its columns); content is never measured. Remaining space is
 /// split equally over the width-less columns.
 ///
-/// `table-layout: auto` (heuristic, not the full CSS algorithm):
-/// 1. The available space is `table_width` minus the horizontal border-spacing
-///    gutters (one between each pair of columns plus the outer two).
-/// 2. Seed explicit widths from `<col>` elements, then scan the first
-///    non-empty row across all provided grids (header first, then body, then
-///    footer).  For each single-column cell in that row:
-///    - If it has an explicit CSS `width` in px or %, assign that to its column.
-///    - Record its pre-pass natural width (from `cell_content_width`) for use
-///      in step 3.
-/// 3. Remaining space is distributed to auto columns proportionally to their
-///    natural content width. Falls back to equal distribution if no content
-///    width information is available.
+/// `table-layout: auto` (CSS 2 §17.5.2.2): every cell contributes its
+/// min-content and max-content width (via [`TableTree::cell_intrinsic_widths`])
+/// and any specified width to its column(s); colspan cells distribute their
+/// requirement over the spanned columns. The used table width is the explicit
+/// width (floored at the min-content total) or, when auto, shrink-to-fit
+/// between the min- and max-content totals capped by `available_width`.
+/// Columns then grow from their min toward their max, with any extra space
+/// distributed over the auto columns.
+///
+/// Returns `(column_widths, used_table_width)`.
 pub fn compute_column_widths<T: TableTree>(
-    tree: &T,
+    tree: &mut T,
     n_cols: usize,
-    table_width: f32,
+    explicit_table_width: Option<f32>,
+    available_width: f32,
     border_spacing_x: f32,
     grids: &[&SectionGrid<T::NodeId>],
     sizing: TableSizing,
     col_specs: &[CssLength],
-) -> Vec<f32> {
+) -> (Vec<f32>, f32) {
     if n_cols == 0 {
-        return Vec::new();
+        return (Vec::new(), 0.0);
     }
 
     // Total space consumed by border-spacing gutters.
     let spacing_total = (n_cols as f32 + 1.0) * border_spacing_x;
-    let available = (table_width - spacing_total).max(0.0);
 
     if sizing == TableSizing::Fixed {
-        return fixed_column_widths(tree, n_cols, table_width, available, grids, col_specs);
+        let table_width = explicit_table_width.unwrap_or(available_width);
+        let available = (table_width - spacing_total).max(0.0);
+        let widths = fixed_column_widths(tree, n_cols, table_width, available, grids, col_specs);
+        return (widths, table_width);
     }
 
-    let mut explicit: Vec<Option<f32>> = vec![None; n_cols];
-    let mut natural: Vec<f32> = vec![0.0; n_cols];
+    // Percentages resolve against the explicit table width when there is one,
+    // otherwise against the containing block.
+    let percent_basis = explicit_table_width.unwrap_or(available_width);
 
-    // Widths from <col>/<colgroup> elements claim their columns first.
-    for (i, spec) in col_specs.iter().take(n_cols).enumerate() {
-        if let Some(px) = spec.resolve(table_width) {
-            explicit[i] = Some(px);
+    let mut min = vec![0.0_f32; n_cols];
+    let mut max = vec![0.0_f32; n_cols];
+    let mut spec: Vec<Option<f32>> = vec![None; n_cols];
+
+    for (i, s) in col_specs.iter().take(n_cols).enumerate() {
+        if let Some(px) = s.resolve(percent_basis) {
+            spec[i] = Some(px);
         }
     }
 
-    // Scan the first non-empty row for explicit widths and natural content widths.
-    'outer: for grid in grids {
-        for row_idx in 0..grid.n_rows {
-            let mut found_any = false;
-            for cell in grid.cells_in_row(row_idx) {
-                found_any = true;
-                if cell.colspan == 1 {
-                    let cw = tree.cell_content_width(cell.node);
-                    if explicit[cell.col].is_none() {
-                        // A specified width cannot shrink a cell below its content's min-width
-                        // (CSS: used width = max(specified, min-content)). Without this, e.g. a
-                        // `width:18px` cell holding a 20px image clips it and eats the padding.
-                        match tree.css_length(cell.node, CssProp::Width) {
-                            CssLength::Px(px) => explicit[cell.col] = Some(px.max(cw)),
-                            CssLength::Percent(p) => explicit[cell.col] = Some((p / 100.0 * table_width).max(cw)),
-                            _ => {}
-                        }
-                    }
-                    if cw > natural[cell.col] {
-                        natural[cell.col] = cw;
-                    }
-                }
-            }
-            if found_any {
-                break 'outer;
-            }
-        }
-    }
-
-    let fixed_total: f32 = explicit.iter().filter_map(|&w| w).sum();
-    let remaining = (available - fixed_total).max(0.0);
-
-    let auto_cols: Vec<usize> = (0..n_cols).filter(|&c| explicit[c].is_none()).collect();
-    if !auto_cols.is_empty() {
-        let total_natural: f32 = auto_cols.iter().map(|&c| natural[c]).sum();
-        if total_natural > 0.0 {
-            // Threshold-based distribution:
-            //   - Narrow auto columns (intrinsic < 50 px) are structural (rank
-            //     numbers, vote buttons) - give them their natural width with a
-            //     14 px floor so they stay visible.
-            //   - Wide auto columns are content columns - they share whatever
-            //     space remains after the narrow columns have taken their share.
-            //     Multiple content columns share proportionally to their natural
-            //     widths; if there are none, fall through to equal distribution.
-            const NARROW_THRESHOLD: f32 = 50.0;
-            const NARROW_FLOOR: f32 = 14.0;
-
-            let narrow_total: f32 = auto_cols
-                .iter()
-                .filter(|&&c| natural[c] < NARROW_THRESHOLD)
-                .map(|&c| natural[c].max(NARROW_FLOOR))
-                .sum();
-
-            let content_natural_total: f32 = auto_cols
-                .iter()
-                .filter(|&&c| natural[c] >= NARROW_THRESHOLD)
-                .map(|&c| natural[c])
-                .sum();
-
-            if content_natural_total > 0.0 {
-                let content_remaining = (remaining - narrow_total).max(0.0);
-                for &col in &auto_cols {
-                    if natural[col] < NARROW_THRESHOLD {
-                        explicit[col] = Some(natural[col].max(NARROW_FLOOR));
-                    } else {
-                        explicit[col] = Some(content_remaining * natural[col] / content_natural_total);
-                    }
+    // Single-column cells contribute directly; colspan cells are collected and
+    // distributed afterwards, shortest spans first.
+    let mut spanners: Vec<(usize, usize, f32, f32, Option<f32>)> = Vec::new();
+    for grid in grids {
+        for cell in grid.cells() {
+            let (min_c, max_c) = tree.cell_intrinsic_widths(cell.node);
+            let max_c = max_c.max(min_c);
+            let w = tree.css_length(cell.node, CssProp::Width).resolve(percent_basis);
+            if cell.colspan == 1 {
+                let c = cell.col;
+                min[c] = min[c].max(min_c);
+                max[c] = max[c].max(max_c);
+                if let Some(w) = w {
+                    spec[c] = Some(spec[c].map_or(w, |prev| prev.max(w)));
                 }
             } else {
-                // All auto columns are narrow - distribute remaining proportionally.
-                for &col in &auto_cols {
-                    explicit[col] = Some(remaining * natural[col] / total_natural);
-                }
-            }
-        } else {
-            // No content width data (mock trees) - fall back to equal distribution.
-            let equal = remaining / auto_cols.len() as f32;
-            for &col in &auto_cols {
-                explicit[col] = Some(equal);
+                spanners.push((cell.col, cell.colspan, min_c, max_c, w));
             }
         }
     }
 
-    explicit.iter().map(|w| w.unwrap_or(0.0)).collect()
+    spanners.sort_by_key(|s| s.1);
+    for (col, colspan, min_c, max_c, w) in spanners {
+        let range = col..(col + colspan).min(n_cols);
+        if range.is_empty() {
+            continue;
+        }
+        // The spanning cell runs across the gutters between its columns.
+        let gutters = border_spacing_x * range.len().saturating_sub(1) as f32;
+        distribute_deficit(&mut min, range.clone(), min_c - gutters, &max);
+        distribute_deficit(&mut max, range.clone(), max_c - gutters, &min);
+        // A specified width on a spanning cell divides evenly over columns
+        // that have no specified width of their own.
+        if let Some(w) = w {
+            let open: Vec<usize> = range.clone().filter(|&c| spec[c].is_none()).collect();
+            if open.len() == range.len() {
+                let share = (w - gutters) / open.len() as f32;
+                for c in open {
+                    spec[c] = Some(share.max(0.0));
+                }
+            }
+        }
+    }
+
+    // A specified width cannot shrink a column below its min-content width; a
+    // specified column contributes that fixed width as both its min and max.
+    let contrib_min: Vec<f32> = (0..n_cols).map(|c| spec[c].map_or(min[c], |s| s.max(min[c]))).collect();
+    let contrib_max: Vec<f32> = (0..n_cols)
+        .map(|c| spec[c].map_or(max[c].max(min[c]), |s| s.max(min[c])))
+        .collect();
+    let cmin: f32 = contrib_min.iter().sum();
+    let cmax: f32 = contrib_max.iter().sum();
+
+    // With no intrinsic information at all (mock trees, fully empty cells)
+    // shrink-to-fit would collapse the table - fill the available width instead.
+    let has_intrinsic = max.iter().any(|&m| m > 0.0) || min.iter().any(|&m| m > 0.0);
+
+    let used_width = match explicit_table_width {
+        Some(w) => w.max(cmin + spacing_total),
+        None if !has_intrinsic => available_width,
+        // Shrink-to-fit: as wide as the content wants, capped by the containing
+        // block, but never below the min-content total.
+        None => (cmax + spacing_total).min(available_width).max(cmin + spacing_total),
+    };
+
+    // Distribute the inner width: start every column at its min contribution,
+    // grow toward the max contributions, then hand any extra to auto columns.
+    let inner = (used_width - spacing_total).max(0.0);
+    let mut widths = contrib_min.clone();
+    let mut extra = inner - cmin;
+    if extra > 0.0 {
+        let growth: Vec<f32> = (0..n_cols).map(|c| contrib_max[c] - contrib_min[c]).collect();
+        let growth_total: f32 = growth.iter().sum();
+        if growth_total > 0.0 {
+            let g = extra.min(growth_total);
+            for c in 0..n_cols {
+                widths[c] += g * growth[c] / growth_total;
+            }
+            extra -= g;
+        }
+        if extra > 0.0 {
+            // Space beyond every column's max: prefer auto columns, weighted by
+            // their max-content width so content-heavy columns absorb more.
+            let autos: Vec<usize> = (0..n_cols).filter(|&c| spec[c].is_none()).collect();
+            let targets = if autos.is_empty() { (0..n_cols).collect() } else { autos };
+            let weight_total: f32 = targets.iter().map(|&c| contrib_max[c]).sum();
+            if weight_total > 0.0 {
+                for &c in &targets {
+                    widths[c] += extra * contrib_max[c] / weight_total;
+                }
+            } else {
+                let equal = extra / targets.len() as f32;
+                for &c in &targets {
+                    widths[c] += equal;
+                }
+            }
+        }
+    }
+
+    (widths, used_width)
+}
+
+/// Raise the values in `range` so they sum to at least `required`. The deficit
+/// is split proportionally to `weights` (content-heavy columns absorb more),
+/// equally when the weights are all zero.
+fn distribute_deficit(vals: &mut [f32], range: std::ops::Range<usize>, required: f32, weights: &[f32]) {
+    let current: f32 = vals[range.clone()].iter().sum();
+    if required <= current {
+        return;
+    }
+    let deficit = required - current;
+    let weight_total: f32 = weights[range.clone()].iter().sum();
+    if weight_total > 0.0 {
+        for c in range {
+            vals[c] += deficit * weights[c] / weight_total;
+        }
+    } else {
+        let equal = deficit / range.len() as f32;
+        for c in range {
+            vals[c] += equal;
+        }
+    }
 }
 
 /// The fixed table layout algorithm: column widths are fully determined by

--- a/crates/gosub_lattice/src/sizing/columns.rs
+++ b/crates/gosub_lattice/src/sizing/columns.rs
@@ -15,12 +15,12 @@ pub fn column_specs<T: TableTree>(tree: &T, model: &TableModel<T::NodeId>) -> Ve
         if group.columns.is_empty() {
             let span = tree.attr_usize(group.node, "span").unwrap_or(1).max(1);
             let w = tree.css_length(group.node, CssProp::Width);
-            specs.extend(std::iter::repeat(w).take(span));
+            specs.extend(std::iter::repeat_n(w, span));
         } else {
             for &col in &group.columns {
                 let span = tree.attr_usize(col, "span").unwrap_or(1).max(1);
                 let w = tree.css_length(col, CssProp::Width);
-                specs.extend(std::iter::repeat(w).take(span));
+                specs.extend(std::iter::repeat_n(w, span));
             }
         }
     }
@@ -146,8 +146,7 @@ pub fn compute_column_widths<T: TableTree>(
     // stub: a measuring implementor's all-zero result means genuinely empty cells,
     // which DO shrink to fit (an empty auto table is CAPMIN/spacing wide, CSS 2
     // §17.5.2.2).
-    let has_intrinsic =
-        tree.measures_intrinsics() || max.iter().any(|&m| m > 0.0) || min.iter().any(|&m| m > 0.0);
+    let has_intrinsic = tree.measures_intrinsics() || max.iter().any(|&m| m > 0.0) || min.iter().any(|&m| m > 0.0);
 
     let used_width = match explicit_table_width {
         Some(w) => w.max(cmin + spacing_total),
@@ -257,10 +256,9 @@ fn fixed_column_widths<T: TableTree>(
                 let padding = read_padding(tree, cell.node);
                 let outer = w + padding.left + padding.right + border.left + border.right;
                 let share = outer / cell.colspan as f32;
-                for c in cell.col..(cell.col + cell.colspan).min(n_cols) {
-                    if explicit[c].is_none() {
-                        explicit[c] = Some(share);
-                    }
+                let end = (cell.col + cell.colspan).min(n_cols);
+                for slot in &mut explicit[cell.col..end] {
+                    slot.get_or_insert(share);
                 }
             }
             if found_any {

--- a/crates/gosub_lattice/src/sizing/columns.rs
+++ b/crates/gosub_lattice/src/sizing/columns.rs
@@ -1,7 +1,9 @@
 use crate::grid::SectionGrid;
 use crate::model::TableModel;
-use crate::types::{CssLength, CssProp, TableSizing};
+use crate::sizing::rows::{effective_border, read_padding};
+use crate::types::{CollapsedBorders, CssLength, CssProp, TableSizing};
 use crate::TableTree;
+use std::collections::HashMap;
 
 /// Per-column width specs from `<colgroup>`/`<col>` elements, in document
 /// order, expanded by their `span` attributes. A `<colgroup>` without `<col>`
@@ -42,6 +44,7 @@ pub fn column_specs<T: TableTree>(tree: &T, model: &TableModel<T::NodeId>) -> Ve
 /// distributed over the auto columns.
 ///
 /// Returns `(column_widths, used_table_width)`.
+#[allow(clippy::too_many_arguments)]
 pub fn compute_column_widths<T: TableTree>(
     tree: &mut T,
     n_cols: usize,
@@ -51,6 +54,7 @@ pub fn compute_column_widths<T: TableTree>(
     grids: &[&SectionGrid<T::NodeId>],
     sizing: TableSizing,
     col_specs: &[CssLength],
+    collapsed_borders: &HashMap<T::NodeId, CollapsedBorders>,
 ) -> (Vec<f32>, f32) {
     if n_cols == 0 {
         return (Vec::new(), 0.0);
@@ -62,7 +66,7 @@ pub fn compute_column_widths<T: TableTree>(
     if sizing == TableSizing::Fixed {
         let table_width = explicit_table_width.unwrap_or(available_width);
         let available = (table_width - spacing_total).max(0.0);
-        let widths = fixed_column_widths(tree, n_cols, table_width, available, grids, col_specs);
+        let widths = fixed_column_widths(tree, n_cols, available, grids, col_specs, collapsed_borders);
         return (widths, table_width);
     }
 
@@ -207,18 +211,22 @@ fn distribute_deficit(vals: &mut [f32], range: std::ops::Range<usize>, required:
 /// The fixed table layout algorithm: column widths are fully determined by
 /// `<col>` elements and the first row's cells - later rows and content play no
 /// part, which is what makes fixed layout single-pass and overflow-prone.
+#[allow(clippy::too_many_arguments)]
 fn fixed_column_widths<T: TableTree>(
     tree: &T,
     n_cols: usize,
-    table_width: f32,
     available: f32,
     grids: &[&SectionGrid<T::NodeId>],
     col_specs: &[CssLength],
+    collapsed_borders: &HashMap<T::NodeId, CollapsedBorders>,
 ) -> Vec<f32> {
     let mut explicit: Vec<Option<f32>> = vec![None; n_cols];
 
+    // Percentages resolve against the space actually available to columns:
+    // the table width minus the border-spacing gutters (CSS 2 §17.5.2.1
+    // "minus borders or cell spacing").
     for (i, spec) in col_specs.iter().take(n_cols).enumerate() {
-        if let Some(px) = spec.resolve(table_width) {
+        if let Some(px) = spec.resolve(available) {
             explicit[i] = Some(px);
         }
     }
@@ -230,10 +238,16 @@ fn fixed_column_widths<T: TableTree>(
             let mut found_any = false;
             for cell in grid.cells_in_row(row_idx) {
                 found_any = true;
-                let Some(w) = tree.css_length(cell.node, CssProp::Width).resolve(table_width) else {
+                let Some(w) = tree.css_length(cell.node, CssProp::Width).resolve(available) else {
                     continue;
                 };
-                let share = w / cell.colspan as f32;
+                // The width property is the CONTENT width; the column gets the
+                // cell's border-box (CSS 2 §17.5.2.1 as clarified on www-style:
+                // padding and borders - halved under collapse - are added).
+                let border = effective_border(tree, cell.node, collapsed_borders);
+                let padding = read_padding(tree, cell.node);
+                let outer = w + padding.left + padding.right + border.left + border.right;
+                let share = outer / cell.colspan as f32;
                 for c in cell.col..(cell.col + cell.colspan).min(n_cols) {
                     if explicit[c].is_none() {
                         explicit[c] = Some(share);

--- a/crates/gosub_lattice/src/sizing/rows.rs
+++ b/crates/gosub_lattice/src/sizing/rows.rs
@@ -1,19 +1,32 @@
-use crate::grid::SectionGrid;
+use std::collections::HashMap;
+
+use crate::grid::{PlacedCell, SectionGrid};
 use crate::types::{BoxEdges, CssLength, CssProp};
 use crate::TableTree;
 
 /// Compute the height of each row in a section.
 ///
-/// For each non-spanning cell we:
+/// Pass 1 - non-spanning cells:
 /// 1. Call [`TableTree::layout_cell`] to let the implementor run normal layout
 ///    (block/flex/inline) inside the cell and get the actual content height.
 /// 2. Also read any explicit CSS `height` on the cell.
 /// 3. Take the maximum of the two, add the cell's own border + padding, and
 ///    use that as the candidate height for the row.
 ///
-/// Cells with `rowspan > 1` are skipped here; their height distribution across
-/// multiple rows is a Phase 2 concern.
-pub fn compute_row_heights<T: TableTree>(tree: &mut T, grid: &SectionGrid<T::NodeId>, col_widths: &[f32]) -> Vec<f32> {
+/// Pass 2 - cells with `rowspan > 1`, shortest spans first: if the cell needs
+/// more than its spanned rows (plus the gutters between them) currently offer,
+/// the deficit is distributed equally over those rows.
+///
+/// Every measured content height is recorded in `content_heights`, keyed by
+/// cell node - `place_cell` uses it to resolve `vertical-align`.
+pub fn compute_row_heights<T: TableTree>(
+    tree: &mut T,
+    grid: &SectionGrid<T::NodeId>,
+    col_widths: &[f32],
+    spacing_x: f32,
+    spacing_y: f32,
+    content_heights: &mut HashMap<T::NodeId, f32>,
+) -> Vec<f32> {
     let mut heights = vec![0.0_f32; grid.n_rows];
 
     for cell in grid.cells() {
@@ -21,34 +34,68 @@ pub fn compute_row_heights<T: TableTree>(tree: &mut T, grid: &SectionGrid<T::Nod
             continue;
         }
 
-        let border = read_border(tree, cell.node);
-        let padding = read_padding(tree, cell.node);
-
-        // Inner width available to the cell's children.
-        let cell_col_w: f32 = col_widths
-            .get(cell.col..cell.col + cell.colspan)
-            .unwrap_or(&[])
-            .iter()
-            .sum();
-        let inner_w = (cell_col_w - border.horizontal() - padding.horizontal()).max(0.0);
-
-        // Ask the implementor to lay out the cell's children and report their height.
-        let content_h = tree.layout_cell(cell.node, inner_w);
-
-        // Explicit CSS `height` is a minimum - content can be taller.
-        let explicit_h = match tree.css_length(cell.node, CssProp::Height) {
-            CssLength::Px(px) => px,
-            CssLength::Zero => 0.0,
-            _ => 0.0,
-        };
-
-        let cell_h = content_h.max(explicit_h) + border.vertical() + padding.vertical();
+        let (content_h, cell_h) = measure_cell(tree, cell, col_widths, spacing_x);
+        content_heights.insert(cell.node, content_h);
         if cell_h > heights[cell.row] {
             heights[cell.row] = cell_h;
         }
     }
 
+    // Spanning cells, shortest spans first so nested spans stack predictably.
+    let mut spanning: Vec<&PlacedCell<T::NodeId>> = grid.cells().iter().filter(|c| c.rowspan > 1).collect();
+    spanning.sort_by_key(|c| c.rowspan);
+
+    for cell in spanning {
+        let (content_h, cell_h) = measure_cell(tree, cell, col_widths, spacing_x);
+        content_heights.insert(cell.node, content_h);
+
+        let span = cell.row..(cell.row + cell.rowspan).min(heights.len());
+        let n_rows = span.len();
+        if n_rows == 0 {
+            continue;
+        }
+        let current: f32 =
+            heights[span.clone()].iter().sum::<f32>() + spacing_y * n_rows.saturating_sub(1) as f32;
+        if cell_h > current {
+            let add = (cell_h - current) / n_rows as f32;
+            for h in &mut heights[span] {
+                *h += add;
+            }
+        }
+    }
+
     heights
+}
+
+/// Lay out one cell's children at its final column width and return
+/// `(content_height, border_box_height)`, honouring an explicit CSS `height`
+/// as a minimum.
+fn measure_cell<T: TableTree>(
+    tree: &mut T,
+    cell: &PlacedCell<T::NodeId>,
+    col_widths: &[f32],
+    spacing_x: f32,
+) -> (f32, f32) {
+    let border = read_border(tree, cell.node);
+    let padding = read_padding(tree, cell.node);
+
+    // Inner width available to the cell's children: the spanned columns plus
+    // the gutters a colspan cell runs across, minus the cell's own edges.
+    let spanned = col_widths.get(cell.col..cell.col + cell.colspan).unwrap_or(&[]);
+    let cell_col_w: f32 = spanned.iter().sum::<f32>() + spacing_x * spanned.len().saturating_sub(1) as f32;
+    let inner_w = (cell_col_w - border.horizontal() - padding.horizontal()).max(0.0);
+
+    // Ask the implementor to lay out the cell's children and report their height.
+    let content_h = tree.layout_cell(cell.node, inner_w);
+
+    // Explicit CSS `height` is a minimum - content can be taller.
+    let explicit_h = match tree.css_length(cell.node, CssProp::Height) {
+        CssLength::Px(px) => px,
+        _ => 0.0,
+    };
+
+    let cell_h = content_h.max(explicit_h) + border.vertical() + padding.vertical();
+    (content_h, cell_h)
 }
 
 // Helpers shared with compute.rs

--- a/crates/gosub_lattice/src/sizing/rows.rs
+++ b/crates/gosub_lattice/src/sizing/rows.rs
@@ -27,8 +27,16 @@ pub fn compute_row_heights<T: TableTree>(
     spacing_y: f32,
     content_heights: &mut HashMap<T::NodeId, f32>,
     collapsed_borders: &HashMap<T::NodeId, CollapsedBorders>,
+    baseline_shifts: &mut HashMap<T::NodeId, f32>,
 ) -> Vec<f32> {
     let mut heights = vec![0.0_f32; grid.n_rows];
+
+    // Baseline alignment (CSS 2 §17.5.3): cells with `vertical-align: baseline` share a
+    // row baseline - the deepest first-line baseline among them; shallower cells shift
+    // down by the difference, which can grow the row.
+    let mut measured: Vec<(&PlacedCell<T::NodeId>, f32)> = Vec::new();
+    let mut row_baseline = vec![0.0_f32; grid.n_rows];
+    let mut cell_baselines: HashMap<T::NodeId, f32> = HashMap::new();
 
     for cell in grid.cells() {
         if cell.rowspan != 1 {
@@ -37,8 +45,27 @@ pub fn compute_row_heights<T: TableTree>(
 
         let (content_h, cell_h) = measure_cell(tree, cell, col_widths, spacing_x, collapsed_borders);
         content_heights.insert(cell.node, content_h);
-        if cell_h > heights[cell.row] {
-            heights[cell.row] = cell_h;
+        measured.push((cell, cell_h));
+
+        if tree.vertical_align(cell.node) == crate::types::VerticalAlign::Baseline {
+            if let Some(b) = tree.cell_baseline(cell.node) {
+                cell_baselines.insert(cell.node, b);
+                row_baseline[cell.row] = row_baseline[cell.row].max(b);
+            }
+        }
+    }
+
+    for (cell, cell_h) in measured {
+        let shift = cell_baselines
+            .get(&cell.node)
+            .map(|b| (row_baseline[cell.row] - b).max(0.0))
+            .unwrap_or(0.0);
+        if shift > 0.0 {
+            baseline_shifts.insert(cell.node, shift);
+        }
+        let effective = cell_h + shift;
+        if effective > heights[cell.row] {
+            heights[cell.row] = effective;
         }
     }
 

--- a/crates/gosub_lattice/src/sizing/rows.rs
+++ b/crates/gosub_lattice/src/sizing/rows.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::grid::{PlacedCell, SectionGrid};
-use crate::types::{BoxEdges, CssLength, CssProp};
+use crate::types::{BoxEdges, CollapsedBorders, CssLength, CssProp};
 use crate::TableTree;
 
 /// Compute the height of each row in a section.
@@ -26,7 +26,7 @@ pub fn compute_row_heights<T: TableTree>(
     spacing_x: f32,
     spacing_y: f32,
     content_heights: &mut HashMap<T::NodeId, f32>,
-    suppressed_borders: &HashMap<T::NodeId, [bool; 4]>,
+    collapsed_borders: &HashMap<T::NodeId, CollapsedBorders>,
 ) -> Vec<f32> {
     let mut heights = vec![0.0_f32; grid.n_rows];
 
@@ -35,7 +35,7 @@ pub fn compute_row_heights<T: TableTree>(
             continue;
         }
 
-        let (content_h, cell_h) = measure_cell(tree, cell, col_widths, spacing_x, suppressed_borders);
+        let (content_h, cell_h) = measure_cell(tree, cell, col_widths, spacing_x, collapsed_borders);
         content_heights.insert(cell.node, content_h);
         if cell_h > heights[cell.row] {
             heights[cell.row] = cell_h;
@@ -47,7 +47,7 @@ pub fn compute_row_heights<T: TableTree>(
     spanning.sort_by_key(|c| c.rowspan);
 
     for cell in spanning {
-        let (content_h, cell_h) = measure_cell(tree, cell, col_widths, spacing_x, suppressed_borders);
+        let (content_h, cell_h) = measure_cell(tree, cell, col_widths, spacing_x, collapsed_borders);
         content_heights.insert(cell.node, content_h);
 
         let span = cell.row..(cell.row + cell.rowspan).min(heights.len());
@@ -70,16 +70,15 @@ pub fn compute_row_heights<T: TableTree>(
 
 /// Lay out one cell's children at its final column width and return
 /// `(content_height, border_box_height)`, honouring an explicit CSS `height`
-/// as a minimum. Borders suppressed by border-collapse conflict resolution
-/// take no space.
+/// as a minimum. Collapsed cells measure with their half-width layout borders.
 fn measure_cell<T: TableTree>(
     tree: &mut T,
     cell: &PlacedCell<T::NodeId>,
     col_widths: &[f32],
     spacing_x: f32,
-    suppressed_borders: &HashMap<T::NodeId, [bool; 4]>,
+    collapsed_borders: &HashMap<T::NodeId, CollapsedBorders>,
 ) -> (f32, f32) {
-    let border = effective_border(tree, cell.node, suppressed_borders);
+    let border = effective_border(tree, cell.node, collapsed_borders);
     let padding = read_padding(tree, cell.node);
 
     // Inner width available to the cell's children: the spanned columns plus
@@ -103,29 +102,18 @@ fn measure_cell<T: TableTree>(
 
 // Helpers shared with compute.rs
 
-/// The cell's border with conflict-suppressed edges zeroed - the widths that
-/// actually take up space and get painted under `border-collapse`.
+/// The border widths that actually occupy layout space: under
+/// `border-collapse` that is half the resolved boundary width per edge
+/// (borders center on the grid lines); otherwise the cell's CSS borders.
 pub(crate) fn effective_border<T: TableTree>(
     tree: &T,
     node: T::NodeId,
-    suppressed_borders: &HashMap<T::NodeId, [bool; 4]>,
+    collapsed_borders: &HashMap<T::NodeId, CollapsedBorders>,
 ) -> BoxEdges {
-    let mut border = read_border(tree, node);
-    if let Some(&[top, right, bottom, left]) = suppressed_borders.get(&node) {
-        if top {
-            border.top = 0.0;
-        }
-        if right {
-            border.right = 0.0;
-        }
-        if bottom {
-            border.bottom = 0.0;
-        }
-        if left {
-            border.left = 0.0;
-        }
+    match collapsed_borders.get(&node) {
+        Some(cb) => cb.layout,
+        None => read_border(tree, node),
     }
-    border
 }
 
 pub(crate) fn read_border<T: TableTree>(tree: &T, node: T::NodeId) -> BoxEdges {

--- a/crates/gosub_lattice/src/sizing/rows.rs
+++ b/crates/gosub_lattice/src/sizing/rows.rs
@@ -26,6 +26,7 @@ pub fn compute_row_heights<T: TableTree>(
     spacing_x: f32,
     spacing_y: f32,
     content_heights: &mut HashMap<T::NodeId, f32>,
+    suppressed_borders: &HashMap<T::NodeId, [bool; 4]>,
 ) -> Vec<f32> {
     let mut heights = vec![0.0_f32; grid.n_rows];
 
@@ -34,7 +35,7 @@ pub fn compute_row_heights<T: TableTree>(
             continue;
         }
 
-        let (content_h, cell_h) = measure_cell(tree, cell, col_widths, spacing_x);
+        let (content_h, cell_h) = measure_cell(tree, cell, col_widths, spacing_x, suppressed_borders);
         content_heights.insert(cell.node, content_h);
         if cell_h > heights[cell.row] {
             heights[cell.row] = cell_h;
@@ -46,7 +47,7 @@ pub fn compute_row_heights<T: TableTree>(
     spanning.sort_by_key(|c| c.rowspan);
 
     for cell in spanning {
-        let (content_h, cell_h) = measure_cell(tree, cell, col_widths, spacing_x);
+        let (content_h, cell_h) = measure_cell(tree, cell, col_widths, spacing_x, suppressed_borders);
         content_heights.insert(cell.node, content_h);
 
         let span = cell.row..(cell.row + cell.rowspan).min(heights.len());
@@ -69,14 +70,16 @@ pub fn compute_row_heights<T: TableTree>(
 
 /// Lay out one cell's children at its final column width and return
 /// `(content_height, border_box_height)`, honouring an explicit CSS `height`
-/// as a minimum.
+/// as a minimum. Borders suppressed by border-collapse conflict resolution
+/// take no space.
 fn measure_cell<T: TableTree>(
     tree: &mut T,
     cell: &PlacedCell<T::NodeId>,
     col_widths: &[f32],
     spacing_x: f32,
+    suppressed_borders: &HashMap<T::NodeId, [bool; 4]>,
 ) -> (f32, f32) {
-    let border = read_border(tree, cell.node);
+    let border = effective_border(tree, cell.node, suppressed_borders);
     let padding = read_padding(tree, cell.node);
 
     // Inner width available to the cell's children: the spanned columns plus
@@ -99,6 +102,31 @@ fn measure_cell<T: TableTree>(
 }
 
 // Helpers shared with compute.rs
+
+/// The cell's border with conflict-suppressed edges zeroed - the widths that
+/// actually take up space and get painted under `border-collapse`.
+pub(crate) fn effective_border<T: TableTree>(
+    tree: &T,
+    node: T::NodeId,
+    suppressed_borders: &HashMap<T::NodeId, [bool; 4]>,
+) -> BoxEdges {
+    let mut border = read_border(tree, node);
+    if let Some(&[top, right, bottom, left]) = suppressed_borders.get(&node) {
+        if top {
+            border.top = 0.0;
+        }
+        if right {
+            border.right = 0.0;
+        }
+        if bottom {
+            border.bottom = 0.0;
+        }
+        if left {
+            border.left = 0.0;
+        }
+    }
+    border
+}
 
 pub(crate) fn read_border<T: TableTree>(tree: &T, node: T::NodeId) -> BoxEdges {
     BoxEdges {

--- a/crates/gosub_lattice/src/sizing/rows.rs
+++ b/crates/gosub_lattice/src/sizing/rows.rs
@@ -19,6 +19,7 @@ use crate::TableTree;
 ///
 /// Every measured content height is recorded in `content_heights`, keyed by
 /// cell node - `place_cell` uses it to resolve `vertical-align`.
+#[allow(clippy::too_many_arguments)]
 pub fn compute_row_heights<T: TableTree>(
     tree: &mut T,
     grid: &SectionGrid<T::NodeId>,
@@ -82,8 +83,7 @@ pub fn compute_row_heights<T: TableTree>(
         if n_rows == 0 {
             continue;
         }
-        let current: f32 =
-            heights[span.clone()].iter().sum::<f32>() + spacing_y * n_rows.saturating_sub(1) as f32;
+        let current: f32 = heights[span.clone()].iter().sum::<f32>() + spacing_y * n_rows.saturating_sub(1) as f32;
         if cell_h > current {
             let add = (cell_h - current) / n_rows as f32;
             for h in &mut heights[span] {

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -934,10 +934,10 @@ mod layout_tests {
         assert_approx!(total_h, 30.0, "row + caption");
     }
 
-    // border-collapse: gutters vanish and adjacent 1px borders overlap so
-    // neighbouring cells share a single border line.
+    // border-collapse: gutters vanish - cells sit flush and conflict
+    // resolution (tested separately) decides which cell paints each boundary.
     #[test]
-    fn border_collapse_overlaps_cells() {
+    fn border_collapse_removes_gutters() {
         let (mut tree, root) = MockTable::new(100.0)
             .width(100.0)
             .spacing(5.0, 5.0) // must be ignored under collapse
@@ -955,15 +955,65 @@ mod layout_tests {
         let (_, total_h) = compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
 
         let cells = tree.nodes_with_role(TableRole::Cell);
-        // Columns are 50px; the second column starts 1px early so the 1px
-        // borders coincide.
         assert_approx!(tree.layout(cells[0]).expect("a").position.x, 0.0, "col 0 at x=0 (no gutter)");
-        assert_approx!(tree.layout(cells[1]).expect("b").position.x, 49.0, "col 1 overlaps by 1px");
+        assert_approx!(tree.layout(cells[1]).expect("b").position.x, 50.0, "col 1 flush against col 0");
 
-        // Rows are 12px tall (10 content + 2 border); row 2 overlaps by 1px.
+        // Rows are 12px tall (10 content + 2 border), stacked without gutters.
         let rows = tree.nodes_with_role(TableRole::Row);
-        assert_approx!(tree.layout(rows[1]).expect("row 1").position.y, 11.0, "row 1 overlaps by 1px");
-        assert_approx!(total_h, 23.0, "12 + 12 - 1 overlap, no gutters");
+        assert_approx!(tree.layout(rows[1]).expect("row 1").position.y, 12.0, "row 1 flush below row 0");
+        assert_approx!(total_h, 24.0, "12 + 12, no gutters");
+    }
+
+    // Collapse conflict resolution, uniform borders: ties go to the left/top
+    // cell, so each cell paints its top+left shared edges' winners - i.e. the
+    // right/bottom cell of every boundary suppresses its facing edge.
+    #[test]
+    fn border_collapse_ties_go_left_top() {
+        let (mut tree, root) = MockTable::new(100.0)
+            .width(100.0)
+            .spacing(0.0, 0.0)
+            .collapse()
+            .body_row(vec![
+                cell("a").border(1.0).height(10.0).padding(0.0),
+                cell("b").border(1.0).height(10.0).padding(0.0),
+            ])
+            .body_row(vec![
+                cell("c").border(1.0).height(10.0).padding(0.0),
+                cell("d").border(1.0).height(10.0).padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+
+        // [top, right, bottom, left]
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        let sup = |i: usize| tree.layout(cells[i]).unwrap().suppressed_borders;
+        assert_eq!(sup(0), [false, false, false, false], "top-left wins both boundaries");
+        assert_eq!(sup(1), [false, false, false, true], "b loses its left edge to a");
+        assert_eq!(sup(2), [true, false, false, false], "c loses its top edge to a");
+        assert_eq!(sup(3), [true, false, false, true], "d loses top and left");
+    }
+
+    // Collapse conflict resolution: the wider border wins even against the
+    // left/top preference.
+    #[test]
+    fn border_collapse_wider_border_wins() {
+        let (mut tree, root) = MockTable::new(100.0)
+            .width(100.0)
+            .spacing(0.0, 0.0)
+            .collapse()
+            .body_row(vec![
+                cell("thin").border(1.0).height(10.0).padding(0.0),
+                cell("thick").border(3.0).height(10.0).padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        let sup = |i: usize| tree.layout(cells[i]).unwrap().suppressed_borders;
+        assert_eq!(sup(0), [false, true, false, false], "thin loses its right edge");
+        assert_eq!(sup(1), [false, false, false, false], "thick paints the shared border");
     }
 
     // Auto layout: <col> widths seed columns; the rest distribute as usual.

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -1200,6 +1200,31 @@ mod layout_tests {
         assert_approx!(w_narrow, 100.0, "CAPMIN wins over a narrower containing block");
     }
 
+    // CSS 2 §17.5.3: baseline-aligned cells share the deepest first-line baseline;
+    // shallower cells shift down and the row grows to fit the shifted content.
+    #[test]
+    fn baseline_cells_align_on_row_baseline() {
+        use crate::types::VerticalAlign;
+        let (mut tree, root) = MockTable::new(300.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![
+                cell("deep").height(30.0).padding(0.0).valign(VerticalAlign::Baseline).baseline(25.0),
+                cell("shallow").height(30.0).padding(0.0).valign(VerticalAlign::Baseline).baseline(10.0),
+                cell("top").height(30.0).padding(0.0),
+            ])
+            .into_tree();
+
+        let (_, total_h) = compute_table_layout(&mut tree, root, 300.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        let off = |i: usize| tree.layout(cells[i]).unwrap().content_offset_y;
+        assert_approx!(off(0), 0.0, "deepest baseline cell stays put");
+        assert_approx!(off(1), 15.0, "shallow cell shifts down by the baseline difference");
+        assert_approx!(off(2), 0.0, "top-aligned cell unaffected");
+        // Row grows to hold the shifted cell: 30 + 15.
+        assert_approx!(total_h, 45.0, "row height includes the baseline shift");
+    }
+
     // Auto layout: <col> widths seed columns; the rest distribute as usual.
     #[test]
     fn col_widths_in_auto_layout() {

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -885,6 +885,87 @@ mod layout_tests {
         assert_approx!(tree.layout(cells[1]).unwrap().content_offset_y, 30.0, "bottom offset inside padding");
     }
 
+    // Caption on top: full table width, grid shifted down below it.
+    #[test]
+    fn caption_on_top() {
+        let (mut tree, root) = MockTable::new(100.0)
+            .width(100.0)
+            .spacing(0.0, 0.0)
+            .caption(20.0, false)
+            .body_row(vec![
+                cell("a").height(10.0).padding(0.0),
+                cell("b").height(10.0).padding(0.0),
+            ])
+            .into_tree();
+
+        let (_, total_h) = compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+
+        let caption = tree.nodes_with_role(TableRole::Caption)[0];
+        let cap_layout = tree.layout(caption).expect("caption");
+        assert_approx!(cap_layout.position.y, 0.0, "caption at the top");
+        assert_approx!(cap_layout.size.width, 100.0, "caption spans the table");
+        assert_approx!(cap_layout.size.height, 20.0, "caption height from content");
+
+        let group = tree.nodes_with_role(TableRole::RowGroup)[0];
+        assert_approx!(tree.layout(group).expect("group").position.y, 20.0, "grid below caption");
+        assert_approx!(total_h, 30.0, "caption + one 10px row");
+    }
+
+    // Caption on the bottom: grid at the top, caption below it.
+    #[test]
+    fn caption_on_bottom() {
+        let (mut tree, root) = MockTable::new(100.0)
+            .width(100.0)
+            .spacing(0.0, 0.0)
+            .caption(20.0, true)
+            .body_row(vec![
+                cell("a").height(10.0).padding(0.0),
+                cell("b").height(10.0).padding(0.0),
+            ])
+            .into_tree();
+
+        let (_, total_h) = compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+
+        let group = tree.nodes_with_role(TableRole::RowGroup)[0];
+        assert_approx!(tree.layout(group).expect("group").position.y, 0.0, "grid at the top");
+
+        let caption = tree.nodes_with_role(TableRole::Caption)[0];
+        assert_approx!(tree.layout(caption).expect("caption").position.y, 10.0, "caption below grid");
+        assert_approx!(total_h, 30.0, "row + caption");
+    }
+
+    // border-collapse: gutters vanish and adjacent 1px borders overlap so
+    // neighbouring cells share a single border line.
+    #[test]
+    fn border_collapse_overlaps_cells() {
+        let (mut tree, root) = MockTable::new(100.0)
+            .width(100.0)
+            .spacing(5.0, 5.0) // must be ignored under collapse
+            .collapse()
+            .body_row(vec![
+                cell("a").border(1.0).height(10.0).padding(0.0),
+                cell("b").border(1.0).height(10.0).padding(0.0),
+            ])
+            .body_row(vec![
+                cell("c").border(1.0).height(10.0).padding(0.0),
+                cell("d").border(1.0).height(10.0).padding(0.0),
+            ])
+            .into_tree();
+
+        let (_, total_h) = compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        // Columns are 50px; the second column starts 1px early so the 1px
+        // borders coincide.
+        assert_approx!(tree.layout(cells[0]).expect("a").position.x, 0.0, "col 0 at x=0 (no gutter)");
+        assert_approx!(tree.layout(cells[1]).expect("b").position.x, 49.0, "col 1 overlaps by 1px");
+
+        // Rows are 12px tall (10 content + 2 border); row 2 overlaps by 1px.
+        let rows = tree.nodes_with_role(TableRole::Row);
+        assert_approx!(tree.layout(rows[1]).expect("row 1").position.y, 11.0, "row 1 overlaps by 1px");
+        assert_approx!(total_h, 23.0, "12 + 12 - 1 overlap, no gutters");
+    }
+
     // Auto layout: <col> widths seed columns; the rest distribute as usual.
     #[test]
     fn col_widths_in_auto_layout() {

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -1313,6 +1313,34 @@ mod layout_tests {
         assert_approx!(w_narrow, 100.0, "CAPMIN wins over a narrower containing block");
     }
 
+    // A caption with no rows at all still gets laid out, floors the width (CAPMIN)
+    // and contributes its height.
+    #[test]
+    fn caption_only_table_lays_out_caption() {
+        use crate::mock::MockTree;
+
+        let mut tree = MockTree::new(0.0, 0.0);
+        let root = tree.alloc(TableRole::Table, None, 1, 1, None, None, 0.0, 0.0);
+        let cap = tree.alloc(
+            TableRole::Caption,
+            Some("cap".into()),
+            1,
+            1,
+            Some(100.0),
+            Some(20.0),
+            0.0,
+            0.0,
+        );
+        tree.add_child(root, cap);
+
+        let (w, h) = compute_table_layout(&mut tree, root, 40.0, None).expect("layout");
+        assert_approx!(w, 100.0, "CAPMIN floors a caption-only table");
+        assert_approx!(h, 20.0, "caption height is the table height");
+        let cap_layout = tree.layout(cap).expect("caption gets a layout");
+        assert_approx!(cap_layout.size.width, 100.0, "caption spans the table");
+        assert_approx!(cap_layout.size.height, 20.0, "caption height from its specified height");
+    }
+
     // CSS 2 §17.5.3: baseline-aligned cells share the deepest first-line baseline;
     // shallower cells shift down and the row grows to fit the shifted content.
     #[test]

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -784,6 +784,52 @@ mod layout_tests {
         assert_approx!(tree.layout(cells[4]).unwrap().size.width, 225.0, "row-2 width ignored");
     }
 
+    // Fixed layout: a first-row cell's width property is its CONTENT width;
+    // the column gets the border-box (width + padding + border), per the
+    // www-style clarification of CSS 2 §17.5.2.1 (WPT fixed-table-layout-003*).
+    #[test]
+    fn fixed_layout_cell_width_includes_padding_and_border() {
+        let (mut tree, root) = MockTable::new(400.0)
+            .width(400.0)
+            .spacing(0.0, 0.0)
+            .fixed()
+            .body_row(vec![
+                cell("a").padding(0.0),
+                cell("b").width(80.0).padding(60.0),
+                cell("c").padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 400.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        assert_approx!(tree.layout(cells[1]).unwrap().size.width, 200.0, "80 + 2*60 padding");
+        assert_approx!(tree.layout(cells[0]).unwrap().size.width, 100.0, "(400-200)/2");
+        assert_approx!(tree.layout(cells[2]).unwrap().size.width, 100.0, "(400-200)/2");
+    }
+
+    // Fixed layout: percentage widths resolve against the table width MINUS
+    // the border-spacing gutters (WPT fixed-table-layout-017..020).
+    #[test]
+    fn fixed_layout_percentage_resolves_minus_spacing() {
+        let (mut tree, root) = MockTable::new(220.0)
+            .width(220.0)
+            .spacing(10.0, 0.0)
+            .fixed()
+            .body_row(vec![
+                cell("a").width_pct(40.0).padding(0.0),
+                cell("b").padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 220.0, None).expect("layout");
+
+        // available = 220 - 3 gutters * 10 = 190
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        assert_approx!(tree.layout(cells[0]).unwrap().size.width, 76.0, "40% of 190");
+        assert_approx!(tree.layout(cells[1]).unwrap().size.width, 114.0, "the rest");
+    }
+
     // Fixed layout: <col> widths claim columns before the first row's cells,
     // and content widths play no part.
     #[test]

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -24,7 +24,7 @@ mod layout_tests {
         };
     }
 
-    // 1. Basic geometry: 2×2 body-only table, no spacing, no border/padding
+    // 1. Basic geometry: 2x2 body-only table, no spacing, no border/padding
     #[test]
     fn basic_2x2_positions() {
         // 100px wide, 2 equal auto columns = 50px each, two rows with explicit heights.
@@ -86,7 +86,7 @@ mod layout_tests {
     #[test]
     fn spacing_shifts_cell_x() {
         // spacing_x=4: gutters are 4px on each side and between columns.
-        // 3 gutters for 2 columns → 12px consumed. 100-12 = 88 for content → 44px each.
+        // 3 gutters for 2 columns -> 12px consumed. 100-12 = 88 for content -> 44px each.
         // col_x[0] = 4, col_x[1] = 4+44+4 = 52.
         let (mut tree, root) = MockTable::new(100.0)
             .spacing(4.0, 0.0)
@@ -112,7 +112,7 @@ mod layout_tests {
     #[test]
     fn explicit_column_width() {
         // First row: cell with explicit width=30px.
-        // Second column: auto → gets (100 - 30) = 70px.
+        // Second column: auto -> gets (100 - 30) = 70px.
         // spacing = 0.
         let (mut tree, root) = MockTable::new(100.0)
             .spacing(0.0, 0.0)
@@ -164,8 +164,8 @@ mod layout_tests {
     // 5. Colspan: cell spans 2 columns, gets combined width
     #[test]
     fn colspan_cell_width() {
-        // Row0: header has 2 cells → 2 columns each 50px
-        // Row1: colspan=2 spanning cell → width = 50+50 = 100px
+        // Row0: header has 2 cells -> 2 columns each 50px
+        // Row1: colspan=2 spanning cell -> width = 50+50 = 100px
         let (mut tree, root) = MockTable::new(100.0)
             .spacing(0.0, 0.0)
             .body_row(vec![
@@ -299,7 +299,7 @@ mod layout_tests {
     // 11. A colspan cell covers the horizontal gutters between its columns.
     #[test]
     fn colspan_covers_gutter() {
-        // spacing_x=4 → available = 100 - 3*4 = 88 → two 44px columns.
+        // spacing_x=4 -> available = 100 - 3*4 = 88 -> two 44px columns.
         let (mut tree, root) = MockTable::new(100.0)
             .spacing(4.0, 0.0)
             .body_row(vec![
@@ -336,7 +336,7 @@ mod layout_tests {
         assert_approx!(span.size.height, 56.0, "20 + 6 (gutter) + 30");
     }
 
-    // 13. Sections render header → body → footer regardless of source order.
+    // 13. Sections render header -> body -> footer regardless of source order.
     #[test]
     fn sections_reordered_from_source_order() {
         use crate::mock::MockTree;
@@ -658,7 +658,7 @@ mod layout_tests {
             .into_tree();
         let host_cell = outer.nodes_with_role(TableRole::Cell)[0];
 
-        // Inner: two columns × two rows, heights 15 and 25.
+        // Inner: two columns x two rows, heights 15 and 25.
         let (inner, inner_root) = MockTable::new(0.0)
             .spacing(0.0, 0.0)
             .body_row(vec![

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -506,7 +506,11 @@ mod layout_tests {
 
         let cells = tree.nodes_with_role(TableRole::Cell);
         assert_approx!(tree.layout(cells[0]).expect("rank").size.width, 20.0, "max-content col");
-        assert_approx!(tree.layout(cells[1]).expect("story").size.width, 100.0, "max-content col");
+        assert_approx!(
+            tree.layout(cells[1]).expect("story").size.width,
+            100.0,
+            "max-content col"
+        );
         assert_approx!(table_w, 120.0, "table shrinks to content");
     }
 
@@ -528,7 +532,11 @@ mod layout_tests {
         // Extra = 210 - 105, split 5:100 over the two columns.
         let cells = tree.nodes_with_role(TableRole::Cell);
         assert_approx!(tree.layout(cells[0]).expect("dot").size.width, 10.0, "5 + 105 * 5/105");
-        assert_approx!(tree.layout(cells[1]).expect("text").size.width, 200.0, "100 + 105 * 100/105");
+        assert_approx!(
+            tree.layout(cells[1]).expect("text").size.width,
+            200.0,
+            "100 + 105 * 100/105"
+        );
     }
 
     // 20. An explicit CSS width cannot shrink a column below its content's
@@ -706,7 +714,11 @@ mod layout_tests {
         let (table_w, _) = compute_table_layout(&mut tree, root, 200.0, None).expect("layout");
 
         let cells = tree.nodes_with_role(TableRole::Cell);
-        assert_approx!(tree.layout(cells[0]).expect("cell").size.width, 80.0, "min-content floor");
+        assert_approx!(
+            tree.layout(cells[0]).expect("cell").size.width,
+            80.0,
+            "min-content floor"
+        );
         assert_approx!(table_w, 80.0, "table overflows its specified 50px");
     }
 
@@ -716,7 +728,10 @@ mod layout_tests {
         let (mut tree, root) = MockTable::new(300.0)
             .width(300.0)
             .spacing(0.0, 0.0)
-            .body_row(vec![cell("a").height(10.0).padding(0.0), cell("b").height(10.0).padding(0.0)])
+            .body_row(vec![
+                cell("a").height(10.0).padding(0.0),
+                cell("b").height(10.0).padding(0.0),
+            ])
             .body_row(vec![
                 cell("c").width(120.0).height(10.0).padding(0.0),
                 cell("d").height(10.0).padding(0.0),
@@ -726,8 +741,16 @@ mod layout_tests {
         compute_table_layout(&mut tree, root, 300.0, None).expect("layout");
 
         let cells = tree.nodes_with_role(TableRole::Cell);
-        assert_approx!(tree.layout(cells[0]).expect("a").size.width, 120.0, "row-2 width wins the column");
-        assert_approx!(tree.layout(cells[1]).expect("b").size.width, 180.0, "auto col gets the rest");
+        assert_approx!(
+            tree.layout(cells[0]).expect("a").size.width,
+            120.0,
+            "row-2 width wins the column"
+        );
+        assert_approx!(
+            tree.layout(cells[1]).expect("b").size.width,
+            180.0,
+            "auto col gets the rest"
+        );
     }
 
     // A colspan cell's min-content requirement distributes over its columns,
@@ -753,8 +776,16 @@ mod layout_tests {
 
         // Deficit 100 splits 10:30 -> col mins 25/75; extra follows the same weights.
         let cells = tree.nodes_with_role(TableRole::Cell);
-        assert_approx!(tree.layout(cells[1]).expect("a").size.width, 50.0, "col 0 = 25 + extra share");
-        assert_approx!(tree.layout(cells[2]).expect("b").size.width, 150.0, "col 1 = 75 + extra share");
+        assert_approx!(
+            tree.layout(cells[1]).expect("a").size.width,
+            50.0,
+            "col 0 = 25 + extra share"
+        );
+        assert_approx!(
+            tree.layout(cells[2]).expect("b").size.width,
+            150.0,
+            "col 1 = 75 + extra share"
+        );
     }
 
     // Fixed layout: widths come from the first row only; later rows are ignored.
@@ -779,8 +810,16 @@ mod layout_tests {
 
         let cells = tree.nodes_with_role(TableRole::Cell);
         assert_approx!(tree.layout(cells[0]).unwrap().size.width, 150.0, "explicit col");
-        assert_approx!(tree.layout(cells[1]).unwrap().size.width, 225.0, "auto col = (600-150)/2");
-        assert_approx!(tree.layout(cells[2]).unwrap().size.width, 225.0, "auto col = (600-150)/2");
+        assert_approx!(
+            tree.layout(cells[1]).unwrap().size.width,
+            225.0,
+            "auto col = (600-150)/2"
+        );
+        assert_approx!(
+            tree.layout(cells[2]).unwrap().size.width,
+            225.0,
+            "auto col = (600-150)/2"
+        );
         assert_approx!(tree.layout(cells[4]).unwrap().size.width, 225.0, "row-2 width ignored");
     }
 
@@ -816,10 +855,7 @@ mod layout_tests {
             .width(220.0)
             .spacing(10.0, 0.0)
             .fixed()
-            .body_row(vec![
-                cell("a").width_pct(40.0).padding(0.0),
-                cell("b").padding(0.0),
-            ])
+            .body_row(vec![cell("a").width_pct(40.0).padding(0.0), cell("b").padding(0.0)])
             .into_tree();
 
         compute_table_layout(&mut tree, root, 220.0, None).expect("layout");
@@ -851,8 +887,16 @@ mod layout_tests {
 
         let cells = tree.nodes_with_role(TableRole::Cell);
         assert_approx!(tree.layout(cells[0]).unwrap().size.width, 100.0, "col-element width");
-        assert_approx!(tree.layout(cells[1]).unwrap().size.width, 250.0, "auto col = (600-100)/2");
-        assert_approx!(tree.layout(cells[2]).unwrap().size.width, 250.0, "auto col = (600-100)/2");
+        assert_approx!(
+            tree.layout(cells[1]).unwrap().size.width,
+            250.0,
+            "auto col = (600-100)/2"
+        );
+        assert_approx!(
+            tree.layout(cells[2]).unwrap().size.width,
+            250.0,
+            "auto col = (600-100)/2"
+        );
     }
 
     // Fixed layout: a colspan cell's width divides evenly over its columns.
@@ -861,7 +905,10 @@ mod layout_tests {
         let (mut tree, root) = MockTable::new(400.0)
             .spacing(0.0, 0.0)
             .fixed()
-            .body_row(vec![cell("ab").width(200.0).colspan(2).padding(0.0), cell("c").padding(0.0)])
+            .body_row(vec![
+                cell("ab").width(200.0).colspan(2).padding(0.0),
+                cell("c").padding(0.0),
+            ])
             .body_row(vec![
                 cell("d").padding(0.0),
                 cell("e").padding(0.0),
@@ -872,8 +919,16 @@ mod layout_tests {
         compute_table_layout(&mut tree, root, 400.0, None).expect("layout");
 
         let cells = tree.nodes_with_role(TableRole::Cell);
-        assert_approx!(tree.layout(cells[0]).unwrap().size.width, 200.0, "colspan cell keeps its width");
-        assert_approx!(tree.layout(cells[1]).unwrap().size.width, 200.0, "third col gets remainder");
+        assert_approx!(
+            tree.layout(cells[0]).unwrap().size.width,
+            200.0,
+            "colspan cell keeps its width"
+        );
+        assert_approx!(
+            tree.layout(cells[1]).unwrap().size.width,
+            200.0,
+            "third col gets remainder"
+        );
         assert_approx!(tree.layout(cells[2]).unwrap().size.width, 100.0, "spanned col = 200/2");
         assert_approx!(tree.layout(cells[3]).unwrap().size.width, 100.0, "spanned col = 200/2");
     }
@@ -897,8 +952,16 @@ mod layout_tests {
 
         let cells = tree.nodes_with_role(TableRole::Cell);
         assert_approx!(tree.layout(cells[0]).unwrap().size.height, 50.0, "spanner height");
-        assert_approx!(tree.layout(cells[1]).unwrap().size.height, 25.0, "row 0 grew by half the deficit");
-        assert_approx!(tree.layout(cells[2]).unwrap().size.height, 25.0, "row 1 grew by half the deficit");
+        assert_approx!(
+            tree.layout(cells[1]).unwrap().size.height,
+            25.0,
+            "row 0 grew by half the deficit"
+        );
+        assert_approx!(
+            tree.layout(cells[2]).unwrap().size.height,
+            25.0,
+            "row 1 grew by half the deficit"
+        );
     }
 
     // Rowspan distribution counts the border-spacing gutter the spanner covers.
@@ -920,7 +983,11 @@ mod layout_tests {
         let cells = tree.nodes_with_role(TableRole::Cell);
         assert_approx!(tree.layout(cells[1]).unwrap().size.height, 10.0, "row 0 unchanged");
         assert_approx!(tree.layout(cells[2]).unwrap().size.height, 10.0, "row 1 unchanged");
-        assert_approx!(tree.layout(cells[0]).unwrap().size.height, 30.0, "spanner = 10 + 10 + 10 gutter");
+        assert_approx!(
+            tree.layout(cells[0]).unwrap().size.height,
+            30.0,
+            "spanner = 10 + 10 + 10 gutter"
+        );
     }
 
     // vertical-align: middle and bottom shift the cell's children within the
@@ -935,8 +1002,14 @@ mod layout_tests {
             .body_row(vec![
                 cell("tall").content_height(40.0).padding(0.0),
                 cell("top").content_height(10.0).padding(0.0),
-                cell("mid").content_height(10.0).valign(VerticalAlign::Middle).padding(0.0),
-                cell("bot").content_height(10.0).valign(VerticalAlign::Bottom).padding(0.0),
+                cell("mid")
+                    .content_height(10.0)
+                    .valign(VerticalAlign::Middle)
+                    .padding(0.0),
+                cell("bot")
+                    .content_height(10.0)
+                    .valign(VerticalAlign::Bottom)
+                    .padding(0.0),
             ])
             .into_tree();
 
@@ -944,9 +1017,17 @@ mod layout_tests {
 
         let cells = tree.nodes_with_role(TableRole::Cell);
         assert_approx!(tree.layout(cells[1]).unwrap().content_offset_y, 0.0, "top offset");
-        assert_approx!(tree.layout(cells[2]).unwrap().content_offset_y, 15.0, "middle = (40-10)/2");
+        assert_approx!(
+            tree.layout(cells[2]).unwrap().content_offset_y,
+            15.0,
+            "middle = (40-10)/2"
+        );
         assert_approx!(tree.layout(cells[3]).unwrap().content_offset_y, 30.0, "bottom = 40-10");
-        assert_approx!(tree.layout(cells[0]).unwrap().content_offset_y, 0.0, "row driver has no free space");
+        assert_approx!(
+            tree.layout(cells[0]).unwrap().content_offset_y,
+            0.0,
+            "row driver has no free space"
+        );
     }
 
     // vertical-align accounts for the cell's own padding: free space is
@@ -961,14 +1042,21 @@ mod layout_tests {
             .spacing(0.0, 0.0)
             .body_row(vec![
                 cell("tall").content_height(40.0).padding(5.0),
-                cell("bot").content_height(10.0).valign(VerticalAlign::Bottom).padding(5.0),
+                cell("bot")
+                    .content_height(10.0)
+                    .valign(VerticalAlign::Bottom)
+                    .padding(5.0),
             ])
             .into_tree();
 
         compute_table_layout(&mut tree, root, 300.0, None).expect("layout");
 
         let cells = tree.nodes_with_role(TableRole::Cell);
-        assert_approx!(tree.layout(cells[1]).unwrap().content_offset_y, 30.0, "bottom offset inside padding");
+        assert_approx!(
+            tree.layout(cells[1]).unwrap().content_offset_y,
+            30.0,
+            "bottom offset inside padding"
+        );
     }
 
     // Caption on top: full table width, grid shifted down below it.
@@ -993,7 +1081,11 @@ mod layout_tests {
         assert_approx!(cap_layout.size.height, 20.0, "caption height from content");
 
         let group = tree.nodes_with_role(TableRole::RowGroup)[0];
-        assert_approx!(tree.layout(group).expect("group").position.y, 20.0, "grid below caption");
+        assert_approx!(
+            tree.layout(group).expect("group").position.y,
+            20.0,
+            "grid below caption"
+        );
         assert_approx!(total_h, 30.0, "caption + one 10px row");
     }
 
@@ -1016,7 +1108,11 @@ mod layout_tests {
         assert_approx!(tree.layout(group).expect("group").position.y, 0.0, "grid at the top");
 
         let caption = tree.nodes_with_role(TableRole::Caption)[0];
-        assert_approx!(tree.layout(caption).expect("caption").position.y, 10.0, "caption below grid");
+        assert_approx!(
+            tree.layout(caption).expect("caption").position.y,
+            10.0,
+            "caption below grid"
+        );
         assert_approx!(total_h, 30.0, "row + caption");
     }
 
@@ -1049,14 +1145,22 @@ mod layout_tests {
             0.5,
             "col 0 starts after the left perimeter half (no gutter)"
         );
-        assert_approx!(tree.layout(cells[1]).expect("b").position.x, 50.5, "col 1 flush against col 0");
+        assert_approx!(
+            tree.layout(cells[1]).expect("b").position.x,
+            50.5,
+            "col 1 flush against col 0"
+        );
 
         // Collapsed borders are centered on the grid lines: each cell's layout
         // reserves half the resolved 1px boundary, so both rows are 0.5+10+0.5 = 11px.
         // Row positions are group-relative; the group itself sits below the top
         // perimeter half.
         let rows = tree.nodes_with_role(TableRole::Row);
-        assert_approx!(tree.layout(rows[1]).expect("row 1").position.y, 11.0, "row 1 flush below row 0");
+        assert_approx!(
+            tree.layout(rows[1]).expect("row 1").position.y,
+            11.0,
+            "row 1 flush below row 0"
+        );
         let groups = tree.nodes_with_role(TableRole::RowGroup);
         assert_approx!(
             tree.layout(groups[0]).expect("group").position.y,
@@ -1184,7 +1288,16 @@ mod layout_tests {
 
         let mut tree = MockTree::new(0.0, 0.0);
         let root = tree.alloc(TableRole::Table, None, 1, 1, None, None, 0.0, 0.0);
-        let cap = tree.alloc(TableRole::Caption, Some("cap".into()), 1, 1, Some(100.0), None, 0.0, 0.0);
+        let cap = tree.alloc(
+            TableRole::Caption,
+            Some("cap".into()),
+            1,
+            1,
+            Some(100.0),
+            None,
+            0.0,
+            0.0,
+        );
         tree.add_child(root, cap);
         let row = tree.alloc(TableRole::Row, None, 1, 1, None, None, 0.0, 0.0);
         tree.add_child(root, row);
@@ -1208,8 +1321,16 @@ mod layout_tests {
         let (mut tree, root) = MockTable::new(300.0)
             .spacing(0.0, 0.0)
             .body_row(vec![
-                cell("deep").height(30.0).padding(0.0).valign(VerticalAlign::Baseline).baseline(25.0),
-                cell("shallow").height(30.0).padding(0.0).valign(VerticalAlign::Baseline).baseline(10.0),
+                cell("deep")
+                    .height(30.0)
+                    .padding(0.0)
+                    .valign(VerticalAlign::Baseline)
+                    .baseline(25.0),
+                cell("shallow")
+                    .height(30.0)
+                    .padding(0.0)
+                    .valign(VerticalAlign::Baseline)
+                    .baseline(10.0),
                 cell("top").height(30.0).padding(0.0),
             ])
             .into_tree();
@@ -1244,7 +1365,15 @@ mod layout_tests {
 
         let cells = tree.nodes_with_role(TableRole::Cell);
         assert_approx!(tree.layout(cells[0]).unwrap().size.width, 80.0, "col-element width");
-        assert_approx!(tree.layout(cells[1]).unwrap().size.width, 110.0, "auto col = (300-80)/2");
-        assert_approx!(tree.layout(cells[2]).unwrap().size.width, 110.0, "auto col = (300-80)/2");
+        assert_approx!(
+            tree.layout(cells[1]).unwrap().size.width,
+            110.0,
+            "auto col = (300-80)/2"
+        );
+        assert_approx!(
+            tree.layout(cells[2]).unwrap().size.width,
+            110.0,
+            "auto col = (300-80)/2"
+        );
     }
 }

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -431,6 +431,46 @@ mod layout_tests {
         assert_approx!(h_cell.size.height, 10.0, "clamped to the header's single row");
     }
 
+    // Spans never cross a section boundary: a tbody cell spanning past the
+    // last body row (here via HTML's rowspan=0, "rest of the row group") is
+    // clipped at the end of the body - the footer keeps its own row.
+    #[test]
+    fn body_span_never_reaches_footer() {
+        let (mut tree, root) = MockTable::new(100.0)
+            .spacing(0.0, 0.0)
+            .header_row(vec![
+                cell("H1").height(10.0).padding(0.0),
+                cell("H2").height(10.0).padding(0.0),
+            ])
+            .body_row(vec![
+                cell("B1").rowspan(0).height(10.0).padding(0.0),
+                cell("B2").height(10.0).padding(0.0),
+            ])
+            .body_row(vec![cell("B3").height(10.0).padding(0.0)])
+            .footer_row(vec![
+                cell("F1").height(10.0).padding(0.0),
+                cell("F2").height(10.0).padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+
+        // Alloc order: H1 H2 B1 B2 B3 F1 F2.
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        let spanner = tree.layout(cells[2]).expect("B1");
+        assert_approx!(spanner.size.height, 20.0, "spans both body rows, not the footer");
+        // B3 sits in column 1 because the spanner still occupies column 0.
+        let b3 = tree.layout(cells[4]).expect("B3");
+        assert!(b3.position.x > 0.0, "B3 pushed out of the spanned column");
+
+        let fg = tree.nodes_with_role(TableRole::FooterGroup);
+        assert_approx!(
+            tree.layout(fg[0]).expect("footer").position.y,
+            30.0,
+            "footer right below header(10) + body(20), unaffected by the span"
+        );
+    }
+
     // 17. Auto columns share space proportionally to their natural content width.
     #[test]
     fn proportional_content_width_distribution() {

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -646,4 +646,102 @@ mod layout_tests {
         let host_layout = tree.outer.layout(host_cell).expect("host cell");
         assert_approx!(host_layout.size.height, 40.0, "host cell height");
     }
+
+    // Fixed layout: widths come from the first row only; later rows are ignored.
+    #[test]
+    fn fixed_layout_widths_from_first_row() {
+        let (mut tree, root) = MockTable::new(600.0)
+            .spacing(0.0, 0.0)
+            .fixed()
+            .body_row(vec![
+                cell("a").width(150.0).padding(0.0),
+                cell("b").padding(0.0),
+                cell("c").padding(0.0),
+            ])
+            .body_row(vec![
+                cell("d").padding(0.0),
+                cell("e").width(900.0).padding(0.0), // row 2: must be ignored
+                cell("f").padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 600.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        assert_approx!(tree.layout(cells[0]).unwrap().size.width, 150.0, "explicit col");
+        assert_approx!(tree.layout(cells[1]).unwrap().size.width, 225.0, "auto col = (600-150)/2");
+        assert_approx!(tree.layout(cells[2]).unwrap().size.width, 225.0, "auto col = (600-150)/2");
+        assert_approx!(tree.layout(cells[4]).unwrap().size.width, 225.0, "row-2 width ignored");
+    }
+
+    // Fixed layout: <col> widths claim columns before the first row's cells,
+    // and content widths play no part.
+    #[test]
+    fn fixed_layout_col_widths_and_equal_split() {
+        let (mut tree, root) = MockTable::new(600.0)
+            .spacing(0.0, 0.0)
+            .fixed()
+            .col(Some(100.0))
+            .col(None)
+            .col(None)
+            .body_row(vec![
+                cell("a").padding(0.0),
+                cell("b").content_width(500.0).padding(0.0), // content must be ignored
+                cell("c").padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 600.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        assert_approx!(tree.layout(cells[0]).unwrap().size.width, 100.0, "col-element width");
+        assert_approx!(tree.layout(cells[1]).unwrap().size.width, 250.0, "auto col = (600-100)/2");
+        assert_approx!(tree.layout(cells[2]).unwrap().size.width, 250.0, "auto col = (600-100)/2");
+    }
+
+    // Fixed layout: a colspan cell's width divides evenly over its columns.
+    #[test]
+    fn fixed_layout_colspan_divides_width() {
+        let (mut tree, root) = MockTable::new(400.0)
+            .spacing(0.0, 0.0)
+            .fixed()
+            .body_row(vec![cell("ab").width(200.0).colspan(2).padding(0.0), cell("c").padding(0.0)])
+            .body_row(vec![
+                cell("d").padding(0.0),
+                cell("e").padding(0.0),
+                cell("f").padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 400.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        assert_approx!(tree.layout(cells[0]).unwrap().size.width, 200.0, "colspan cell keeps its width");
+        assert_approx!(tree.layout(cells[1]).unwrap().size.width, 200.0, "third col gets remainder");
+        assert_approx!(tree.layout(cells[2]).unwrap().size.width, 100.0, "spanned col = 200/2");
+        assert_approx!(tree.layout(cells[3]).unwrap().size.width, 100.0, "spanned col = 200/2");
+    }
+
+    // Auto layout: <col> widths seed columns; the rest distribute as usual.
+    #[test]
+    fn col_widths_in_auto_layout() {
+        let (mut tree, root) = MockTable::new(300.0)
+            .spacing(0.0, 0.0)
+            .col(Some(80.0))
+            .col(None)
+            .col(None)
+            .body_row(vec![
+                cell("a").padding(0.0),
+                cell("b").padding(0.0),
+                cell("c").padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 300.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        assert_approx!(tree.layout(cells[0]).unwrap().size.width, 80.0, "col-element width");
+        assert_approx!(tree.layout(cells[1]).unwrap().size.width, 110.0, "auto col = (300-80)/2");
+        assert_approx!(tree.layout(cells[2]).unwrap().size.width, 110.0, "auto col = (300-80)/2");
+    }
 }

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -1162,6 +1162,31 @@ mod layout_tests {
         );
     }
 
+    // CSS 2 §17.5.2: the used table width is floored at CAPMIN (the caption's minimum
+    // width) - an empty auto table with a 100px caption is 100px wide, not 0 and not
+    // fill-available (WPT anonymous-table-box-width-001).
+    #[test]
+    fn caption_min_width_floors_table_width() {
+        use crate::mock::MockTree;
+
+        let mut tree = MockTree::new(0.0, 0.0);
+        let root = tree.alloc(TableRole::Table, None, 1, 1, None, None, 0.0, 0.0);
+        let cap = tree.alloc(TableRole::Caption, Some("cap".into()), 1, 1, Some(100.0), None, 0.0, 0.0);
+        tree.add_child(root, cap);
+        let row = tree.alloc(TableRole::Row, None, 1, 1, None, None, 0.0, 0.0);
+        tree.add_child(root, row);
+        let cell = tree.alloc_cell(cell("empty").padding(0.0));
+        tree.add_child(row, cell);
+
+        let (w, _) = compute_table_layout(&mut tree, root, 784.0, None).expect("layout");
+        // Mock trees keep the fill-available fallback ONLY without a caption; CAPMIN
+        // must still floor the result. With the mock's no-intrinsics fallback the
+        // table fills 784 (>100), so assert the floor via a narrow container instead.
+        let (w_narrow, _) = compute_table_layout(&mut tree, root, 40.0, None).expect("layout");
+        assert!(w >= 100.0, "caption keeps table at least 100px, got {w}");
+        assert_approx!(w_narrow, 100.0, "CAPMIN wins over a narrower containing block");
+    }
+
     // Auto layout: <col> widths seed columns; the rest distribute as usual.
     #[test]
     fn col_widths_in_auto_layout() {

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -722,6 +722,99 @@ mod layout_tests {
         assert_approx!(tree.layout(cells[3]).unwrap().size.width, 100.0, "spanned col = 200/2");
     }
 
+    // Rowspan: a tall spanning cell distributes its height deficit equally
+    // over the rows it spans.
+    #[test]
+    fn rowspan_distributes_height_to_rows() {
+        // Rows 0/1 have 10px cells; the spanner needs 50px over both rows.
+        // Deficit = 50 - 20 = 30 -> each row grows by 15 -> rows 25/25.
+        let (mut tree, root) = MockTable::new(100.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![
+                cell("Span").rowspan(2).content_height(50.0).padding(0.0),
+                cell("R0C1").height(10.0).padding(0.0),
+            ])
+            .body_row(vec![cell("R1C1").height(10.0).padding(0.0)])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        assert_approx!(tree.layout(cells[0]).unwrap().size.height, 50.0, "spanner height");
+        assert_approx!(tree.layout(cells[1]).unwrap().size.height, 25.0, "row 0 grew by half the deficit");
+        assert_approx!(tree.layout(cells[2]).unwrap().size.height, 25.0, "row 1 grew by half the deficit");
+    }
+
+    // Rowspan distribution counts the border-spacing gutter the spanner covers.
+    #[test]
+    fn rowspan_distribution_counts_spacing() {
+        // Rows are 10px each with a 10px gutter between: the spanner already
+        // has 30px available, so a 30px spanner adds nothing.
+        let (mut tree, root) = MockTable::new(100.0)
+            .spacing(0.0, 10.0)
+            .body_row(vec![
+                cell("Span").rowspan(2).content_height(30.0).padding(0.0),
+                cell("R0C1").height(10.0).padding(0.0),
+            ])
+            .body_row(vec![cell("R1C1").height(10.0).padding(0.0)])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        assert_approx!(tree.layout(cells[1]).unwrap().size.height, 10.0, "row 0 unchanged");
+        assert_approx!(tree.layout(cells[2]).unwrap().size.height, 10.0, "row 1 unchanged");
+        assert_approx!(tree.layout(cells[0]).unwrap().size.height, 30.0, "spanner = 10 + 10 + 10 gutter");
+    }
+
+    // vertical-align: middle and bottom shift the cell's children within the
+    // free space; top leaves them at the content-box top.
+    #[test]
+    fn vertical_align_offsets() {
+        use crate::types::VerticalAlign;
+
+        // The 40px cell drives the row; the 10px-content cells align within it.
+        let (mut tree, root) = MockTable::new(300.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![
+                cell("tall").content_height(40.0).padding(0.0),
+                cell("top").content_height(10.0).padding(0.0),
+                cell("mid").content_height(10.0).valign(VerticalAlign::Middle).padding(0.0),
+                cell("bot").content_height(10.0).valign(VerticalAlign::Bottom).padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 300.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        assert_approx!(tree.layout(cells[1]).unwrap().content_offset_y, 0.0, "top offset");
+        assert_approx!(tree.layout(cells[2]).unwrap().content_offset_y, 15.0, "middle = (40-10)/2");
+        assert_approx!(tree.layout(cells[3]).unwrap().content_offset_y, 30.0, "bottom = 40-10");
+        assert_approx!(tree.layout(cells[0]).unwrap().content_offset_y, 0.0, "row driver has no free space");
+    }
+
+    // vertical-align accounts for the cell's own padding: free space is
+    // measured inside the content box.
+    #[test]
+    fn vertical_align_respects_padding() {
+        use crate::types::VerticalAlign;
+
+        // Row is driven to 40px content + 2*5px padding = 50px border-box.
+        // The bottom cell: inner = 50 - 10 = 40, content 10 -> offset 30.
+        let (mut tree, root) = MockTable::new(300.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![
+                cell("tall").content_height(40.0).padding(5.0),
+                cell("bot").content_height(10.0).valign(VerticalAlign::Bottom).padding(5.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 300.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        assert_approx!(tree.layout(cells[1]).unwrap().content_offset_y, 30.0, "bottom offset inside padding");
+    }
+
     // Auto layout: <col> widths seed columns; the rest distribute as usual.
     #[test]
     fn col_widths_in_auto_layout() {

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -450,10 +450,10 @@ mod layout_tests {
         assert_approx!(tree.layout(cells[1]).expect("B").size.width, 140.0, "200 * 140/200");
     }
 
-    // 18. Narrow columns (natural < 50px) keep their natural width; wide
-    //     content columns absorb the remaining space.
+    // 18. Auto table width shrinks to fit its content: columns get their
+    //     max-content width and the table is only as wide as their sum.
     #[test]
-    fn narrow_column_keeps_natural_width() {
+    fn shrink_to_fit_auto_table() {
         let (mut tree, root) = MockTable::new(200.0)
             .spacing(0.0, 0.0)
             .body_row(vec![
@@ -462,25 +462,20 @@ mod layout_tests {
             ])
             .into_tree();
 
-        compute_table_layout(&mut tree, root, 200.0, None).expect("layout");
+        let (table_w, _) = compute_table_layout(&mut tree, root, 200.0, None).expect("layout");
 
         let cells = tree.nodes_with_role(TableRole::Cell);
-        assert_approx!(
-            tree.layout(cells[0]).expect("rank").size.width,
-            20.0,
-            "narrow keeps natural"
-        );
-        assert_approx!(
-            tree.layout(cells[1]).expect("story").size.width,
-            180.0,
-            "content col absorbs rest"
-        );
+        assert_approx!(tree.layout(cells[0]).expect("rank").size.width, 20.0, "max-content col");
+        assert_approx!(tree.layout(cells[1]).expect("story").size.width, 100.0, "max-content col");
+        assert_approx!(table_w, 120.0, "table shrinks to content");
     }
 
-    // 19. Very narrow columns are floored at 14px so they stay visible.
+    // 19. Space beyond every column's max-content width goes to auto columns
+    //     proportionally to their max-content width.
     #[test]
-    fn narrow_column_floor() {
-        let (mut tree, root) = MockTable::new(200.0)
+    fn extra_space_distributed_by_content() {
+        let (mut tree, root) = MockTable::new(300.0)
+            .width(210.0)
             .spacing(0.0, 0.0)
             .body_row(vec![
                 cell("dot").content_width(5.0).height(10.0).padding(0.0),
@@ -488,21 +483,28 @@ mod layout_tests {
             ])
             .into_tree();
 
-        compute_table_layout(&mut tree, root, 200.0, None).expect("layout");
+        compute_table_layout(&mut tree, root, 300.0, None).expect("layout");
 
+        // Extra = 210 - 105, split 5:100 over the two columns.
         let cells = tree.nodes_with_role(TableRole::Cell);
-        assert_approx!(tree.layout(cells[0]).expect("dot").size.width, 14.0, "floored at 14px");
-        assert_approx!(tree.layout(cells[1]).expect("text").size.width, 186.0, "200 - 14");
+        assert_approx!(tree.layout(cells[0]).expect("dot").size.width, 10.0, "5 + 105 * 5/105");
+        assert_approx!(tree.layout(cells[1]).expect("text").size.width, 200.0, "100 + 105 * 100/105");
     }
 
     // 20. An explicit CSS width cannot shrink a column below its content's
-    //     natural width (used width = max(specified, min-content)).
+    //     min-content width (used width = max(specified, min-content)).
     #[test]
     fn explicit_width_clamped_to_content() {
         let (mut tree, root) = MockTable::new(100.0)
+            .width(100.0)
             .spacing(0.0, 0.0)
             .body_row(vec![
-                cell("img").width(18.0).content_width(20.0).height(10.0).padding(0.0),
+                cell("img")
+                    .width(18.0)
+                    .min_content_width(20.0)
+                    .content_width(20.0)
+                    .height(10.0)
+                    .padding(0.0),
                 cell("rest").height(10.0).padding(0.0),
             ])
             .into_tree();
@@ -585,8 +587,8 @@ mod layout_tests {
             fn set_layout(&mut self, id: u32, layout: CellLayout) {
                 self.outer.set_layout(id, layout);
             }
-            fn cell_content_width(&self, id: u32) -> f32 {
-                self.outer.cell_content_width(id)
+            fn cell_intrinsic_widths(&mut self, id: u32) -> (f32, f32) {
+                self.outer.cell_intrinsic_widths(id)
             }
 
             fn layout_cell(&mut self, id: u32, available_width: f32) -> f32 {
@@ -645,6 +647,74 @@ mod layout_tests {
         assert_approx!(outer_h, 40.0, "outer row height = inner table height");
         let host_layout = tree.outer.layout(host_cell).expect("host cell");
         assert_approx!(host_layout.size.height, 40.0, "host cell height");
+    }
+
+    // A column's min-content width overrides even the table's explicit width:
+    // the table overflows rather than clipping unbreakable content.
+    #[test]
+    fn min_content_overrides_table_width() {
+        let (mut tree, root) = MockTable::new(200.0)
+            .width(50.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![cell("longword")
+                .min_content_width(80.0)
+                .content_width(80.0)
+                .height(10.0)
+                .padding(0.0)])
+            .into_tree();
+
+        let (table_w, _) = compute_table_layout(&mut tree, root, 200.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        assert_approx!(tree.layout(cells[0]).expect("cell").size.width, 80.0, "min-content floor");
+        assert_approx!(table_w, 80.0, "table overflows its specified 50px");
+    }
+
+    // Explicit widths on cells in ANY row claim the column, not just row 1.
+    #[test]
+    fn explicit_width_on_later_row() {
+        let (mut tree, root) = MockTable::new(300.0)
+            .width(300.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![cell("a").height(10.0).padding(0.0), cell("b").height(10.0).padding(0.0)])
+            .body_row(vec![
+                cell("c").width(120.0).height(10.0).padding(0.0),
+                cell("d").height(10.0).padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 300.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        assert_approx!(tree.layout(cells[0]).expect("a").size.width, 120.0, "row-2 width wins the column");
+        assert_approx!(tree.layout(cells[1]).expect("b").size.width, 180.0, "auto col gets the rest");
+    }
+
+    // A colspan cell's min-content requirement distributes over its columns,
+    // weighted by their max-content widths.
+    #[test]
+    fn colspan_min_content_distributes() {
+        let (mut tree, root) = MockTable::new(200.0)
+            .width(200.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![cell("span")
+                .colspan(2)
+                .min_content_width(100.0)
+                .content_width(100.0)
+                .height(10.0)
+                .padding(0.0)])
+            .body_row(vec![
+                cell("a").content_width(10.0).height(10.0).padding(0.0),
+                cell("b").content_width(30.0).height(10.0).padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 200.0, None).expect("layout");
+
+        // Deficit 100 splits 10:30 -> col mins 25/75; extra follows the same weights.
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        assert_approx!(tree.layout(cells[1]).expect("a").size.width, 50.0, "col 0 = 25 + extra share");
+        assert_approx!(tree.layout(cells[2]).expect("b").size.width, 150.0, "col 1 = 75 + extra share");
     }
 
     // Fixed layout: widths come from the first row only; later rows are ignored.

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -958,10 +958,12 @@ mod layout_tests {
         assert_approx!(tree.layout(cells[0]).expect("a").position.x, 0.0, "col 0 at x=0 (no gutter)");
         assert_approx!(tree.layout(cells[1]).expect("b").position.x, 50.0, "col 1 flush against col 0");
 
-        // Rows are 12px tall (10 content + 2 border), stacked without gutters.
+        // Row 0 keeps both its borders (12px); row 1's top border lost the
+        // boundary conflict and takes no space (11px) - every internal
+        // boundary is a single 1px line, total 1+10+1+10+1 like a browser.
         let rows = tree.nodes_with_role(TableRole::Row);
         assert_approx!(tree.layout(rows[1]).expect("row 1").position.y, 12.0, "row 1 flush below row 0");
-        assert_approx!(total_h, 24.0, "12 + 12, no gutters");
+        assert_approx!(total_h, 23.0, "single shared border per boundary");
     }
 
     // Collapse conflict resolution, uniform borders: ties go to the left/top

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -1105,6 +1105,63 @@ mod layout_tests {
         assert_eq!(sup(1), [false, false, false, false], "thick paints the shared border");
     }
 
+    // CSS 2.1 §17.2.1: bare cells sitting BETWEEN two row groups form an anonymous row that
+    // must keep its source position - after group 1's rows, before group 2's
+    // (WPT table-anonymous-objects-063).
+    #[test]
+    fn bare_cells_between_row_groups_keep_source_order() {
+        use crate::mock::MockTree;
+
+        let mut tree = MockTree::new(0.0, 0.0);
+        let root = tree.alloc(TableRole::Table, None, 1, 1, None, None, 0.0, 0.0);
+
+        let g1 = tree.alloc(TableRole::RowGroup, None, 1, 1, None, None, 0.0, 0.0);
+        tree.add_child(root, g1);
+        let r1 = tree.alloc(TableRole::Row, None, 1, 1, None, None, 0.0, 0.0);
+        tree.add_child(g1, r1);
+        for label in ["a1", "a2", "a3"] {
+            let c = tree.alloc_cell(cell(label).height(20.0).padding(0.0));
+            tree.add_child(r1, c);
+        }
+
+        for label in ["b1", "b2", "b3"] {
+            let c = tree.alloc_cell(cell(label).height(20.0).padding(0.0));
+            tree.add_child(root, c);
+        }
+
+        let g2 = tree.alloc(TableRole::RowGroup, None, 1, 1, None, None, 0.0, 0.0);
+        tree.add_child(root, g2);
+        let r2 = tree.alloc(TableRole::Row, None, 1, 1, None, None, 0.0, 0.0);
+        tree.add_child(g2, r2);
+        for label in ["c1", "c2", "c3"] {
+            let c = tree.alloc_cell(cell(label).height(20.0).padding(0.0));
+            tree.add_child(r2, c);
+        }
+
+        compute_table_layout(&mut tree, root, 300.0, None).expect("layout");
+
+        let y_of = |label: &str| {
+            let cells = tree.nodes_with_role(TableRole::Cell);
+            let id = cells
+                .iter()
+                .copied()
+                .find(|&id| tree.label(id) == Some(label))
+                .expect("cell exists");
+            tree.layout(id).expect("cell laid out").position.y
+        };
+        // Positions are relative to the DOM parent: cells in real rows stay row-relative,
+        // while the bare cells (whose DOM parent is the table) carry the anonymous row's
+        // table-relative offset themselves.
+        assert_approx!(y_of("a1"), 0.0, "cell in group-1's real row is row-relative");
+        assert_approx!(y_of("b1"), 20.0, "bare cell carries the anonymous row's offset");
+        assert_approx!(y_of("c1"), 0.0, "cell in group-2's real row is row-relative");
+        assert_approx!(
+            tree.layout(g2).expect("group 2 laid out").position.y,
+            40.0,
+            "group 2 sits below the anonymous row"
+        );
+    }
+
     // Auto layout: <col> widths seed columns; the rest distribute as usual.
     #[test]
     fn col_widths_in_auto_layout() {

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -1040,17 +1040,30 @@ mod layout_tests {
 
         let (_, total_h) = compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
 
+        // The table box spans outer border edge to outer border edge (like browsers):
+        // the perimeter half-borders (0.5 for a 1px border) are inside the box, so the
+        // grid starts at 0.5 and the box is 23px tall (0.5 + 11 + 11 + 0.5).
         let cells = tree.nodes_with_role(TableRole::Cell);
-        assert_approx!(tree.layout(cells[0]).expect("a").position.x, 0.0, "col 0 at x=0 (no gutter)");
-        assert_approx!(tree.layout(cells[1]).expect("b").position.x, 50.0, "col 1 flush against col 0");
+        assert_approx!(
+            tree.layout(cells[0]).expect("a").position.x,
+            0.5,
+            "col 0 starts after the left perimeter half (no gutter)"
+        );
+        assert_approx!(tree.layout(cells[1]).expect("b").position.x, 50.5, "col 1 flush against col 0");
 
         // Collapsed borders are centered on the grid lines: each cell's layout
-        // reserves half the resolved 1px boundary, so both rows are
-        // 0.5+10+0.5 = 11px, and the table box is 22px with the outer
-        // half-borders sticking out (painted via border_outsets).
+        // reserves half the resolved 1px boundary, so both rows are 0.5+10+0.5 = 11px.
+        // Row positions are group-relative; the group itself sits below the top
+        // perimeter half.
         let rows = tree.nodes_with_role(TableRole::Row);
         assert_approx!(tree.layout(rows[1]).expect("row 1").position.y, 11.0, "row 1 flush below row 0");
-        assert_approx!(total_h, 22.0, "half the boundary on each side of every grid line");
+        let groups = tree.nodes_with_role(TableRole::RowGroup);
+        assert_approx!(
+            tree.layout(groups[0]).expect("group").position.y,
+            0.5,
+            "group starts after the top perimeter half"
+        );
+        assert_approx!(total_h, 23.0, "grid plus a perimeter half-border on each side");
     }
 
     // Collapse conflict resolution, uniform borders: ties go to the left/top

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -958,12 +958,13 @@ mod layout_tests {
         assert_approx!(tree.layout(cells[0]).expect("a").position.x, 0.0, "col 0 at x=0 (no gutter)");
         assert_approx!(tree.layout(cells[1]).expect("b").position.x, 50.0, "col 1 flush against col 0");
 
-        // Row 0 keeps both its borders (12px); row 1's top border lost the
-        // boundary conflict and takes no space (11px) - every internal
-        // boundary is a single 1px line, total 1+10+1+10+1 like a browser.
+        // Collapsed borders are centered on the grid lines: each cell's layout
+        // reserves half the resolved 1px boundary, so both rows are
+        // 0.5+10+0.5 = 11px, and the table box is 22px with the outer
+        // half-borders sticking out (painted via border_outsets).
         let rows = tree.nodes_with_role(TableRole::Row);
-        assert_approx!(tree.layout(rows[1]).expect("row 1").position.y, 12.0, "row 1 flush below row 0");
-        assert_approx!(total_h, 23.0, "single shared border per boundary");
+        assert_approx!(tree.layout(rows[1]).expect("row 1").position.y, 11.0, "row 1 flush below row 0");
+        assert_approx!(total_h, 22.0, "half the boundary on each side of every grid line");
     }
 
     // Collapse conflict resolution, uniform borders: ties go to the left/top

--- a/crates/gosub_lattice/src/types.rs
+++ b/crates/gosub_lattice/src/types.rs
@@ -118,6 +118,9 @@ pub enum VerticalAlign {
     Top,
     Middle,
     Bottom,
+    /// Align the cell's first in-flow line baseline with the row baseline
+    /// (CSS 2 §17.5.3). Cells without a line box fall back to Top.
+    Baseline,
 }
 
 /// The computed layout written back to the tree for each table-internal node.

--- a/crates/gosub_lattice/src/types.rs
+++ b/crates/gosub_lattice/src/types.rs
@@ -138,6 +138,12 @@ pub struct CellLayout {
     /// of the two adjacent cells (the wider border wins; ties go to the
     /// left/top cell) - the losing cell gets its edge flagged here.
     pub suppressed_borders: [bool; 4],
+    /// How far outside the border box each painted edge extends, as
+    /// `[top, right, bottom, left]` px. Collapsed borders are centered on the
+    /// grid line: the cell's layout only reserves half the border (in
+    /// `border`), and the winning cell paints its full border shifted outward
+    /// by the other half. Zero everywhere for separate-border tables.
+    pub border_outsets: [f32; 4],
 }
 
 impl Default for CellLayout {
@@ -149,6 +155,7 @@ impl Default for CellLayout {
             padding: BoxEdges::default(),
             content_offset_y: 0.0,
             suppressed_borders: [false; 4],
+            border_outsets: [0.0; 4],
         }
     }
 }
@@ -161,6 +168,21 @@ pub enum TableSizing {
     Auto,
     /// `table-layout: fixed` - column widths from first row / `<col>` elements.
     Fixed,
+}
+
+/// Per-cell result of border-collapse conflict resolution.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CollapsedBorders {
+    /// The layout border: HALF the resolved boundary width on every edge
+    /// (collapsed borders are centered on the grid lines, so each adjacent
+    /// cell's geometry carries half; outer table edges carry half too, the
+    /// other half sticking out of the table box like in browsers).
+    pub layout: BoxEdges,
+    /// Edges this cell lost - it paints nothing there.
+    pub suppressed: [bool; 4],
+    /// Paint outset per edge (`[top, right, bottom, left]`): the winning cell
+    /// paints its full CSS border shifted outward by half its width.
+    pub outsets: [f32; 4],
 }
 
 /// `border-collapse` property.

--- a/crates/gosub_lattice/src/types.rs
+++ b/crates/gosub_lattice/src/types.rs
@@ -133,6 +133,11 @@ pub struct CellLayout {
     /// to the content-box top) to realize `vertical-align` when the cell is
     /// taller than its content. Always 0 for non-cell nodes.
     pub content_offset_y: f32,
+    /// Border edges the host should NOT paint, as `[top, right, bottom, left]`.
+    /// Under `border-collapse` every shared boundary is painted by exactly one
+    /// of the two adjacent cells (the wider border wins; ties go to the
+    /// left/top cell) - the losing cell gets its edge flagged here.
+    pub suppressed_borders: [bool; 4],
 }
 
 impl Default for CellLayout {
@@ -143,6 +148,7 @@ impl Default for CellLayout {
             border: BoxEdges::default(),
             padding: BoxEdges::default(),
             content_offset_y: 0.0,
+            suppressed_borders: [false; 4],
         }
     }
 }

--- a/crates/gosub_lattice/src/types.rs
+++ b/crates/gosub_lattice/src/types.rs
@@ -109,6 +109,17 @@ impl BoxEdges {
     }
 }
 
+/// `vertical-align` on a table cell - the subset that applies to cell boxes.
+/// `baseline` (the CSS initial) is approximated as `Top` until real first-line
+/// baseline metrics are available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum VerticalAlign {
+    #[default]
+    Top,
+    Middle,
+    Bottom,
+}
+
 /// The computed layout written back to the tree for each table-internal node.
 #[derive(Debug, Clone)]
 pub struct CellLayout {
@@ -118,6 +129,10 @@ pub struct CellLayout {
     pub size: Size,
     pub border: BoxEdges,
     pub padding: BoxEdges,
+    /// Vertical offset the host should add to the cell's *children* (relative
+    /// to the content-box top) to realize `vertical-align` when the cell is
+    /// taller than its content. Always 0 for non-cell nodes.
+    pub content_offset_y: f32,
 }
 
 impl Default for CellLayout {
@@ -127,6 +142,7 @@ impl Default for CellLayout {
             size: Size::new(0.0, 0.0),
             border: BoxEdges::default(),
             padding: BoxEdges::default(),
+            content_offset_y: 0.0,
         }
     }
 }

--- a/crates/gosub_render_pipeline/examples/screenshot.rs
+++ b/crates/gosub_render_pipeline/examples/screenshot.rs
@@ -131,7 +131,7 @@ fn main() {
                     );
                 }
             }
-            ElementContext::Image(_) | ElementContext::Svg(_) => {}
+            _ => {}
         }
 
         for &child_id in el.children.iter().rev() {

--- a/crates/gosub_render_pipeline/examples/screenshot.rs
+++ b/crates/gosub_render_pipeline/examples/screenshot.rs
@@ -116,20 +116,18 @@ fn main() {
                     }
                 }
             }
-            ElementContext::Text(ctx) => {
-                if !ctx.text.trim().is_empty() {
-                    // Approximate text as a dark semi-transparent bar sized to the font.
-                    let bb = &el.box_model.content_box;
-                    let bar_h = (ctx.font_info.size as f32 * 0.6).max(4.0);
-                    fill_rect(
-                        &mut img,
-                        bb.x as f32,
-                        (bb.y + ctx.text_offset.y) as f32,
-                        (bb.width as f32).max(8.0),
-                        bar_h,
-                        [40, 40, 40, 200],
-                    );
-                }
+            ElementContext::Text(ctx) if !ctx.text.trim().is_empty() => {
+                // Approximate text as a dark semi-transparent bar sized to the font.
+                let bb = &el.box_model.content_box;
+                let bar_h = (ctx.font_info.size as f32 * 0.6).max(4.0);
+                fill_rect(
+                    &mut img,
+                    bb.x as f32,
+                    (bb.y + ctx.text_offset.y) as f32,
+                    (bb.width as f32).max(8.0),
+                    bar_h,
+                    [40, 40, 40, 200],
+                );
             }
             _ => {}
         }

--- a/crates/gosub_render_pipeline/src/common/document/inline_style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/inline_style.rs
@@ -259,6 +259,8 @@ fn apply_style_kv(style: &mut NodeStyle, key: &str, value: &str) {
         "border" => apply_border_shorthand(style, value),
 
         "vertical-align" => style.set(StyleProperty::VerticalAlign, parse_style_str(value)),
+        "border-collapse" => style.set(StyleProperty::BorderCollapse, parse_style_str(value)),
+        "caption-side" => style.set(StyleProperty::CaptionSide, parse_style_str(value)),
 
         // One length applies to both axes; two are horizontal then vertical.
         "border-spacing" => {

--- a/crates/gosub_render_pipeline/src/common/document/inline_style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/inline_style.rs
@@ -419,6 +419,7 @@ fn parse_display(value: &str) -> Value {
         "grid" => Value::Display(Display::Grid),
         "inline-grid" => Value::Display(Display::InlineGrid),
         "table" => Value::Display(Display::Table),
+        "inline-table" => Value::Display(Display::InlineTable),
         "table-caption" => Value::Display(Display::TableCaption),
         "table-cell" => Value::Display(Display::TableCell),
         "table-footer-group" => Value::Display(Display::TableFooterGroup),

--- a/crates/gosub_render_pipeline/src/common/document/inline_style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/inline_style.rs
@@ -425,6 +425,8 @@ fn parse_display(value: &str) -> Value {
         "table-header-group" => Value::Display(Display::TableHeaderGroup),
         "table-row" => Value::Display(Display::TableRow),
         "table-row-group" => Value::Display(Display::TableRowGroup),
+        "table-column" => Value::Display(Display::TableColumn),
+        "table-column-group" => Value::Display(Display::TableColumnGroup),
         _ => Value::Keyword(intern(value)),
     }
 }

--- a/crates/gosub_render_pipeline/src/common/document/inline_style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/inline_style.rs
@@ -258,6 +258,23 @@ fn apply_style_kv(style: &mut NodeStyle, key: &str, value: &str) {
 
         "border" => apply_border_shorthand(style, value),
 
+        // One length applies to both axes; two are horizontal then vertical.
+        "border-spacing" => {
+            let parts: Vec<&str> = value.split_whitespace().collect();
+            match parts.as_slice() {
+                [both] => {
+                    let v = parse_style_value(both);
+                    style.set(StyleProperty::BorderSpacingX, v.clone());
+                    style.set(StyleProperty::BorderSpacingY, v);
+                }
+                [x, y, ..] => {
+                    style.set(StyleProperty::BorderSpacingX, parse_style_value(x));
+                    style.set(StyleProperty::BorderSpacingY, parse_style_value(y));
+                }
+                [] => {}
+            }
+        }
+
         "color" => style.set(StyleProperty::Color, parse_named_color(value)),
         "background-color" => style.set(StyleProperty::BackgroundColor, parse_named_color(value)),
         "background" => {

--- a/crates/gosub_render_pipeline/src/common/document/inline_style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/inline_style.rs
@@ -149,7 +149,9 @@ fn is_border_style_keyword(s: &str) -> bool {
     )
 }
 
-fn apply_border_shorthand(style: &mut NodeStyle, value: &str) {
+/// `<line-width> || <line-style> || <color>` in any order; omitted parts take their initial
+/// values (medium = 3px, none, black).
+fn parse_border_parts(value: &str) -> (Value, Value, Value) {
     let mut width = Value::Unit(3.0, Unit::Px);
     let mut bstyle = Value::BorderStyle(BorderStyle::None);
     let mut color = Value::Color(0, 0, 0, 255);
@@ -161,31 +163,49 @@ fn apply_border_shorthand(style: &mut NodeStyle, value: &str) {
             _ => color = parse_named_color(part),
         }
     }
+    (width, bstyle, color)
+}
 
-    for prop in &[
+/// Longhands `[width, style, color]` for one side, `sides` in TRBL order.
+const BORDER_SIDE_LONGHANDS: [[StyleProperty; 3]; 4] = [
+    [
         StyleProperty::BorderTopWidth,
-        StyleProperty::BorderRightWidth,
-        StyleProperty::BorderBottomWidth,
-        StyleProperty::BorderLeftWidth,
-    ] {
-        style.set(prop.clone(), width.clone());
-    }
-    for prop in &[
         StyleProperty::BorderTopStyle,
-        StyleProperty::BorderRightStyle,
-        StyleProperty::BorderBottomStyle,
-        StyleProperty::BorderLeftStyle,
-    ] {
-        style.set(prop.clone(), bstyle.clone());
-    }
-    for prop in &[
         StyleProperty::BorderTopColor,
+    ],
+    [
+        StyleProperty::BorderRightWidth,
+        StyleProperty::BorderRightStyle,
         StyleProperty::BorderRightColor,
+    ],
+    [
+        StyleProperty::BorderBottomWidth,
+        StyleProperty::BorderBottomStyle,
         StyleProperty::BorderBottomColor,
+    ],
+    [
+        StyleProperty::BorderLeftWidth,
+        StyleProperty::BorderLeftStyle,
         StyleProperty::BorderLeftColor,
-    ] {
-        style.set(prop.clone(), color.clone());
+    ],
+];
+
+fn apply_border_shorthand(style: &mut NodeStyle, value: &str) {
+    let (width, bstyle, color) = parse_border_parts(value);
+    for side in &BORDER_SIDE_LONGHANDS {
+        style.set(side[0].clone(), width.clone());
+        style.set(side[1].clone(), bstyle.clone());
+        style.set(side[2].clone(), color.clone());
     }
+}
+
+/// `border-top` / `border-right` / `border-bottom` / `border-left`.
+fn apply_border_side_shorthand(style: &mut NodeStyle, side: usize, value: &str) {
+    let (width, bstyle, color) = parse_border_parts(value);
+    let props = &BORDER_SIDE_LONGHANDS[side];
+    style.set(props[0].clone(), width);
+    style.set(props[1].clone(), bstyle);
+    style.set(props[2].clone(), color);
 }
 
 fn apply_style_kv(style: &mut NodeStyle, key: &str, value: &str) {
@@ -257,6 +277,10 @@ fn apply_style_kv(style: &mut NodeStyle, key: &str, value: &str) {
         "padding-bottom" | "padding-block-end" => style.set(StyleProperty::PaddingBottom, parse_style_value(value)),
 
         "border" => apply_border_shorthand(style, value),
+        "border-top" => apply_border_side_shorthand(style, 0, value),
+        "border-right" => apply_border_side_shorthand(style, 1, value),
+        "border-bottom" => apply_border_side_shorthand(style, 2, value),
+        "border-left" => apply_border_side_shorthand(style, 3, value),
 
         "vertical-align" => style.set(StyleProperty::VerticalAlign, parse_style_str(value)),
         "border-collapse" => style.set(StyleProperty::BorderCollapse, parse_style_str(value)),

--- a/crates/gosub_render_pipeline/src/common/document/inline_style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/inline_style.rs
@@ -394,7 +394,7 @@ fn parse_text_align(val: &str) -> Value {
         "right" => Value::TextAlign(TextAlign::End),
         "start" => Value::TextAlign(TextAlign::Start),
         "end" => Value::TextAlign(TextAlign::End),
-        "center" => Value::TextAlign(TextAlign::Center),
+        "center" | "-webkit-center" => Value::TextAlign(TextAlign::Center),
         "justify" => Value::TextAlign(TextAlign::Justify),
         _ => Value::TextAlign(TextAlign::Start),
     }

--- a/crates/gosub_render_pipeline/src/common/document/inline_style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/inline_style.rs
@@ -258,6 +258,8 @@ fn apply_style_kv(style: &mut NodeStyle, key: &str, value: &str) {
 
         "border" => apply_border_shorthand(style, value),
 
+        "vertical-align" => style.set(StyleProperty::VerticalAlign, parse_style_str(value)),
+
         // One length applies to both axes; two are horizontal then vertical.
         "border-spacing" => {
             let parts: Vec<&str> = value.split_whitespace().collect();

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -1086,6 +1086,10 @@ where
     /// `None` means "no generated box". Populated lazily.
     #[allow(clippy::type_complexity)]
     pseudo_cache: Mutex<HashMap<(NodeId, bool), Option<Arc<PseudoBox<<C::CssSystem as CssSystem>::PropertyMap>>>>>,
+    /// `parent()` resolves anonymous-wrapper parents by scanning the real parent's child
+    /// list; `get_style` calls it per inherited property, which made style resolution
+    /// quadratic in table size. Keyed on the (possibly synthetic) id.
+    parent_cache: Mutex<HashMap<NodeId, Option<NodeId>>>,
 }
 
 impl<C> GosubDocumentAdapter<C>
@@ -1094,12 +1098,73 @@ where
     C::Document: Send + Sync,
     <C::CssSystem as CssSystem>::PropertyMap: Send + Sync,
 {
+    fn parent_uncached(&self, id: NodeId) -> Option<NodeId> {
+        // Synthetic anonymous boxes: parent is the members' real parent when it provides the
+        // right context, else the next synthetic wrapper up - located by finding the enclosing
+        // run's start among the real parent's children.
+        if is_anon_cell_id(u64::from(id)) {
+            let first = decode_anon_box(id);
+            let real_parent = self.doc.parent(first)?;
+            if matches!(self.display_of(real_parent), Some(Display::TableRow)) {
+                return Some(real_parent);
+            }
+            // The enclosing anonymous row wraps the row-level run containing this cell run.
+            let rmembers = self.row_run_members_for(first);
+            return Some(encode_anon_row(rmembers[0]));
+        }
+        if is_anon_row_id(u64::from(id)) {
+            let first = decode_anon_box(id);
+            let real_parent = self.doc.parent(first)?;
+            let parent_display = self.display_of(real_parent);
+            if matches!(
+                parent_display,
+                Some(Display::Table | Display::TableRowGroup | Display::TableHeaderGroup | Display::TableFooterGroup)
+            ) {
+                return Some(real_parent);
+            }
+            // The enclosing anonymous table wraps the table-level run containing this row run.
+            let start = self
+                .run_start_containing(real_parent, first, |c| {
+                    self.display_of(c)
+                        .is_some_and(|d| needs_table_parent(&d, parent_display.as_ref()))
+                })
+                .unwrap_or(first);
+            return Some(encode_anon_table(start));
+        }
+        if is_anon_table_id(u64::from(id)) {
+            return self.doc.parent(decode_anon_box(id));
+        }
+        // Members of a synthesized run report the wrapper as their parent, so the parent
+        // chain matches the child lists children() hands out.
+        if let Some(wrapper) = self.synthetic_parent_of(id) {
+            return Some(wrapper);
+        }
+        if is_pseudo_id(u64::from(id)) {
+            let (owner, role) = decode_pseudo(id);
+            // Text child's parent is its pseudo-element; the pseudo-element's parent is the owner.
+            return Some(if role_is_text(role) {
+                encode_pseudo(
+                    owner,
+                    if role_is_after(role) {
+                        ROLE_AFTER_ELEM
+                    } else {
+                        ROLE_BEFORE_ELEM
+                    },
+                )
+            } else {
+                owner
+            });
+        }
+        self.doc.parent(id)
+    }
+
     pub fn new(doc: Arc<C::Document>) -> Self {
         Self {
             doc,
             style_cache: Mutex::new(HashMap::new()),
             inline_style_cache: Mutex::new(HashMap::new()),
             pseudo_cache: Mutex::new(HashMap::new()),
+            parent_cache: Mutex::new(HashMap::new()),
         }
     }
 
@@ -1858,63 +1923,12 @@ where
     }
 
     fn parent(&self, id: NodeId) -> Option<NodeId> {
-        // Synthetic anonymous boxes: parent is the members' real parent when it provides the
-        // right context, else the next synthetic wrapper up - located by finding the enclosing
-        // run's start among the real parent's children.
-        if is_anon_cell_id(u64::from(id)) {
-            let first = decode_anon_box(id);
-            let real_parent = self.doc.parent(first)?;
-            if matches!(self.display_of(real_parent), Some(Display::TableRow)) {
-                return Some(real_parent);
-            }
-            // The enclosing anonymous row wraps the row-level run containing this cell run.
-            let rmembers = self.row_run_members_for(first);
-            return Some(encode_anon_row(rmembers[0]));
+        if let Some(&cached) = self.parent_cache.lock().get(&id) {
+            return cached;
         }
-        if is_anon_row_id(u64::from(id)) {
-            let first = decode_anon_box(id);
-            let real_parent = self.doc.parent(first)?;
-            let parent_display = self.display_of(real_parent);
-            if matches!(
-                parent_display,
-                Some(Display::Table | Display::TableRowGroup | Display::TableHeaderGroup | Display::TableFooterGroup)
-            ) {
-                return Some(real_parent);
-            }
-            // The enclosing anonymous table wraps the table-level run containing this row run.
-            let start = self
-                .run_start_containing(real_parent, first, |c| {
-                    self.display_of(c)
-                        .is_some_and(|d| needs_table_parent(&d, parent_display.as_ref()))
-                })
-                .unwrap_or(first);
-            return Some(encode_anon_table(start));
-        }
-        if is_anon_table_id(u64::from(id)) {
-            return self.doc.parent(decode_anon_box(id));
-        }
-        // Members of a synthesized run report the wrapper as their parent, so the parent
-        // chain matches the child lists children() hands out.
-        if let Some(wrapper) = self.synthetic_parent_of(id) {
-            return Some(wrapper);
-        }
-        if is_pseudo_id(u64::from(id)) {
-            let (owner, role) = decode_pseudo(id);
-            // Text child's parent is its pseudo-element; the pseudo-element's parent is the owner.
-            return Some(if role_is_text(role) {
-                encode_pseudo(
-                    owner,
-                    if role_is_after(role) {
-                        ROLE_AFTER_ELEM
-                    } else {
-                        ROLE_BEFORE_ELEM
-                    },
-                )
-            } else {
-                owner
-            });
-        }
-        self.doc.parent(id)
+        let parent = self.parent_uncached(id);
+        self.parent_cache.lock().insert(id, parent);
+        parent
     }
 
     fn get_own_style(&self, id: NodeId, prop: &StyleProperty) -> Option<Value> {
@@ -2101,6 +2115,7 @@ where
         self.style_cache.lock().clear();
         self.inline_style_cache.lock().clear();
         self.pseudo_cache.lock().clear();
+        self.parent_cache.lock().clear();
     }
 
     fn invalidate_style_for_nodes(&self, ids: &[NodeId]) {
@@ -2130,6 +2145,9 @@ where
                 self.invalidate_subtree(id);
             }
         }
+        // A display change on any node can reshape the anonymous-wrapper runs around its
+        // siblings, so the parent memo is dropped wholesale (it is cheap to rebuild).
+        self.parent_cache.lock().clear();
     }
 
     fn html_node_id(&self) -> Option<NodeId> {

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -760,6 +760,18 @@ pub trait PipelineDocument: Send + Sync {
         let raw = if let Some(v) = self.get_own_style(id, prop) {
             v
         } else {
+            // border-*-color's initial value is `currentColor`, not black: an undeclared
+            // border color renders in the element's computed `color`
+            // (`td { border: solid; color: blue }` draws blue borders).
+            if matches!(
+                prop,
+                StyleProperty::BorderTopColor
+                    | StyleProperty::BorderRightColor
+                    | StyleProperty::BorderBottomColor
+                    | StyleProperty::BorderLeftColor
+            ) {
+                return self.get_style(id, &StyleProperty::Color);
+            }
             // Monospace default-size quirk (Chrome/Firefox both do this): the default
             // font-size is 13px instead of 16px for elements whose font-family is the bare
             // generic `monospace`. Browsers keep the `medium` keyword identity through

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -82,7 +82,9 @@ fn css_property_to_value<S: CssSystem>(p: &S::Property, prop: &StyleProperty) ->
             let ta = match p.as_string()? {
                 "left" => TextAlign::Left,
                 "right" => TextAlign::Right,
-                "center" => TextAlign::Center,
+                // `-webkit-center` is what the HTML rendering spec's UA sheet
+                // uses for `<caption>`; treat it as plain center.
+                "center" | "-webkit-center" => TextAlign::Center,
                 "justify" => TextAlign::Justify,
                 "start" => TextAlign::Start,
                 "end" => TextAlign::End,

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -971,7 +971,10 @@ fn needs_table_parent(child: &Display, parent: Option<&Display>) -> bool {
             parent,
             Some(Table | TableRow | TableRowGroup | TableHeaderGroup | TableFooterGroup)
         ),
-        TableRow => !matches!(parent, Some(Table | TableRowGroup | TableHeaderGroup | TableFooterGroup)),
+        TableRow => !matches!(
+            parent,
+            Some(Table | TableRowGroup | TableHeaderGroup | TableFooterGroup)
+        ),
         TableRowGroup | TableHeaderGroup | TableFooterGroup | TableCaption | TableColumnGroup => {
             !matches!(parent, Some(Table))
         }
@@ -1283,11 +1286,15 @@ where
         !self.run_skippable(id) && !matches!(self.display_of(id), Some(Display::TableCell))
     }
 
-
     /// Generic run-collapser: replace each run of consecutive `needy` children with one
     /// synthetic id (`encode` of the first member). Skippable children (whitespace text,
     /// comments, display:none) BETWEEN run members are absorbed into the run and dropped.
-    fn collapse_runs(&self, kids: Vec<NodeId>, needy: impl Fn(NodeId) -> bool, encode: fn(NodeId) -> NodeId) -> Vec<NodeId> {
+    fn collapse_runs(
+        &self,
+        kids: Vec<NodeId>,
+        needy: impl Fn(NodeId) -> bool,
+        encode: fn(NodeId) -> NodeId,
+    ) -> Vec<NodeId> {
         if !kids.iter().any(|&k| needy(k)) {
             return kids;
         }
@@ -1395,7 +1402,10 @@ where
         }
         self.collapse_runs(
             kids,
-            |id| self.display_of(id).is_some_and(|d| needs_table_parent(&d, parent_display)),
+            |id| {
+                self.display_of(id)
+                    .is_some_and(|d| needs_table_parent(&d, parent_display))
+            },
             encode_anon_table,
         )
     }
@@ -1474,8 +1484,10 @@ where
         }
 
         // No table context at all: table-internal children live inside an anonymous table.
-        let table_needy =
-            |c: NodeId| self.display_of(c).is_some_and(|dd| needs_table_parent(&dd, parent_display.as_ref()));
+        let table_needy = |c: NodeId| {
+            self.display_of(c)
+                .is_some_and(|dd| needs_table_parent(&dd, parent_display.as_ref()))
+        };
         if !table_needy(id) {
             return None;
         }
@@ -1528,8 +1540,10 @@ where
                 .unwrap_or(id);
             return self.run_members(rstart, |c| self.needy_for_row(c, &pd));
         }
-        let table_needy =
-            |c: NodeId| self.display_of(c).is_some_and(|d| needs_table_parent(&d, parent_display.as_ref()));
+        let table_needy = |c: NodeId| {
+            self.display_of(c)
+                .is_some_and(|d| needs_table_parent(&d, parent_display.as_ref()))
+        };
         let tstart = self.run_start_containing(parent, id, table_needy).unwrap_or(id);
         let tmembers = self.run_members(tstart, table_needy);
         let rstart = self.sub_run_start(&tmembers, id, |c| self.needy_for_row(c, &Display::Table));
@@ -1548,7 +1562,8 @@ where
 
         if is_anon_table_id(raw) {
             return self.run_members(first, |id| {
-                self.display_of(id).is_some_and(|d| needs_table_parent(&d, parent_display.as_ref()))
+                self.display_of(id)
+                    .is_some_and(|d| needs_table_parent(&d, parent_display.as_ref()))
             });
         }
 
@@ -2145,9 +2160,7 @@ where
                 let parent_inline = self.parent(id).is_some_and(|p| {
                     matches!(
                         self.display_of(p),
-                        None | Some(
-                            Display::Inline | Display::InlineBlock | Display::InlineFlex | Display::InlineGrid
-                        )
+                        None | Some(Display::Inline | Display::InlineBlock | Display::InlineFlex | Display::InlineGrid)
                     ) && !matches!(self.doc.node_type(p), GosubNodeType::DocumentNode)
                 });
                 if parent_inline {

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -200,6 +200,33 @@ fn css_property_to_value<S: CssSystem>(p: &S::Property, prop: &StyleProperty) ->
             Some(Value::Keyword(intern(&s)))
         }
 
+        // ── border-spacing: one length (both axes) or two (horizontal vertical) ──
+        StyleProperty::BorderSpacingX | StyleProperty::BorderSpacingY => {
+            if let Some(list) = p.as_list() {
+                let lengths: Vec<f32> = list
+                    .iter()
+                    .filter_map(|v| {
+                        if v.as_unit().is_some() {
+                            Some(v.unit_to_px())
+                        } else {
+                            // Bare `0` is a valid length.
+                            v.as_number()
+                        }
+                    })
+                    .collect();
+                let px = match (prop, lengths.as_slice()) {
+                    (StyleProperty::BorderSpacingY, [_, y, ..]) => *y,
+                    (_, [x, ..]) => *x,
+                    _ => return None,
+                };
+                return Some(Value::Unit(px, Unit::Px));
+            }
+            if p.as_unit().is_some() {
+                return Some(Value::Unit(p.unit_to_px(), Unit::Px));
+            }
+            p.as_number().map(|n| Value::Unit(n, Unit::Px))
+        }
+
         // ── Default: unit-based or keyword ────────────────────────────────
         _ => {
             if let Some((v, unit)) = p.as_unit() {

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -1269,7 +1269,9 @@ where
     /// Is `id` an improper child of a row container with display `parent_display`
     /// (a table or row group), i.e. must it be wrapped in an anonymous row?
     fn needy_for_row(&self, id: NodeId, parent_display: &Display) -> bool {
-        if self.run_skippable(id) {
+        // Pseudo ids carry PSEUDO_FLAG; OR-ing an anon flag onto one would decode as a
+        // pseudo of a nonexistent owner, so they never become run members.
+        if is_pseudo_id(u64::from(id)) || self.run_skippable(id) {
             return false;
         }
         let d = self.display_of(id);
@@ -1283,7 +1285,9 @@ where
     /// Is `id` an improper (non-cell) child of a row, i.e. must it be wrapped in an
     /// anonymous cell?
     fn needy_for_cell(&self, id: NodeId) -> bool {
-        !self.run_skippable(id) && !matches!(self.display_of(id), Some(Display::TableCell))
+        !is_pseudo_id(u64::from(id))
+            && !self.run_skippable(id)
+            && !matches!(self.display_of(id), Some(Display::TableCell))
     }
 
     /// Generic run-collapser: replace each run of consecutive `needy` children with one
@@ -1403,8 +1407,10 @@ where
         self.collapse_runs(
             kids,
             |id| {
-                self.display_of(id)
-                    .is_some_and(|d| needs_table_parent(&d, parent_display))
+                !is_pseudo_id(u64::from(id))
+                    && self
+                        .display_of(id)
+                        .is_some_and(|d| needs_table_parent(&d, parent_display))
             },
             encode_anon_table,
         )

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -1,12 +1,12 @@
 use crate::common::document::node::{AttrMap, ElementData, Node, NodeType};
 use crate::common::document::style::{
-    intern, BorderStyle, Display, FontWeight, NodeStyle, StyleProperty, TextAlign, TextWrap, Unit, Value,
+    intern, lookup, BorderStyle, Display, FontWeight, NodeStyle, StyleProperty, TextAlign, TextWrap, Unit, Value,
 };
 use crate::painter::commands::color::Color;
 use crate::painter::commands::gradient::{ColorStop, Gradient, LinearGradient, Tiling};
 use cow_utils::CowUtils;
 use gosub_interface::config::HasDocument;
-use gosub_interface::css3::{CssProperty, CssPropertyMap, CssSystem, CssValue};
+use gosub_interface::css3::{CssOrigin, CssProperty, CssPropertyMap, CssSystem, CssValue};
 use gosub_interface::document::Document as _;
 use gosub_interface::node::NodeType as GosubNodeType;
 use gosub_shared::node::NodeId;
@@ -760,6 +760,34 @@ pub trait PipelineDocument: Send + Sync {
         let raw = if let Some(v) = self.get_own_style(id, prop) {
             v
         } else {
+            // Monospace default-size quirk (Chrome/Firefox both do this): the default
+            // font-size is 13px instead of 16px for elements whose font-family is the bare
+            // generic `monospace`. Browsers keep the `medium` keyword identity through
+            // inheritance and re-evaluate it per family; we approximate by applying the
+            // quirk when no ancestor declares a font-size at all.
+            if matches!(prop, StyleProperty::FontSize) {
+                let family_is_monospace = match self.get_style(id, &StyleProperty::FontFamily) {
+                    Value::Keyword(fam) => lookup(fam)
+                        .split(',')
+                        .next()
+                        .is_some_and(|f| f.trim().eq_ignore_ascii_case("monospace")),
+                    _ => false,
+                };
+                if family_is_monospace {
+                    let mut cur = self.parent(id);
+                    let mut declared = false;
+                    while let Some(p) = cur {
+                        if self.get_own_style(p, prop).is_some() {
+                            declared = true;
+                            break;
+                        }
+                        cur = self.parent(p);
+                    }
+                    if !declared {
+                        return Value::Unit(13.0, Unit::Px);
+                    }
+                }
+            }
             let meta = prop.meta();
             if meta.inherited {
                 if let Some(parent) = self.parent(id) {
@@ -837,6 +865,106 @@ fn decode_pseudo(id: NodeId) -> (NodeId, u64) {
 
 const fn role_is_after(role: u64) -> bool {
     matches!(role, ROLE_AFTER_ELEM | ROLE_AFTER_TEXT)
+}
+
+// ── Anonymous table boxes (CSS 2.1 §17.2.1, "generate missing parents") ───────
+//
+// A run of consecutive table-internal children (display: table-cell / table-row /
+// row groups / ...) whose parent provides no table context must be wrapped in an
+// anonymous table box. The wrapper is minted like a pseudo-element id: bit 61 flags
+// the id and the payload is the run's FIRST member. Downstream (render tree, taffy,
+// lattice, painter) then sees a regular `display: table` element; lattice's own
+// fixup generates the missing rows/row-groups inside it.
+const ANON_TABLE_FLAG: u64 = 1 << 61;
+/// Anonymous table-ROW wrapper around a run of children that are not proper table/row-group
+/// children. Needed not just for CSS structure: the taffy FIRST pass approximates a row as a
+/// flex row, so without the wrapper bare cells stack vertically and a fit-content ancestor
+/// (e.g. an abs-positioned overlay div) collapses to one cell's width.
+const ANON_ROW_FLAG: u64 = 1 << 60;
+/// Anonymous table-CELL wrapper around a run of non-cell children inside a row.
+const ANON_CELL_FLAG: u64 = 1 << 59;
+
+const ANON_FLAGS: u64 = ANON_TABLE_FLAG | ANON_ROW_FLAG | ANON_CELL_FLAG;
+
+const fn is_anon_table_id(id_val: u64) -> bool {
+    id_val & ANON_FLAGS == ANON_TABLE_FLAG && id_val & PSEUDO_FLAG == 0
+}
+
+const fn is_anon_row_id(id_val: u64) -> bool {
+    id_val & ANON_FLAGS == ANON_ROW_FLAG && id_val & PSEUDO_FLAG == 0
+}
+
+const fn is_anon_cell_id(id_val: u64) -> bool {
+    id_val & ANON_FLAGS == ANON_CELL_FLAG && id_val & PSEUDO_FLAG == 0
+}
+
+/// Any flavour of synthetic anonymous table box.
+const fn is_anon_box_id(id_val: u64) -> bool {
+    is_anon_table_id(id_val) || is_anon_row_id(id_val) || is_anon_cell_id(id_val)
+}
+
+/// The display a synthetic anonymous box carries.
+fn anon_box_display(id_val: u64) -> Option<Display> {
+    if is_anon_table_id(id_val) {
+        Some(Display::Table)
+    } else if is_anon_row_id(id_val) {
+        Some(Display::TableRow)
+    } else if is_anon_cell_id(id_val) {
+        Some(Display::TableCell)
+    } else {
+        None
+    }
+}
+
+fn encode_anon_table(first_member: NodeId) -> NodeId {
+    NodeId::from(ANON_TABLE_FLAG | u64::from(first_member))
+}
+
+fn encode_anon_row(first_member: NodeId) -> NodeId {
+    NodeId::from(ANON_ROW_FLAG | u64::from(first_member))
+}
+
+fn encode_anon_cell(first_member: NodeId) -> NodeId {
+    NodeId::from(ANON_CELL_FLAG | u64::from(first_member))
+}
+
+fn decode_anon_box(id: NodeId) -> NodeId {
+    NodeId::from(u64::from(id) & !ANON_FLAGS)
+}
+
+/// Is `child` a proper child of a table box (CSS 2.1 §17.2)? Everything else inside a table
+/// gets wrapped in an anonymous row.
+fn proper_table_child(d: Option<&Display>) -> bool {
+    matches!(
+        d,
+        Some(
+            Display::TableRow
+                | Display::TableRowGroup
+                | Display::TableHeaderGroup
+                | Display::TableFooterGroup
+                | Display::TableCaption
+                | Display::TableColumn
+                | Display::TableColumnGroup
+        )
+    )
+}
+
+/// Does a child with display `child` require a table ancestor that a parent with
+/// display `parent` does not provide?
+fn needs_table_parent(child: &Display, parent: Option<&Display>) -> bool {
+    use Display::*;
+    match child {
+        TableCell => !matches!(
+            parent,
+            Some(Table | TableRow | TableRowGroup | TableHeaderGroup | TableFooterGroup)
+        ),
+        TableRow => !matches!(parent, Some(Table | TableRowGroup | TableHeaderGroup | TableFooterGroup)),
+        TableRowGroup | TableHeaderGroup | TableFooterGroup | TableCaption | TableColumnGroup => {
+            !matches!(parent, Some(Table))
+        }
+        TableColumn => !matches!(parent, Some(Table | TableColumnGroup)),
+        _ => false,
+    }
 }
 
 const fn role_is_text(role: u64) -> bool {
@@ -1076,6 +1204,399 @@ where
         self.style_from_map(id, prop, pb.styles.as_ref())
     }
 
+    // ── Anonymous table synthesis ─────────────────────────────────────────────
+
+    /// The node's computed `display`, if the cascade assigned one.
+    fn display_of(&self, id: NodeId) -> Option<Display> {
+        match self.get_own_style(id, &StyleProperty::Display) {
+            Some(Value::Display(d)) => Some(d),
+            _ => None,
+        }
+    }
+
+    /// Children skipped silently when collecting anonymous runs: whitespace-only text,
+    /// comments/doctypes, and `display: none` children (none of them generate a box).
+    fn run_skippable(&self, id: NodeId) -> bool {
+        let raw = u64::from(id);
+        if is_pseudo_id(raw) || is_anon_box_id(raw) {
+            return false;
+        }
+        match self.doc.node_type(id) {
+            GosubNodeType::TextNode => self.doc.text_value(id).is_none_or(|t| t.trim().is_empty()),
+            GosubNodeType::CommentNode | GosubNodeType::DocTypeNode => true,
+            _ => matches!(self.display_of(id), Some(Display::None)),
+        }
+    }
+
+    /// Is `id` an improper child of a row container with display `parent_display`
+    /// (a table or row group), i.e. must it be wrapped in an anonymous row?
+    fn needy_for_row(&self, id: NodeId, parent_display: &Display) -> bool {
+        if self.run_skippable(id) {
+            return false;
+        }
+        let d = self.display_of(id);
+        match parent_display {
+            Display::Table => !proper_table_child(d.as_ref()),
+            // Row groups: only rows are proper.
+            _ => !matches!(d, Some(Display::TableRow)),
+        }
+    }
+
+    /// Is `id` an improper (non-cell) child of a row, i.e. must it be wrapped in an
+    /// anonymous cell?
+    fn needy_for_cell(&self, id: NodeId) -> bool {
+        !self.run_skippable(id) && !matches!(self.display_of(id), Some(Display::TableCell))
+    }
+
+
+    /// Generic run-collapser: replace each run of consecutive `needy` children with one
+    /// synthetic id (`encode` of the first member). Skippable children (whitespace text,
+    /// comments, display:none) BETWEEN run members are absorbed into the run and dropped.
+    fn collapse_runs(&self, kids: Vec<NodeId>, needy: impl Fn(NodeId) -> bool, encode: fn(NodeId) -> NodeId) -> Vec<NodeId> {
+        if !kids.iter().any(|&k| needy(k)) {
+            return kids;
+        }
+        let mut out = Vec::with_capacity(kids.len());
+        let mut i = 0;
+        while i < kids.len() {
+            if !needy(kids[i]) {
+                out.push(kids[i]);
+                i += 1;
+                continue;
+            }
+            out.push(encode(kids[i]));
+            i += 1;
+            loop {
+                let mut j = i;
+                while j < kids.len() && self.run_skippable(kids[j]) {
+                    j += 1;
+                }
+                if j < kids.len() && needy(kids[j]) {
+                    i = j + 1;
+                } else {
+                    break;
+                }
+            }
+        }
+        out
+    }
+
+    /// The real members of a synthetic run: the needy siblings starting at `first`
+    /// (interior skippable children are dropped).
+    fn run_members(&self, first: NodeId, needy: impl Fn(NodeId) -> bool) -> Vec<NodeId> {
+        let mut members = vec![first];
+        let Some(parent) = self.doc.parent(first) else {
+            return members;
+        };
+        let kids = self.doc.children(parent);
+        let Some(pos) = kids.iter().position(|&k| k == first) else {
+            return members;
+        };
+        let mut i = pos + 1;
+        loop {
+            let mut j = i;
+            while j < kids.len() && self.run_skippable(kids[j]) {
+                j += 1;
+            }
+            if j < kids.len() && needy(kids[j]) {
+                members.push(kids[j]);
+                i = j + 1;
+            } else {
+                break;
+            }
+        }
+        members
+    }
+
+    /// First member of the run (per `needy`) among `parent`'s children that contains
+    /// `member`, mirroring `collapse_runs`' grouping.
+    fn run_start_containing(&self, parent: NodeId, member: NodeId, needy: impl Fn(NodeId) -> bool) -> Option<NodeId> {
+        let kids = self.doc.children(parent);
+        let mut i = 0;
+        while i < kids.len() {
+            if !needy(kids[i]) {
+                i += 1;
+                continue;
+            }
+            let start = kids[i];
+            let mut hit = kids[i] == member;
+            i += 1;
+            loop {
+                let mut j = i;
+                while j < kids.len() && self.run_skippable(kids[j]) {
+                    j += 1;
+                }
+                if j < kids.len() && needy(kids[j]) {
+                    hit |= kids[j] == member;
+                    i = j + 1;
+                } else {
+                    break;
+                }
+            }
+            if hit {
+                return Some(start);
+            }
+        }
+        None
+    }
+
+    /// Collapse each run of table-internal children lacking a table parent into one
+    /// anonymous-table id (CSS 2.1 §17.2.1 "generate missing parents").
+    fn wrap_anon_table_runs(&self, parent_display: Option<&Display>, kids: Vec<NodeId>) -> Vec<NodeId> {
+        // A parent that itself provides table context never wraps a table: the anonymous
+        // row/cell wrappers below own the interior of a table.
+        if matches!(
+            parent_display,
+            Some(
+                Display::Table
+                    | Display::TableRow
+                    | Display::TableRowGroup
+                    | Display::TableHeaderGroup
+                    | Display::TableFooterGroup
+                    | Display::TableColumnGroup
+            )
+        ) {
+            return kids;
+        }
+        self.collapse_runs(
+            kids,
+            |id| self.display_of(id).is_some_and(|d| needs_table_parent(&d, parent_display)),
+            encode_anon_table,
+        )
+    }
+
+    /// Collapse each run of improper children of a table / row group into one
+    /// anonymous-row id.
+    fn wrap_anon_row_runs(&self, parent_display: Option<&Display>, kids: Vec<NodeId>) -> Vec<NodeId> {
+        let Some(pd) = parent_display else { return kids };
+        if !matches!(
+            pd,
+            Display::Table | Display::TableRowGroup | Display::TableHeaderGroup | Display::TableFooterGroup
+        ) {
+            return kids;
+        }
+        self.collapse_runs(kids, |id| self.needy_for_row(id, pd), encode_anon_row)
+    }
+
+    /// Collapse each run of non-cell children of a (real or anonymous) row into one
+    /// anonymous-cell id.
+    fn wrap_anon_cell_runs(&self, parent_display: Option<&Display>, kids: Vec<NodeId>) -> Vec<NodeId> {
+        if !matches!(parent_display, Some(Display::TableRow)) {
+            return kids;
+        }
+        self.collapse_runs(kids, |id| self.needy_for_cell(id), encode_anon_cell)
+    }
+
+    /// Start of the maximal sub-run of consecutive `pred` members containing `id`.
+    fn sub_run_start(&self, members: &[NodeId], id: NodeId, pred: impl Fn(NodeId) -> bool) -> NodeId {
+        let Some(mut i) = members.iter().position(|&m| m == id) else {
+            return id;
+        };
+        while i > 0 && pred(members[i - 1]) {
+            i -= 1;
+        }
+        members[i]
+    }
+
+    /// The synthetic wrapper `children()` places `id` under, if any. Run members' parent
+    /// chain must route through the anonymous boxes, or sibling walks (whitespace
+    /// collapsing, vertical-align resolution) diverge from the tree children() produces.
+    fn synthetic_parent_of(&self, id: NodeId) -> Option<NodeId> {
+        let raw = u64::from(id);
+        if is_pseudo_id(raw) || is_anon_box_id(raw) {
+            return None;
+        }
+        let parent = self.doc.parent(id)?;
+        let parent_display = self.display_of(parent);
+        let d = self.display_of(id);
+
+        // Inside a real row: non-cell children live in an anonymous cell.
+        if matches!(parent_display, Some(Display::TableRow)) {
+            if matches!(d, Some(Display::TableCell)) || self.run_skippable(id) {
+                return None;
+            }
+            let start = self.run_start_containing(parent, id, |c| self.needy_for_cell(c))?;
+            return Some(encode_anon_cell(start));
+        }
+
+        // Inside a real table / row group: improper children live in an anonymous row,
+        // and non-cells among them one level deeper in an anonymous cell.
+        if matches!(
+            parent_display,
+            Some(Display::Table | Display::TableRowGroup | Display::TableHeaderGroup | Display::TableFooterGroup)
+        ) {
+            let pd = parent_display.clone().unwrap_or(Display::Table);
+            if !self.needy_for_row(id, &pd) {
+                return None;
+            }
+            let rstart = self.run_start_containing(parent, id, |c| self.needy_for_row(c, &pd))?;
+            if matches!(d, Some(Display::TableCell)) {
+                return Some(encode_anon_row(rstart));
+            }
+            let rmembers = self.anon_box_members(encode_anon_row(rstart));
+            let cstart = self.sub_run_start(&rmembers, id, |c| self.needy_for_cell(c));
+            return Some(encode_anon_cell(cstart));
+        }
+
+        // No table context at all: table-internal children live inside an anonymous table.
+        let table_needy =
+            |c: NodeId| self.display_of(c).is_some_and(|dd| needs_table_parent(&dd, parent_display.as_ref()));
+        if !table_needy(id) {
+            return None;
+        }
+        let tstart = self.run_start_containing(parent, id, table_needy)?;
+        if proper_table_child(d.as_ref()) {
+            return Some(encode_anon_table(tstart));
+        }
+        let tmembers = self.anon_box_members(encode_anon_table(tstart));
+        let rstart = self.sub_run_start(&tmembers, id, |c| self.needy_for_row(c, &Display::Table));
+        if matches!(d, Some(Display::TableCell)) {
+            return Some(encode_anon_row(rstart));
+        }
+        let rmembers = self.anon_box_members(encode_anon_row(rstart));
+        let cstart = self.sub_run_start(&rmembers, id, |c| self.needy_for_cell(c));
+        Some(encode_anon_cell(cstart))
+    }
+
+    /// The prefix of `members` starting at `first` for which `pred` holds contiguously.
+    fn members_sub_run(&self, members: &[NodeId], first: NodeId, pred: impl Fn(NodeId) -> bool) -> Vec<NodeId> {
+        let Some(i) = members.iter().position(|&m| m == first) else {
+            return vec![first];
+        };
+        let mut out = vec![first];
+        for &m in &members[i + 1..] {
+            if pred(m) {
+                out.push(m);
+            } else {
+                break;
+            }
+        }
+        out
+    }
+
+    /// Members of the row-level run containing `id`. In a real table/row-group the run is
+    /// collected over the raw siblings; inside an anonymous table it is BOUNDED by the
+    /// table's own member run - the broad "improper child" predicate must never leak past
+    /// the anonymous table and absorb ordinary siblings (`a <cell/><cell/> d`).
+    fn row_run_members_for(&self, id: NodeId) -> Vec<NodeId> {
+        let Some(parent) = self.doc.parent(id) else {
+            return vec![id];
+        };
+        let parent_display = self.display_of(parent);
+        if matches!(
+            parent_display,
+            Some(Display::Table | Display::TableRowGroup | Display::TableHeaderGroup | Display::TableFooterGroup)
+        ) {
+            let pd = parent_display.clone().unwrap_or(Display::Table);
+            let rstart = self
+                .run_start_containing(parent, id, |c| self.needy_for_row(c, &pd))
+                .unwrap_or(id);
+            return self.run_members(rstart, |c| self.needy_for_row(c, &pd));
+        }
+        let table_needy =
+            |c: NodeId| self.display_of(c).is_some_and(|d| needs_table_parent(&d, parent_display.as_ref()));
+        let tstart = self.run_start_containing(parent, id, table_needy).unwrap_or(id);
+        let tmembers = self.run_members(tstart, table_needy);
+        let rstart = self.sub_run_start(&tmembers, id, |c| self.needy_for_row(c, &Display::Table));
+        self.members_sub_run(&tmembers, rstart, |c| self.needy_for_row(c, &Display::Table))
+    }
+
+    /// The real members of a synthetic anonymous box's run (the wrapper's flavour decides
+    /// the run predicate).
+    fn anon_box_members(&self, anon: NodeId) -> Vec<NodeId> {
+        let raw = u64::from(anon);
+        let first = decode_anon_box(anon);
+        let Some(parent) = self.doc.parent(first) else {
+            return vec![first];
+        };
+        let parent_display = self.display_of(parent);
+
+        if is_anon_table_id(raw) {
+            return self.run_members(first, |id| {
+                self.display_of(id).is_some_and(|d| needs_table_parent(&d, parent_display.as_ref()))
+            });
+        }
+
+        if is_anon_row_id(raw) {
+            return self.row_run_members_for(first);
+        }
+
+        // Anonymous cell: bounded by the enclosing row's members unless the parent is a
+        // real row (then the raw sibling run is the row's interior).
+        if matches!(parent_display, Some(Display::TableRow)) {
+            return self.run_members(first, |id| self.needy_for_cell(id));
+        }
+        let rmembers = self.row_run_members_for(first);
+        self.members_sub_run(&rmembers, first, |c| self.needy_for_cell(c))
+    }
+
+    /// HTML `cellspacing` (on the table -> border-spacing) and `cellpadding` (on the table ->
+    /// in-table td/th padding, defaulting to 1px like WebKit's
+    /// `HTMLTableCellElement::additionalPresentationAttributeStyle` - see the UA sheet comment
+    /// at `td:not(table td)`). Returns `None` whenever an author declaration exists for the
+    /// property: author styles always beat presentational markup, UA rules never do.
+    fn table_attr_hint(
+        &self,
+        id: NodeId,
+        prop: &StyleProperty,
+        map: &<C::CssSystem as CssSystem>::PropertyMap,
+    ) -> Option<Value> {
+        let author_declared = |name: &str| {
+            <_ as CssPropertyMap<C::CssSystem>>::get(map, name)
+                .and_then(|p| p.winning_origin())
+                .is_some_and(|o| matches!(o, CssOrigin::Author))
+        };
+        let attr_px = |node: NodeId, attr: &str| -> Option<f32> {
+            self.doc
+                .attributes(node)?
+                .get(attr)?
+                .trim()
+                .parse::<f32>()
+                .ok()
+                .map(|v| v.max(0.0))
+        };
+
+        match prop {
+            StyleProperty::BorderSpacingX | StyleProperty::BorderSpacingY => {
+                if !self.doc.tag_name(id).is_some_and(|t| t.eq_ignore_ascii_case("table")) {
+                    return None;
+                }
+                if author_declared("border-spacing") {
+                    return None;
+                }
+                attr_px(id, "cellspacing").map(|v| Value::Unit(v, Unit::Px))
+            }
+            StyleProperty::PaddingTop
+            | StyleProperty::PaddingRight
+            | StyleProperty::PaddingBottom
+            | StyleProperty::PaddingLeft => {
+                if !self
+                    .doc
+                    .tag_name(id)
+                    .is_some_and(|t| t.eq_ignore_ascii_case("td") || t.eq_ignore_ascii_case("th"))
+                {
+                    return None;
+                }
+                // The hint applies to in-table cells only; a parentless td keeps the UA default.
+                let mut table = None;
+                let mut cur = self.doc.parent(id);
+                while let Some(p) = cur {
+                    if self.doc.tag_name(p).is_some_and(|t| t.eq_ignore_ascii_case("table")) {
+                        table = Some(p);
+                        break;
+                    }
+                    cur = self.doc.parent(p);
+                }
+                let table = table?;
+                if author_declared(prop.css_name()) || author_declared("padding") {
+                    return None;
+                }
+                Some(Value::Unit(attr_px(table, "cellpadding").unwrap_or(1.0), Unit::Px))
+            }
+            _ => None,
+        }
+    }
+
     /// Bridges a computed `PropertyMap` to a single `Value`, shared by real elements and
     /// pseudo-elements. Handles the `text-decoration` / `background[-image]` shorthands and
     /// `currentColor`. `id` is only used to resolve `currentColor` against the node's `color`.
@@ -1198,6 +1719,19 @@ where
     }
 
     fn children(&self, id: NodeId) -> Vec<NodeId> {
+        if is_anon_table_id(u64::from(id)) {
+            // The anonymous table's members may need row wrappers of their own.
+            let members = self.anon_box_members(id);
+            return self.wrap_anon_row_runs(Some(&Display::Table), members);
+        }
+        if is_anon_row_id(u64::from(id)) {
+            // ...and an anonymous row's members may need cell wrappers.
+            let members = self.anon_box_members(id);
+            return self.wrap_anon_cell_runs(Some(&Display::TableRow), members);
+        }
+        if is_anon_cell_id(u64::from(id)) {
+            return self.anon_box_members(id);
+        }
         if is_pseudo_id(u64::from(id)) {
             let (owner, role) = decode_pseudo(id);
             // A pseudo-element's only child is its generated text (if any); text nodes are leaves.
@@ -1226,10 +1760,16 @@ where
         if self.pseudo_box(id, true).is_some() {
             out.push(encode_pseudo(id, ROLE_AFTER_ELEM));
         }
-        out
+        let display = self.display_of(id);
+        let out = self.wrap_anon_table_runs(display.as_ref(), out);
+        let out = self.wrap_anon_row_runs(display.as_ref(), out);
+        self.wrap_anon_cell_runs(display.as_ref(), out)
     }
 
     fn node_kind(&self, id: NodeId) -> PipelineNodeKind {
+        if is_anon_box_id(u64::from(id)) {
+            return PipelineNodeKind::Element;
+        }
         if is_pseudo_id(u64::from(id)) {
             let (_, role) = decode_pseudo(id);
             return if role_is_text(role) {
@@ -1247,8 +1787,8 @@ where
     }
 
     fn tag_name(&self, id: NodeId) -> Option<String> {
-        // Pseudo-elements have no tag name.
-        if is_pseudo_id(u64::from(id)) {
+        // Pseudo-elements and anonymous table boxes have no tag name.
+        if is_pseudo_id(u64::from(id)) || is_anon_box_id(u64::from(id)) {
             return None;
         }
         self.doc.tag_name(id).map(|s| s.to_string())
@@ -1262,6 +1802,46 @@ where
     }
 
     fn parent(&self, id: NodeId) -> Option<NodeId> {
+        // Synthetic anonymous boxes: parent is the members' real parent when it provides the
+        // right context, else the next synthetic wrapper up - located by finding the enclosing
+        // run's start among the real parent's children.
+        if is_anon_cell_id(u64::from(id)) {
+            let first = decode_anon_box(id);
+            let real_parent = self.doc.parent(first)?;
+            if matches!(self.display_of(real_parent), Some(Display::TableRow)) {
+                return Some(real_parent);
+            }
+            // The enclosing anonymous row wraps the row-level run containing this cell run.
+            let rmembers = self.row_run_members_for(first);
+            return Some(encode_anon_row(rmembers[0]));
+        }
+        if is_anon_row_id(u64::from(id)) {
+            let first = decode_anon_box(id);
+            let real_parent = self.doc.parent(first)?;
+            let parent_display = self.display_of(real_parent);
+            if matches!(
+                parent_display,
+                Some(Display::Table | Display::TableRowGroup | Display::TableHeaderGroup | Display::TableFooterGroup)
+            ) {
+                return Some(real_parent);
+            }
+            // The enclosing anonymous table wraps the table-level run containing this row run.
+            let start = self
+                .run_start_containing(real_parent, first, |c| {
+                    self.display_of(c)
+                        .is_some_and(|d| needs_table_parent(&d, parent_display.as_ref()))
+                })
+                .unwrap_or(first);
+            return Some(encode_anon_table(start));
+        }
+        if is_anon_table_id(u64::from(id)) {
+            return self.doc.parent(decode_anon_box(id));
+        }
+        // Members of a synthesized run report the wrapper as their parent, so the parent
+        // chain matches the child lists children() hands out.
+        if let Some(wrapper) = self.synthetic_parent_of(id) {
+            return Some(wrapper);
+        }
         if is_pseudo_id(u64::from(id)) {
             let (owner, role) = decode_pseudo(id);
             // Text child's parent is its pseudo-element; the pseudo-element's parent is the owner.
@@ -1282,6 +1862,11 @@ where
     }
 
     fn get_own_style(&self, id: NodeId, prop: &StyleProperty) -> Option<Value> {
+        // An anonymous table box IS its display (table / table-row) and has no other own
+        // styles; inherited properties resolve through its (real) parent.
+        if let Some(d) = anon_box_display(u64::from(id)) {
+            return matches!(prop, StyleProperty::Display).then(|| Value::Display(d));
+        }
         // Generated content (::before / ::after) draws its styles from a separate map.
         if is_pseudo_id(u64::from(id)) {
             return self.pseudo_own_style(id, prop);
@@ -1294,6 +1879,13 @@ where
             if let Some(v) = inline.get_own(prop) {
                 return Some(v.clone());
             }
+        }
+
+        // `cellspacing`/`cellpadding` are presentational hints that sit BETWEEN origins: they
+        // beat user-agent rules (notably the UA `table { border-spacing: 2px }`) but lose to
+        // any author declaration, so they must be consulted before the cascaded map.
+        if let Some(v) = self.table_attr_hint(id, prop, arc.as_ref()) {
+            return Some(v);
         }
 
         if let Some(v) = self.style_from_map(id, prop, arc.as_ref()) {
@@ -1309,6 +1901,9 @@ where
     }
 
     fn background_layers(&self, id: NodeId) -> Vec<Gradient> {
+        if is_anon_box_id(u64::from(id)) {
+            return Vec::new();
+        }
         // Read the layers from the pseudo-element's own map, never the owner's.
         let arc = if is_pseudo_id(u64::from(id)) {
             let (owner, role) = decode_pseudo(id);
@@ -1373,6 +1968,9 @@ where
     }
 
     fn background_image_layout(&self, id: NodeId) -> BgImageLayout {
+        if is_anon_box_id(u64::from(id)) {
+            return BgImageLayout::default();
+        }
         let arc = self.cached_styles(id);
         let map = arc.as_ref();
 
@@ -1493,13 +2091,46 @@ where
     }
 
     fn inner_html(&self, id: NodeId) -> String {
-        if is_pseudo_id(u64::from(id)) {
+        if is_pseudo_id(u64::from(id)) || is_anon_box_id(u64::from(id)) {
             return String::new();
         }
         self.doc.write_from_node(id)
     }
 
     fn get_node_by_id(&self, id: NodeId) -> Option<Node> {
+        // Synthetic anonymous-table wrapper: a tagless `display: table` / `table-row` element.
+        if let Some(d) = anon_box_display(u64::from(id)) {
+            let mut style = NodeStyle::new();
+            // An anonymous table generated in INLINE context is an inline-table (CSS 2.1
+            // §17.2.1). We have no inline-table display; marking the synthetic NODE
+            // inline-block makes the layouter's line grouping keep it (and the whitespace
+            // around it) in the line box, while the cascade via get_own_style still reports
+            // `table` to the converter, lattice, and painter.
+            let node_display = if matches!(d, Display::Table) {
+                let parent_inline = self.parent(id).is_some_and(|p| {
+                    matches!(
+                        self.display_of(p),
+                        None | Some(
+                            Display::Inline | Display::InlineBlock | Display::InlineFlex | Display::InlineGrid
+                        )
+                    ) && !matches!(self.doc.node_type(p), GosubNodeType::DocumentNode)
+                });
+                if parent_inline {
+                    Display::InlineBlock
+                } else {
+                    d
+                }
+            } else {
+                d
+            };
+            style.set(StyleProperty::Display, Value::Display(node_display));
+            return Some(Node {
+                node_id: id,
+                parent_id: self.parent(id),
+                children: self.children(id),
+                node_type: NodeType::Element(ElementData::new(String::new(), Some(AttrMap::new()), Some(style))),
+            });
+        }
         // Synthetic pseudo nodes: build a transient Element (the box) or Text (its content).
         if is_pseudo_id(u64::from(id)) {
             let (owner, role) = decode_pseudo(id);

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -132,8 +132,18 @@ fn css_property_to_value<S: CssSystem>(p: &S::Property, prop: &StyleProperty) ->
 
         // ── line-height: unitless number is a multiplier, not pixels ───────
         StyleProperty::LineHeight => {
-            if p.as_unit().is_some() {
+            if let Some((v, unit)) = p.as_unit() {
+                // `em` needs the element's font-size, unknown here - defer to `get_style`
+                // (`unit_to_px` would resolve it against a hardcoded 16px).
+                if unit == "em" {
+                    return Some(Value::Unit(v, Unit::Em));
+                }
                 Some(Value::Unit(p.unit_to_px(), Unit::Px))
+            } else if let Some(pct) = p.as_percentage() {
+                // Percentages resolve against the element's own font-size, i.e. exactly `em`
+                // semantics - and `get_style` resolves `em` at the declaring element, giving the
+                // spec's inherit-as-computed-px behaviour for free.
+                Some(Value::Unit(pct / 100.0, Unit::Em))
             } else if let Some(n) = p.as_number() {
                 Some(Value::Number(n))
             } else {

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -49,6 +49,7 @@ fn css_property_to_value<S: CssSystem>(p: &S::Property, prop: &StyleProperty) ->
                 "grid" => Display::Grid,
                 "inline-grid" => Display::InlineGrid,
                 "table" => Display::Table,
+                "inline-table" => Display::InlineTable,
                 "table-caption" => Display::TableCaption,
                 "table-cell" => Display::TableCell,
                 "table-footer-group" => Display::TableFooterGroup,
@@ -1221,6 +1222,10 @@ where
     /// The node's computed `display`, if the cascade assigned one.
     fn display_of(&self, id: NodeId) -> Option<Display> {
         match self.get_own_style(id, &StyleProperty::Display) {
+            // Inline-table differs from table only in OUTER display (how it participates in
+            // its parent's formatting context); every display_of consumer asks about table
+            // structure, so normalize here and keep the inline-ness at the Node level.
+            Some(Value::Display(Display::InlineTable)) => Some(Display::Table),
             Some(Value::Display(d)) => Some(d),
             _ => None,
         }
@@ -2213,6 +2218,14 @@ where
                 // fallback, since the incomplete UA stylesheet makes get_style()'s `inline`
                 // initial value the wrong answer here.
                 let styles = self.get_own_style(id, &StyleProperty::Display).map(|display| {
+                    // Same trick as anonymous inline-context tables: the Node carries
+                    // inline-block so line grouping keeps the element in the line box,
+                    // while the cascade (display_of + explicit matches) reports table
+                    // structure to the converter, lattice, and painter.
+                    let display = match display {
+                        Value::Display(Display::InlineTable) => Value::Display(Display::InlineBlock),
+                        d => d,
+                    };
                     let mut style = NodeStyle::new();
                     style.set(StyleProperty::Display, display);
                     style

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -14,7 +14,7 @@ use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-// ── Bridge: CssProperty → Value ──────────────────────────────────────────────
+// ── Bridge: CssProperty -> Value ──────────────────────────────────────────────
 
 /// `None` when the property carries no usable value (e.g. `CssValue::None`).
 fn css_property_to_value<S: CssSystem>(p: &S::Property, prop: &StyleProperty) -> Option<Value> {
@@ -192,7 +192,7 @@ fn css_property_to_value<S: CssSystem>(p: &S::Property, prop: &StyleProperty) ->
             }
         }
 
-        // ── Grid track lists: `repeat(3, 1fr)`, `210px 1fr`, `auto`, … ─────
+        // ── Grid track lists: `repeat(3, 1fr)`, `210px 1fr`, `auto`, ... ─────
         // Stored as a `Function` (repeat/minmax) or a `List` - neither of which `as_string()`
         // returns - and a bare `1fr` is a `Unit`, so the default branch would drop or mis-type
         // them. Re-serialize to canonical CSS text for the layouter's `parse_grid_template`.
@@ -276,7 +276,7 @@ fn css_property_to_value<S: CssSystem>(p: &S::Property, prop: &StyleProperty) ->
 }
 
 /// Serializes one grid track-list value back to canonical CSS text (`1fr`, `minmax(100px, 1fr)`,
-/// …), reconstructing a `grid-template-*` string the layouter can parse.
+/// ...), reconstructing a `grid-template-*` string the layouter can parse.
 fn grid_value_to_string<S: CssSystem>(v: &S::Value) -> String {
     if let Some(s) = v.as_string() {
         return s.to_string();
@@ -539,7 +539,7 @@ enum BgTok {
     /// today a percentage size/position falls back to "fill box" / zero offset.
     #[allow(dead_code)]
     Pct(f32),
-    /// A keyword (`cover`, `center`, `no-repeat`, …), lowercased.
+    /// A keyword (`cover`, `center`, `no-repeat`, ...), lowercased.
     Kw(String),
 }
 
@@ -603,7 +603,7 @@ fn bg_token_groups<S: CssSystem>(p: &S::Property) -> Vec<Vec<BgTok>> {
     }
 }
 
-/// `background-size` group → tile size in px, or `None` for `auto`/`cover`/`contain`/`%`
+/// `background-size` group -> tile size in px, or `None` for `auto`/`cover`/`contain`/`%`
 /// (which mean "fill the box", i.e. no tiling).
 fn resolve_bg_size(group: &[BgTok]) -> Option<(f32, f32)> {
     let mut dims = Vec::new();
@@ -622,7 +622,7 @@ fn resolve_bg_size(group: &[BgTok]) -> Option<(f32, f32)> {
     }
 }
 
-/// `background-position` group → (x, y) px phase offset. Percentages and edge keywords need the
+/// `background-position` group -> (x, y) px phase offset. Percentages and edge keywords need the
 /// box size, so they resolve to 0 for now; px offsets are exact.
 fn resolve_bg_position(group: &[BgTok]) -> (f32, f32) {
     let lens: Vec<f32> = group
@@ -639,7 +639,7 @@ fn resolve_bg_position(group: &[BgTok]) -> (f32, f32) {
     }
 }
 
-/// `background-repeat` group → (repeat_x, repeat_y). Defaults to repeating both axes.
+/// `background-repeat` group -> (repeat_x, repeat_y). Defaults to repeating both axes.
 fn resolve_bg_repeat(group: &[BgTok]) -> (bool, bool) {
     let kws: Vec<&str> = group
         .iter()
@@ -1942,7 +1942,7 @@ where
             return Some(v);
         }
 
-        // HTML presentation attributes (bgcolor, width, …) as lowest-specificity fallback.
+        // HTML presentation attributes (bgcolor, width, ...) as lowest-specificity fallback.
         if let Some(attrs) = self.doc.attributes(id) {
             return crate::common::document::inline_style::html_presentation_attr(attrs, prop);
         }
@@ -1996,7 +1996,7 @@ where
 
         for (i, g) in layers.iter_mut().enumerate() {
             let Some((tw, th)) = pick(&size_groups, i).and_then(|j| resolve_bg_size(&size_groups[j])) else {
-                continue; // no explicit size → fill the box (no tiling)
+                continue; // no explicit size -> fill the box (no tiling)
             };
             if tw <= 0.0 || th <= 0.0 {
                 continue;

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -55,6 +55,8 @@ fn css_property_to_value<S: CssSystem>(p: &S::Property, prop: &StyleProperty) ->
                 "table-header-group" => Display::TableHeaderGroup,
                 "table-row" => Display::TableRow,
                 "table-row-group" => Display::TableRowGroup,
+                "table-column" => Display::TableColumn,
+                "table-column-group" => Display::TableColumnGroup,
                 _ => Display::Block,
             };
             Some(Value::Display(d))

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -1222,7 +1222,25 @@ where
             return false;
         }
         match self.doc.node_type(id) {
-            GosubNodeType::TextNode => self.doc.text_value(id).is_none_or(|t| t.trim().is_empty()),
+            GosubNodeType::TextNode => {
+                if self.doc.text_value(id).is_some_and(|t| !t.trim().is_empty()) {
+                    return false;
+                }
+                // Whitespace-only text: skippable only when collapsing would remove it.
+                // Under `white-space: pre`/`pre-wrap` the spaces are content and generate
+                // anonymous boxes (CSS 2.1 §17.2.1 considers only whitespace "that would be
+                // collapsed"). Resolved over the RAW DOM parent chain: `get_style` routes
+                // through `parent()`, whose synthetic-wrapper resolution calls back into
+                // `run_skippable` - a cycle.
+                let mut cur = self.doc.parent(id);
+                while let Some(p) = cur {
+                    if let Some(Value::Keyword(k)) = self.get_own_style(p, &StyleProperty::WhiteSpace) {
+                        return !matches!(lookup(k).as_str(), "pre" | "pre-wrap");
+                    }
+                    cur = self.doc.parent(p);
+                }
+                true
+            }
             GosubNodeType::CommentNode | GosubNodeType::DocTypeNode => true,
             _ => matches!(self.display_of(id), Some(Display::None)),
         }

--- a/crates/gosub_render_pipeline/src/common/document/style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/style.rs
@@ -59,6 +59,11 @@ pub enum Display {
     Grid,
     InlineGrid,
     Table,
+    /// Table interior, but participates in its parent's inline formatting context
+    /// (CSS 2.1 §17.4). Table machinery treats it as `Table` (via `display_of`
+    /// normalization and explicit matches); only the layouter's line grouping sees
+    /// its inline-level nature (the Node carries `InlineBlock`).
+    InlineTable,
     TableCaption,
     TableCell,
     TableFooterGroup,
@@ -161,6 +166,7 @@ impl Value {
                 Display::Grid => "grid",
                 Display::InlineGrid => "inline-grid",
                 Display::Table => "table",
+                Display::InlineTable => "inline-table",
                 Display::TableCaption => "table-caption",
                 Display::TableCell => "table-cell",
                 Display::TableFooterGroup => "table-footer-group",

--- a/crates/gosub_render_pipeline/src/common/document/style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/style.rs
@@ -299,6 +299,11 @@ pub enum StyleProperty {
     ZIndex,
     LetterSpacing,
     MixBlendMode,
+    /// Horizontal component of `border-spacing` (both variants read the same
+    /// declaration; X takes the first length, Y the second, per CSS 2 §17.6.1).
+    BorderSpacingX,
+    /// Vertical component of `border-spacing`.
+    BorderSpacingY,
 }
 
 impl StyleProperty {
@@ -383,6 +388,8 @@ impl StyleProperty {
             StyleProperty::ZIndex => 75,
             StyleProperty::LetterSpacing => 76,
             StyleProperty::MixBlendMode => 77,
+            StyleProperty::BorderSpacingX => 78,
+            StyleProperty::BorderSpacingY => 79,
         }
     }
 
@@ -917,6 +924,18 @@ static PROPERTIES: &[PropertyMeta] = &[
         inherited: false,
         initial_kind: InitialKind::Keyword("normal"),
     },
+    // 78/79 border-spacing - inherited; initial = 0. Two internal longhands share the
+    // one CSS declaration: the value bridge picks the first length for X, second for Y.
+    PropertyMeta {
+        name: "border-spacing",
+        inherited: true,
+        initial_kind: InitialKind::Unit(0.0, Unit::Px),
+    },
+    PropertyMeta {
+        name: "border-spacing",
+        inherited: true,
+        initial_kind: InitialKind::Unit(0.0, Unit::Px),
+    },
 ];
 
 // ── NodeStyle - replaces StylePropertyList ────────────────────────────────────
@@ -1056,6 +1075,8 @@ fn from_id(id: u8) -> Option<StyleProperty> {
         75 => Some(StyleProperty::ZIndex),
         76 => Some(StyleProperty::LetterSpacing),
         77 => Some(StyleProperty::MixBlendMode),
+        78 => Some(StyleProperty::BorderSpacingX),
+        79 => Some(StyleProperty::BorderSpacingY),
         _ => None,
     }
 }

--- a/crates/gosub_render_pipeline/src/common/document/style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/style.rs
@@ -114,14 +114,14 @@ pub enum TextWrap {
     Unset,
 }
 
-// ── Value - replaces StyleValue, ≤8 bytes, zero heap ─────────────────────────
+// ── Value - replaces StyleValue, <=8 bytes, zero heap ─────────────────────────
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Value {
     Unit(f32, Unit),
     /// Each channel 0-255; alpha 255 = fully opaque.
     Color(u8, u8, u8, u8),
-    /// Unitless number (flex-grow, flex-shrink, aspect-ratio, …).
+    /// Unitless number (flex-grow, flex-shrink, aspect-ratio, ...).
     Number(f32),
     Percentage(f32),
     Display(Display),
@@ -129,7 +129,7 @@ pub enum Value {
     TextAlign(TextAlign),
     TextWrap(TextWrap),
     BorderStyle(BorderStyle),
-    /// An interned keyword string (font-family, position, flex-direction, …).
+    /// An interned keyword string (font-family, position, flex-direction, ...).
     Keyword(u32),
 }
 
@@ -1163,7 +1163,7 @@ mod tests {
 
     #[test]
     fn test_id_round_trip() {
-        // Every StyleProperty should round-trip through id → from_id
+        // Every StyleProperty should round-trip through id -> from_id
         let props = [
             StyleProperty::Color,
             StyleProperty::BackgroundColor,

--- a/crates/gosub_render_pipeline/src/common/document/style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/style.rs
@@ -314,6 +314,10 @@ pub enum StyleProperty {
     TableLayout,
     /// `vertical-align` (keyword form; only cell alignment is consumed so far).
     VerticalAlign,
+    /// `border-collapse`: `separate` | `collapse`.
+    BorderCollapse,
+    /// `caption-side`: `top` | `bottom`.
+    CaptionSide,
 }
 
 impl StyleProperty {
@@ -402,6 +406,8 @@ impl StyleProperty {
             StyleProperty::BorderSpacingY => 79,
             StyleProperty::TableLayout => 80,
             StyleProperty::VerticalAlign => 81,
+            StyleProperty::BorderCollapse => 82,
+            StyleProperty::CaptionSide => 83,
         }
     }
 
@@ -961,6 +967,18 @@ static PROPERTIES: &[PropertyMeta] = &[
         inherited: false,
         initial_kind: InitialKind::Keyword("baseline"),
     },
+    // 82 border-collapse
+    PropertyMeta {
+        name: "border-collapse",
+        inherited: true,
+        initial_kind: InitialKind::Keyword("separate"),
+    },
+    // 83 caption-side
+    PropertyMeta {
+        name: "caption-side",
+        inherited: true,
+        initial_kind: InitialKind::Keyword("top"),
+    },
 ];
 
 // ── NodeStyle - replaces StylePropertyList ────────────────────────────────────
@@ -1104,6 +1122,8 @@ fn from_id(id: u8) -> Option<StyleProperty> {
         79 => Some(StyleProperty::BorderSpacingY),
         80 => Some(StyleProperty::TableLayout),
         81 => Some(StyleProperty::VerticalAlign),
+        82 => Some(StyleProperty::BorderCollapse),
+        83 => Some(StyleProperty::CaptionSide),
         _ => None,
     }
 }

--- a/crates/gosub_render_pipeline/src/common/document/style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/style.rs
@@ -65,6 +65,10 @@ pub enum Display {
     TableHeaderGroup,
     TableRow,
     TableRowGroup,
+    /// `<col>` - defines column properties, generates no box of its own.
+    TableColumn,
+    /// `<colgroup>` - groups `<col>` elements, generates no box of its own.
+    TableColumnGroup,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -163,6 +167,8 @@ impl Value {
                 Display::TableHeaderGroup => "table-header-group",
                 Display::TableRow => "table-row",
                 Display::TableRowGroup => "table-row-group",
+                Display::TableColumn => "table-column",
+                Display::TableColumnGroup => "table-column-group",
             }
             .to_string(),
             Value::FontWeight(fw) => match fw {
@@ -304,6 +310,8 @@ pub enum StyleProperty {
     BorderSpacingX,
     /// Vertical component of `border-spacing`.
     BorderSpacingY,
+    /// `table-layout`: `auto` | `fixed`.
+    TableLayout,
 }
 
 impl StyleProperty {
@@ -390,6 +398,7 @@ impl StyleProperty {
             StyleProperty::MixBlendMode => 77,
             StyleProperty::BorderSpacingX => 78,
             StyleProperty::BorderSpacingY => 79,
+            StyleProperty::TableLayout => 80,
         }
     }
 
@@ -936,6 +945,12 @@ static PROPERTIES: &[PropertyMeta] = &[
         inherited: true,
         initial_kind: InitialKind::Unit(0.0, Unit::Px),
     },
+    // 80 table-layout
+    PropertyMeta {
+        name: "table-layout",
+        inherited: false,
+        initial_kind: InitialKind::Keyword("auto"),
+    },
 ];
 
 // ── NodeStyle - replaces StylePropertyList ────────────────────────────────────
@@ -1077,6 +1092,7 @@ fn from_id(id: u8) -> Option<StyleProperty> {
         77 => Some(StyleProperty::MixBlendMode),
         78 => Some(StyleProperty::BorderSpacingX),
         79 => Some(StyleProperty::BorderSpacingY),
+        80 => Some(StyleProperty::TableLayout),
         _ => None,
     }
 }

--- a/crates/gosub_render_pipeline/src/common/document/style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/style.rs
@@ -312,6 +312,8 @@ pub enum StyleProperty {
     BorderSpacingY,
     /// `table-layout`: `auto` | `fixed`.
     TableLayout,
+    /// `vertical-align` (keyword form; only cell alignment is consumed so far).
+    VerticalAlign,
 }
 
 impl StyleProperty {
@@ -399,6 +401,7 @@ impl StyleProperty {
             StyleProperty::BorderSpacingX => 78,
             StyleProperty::BorderSpacingY => 79,
             StyleProperty::TableLayout => 80,
+            StyleProperty::VerticalAlign => 81,
         }
     }
 
@@ -951,6 +954,13 @@ static PROPERTIES: &[PropertyMeta] = &[
         inherited: false,
         initial_kind: InitialKind::Keyword("auto"),
     },
+    // 81 vertical-align - not inherited per CSS; the HTML rendering spec puts
+    // `vertical-align: inherit` on cells, which consumers resolve by walking up.
+    PropertyMeta {
+        name: "vertical-align",
+        inherited: false,
+        initial_kind: InitialKind::Keyword("baseline"),
+    },
 ];
 
 // ── NodeStyle - replaces StylePropertyList ────────────────────────────────────
@@ -1093,6 +1103,7 @@ fn from_id(id: u8) -> Option<StyleProperty> {
         78 => Some(StyleProperty::BorderSpacingX),
         79 => Some(StyleProperty::BorderSpacingY),
         80 => Some(StyleProperty::TableLayout),
+        81 => Some(StyleProperty::VerticalAlign),
         _ => None,
     }
 }

--- a/crates/gosub_render_pipeline/src/common/font.rs
+++ b/crates/gosub_render_pipeline/src/common/font.rs
@@ -19,8 +19,9 @@ pub struct FontInfo {
     pub width: i32,
     /// Font slant (0-1000)
     pub slant: i32,
-    /// Line height in px
-    pub line_height: f64,
+    /// CSS line-height in px. `None` = `normal`: the font system uses the font's natural
+    /// metrics; `Some` line boxes are exactly this tall (half-leading model).
+    pub line_height: Option<f64>,
     /// Extra spacing between characters in px (CSS `letter-spacing`; 0 = `normal`)
     pub letter_spacing: f64,
     pub alignment: FontAlignment,

--- a/crates/gosub_render_pipeline/src/common/media/decoder.rs
+++ b/crates/gosub_render_pipeline/src/common/media/decoder.rs
@@ -282,7 +282,7 @@ mod tests {
 
     #[test]
     fn decodes_png_with_bad_chunk_crc() {
-        // A 1×1 grayscale+alpha PNG whose IDAT chunk carries an incorrect CRC (stored 0x018084a9,
+        // A 1x1 grayscale+alpha PNG whose IDAT chunk carries an incorrect CRC (stored 0x018084a9,
         // correct 0x1fa2b2f0). The strict `image` decoder rejects it; browsers tolerate it, so the
         // RasterDecoder retries with checksum validation disabled. Bytes are the base64 payload of
         // the `data:image/png` edge case on tests.gosub.io/images.html.

--- a/crates/gosub_render_pipeline/src/common/media/decoder/raster.rs
+++ b/crates/gosub_render_pipeline/src/common/media/decoder/raster.rs
@@ -52,7 +52,7 @@ fn decode_png_lenient(bytes: &[u8]) -> anyhow::Result<image::RgbaImage> {
     let mut options = png::DecodeOptions::default();
     options.set_ignore_checksums(true);
     let mut decoder = png::Decoder::new_with_options(std::io::Cursor::new(bytes), options);
-    // EXPAND: palette → RGB, sub-8-bit → 8-bit, and tRNS → alpha channel. STRIP_16: 16-bit → 8-bit.
+    // EXPAND: palette -> RGB, sub-8-bit -> 8-bit, and tRNS -> alpha channel. STRIP_16: 16-bit -> 8-bit.
     decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
 
     let mut reader = decoder.read_info()?;

--- a/crates/gosub_render_pipeline/src/common/media/media_store.rs
+++ b/crates/gosub_render_pipeline/src/common/media/media_store.rs
@@ -199,7 +199,7 @@ impl MediaStore {
         Ok(media_id)
     }
 
-    /// Rasterize an SVG background to a `w`×`h` raster tile and return its media id, so a tiled
+    /// Rasterize an SVG background to a `w`x`h` raster tile and return its media id, so a tiled
     /// `background-image: url(x.svg)` reuses the raster tiling path. Cached per (svg id, w, h) so
     /// it renders once. Returns `None` if the source is not an SVG or the pixmap can't allocate.
     pub fn svg_raster_tile(&self, svg_media_id: MediaId, w: u32, h: u32) -> Option<MediaId> {
@@ -335,7 +335,7 @@ fn decode_data_uri(rest: &str) -> anyhow::Result<(Option<String>, Vec<u8>)> {
             .decode(cleaned.as_bytes())
             .map_err(|e| anyhow::anyhow!("invalid base64 in data URI: {e}"))?
     } else {
-        // Percent-decode a plain (text) payload, e.g. `data:image/svg+xml,<svg …>`.
+        // Percent-decode a plain (text) payload, e.g. `data:image/svg+xml,<svg ...>`.
         percent_decode(data)
     };
 
@@ -363,7 +363,7 @@ fn percent_decode(s: &str) -> Vec<u8> {
     out
 }
 
-/// Rasterize a `usvg` tree to a straight-alpha RGBA [`Image`] of `w`×`h` px (scaling the tree's
+/// Rasterize a `usvg` tree to a straight-alpha RGBA [`Image`] of `w`x`h` px (scaling the tree's
 /// intrinsic size to fit). Returns `None` if the pixmap can't be allocated.
 fn render_svg_tree_to_image(tree: &resvg::usvg::Tree, w: u32, h: u32) -> Option<Image> {
     let size = tree.size();

--- a/crates/gosub_render_pipeline/src/layering/layer.rs
+++ b/crates/gosub_render_pipeline/src/layering/layer.rs
@@ -274,7 +274,9 @@ impl LayerList {
                 let Some(l) = layers.get(id) else { continue };
                 eprintln!("layer {} order={}", id, l.order);
                 for &eid in &l.elements {
-                    let Some(el) = self.layout_tree.get_node_by_id(eid) else { continue };
+                    let Some(el) = self.layout_tree.get_node_by_id(eid) else {
+                        continue;
+                    };
                     let doc = &self.layout_tree.render_tree.doc;
                     let tag = doc.tag_name(el.dom_node_id).unwrap_or_default();
                     let b = el.box_model.border_box;
@@ -318,7 +320,10 @@ impl LayerList {
         // shares the table's DOM node, so style-driven promotion (position/opacity/fixed) would
         // re-promote it into a layer of its own - painting it out of order with respect to its
         // table. It always joins the enclosing layer.
-        if matches!(layout_element.context, crate::layouter::ElementContext::TableBorderOverlay(_)) {
+        if matches!(
+            layout_element.context,
+            crate::layouter::ElementContext::TableBorderOverlay(_)
+        ) {
             self.add_to_layer(layer_id, layout_element.id);
             return;
         }

--- a/crates/gosub_render_pipeline/src/layering/layer.rs
+++ b/crates/gosub_render_pipeline/src/layering/layer.rs
@@ -140,6 +140,13 @@ impl LayerList {
                     log::warn!("Layout element {:?} not found during hit test", element_id);
                     continue;
                 };
+                // The collapsed-border overlay is a paint phase, not content - never a hit target.
+                if matches!(
+                    layout_element.context,
+                    crate::layouter::ElementContext::TableBorderOverlay(_)
+                ) {
+                    continue;
+                }
                 let box_model = &layout_element.box_model;
 
                 // @TODO: use rtree for this

--- a/crates/gosub_render_pipeline/src/layering/layer.rs
+++ b/crates/gosub_render_pipeline/src/layering/layer.rs
@@ -268,6 +268,30 @@ impl LayerList {
         self.layer_ids
             .write()
             .sort_by_key(|id| layers.get(id).map(|l| l.order).unwrap_or(0));
+
+        if std::env::var("LATTICE_DEBUG_LAYERS").is_ok() {
+            for id in self.layer_ids.read().iter() {
+                let Some(l) = layers.get(id) else { continue };
+                eprintln!("layer {} order={}", id, l.order);
+                for &eid in &l.elements {
+                    let Some(el) = self.layout_tree.get_node_by_id(eid) else { continue };
+                    let doc = &self.layout_tree.render_tree.doc;
+                    let tag = doc.tag_name(el.dom_node_id).unwrap_or_default();
+                    let b = el.box_model.border_box;
+                    let ctx = match &el.context {
+                        crate::layouter::ElementContext::None => "none",
+                        crate::layouter::ElementContext::Text(_) => "text",
+                        crate::layouter::ElementContext::Image(_) => "image",
+                        crate::layouter::ElementContext::Svg(_) => "svg",
+                        crate::layouter::ElementContext::TableBorderOverlay(_) => "overlay",
+                    };
+                    eprintln!(
+                        "  el {:?} dom={:?} <{}> ctx={} border_box=({},{} {}x{})",
+                        eid, el.dom_node_id, tag, ctx, b.x, b.y, b.width, b.height
+                    );
+                }
+            }
+        }
     }
 
     /// Walk the layout tree assigning each element to a layer. An element is *promoted* to its own
@@ -289,6 +313,15 @@ impl LayerList {
             return;
         };
         let doc = &self.layout_tree.render_tree.doc;
+
+        // The collapsed-border overlay is a paint phase of its table, not a real element. It
+        // shares the table's DOM node, so style-driven promotion (position/opacity/fixed) would
+        // re-promote it into a layer of its own - painting it out of order with respect to its
+        // table. It always joins the enclosing layer.
+        if matches!(layout_element.context, crate::layouter::ElementContext::TableBorderOverlay(_)) {
+            self.add_to_layer(layer_id, layout_element.id);
+            return;
+        }
 
         // OWN (non-inherited) styles only: descendants inherit the group through the layer and
         // must not each re-promote.
@@ -343,6 +376,20 @@ impl LayerList {
             }
             for &child_id in &layout_element.children {
                 self.traverse(group_layer_id, child_id, true, faded, order);
+            }
+            return;
+        }
+
+        // Positioned elements with `z-index: auto` paint after ALL in-flow content of their
+        // stacking context (CSS 2.1 Appendix E step 8). A fresh layer at the same stacking level
+        // achieves this: the stable sort keeps creation order, so it composites after the
+        // enclosing layer, which holds both earlier and later in-flow siblings. Inside a
+        // promoted group the split would break group compositing, so the subtree stays put.
+        if is_positioned && z_index.is_none() && !in_promoted_group {
+            let positioned_layer_id = self.new_layer(order);
+            self.add_to_layer(positioned_layer_id, layout_element.id);
+            for &child_id in &layout_element.children {
+                self.traverse(positioned_layer_id, child_id, in_promoted_group, group_faded, order);
             }
             return;
         }

--- a/crates/gosub_render_pipeline/src/layering/layer.rs
+++ b/crates/gosub_render_pipeline/src/layering/layer.rs
@@ -385,7 +385,16 @@ impl LayerList {
         // achieves this: the stable sort keeps creation order, so it composites after the
         // enclosing layer, which holds both earlier and later in-flow siblings. Inside a
         // promoted group the split would break group compositing, so the subtree stays put.
-        if is_positioned && z_index.is_none() && !in_promoted_group {
+        //
+        // Inline-tables get the same treatment for a related reason: as atomic inline-level
+        // content they paint in Appendix E step 7, after in-flow block borders (step 4) -
+        // including an enclosing table's collapsed borders (w3c/csswg-drafts#11570). Painting
+        // strictly in DOM order would put a following block sibling's border on top of them.
+        let is_inline_table = matches!(
+            doc.get_own_style(layout_element.dom_node_id, &StyleProperty::Display),
+            Some(Value::Display(crate::common::document::style::Display::InlineTable))
+        );
+        if (is_positioned && z_index.is_none() || is_inline_table) && !in_promoted_group {
             let positioned_layer_id = self.new_layer(order);
             self.add_to_layer(positioned_layer_id, layout_element.id);
             for &child_id in &layout_element.children {

--- a/crates/gosub_render_pipeline/src/layouter.rs
+++ b/crates/gosub_render_pipeline/src/layouter.rs
@@ -152,10 +152,30 @@ pub struct LayoutElementNode {
     pub context: ElementContext,
     /// Resolved CSS `background-image`, loaded into the media store during layout.
     pub background_media: Option<BackgroundMedia>,
-    /// Border edges the painter must skip, `[top, right, bottom, left]`. Set by
-    /// the table layouter for cells that lose a `border-collapse` conflict (the
-    /// adjacent cell paints the shared border instead).
-    pub suppressed_borders: [bool; 4],
+    /// `Some` for cells of a `border-collapse` table: how the painter must
+    /// draw this cell's borders instead of reading the CSS border properties.
+    pub collapsed_borders: Option<CollapsedCellBorders>,
+}
+
+/// Paint instructions for one collapsed table cell's borders, produced by the
+/// table layouter. Collapsed borders are centered on the grid lines and each
+/// cell paints its own half of every boundary, so the rendered table doesn't
+/// depend on the order cells are painted in (a later cell's opaque background
+/// can never cover an earlier cell's border). Edge order everywhere:
+/// `[top, right, bottom, left]`.
+#[derive(Debug, Clone, Copy)]
+pub struct CollapsedCellBorders {
+    /// Width to paint per edge - the cell's layout border, i.e. half the
+    /// resolved boundary width.
+    pub widths: [f32; 4],
+    /// Extra distance the painted edge extends outside the border box. Only
+    /// non-zero on table-perimeter edges, where the other half of the border
+    /// sticks out of the table box (nothing paints over it there).
+    pub outsets: [f32; 4],
+    /// Node whose CSS border color/style paints each edge: `None` for the
+    /// cell's own border, `Some(winner)` when this edge lost its conflict and
+    /// must render in the adjacent winner's style.
+    pub owners: [Option<DomNodeId>; 4],
 }
 
 /// A resolved CSS `background-image` and its media kind. The painter finalizes tile geometry once

--- a/crates/gosub_render_pipeline/src/layouter.rs
+++ b/crates/gosub_render_pipeline/src/layouter.rs
@@ -152,6 +152,10 @@ pub struct LayoutElementNode {
     pub context: ElementContext,
     /// Resolved CSS `background-image`, loaded into the media store during layout.
     pub background_media: Option<BackgroundMedia>,
+    /// Border edges the painter must skip, `[top, right, bottom, left]`. Set by
+    /// the table layouter for cells that lose a `border-collapse` conflict (the
+    /// adjacent cell paints the shared border instead).
+    pub suppressed_borders: [bool; 4],
 }
 
 /// A resolved CSS `background-image` and its media kind. The painter finalizes tile geometry once

--- a/crates/gosub_render_pipeline/src/layouter.rs
+++ b/crates/gosub_render_pipeline/src/layouter.rs
@@ -89,6 +89,11 @@ pub enum ElementContext {
     Text(ElementContextText),
     Image(ElementContextImage),
     Svg(ElementContextSvg),
+    /// Synthetic overlay appended as a collapsed table's LAST child: paints every listed
+    /// cell's collapsed border AFTER the table's content, per the css-tables resolution
+    /// that collapsed borders paint in front of all table descendants
+    /// (w3c/csswg-drafts#11570). Carries the cells (in paint order) whose borders it owns.
+    TableBorderOverlay(Vec<LayoutElementId>),
 }
 
 impl ElementContext {

--- a/crates/gosub_render_pipeline/src/layouter/box_model.rs
+++ b/crates/gosub_render_pipeline/src/layouter/box_model.rs
@@ -9,6 +9,15 @@ pub struct Edges {
     pub left: f64,
 }
 
+impl Edges {
+    pub const ZERO: Self = Self {
+        top: 0.0,
+        right: 0.0,
+        bottom: 0.0,
+        left: 0.0,
+    };
+}
+
 /// The box model of an element.
 #[derive(Clone, Copy)]
 pub struct BoxModel {

--- a/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
+++ b/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
@@ -119,7 +119,9 @@ impl<'a> CssTaffyConverter<'a> {
                 ts.flex_direction = FlexDirection::Row;
             }
             Some(Value::Display(CssDisplay::TableCell)) => {
-                ts.display = Display::Flex;
+                // Block inner layout so child blocks stack vertically; flex_grow
+                // still applies to the cell as an item of its flex-row row.
+                ts.display = Display::Block;
                 ts.flex_grow = 1.0;
             }
             Some(Value::Display(CssDisplay::TableFooterGroup)) => {

--- a/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
+++ b/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
@@ -164,6 +164,21 @@ impl<'a> CssTaffyConverter<'a> {
             _ => {}
         }
 
+        // CSS 2 §10.3.7: an absolutely-positioned box with `width: auto` shrinks to fit but
+        // never beyond its containing block. Taffy sizes such children to raw fit-content
+        // (an abs-positioned wide table would overflow the viewport), so cap the BORDER box
+        // at 100%. Flipping box-sizing is safe here: it only reinterprets non-auto sizes,
+        // and every size except the cap itself is auto in this branch.
+        if ts.position == Position::Absolute
+            && ts.size.width.is_auto()
+            && ts.size.height.is_auto()
+            && ts.max_size.width.is_auto()
+            && ts.min_size.width.is_auto()
+        {
+            ts.box_sizing = BoxSizing::BorderBox;
+            ts.max_size.width = Dimension::percent(1.0);
+        }
+
         ts
     }
 

--- a/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
+++ b/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
@@ -110,7 +110,7 @@ impl<'a> CssTaffyConverter<'a> {
 
         // Adjust display for table and inline elements.
         match self.get_own(&StyleProperty::Display) {
-            Some(Value::Display(CssDisplay::Table)) => {
+            Some(Value::Display(CssDisplay::Table | CssDisplay::InlineTable)) => {
                 ts.display = Display::Flex;
                 ts.flex_direction = FlexDirection::Column;
             }

--- a/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
+++ b/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
@@ -136,6 +136,11 @@ impl<'a> CssTaffyConverter<'a> {
                 ts.display = Display::Flex;
                 ts.flex_direction = FlexDirection::Column;
             }
+            // <col>/<colgroup> generate no boxes; lattice reads their widths
+            // straight from the DOM.
+            Some(Value::Display(CssDisplay::TableColumn | CssDisplay::TableColumnGroup)) => {
+                ts.display = Display::None;
+            }
             Some(Value::Display(CssDisplay::InlineBlock)) => {
                 ts.display = Display::Flex;
                 ts.flex_direction = FlexDirection::Row;

--- a/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
+++ b/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
@@ -558,7 +558,7 @@ fn split_grid_tokens(s: &str) -> Vec<String> {
 }
 
 /// Parse a grid-template-columns/rows value string ("1fr 1fr 1fr", "200px 1fr 100px",
-/// "repeat(3, 1fr)", …).
+/// "repeat(3, 1fr)", ...).
 fn parse_grid_template(s: &str) -> Option<Vec<GridTemplateComponent<String>>> {
     let mut tracks = Vec::new();
     for token in split_grid_tokens(s) {
@@ -591,7 +591,7 @@ fn parse_grid_template(s: &str) -> Option<Vec<GridTemplateComponent<String>>> {
     }
 }
 
-/// Parse a grid-column/row placement value ("auto", "span 2", "1", "2 / 4", …).
+/// Parse a grid-column/row placement value ("auto", "span 2", "1", "2 / 4", ...).
 fn parse_grid_placement(s: &str) -> Option<Line<GridPlacement>> {
     let s = s.trim();
     if s == "auto" {

--- a/crates/gosub_render_pipeline/src/layouter/inline_run.rs
+++ b/crates/gosub_render_pipeline/src/layouter/inline_run.rs
@@ -242,7 +242,7 @@ fn finish_box(entries: Vec<TextEntry>) -> Vec<InlineSegment> {
             });
         }
     }
-    // A trailing `pending_space` is never flushed → trailing whitespace is trimmed.
+    // A trailing `pending_space` is never flushed -> trailing whitespace is trimmed.
     out
 }
 
@@ -388,7 +388,7 @@ mod tests {
 
     #[test]
     fn copyright_case_splits_and_orders_correctly() {
-        // <p>Copyright …, the Gosub community.<br>Spotted an issue? <a>Send a PR on GitHub</a>.</p>
+        // <p>Copyright ..., the Gosub community.<br>Spotted an issue? <a>Send a PR on GitHub</a>.</p>
         let raw = vec![
             RawEntry::Text(te("Copyright 2024\u{2013}2026, the Gosub community.", 1)),
             RawEntry::Break(20.0),

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -91,11 +91,26 @@ impl<'a> PipelineTableTree<'a> {
     /// Convert pending relative positions to absolute `BoxModel`s in the arena.
     /// Must be called after `compute_table_layout` returns.
     pub fn apply_positions(&mut self, table_dom_id: DomNodeId) {
+        // Under border-collapse the grid (incl. the perimeter border halves) starts at
+        // the table's BORDER box origin - the table's own border joined the conflict
+        // inside lattice and no longer insets the content. The box model read here is
+        // still the taffy first-pass one, whose border/padding would inset wrongly.
+        let collapse = matches!(
+            self.doc.get_style(table_dom_id, &StyleProperty::BorderCollapse),
+            Value::Keyword(k) if lookup(k) == "collapse"
+        );
         let table_abs = self
             .dom_to_layout
             .get(&table_dom_id)
             .and_then(|id| self.layout_tree.arena.get(id))
-            .map(|e| Coordinate::new(e.box_model.content_box.x, e.box_model.content_box.y))
+            .map(|e| {
+                let b = if collapse {
+                    e.box_model.border_box
+                } else {
+                    e.box_model.content_box
+                };
+                Coordinate::new(b.x, b.y)
+            })
             .unwrap_or(Coordinate::ZERO);
 
         let pending = std::mem::take(&mut self.pending);
@@ -525,10 +540,20 @@ fn lay_out_one_table(
             // Lattice returns the GRID extents (content box); the table's own border
             // and padding wrap around them to form the border box - without this a
             // `border-bottom: 100px` table collapsed to its (possibly zero) grid.
+            // Under border-collapse the table has no padding and its border joined the
+            // perimeter conflict inside lattice (the resolved halves are part of the
+            // returned extents), so nothing wraps around the grid.
+            let collapse = matches!(
+                doc.get_style(table_dom_id, &StyleProperty::BorderCollapse),
+                Value::Keyword(k) if lookup(k) == "collapse"
+            );
             if let Some(el) = layout_tree.arena.get_mut(&table_layout_id) {
                 let bb = el.box_model.border_box;
-                let border = el.box_model.border;
-                let padding = el.box_model.padding;
+                let (border, padding) = if collapse {
+                    (Edges::ZERO, Edges::ZERO)
+                } else {
+                    (el.box_model.border, el.box_model.padding)
+                };
                 let bw = table_width as f64 + border.left + border.right + padding.left + padding.right;
                 let bh = table_height as f64 + border.top + border.bottom + padding.top + padding.bottom;
                 el.box_model = BoxModel::new(Rect::new(bb.x, bb.y, bw, bh), padding, border, el.box_model.margin);

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -2,7 +2,7 @@ use gosub_lattice::{CellLayout, CssLength, CssProp, TableRole, TableTree};
 
 use crate::common::document::node::{NodeId as DomNodeId, NodeType};
 use crate::common::document::pipeline_doc::PipelineDocument;
-use crate::common::document::style::{Display, StyleProperty, Unit, Value};
+use crate::common::document::style::{lookup, Display, StyleProperty, Unit, Value};
 use crate::common::geo::{Coordinate, Rect};
 use crate::layouter::box_model::{BoxModel, Edges};
 use crate::layouter::taffy::TaffyLayouter;
@@ -221,6 +221,8 @@ impl TableTree for PipelineTableTree<'_> {
             Some(Value::Display(d)) => match d {
                 Display::Table => TableRole::Table,
                 Display::TableCaption => TableRole::Caption,
+                Display::TableColumnGroup => TableRole::ColumnGroup,
+                Display::TableColumn => TableRole::Column,
                 Display::TableRowGroup => TableRole::RowGroup,
                 Display::TableHeaderGroup => TableRole::HeaderGroup,
                 Display::TableFooterGroup => TableRole::FooterGroup,
@@ -252,10 +254,15 @@ impl TableTree for PipelineTableTree<'_> {
             // the cascade down to the UA default (`table { border-spacing: 2px }`).
             CssProp::BorderSpacingX => StyleProperty::BorderSpacingX,
             CssProp::BorderSpacingY => StyleProperty::BorderSpacingY,
-            // Keyword-only properties not wired up yet.
-            CssProp::BorderCollapse | CssProp::TableLayout | CssProp::VerticalAlign | CssProp::CaptionSide => {
-                return CssLength::Auto
+            // Px(1.0) is the lattice sentinel for `table-layout: fixed`.
+            CssProp::TableLayout => {
+                return match self.doc.get_style(id, &StyleProperty::TableLayout) {
+                    Value::Keyword(k) if lookup(k) == "fixed" => CssLength::Px(1.0),
+                    _ => CssLength::Auto,
+                };
             }
+            // Keyword-only properties not wired up yet.
+            CssProp::BorderCollapse | CssProp::VerticalAlign | CssProp::CaptionSide => return CssLength::Auto,
         };
 
         match self.doc.get_style(id, &style_prop) {

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -391,9 +391,16 @@ impl TableTree for PipelineTableTree<'_> {
 
     fn cell_intrinsic_widths(&mut self, id: DomNodeId) -> (f32, f32) {
         let Some(&layout_id) = self.dom_to_layout.get(&id) else {
+            if std::env::var("LATTICE_DEBUG").is_ok() {
+                eprintln!("lattice-dbg: cell {:?} NOT in dom_to_layout", id);
+            }
             return (0.0, 0.0);
         };
-        self.layouter.measure_intrinsic_widths(layout_id).unwrap_or((0.0, 0.0))
+        let w = self.layouter.measure_intrinsic_widths(layout_id).unwrap_or((0.0, 0.0));
+        if std::env::var("LATTICE_DEBUG").is_ok() {
+            eprintln!("lattice-dbg: cell {:?} intrinsics={:?}", id, w);
+        }
+        w
     }
 }
 
@@ -475,18 +482,30 @@ fn lay_out_one_table(
     // tables the parent is a table cell whose box model was already updated
     // by the outer table's apply_positions call, giving us the correct width.
     // Fall back to the table's own Taffy-computed width for root-level tables.
-    let available_width = doc
-        .parent(table_dom_id)
-        .and_then(|p| dom_to_layout.get(&p))
-        .and_then(|&pid| layout_tree.arena.get(&pid))
-        .map(|el| el.box_model.content_box.width as f32)
-        .unwrap_or_else(|| {
-            layout_tree
-                .arena
-                .get(&table_layout_id)
-                .map(|e| e.box_model.content_box.width as f32)
-                .unwrap_or(0.0)
-        });
+    //
+    // An absolutely-positioned table is the exception: its width is constrained by its
+    // insets (`left`/`right`), which taffy has already resolved in the first pass - the
+    // parent's content width would ignore them (CSS 2 §10.3.7).
+    let table_is_abs = matches!(
+        doc.get_own_style(table_dom_id, &StyleProperty::Position),
+        Some(Value::Keyword(id)) if matches!(lookup(id).as_str(), "absolute" | "fixed")
+    );
+    let own_width = || {
+        layout_tree
+            .arena
+            .get(&table_layout_id)
+            .map(|e| e.box_model.content_box.width as f32)
+            .unwrap_or(0.0)
+    };
+    let available_width = if table_is_abs {
+        own_width()
+    } else {
+        doc.parent(table_dom_id)
+            .and_then(|p| dom_to_layout.get(&p))
+            .and_then(|&pid| layout_tree.arena.get(&pid))
+            .map(|el| el.box_model.content_box.width as f32)
+            .unwrap_or_else(own_width)
+    };
 
     let old_box = layout_tree.arena.get(&table_layout_id).map(|e| e.box_model.border_box);
 

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -159,7 +159,18 @@ fn apply_recursive(
                         translate_box_model(&mut element.box_model, offset);
                     }
                 }
-                apply_recursive(doc, child_id, parent_abs, offset, pending, edge_owners, relaid, border_corrected, dom_to_layout, arena);
+                apply_recursive(
+                    doc,
+                    child_id,
+                    parent_abs,
+                    offset,
+                    pending,
+                    edge_owners,
+                    relaid,
+                    border_corrected,
+                    dom_to_layout,
+                    arena,
+                );
             }
             Some(cell_layout) => {
                 let abs = Coordinate::new(
@@ -216,7 +227,18 @@ fn apply_recursive(
                     abs.x - old_abs.x + border_delta.x,
                     abs.y - old_abs.y + valign_shift + border_delta.y,
                 );
-                apply_recursive(doc, child_id, abs, child_offset, pending, edge_owners, relaid, border_corrected, dom_to_layout, arena);
+                apply_recursive(
+                    doc,
+                    child_id,
+                    abs,
+                    child_offset,
+                    pending,
+                    edge_owners,
+                    relaid,
+                    border_corrected,
+                    dom_to_layout,
+                    arena,
+                );
             }
         }
     }
@@ -385,7 +407,9 @@ impl TableTree for PipelineTableTree<'_> {
             .arena
             .get(&layout_id)
             .map(|el| {
-                (el.box_model.border.left + el.box_model.border.right + el.box_model.padding.left
+                (el.box_model.border.left
+                    + el.box_model.border.right
+                    + el.box_model.padding.left
                     + el.box_model.padding.right) as f32
             })
             .unwrap_or(0.0);
@@ -419,9 +443,7 @@ impl TableTree for PipelineTableTree<'_> {
                     "bottom" => return VerticalAlign::Bottom,
                     // CSS 2 §17.5.3: cell values other than top/middle/bottom behave
                     // as baseline.
-                    "baseline" | "text-top" | "text-bottom" | "sub" | "super" => {
-                        return VerticalAlign::Baseline
-                    }
+                    "baseline" | "text-top" | "text-bottom" | "sub" | "super" => return VerticalAlign::Baseline,
                     // "inherit" (or anything unrecognised): keep walking.
                     _ => {}
                 }
@@ -601,7 +623,9 @@ pub fn post_process_tables(layouter: &mut TaffyLayouter, layout_tree: &mut Layou
 fn collect_collapsed_cells(layout_tree: &LayoutTree, id: LayoutElementId, out: &mut Vec<LayoutElementId>) {
     let Some(el) = layout_tree.arena.get(&id) else { return };
     for &child_id in &el.children {
-        let Some(child) = layout_tree.arena.get(&child_id) else { continue };
+        let Some(child) = layout_tree.arena.get(&child_id) else {
+            continue;
+        };
         if child.collapsed_borders.is_some() {
             out.push(child_id);
         }
@@ -765,7 +789,11 @@ fn collect_subtree(layout_tree: &LayoutTree, id: LayoutElementId, out: &mut Hash
     if !out.insert(id) {
         return;
     }
-    let children = layout_tree.arena.get(&id).map(|e| e.children.clone()).unwrap_or_default();
+    let children = layout_tree
+        .arena
+        .get(&id)
+        .map(|e| e.children.clone())
+        .unwrap_or_default();
     for child in children {
         collect_subtree(layout_tree, child, out);
     }

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -56,7 +56,7 @@ impl<'a> PipelineTableTree<'a> {
         self.doc.children(id).iter().any(|&child| {
             matches!(
                 self.doc.get_own_style(child, &StyleProperty::Display),
-                Some(Value::Display(Display::Table))
+                Some(Value::Display(Display::Table | Display::InlineTable))
             ) || self.subtree_contains_table(child)
         })
     }
@@ -75,7 +75,7 @@ impl<'a> PipelineTableTree<'a> {
             };
             let is_table = matches!(
                 self.doc.get_own_style(child.dom_node_id, &StyleProperty::Display),
-                Some(Value::Display(Display::Table))
+                Some(Value::Display(Display::Table | Display::InlineTable))
             );
             if is_table {
                 // Self-contained nested table - stop here, don't double-count its inner tables.
@@ -271,7 +271,7 @@ impl TableTree for PipelineTableTree<'_> {
     fn table_role(&self, id: DomNodeId) -> TableRole {
         match self.doc.get_own_style(id, &StyleProperty::Display) {
             Some(Value::Display(d)) => match d {
-                Display::Table => TableRole::Table,
+                Display::Table | Display::InlineTable => TableRole::Table,
                 Display::TableCaption => TableRole::Caption,
                 Display::TableColumnGroup => TableRole::ColumnGroup,
                 Display::TableColumn => TableRole::Column,
@@ -447,7 +447,7 @@ impl TableTree for PipelineTableTree<'_> {
             }
             if matches!(
                 doc.get_own_style(el.dom_node_id, &StyleProperty::Display),
-                Some(Value::Display(Display::Table))
+                Some(Value::Display(Display::Table | Display::InlineTable))
             ) {
                 return None;
             }
@@ -610,7 +610,7 @@ fn collect_collapsed_cells(layout_tree: &LayoutTree, id: LayoutElementId, out: &
                 .render_tree
                 .doc
                 .get_own_style(child.dom_node_id, &StyleProperty::Display),
-            Some(Value::Display(Display::Table))
+            Some(Value::Display(Display::Table | Display::InlineTable))
         );
         if !child_is_table {
             collect_collapsed_cells(layout_tree, child_id, out);
@@ -780,7 +780,7 @@ fn collect_tables_preorder(
 ) {
     if matches!(
         doc.get_own_style(id, &StyleProperty::Display),
-        Some(Value::Display(Display::Table))
+        Some(Value::Display(Display::Table | Display::InlineTable))
     ) {
         if let Some(&layout_id) = dom_to_layout.get(&id) {
             out.push((id, layout_id));

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -6,7 +6,7 @@ use crate::common::document::style::{lookup, Display, StyleProperty, Unit, Value
 use crate::common::geo::{Coordinate, Rect};
 use crate::layouter::box_model::{BoxModel, Edges};
 use crate::layouter::taffy::TaffyLayouter;
-use crate::layouter::{ElementContext, LayoutElementId, LayoutElementNode, LayoutTree};
+use crate::layouter::{LayoutElementId, LayoutElementNode, LayoutTree};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -203,28 +203,6 @@ fn cell_layout_to_box_model(layout: &CellLayout, abs: Coordinate) -> BoxModel {
     )
 }
 
-/// Returns the intrinsic content width of a layout subtree - the actual measured
-/// width of text/image leaf nodes, not the container's allocated width.
-///
-/// Text leaf nodes carry the Parley-measured line width (e.g. "1." → ~20 px),
-/// which is much narrower than the equal-distributed Taffy cell width.
-/// This lets `compute_column_widths` keep narrow structural columns narrow.
-fn intrinsic_content_width(el: &LayoutElementNode, arena: &HashMap<LayoutElementId, LayoutElementNode>) -> f32 {
-    match &el.context {
-        ElementContext::Text(_) => el.box_model.content_box.width as f32,
-        // Replaced elements: use the laid-out border-box width so the column is wide enough for
-        // the image *including its own CSS border* (the bare `dimension` omits it). Images are
-        // never stretched to the cell width, so the border box is the true intrinsic width.
-        ElementContext::Image(_) | ElementContext::Svg(_) => el.box_model.border_box.width as f32,
-        ElementContext::None => el
-            .children
-            .iter()
-            .filter_map(|&cid| arena.get(&cid))
-            .map(|child| intrinsic_content_width(child, arena))
-            .fold(0.0f32, f32::max),
-    }
-}
-
 impl TableTree for PipelineTableTree<'_> {
     type NodeId = DomNodeId;
 
@@ -373,16 +351,11 @@ impl TableTree for PipelineTableTree<'_> {
         VerticalAlign::Top
     }
 
-    fn cell_content_width(&self, id: DomNodeId) -> f32 {
-        if let Some(&layout_id) = self.dom_to_layout.get(&id) {
-            if let Some(element) = self.layout_tree.arena.get(&layout_id) {
-                // Include the cell's own horizontal padding so the column is wide enough to hold
-                // the content *and* its padding (e.g. HN's logo cell: 20px image + 4px padding-right).
-                let pad = (element.box_model.padding.left + element.box_model.padding.right) as f32;
-                return intrinsic_content_width(element, &self.layout_tree.arena) + pad;
-            }
-        }
-        0.0
+    fn cell_intrinsic_widths(&mut self, id: DomNodeId) -> (f32, f32) {
+        let Some(&layout_id) = self.dom_to_layout.get(&id) else {
+            return (0.0, 0.0);
+        };
+        self.layouter.measure_intrinsic_widths(layout_id).unwrap_or((0.0, 0.0))
     }
 }
 

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -402,6 +402,12 @@ impl TableTree for PipelineTableTree<'_> {
         }
         w
     }
+
+    // Taffy genuinely measures: all-zero intrinsics mean truly empty cells, which
+    // shrink to fit rather than triggering the mock-tree fill-available fallback.
+    fn measures_intrinsics(&self) -> bool {
+        true
+    }
 }
 
 /// Post-process all `display: table` nodes in the layout tree after the
@@ -516,14 +522,16 @@ fn lay_out_one_table(
             tree.apply_positions(table_dom_id);
             // Write back both dimensions so deeply-nested tables can read the
             // correct width from this table's box model via their parent lookup.
+            // Lattice returns the GRID extents (content box); the table's own border
+            // and padding wrap around them to form the border box - without this a
+            // `border-bottom: 100px` table collapsed to its (possibly zero) grid.
             if let Some(el) = layout_tree.arena.get_mut(&table_layout_id) {
                 let bb = el.box_model.border_box;
-                el.box_model = BoxModel::new(
-                    Rect::new(bb.x, bb.y, table_width as f64, table_height as f64),
-                    el.box_model.padding,
-                    el.box_model.border,
-                    el.box_model.margin,
-                );
+                let border = el.box_model.border;
+                let padding = el.box_model.padding;
+                let bw = table_width as f64 + border.left + border.right + padding.left + padding.right;
+                let bh = table_height as f64 + border.top + border.bottom + padding.top + padding.bottom;
+                el.box_model = BoxModel::new(Rect::new(bb.x, bb.y, bw, bh), padding, border, el.box_model.margin);
             }
             // The first taffy pass only approximated the table's height; when
             // lattice's real height differs, the rest of the document flow
@@ -534,7 +542,18 @@ fn lay_out_one_table(
             // geometry around them.
             if !is_nested {
                 if let Some(old) = old_box {
-                    let delta = table_height as f64 - old.height;
+                    let new_h = layout_tree
+                        .arena
+                        .get(&table_layout_id)
+                        .map(|e| e.box_model.border_box.height)
+                        .unwrap_or(table_height as f64);
+                    let delta = new_h - old.height;
+                    if std::env::var("LATTICE_DEBUG").is_ok() {
+                        eprintln!(
+                            "lattice-dbg: shift table {:?} old_h={} new_h={} delta={}",
+                            table_dom_id, old.height, new_h, delta
+                        );
+                    }
                     if delta.abs() > 0.5 {
                         shift_flow_below(layout_tree, table_layout_id, old.y + old.height, delta);
                     }

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -522,6 +522,70 @@ pub fn post_process_tables(layouter: &mut TaffyLayouter, layout_tree: &mut Layou
             );
         }
     }
+
+    // Collapsed borders paint IN FRONT of all table content (css-tables /
+    // w3c/csswg-drafts#11570): append a synthetic overlay element as each collapsed
+    // table's last child. The paint-order DFS then emits the cells' border strips after
+    // the whole subtree, so descendants (negative margins, abs boxes) cannot cover them.
+    for (table_dom_id, table_layout_id) in table_nodes {
+        let collapse = matches!(
+            doc.get_style(table_dom_id, &StyleProperty::BorderCollapse),
+            Value::Keyword(k) if lookup(k) == "collapse"
+        );
+        if !collapse {
+            continue;
+        }
+        let mut cells: Vec<LayoutElementId> = Vec::new();
+        collect_collapsed_cells(layout_tree, table_layout_id, &mut cells);
+        if cells.is_empty() {
+            continue;
+        }
+        let Some(table_el) = layout_tree.arena.get(&table_layout_id) else {
+            continue;
+        };
+        let (bm, render_node_id) = (table_el.box_model, table_el.render_node_id);
+        let overlay_id = layout_tree.next_node_id();
+        layout_tree.arena.insert(
+            overlay_id,
+            LayoutElementNode {
+                id: overlay_id,
+                dom_node_id: table_dom_id,
+                render_node_id,
+                parent: Some(table_layout_id),
+                box_model: bm,
+                children: vec![],
+                context: crate::layouter::ElementContext::TableBorderOverlay(cells),
+                background_media: None,
+                collapsed_borders: None,
+            },
+        );
+        if let Some(table_el) = layout_tree.arena.get_mut(&table_layout_id) {
+            table_el.children.push(overlay_id);
+        }
+    }
+}
+
+/// DFS-collect (in paint order) the layout elements under `id` that carry collapsed
+/// borders. Nested collapsed tables collect their own overlay, so recursion stops at
+/// inner `display: table` boundaries.
+fn collect_collapsed_cells(layout_tree: &LayoutTree, id: LayoutElementId, out: &mut Vec<LayoutElementId>) {
+    let Some(el) = layout_tree.arena.get(&id) else { return };
+    for &child_id in &el.children {
+        let Some(child) = layout_tree.arena.get(&child_id) else { continue };
+        if child.collapsed_borders.is_some() {
+            out.push(child_id);
+        }
+        let child_is_table = matches!(
+            layout_tree
+                .render_tree
+                .doc
+                .get_own_style(child.dom_node_id, &StyleProperty::Display),
+            Some(Value::Display(Display::Table))
+        );
+        if !child_is_table {
+            collect_collapsed_cells(layout_tree, child_id, out);
+        }
+    }
 }
 
 /// Run lattice for a single table node and write the computed cell positions and the table's

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -255,8 +255,22 @@ impl TableTree for PipelineTableTree<'_> {
                     _ => CssLength::Auto,
                 };
             }
-            // Keyword-only properties not wired up yet.
-            CssProp::BorderCollapse | CssProp::VerticalAlign | CssProp::CaptionSide => return CssLength::Auto,
+            // Px(1.0) = `border-collapse: collapse` (inherited, so get_style walks up).
+            CssProp::BorderCollapse => {
+                return match self.doc.get_style(id, &StyleProperty::BorderCollapse) {
+                    Value::Keyword(k) if lookup(k) == "collapse" => CssLength::Px(1.0),
+                    _ => CssLength::Auto,
+                };
+            }
+            // Px(1.0) = `caption-side: bottom`.
+            CssProp::CaptionSide => {
+                return match self.doc.get_style(id, &StyleProperty::CaptionSide) {
+                    Value::Keyword(k) if lookup(k) == "bottom" => CssLength::Px(1.0),
+                    _ => CssLength::Auto,
+                };
+            }
+            // Resolved by the dedicated trait method, not css_length.
+            CssProp::VerticalAlign => return CssLength::Auto,
         };
 
         match self.doc.get_style(id, &style_prop) {

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -1,4 +1,4 @@
-use gosub_lattice::{CellLayout, CssLength, CssProp, TableRole, TableTree};
+use gosub_lattice::{CellLayout, CssLength, CssProp, TableRole, TableTree, VerticalAlign};
 
 use crate::common::document::node::{NodeId as DomNodeId, NodeType};
 use crate::common::document::pipeline_doc::PipelineDocument;
@@ -7,7 +7,7 @@ use crate::common::geo::{Coordinate, Rect};
 use crate::layouter::box_model::{BoxModel, Edges};
 use crate::layouter::taffy::TaffyLayouter;
 use crate::layouter::{ElementContext, LayoutElementId, LayoutElementNode, LayoutTree};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 /// Adapter that bridges `gosub_lattice`'s `TableTree` with the render pipeline's
@@ -21,6 +21,10 @@ pub struct PipelineTableTree<'a> {
     dom_to_layout: &'a HashMap<DomNodeId, LayoutElementId>,
     /// Relative CellLayouts written by `compute_table_layout`.
     pending: HashMap<DomNodeId, CellLayout>,
+    /// Cells whose subtree was re-laid-out via `relayout_cell` this pass. Only
+    /// these get the `content_offset_y` vertical-align shift: their children
+    /// are freshly anchored at the cell top, so the shift applies exactly once.
+    relaid: HashSet<DomNodeId>,
 }
 
 impl<'a> PipelineTableTree<'a> {
@@ -36,6 +40,7 @@ impl<'a> PipelineTableTree<'a> {
             layout_tree,
             dom_to_layout,
             pending: HashMap::new(),
+            relaid: HashSet::new(),
         }
     }
 
@@ -95,20 +100,24 @@ impl<'a> PipelineTableTree<'a> {
             table_abs,
             Coordinate::ZERO,
             &pending,
+            &self.relaid,
             self.dom_to_layout,
             &mut self.layout_tree.arena,
         );
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn apply_recursive(
     doc: &dyn PipelineDocument,
     id: DomNodeId,
     parent_abs: Coordinate,
     // Translation to apply to non-pending children. For nodes inside a
-    // lattice-repositioned cell this is (new_cell_abs - old_cell_abs).
+    // lattice-repositioned cell this is (new_cell_abs - old_cell_abs), plus
+    // the cell's vertical-align shift when its subtree was re-anchored.
     offset: Coordinate,
     pending: &HashMap<DomNodeId, CellLayout>,
+    relaid: &HashSet<DomNodeId>,
     dom_to_layout: &HashMap<DomNodeId, LayoutElementId>,
     arena: &mut HashMap<LayoutElementId, LayoutElementNode>,
 ) {
@@ -122,7 +131,7 @@ fn apply_recursive(
                         translate_box_model(&mut element.box_model, offset);
                     }
                 }
-                apply_recursive(doc, child_id, parent_abs, offset, pending, dom_to_layout, arena);
+                apply_recursive(doc, child_id, parent_abs, offset, pending, relaid, dom_to_layout, arena);
             }
             Some(cell_layout) => {
                 let abs = Coordinate::new(
@@ -141,8 +150,15 @@ fn apply_recursive(
                         element.box_model = cell_layout_to_box_model(cell_layout, abs);
                     }
                 }
-                let child_offset = Coordinate::new(abs.x - old_abs.x, abs.y - old_abs.y);
-                apply_recursive(doc, child_id, abs, child_offset, pending, dom_to_layout, arena);
+                // vertical-align: only cells whose subtree was re-anchored at the
+                // cell top this pass get the shift, so it applies exactly once.
+                let valign_shift = if relaid.contains(&child_id) {
+                    cell_layout.content_offset_y as f64
+                } else {
+                    0.0
+                };
+                let child_offset = Coordinate::new(abs.x - old_abs.x, abs.y - old_abs.y + valign_shift);
+                apply_recursive(doc, child_id, abs, child_offset, pending, relaid, dom_to_layout, arena);
             }
         }
     }
@@ -320,6 +336,7 @@ impl TableTree for PipelineTableTree<'_> {
             .layouter
             .relayout_cell(self.layout_tree, layout_id, available_width + extras)
         {
+            self.relaid.insert(id);
             return content_h;
         }
 
@@ -329,6 +346,31 @@ impl TableTree for PipelineTableTree<'_> {
             .get(&layout_id)
             .map(|el| el.box_model.content_box.height as f32)
             .unwrap_or(0.0)
+    }
+
+    /// Resolves `vertical-align` for a cell by walking up to the table: the
+    /// HTML rendering spec puts `vertical-align: inherit` on cells and
+    /// `middle` on rows/sections, so the browser default falls out of the walk.
+    /// `baseline` (and the inline-only keywords) approximate as Top.
+    fn vertical_align(&self, id: DomNodeId) -> VerticalAlign {
+        let mut cur = Some(id);
+        while let Some(node) = cur {
+            if let Some(Value::Keyword(k)) = self.doc.get_own_style(node, &StyleProperty::VerticalAlign) {
+                match lookup(k).as_str() {
+                    "top" => return VerticalAlign::Top,
+                    "middle" => return VerticalAlign::Middle,
+                    "bottom" => return VerticalAlign::Bottom,
+                    "baseline" | "text-top" | "text-bottom" | "sub" | "super" => return VerticalAlign::Top,
+                    // "inherit" (or anything unrecognised): keep walking.
+                    _ => {}
+                }
+            }
+            if self.table_role(node) == TableRole::Table {
+                break;
+            }
+            cur = self.doc.parent(node);
+        }
+        VerticalAlign::Top
     }
 
     fn cell_content_width(&self, id: DomNodeId) -> f32 {

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -6,7 +6,7 @@ use crate::common::document::style::{lookup, Display, StyleProperty, Unit, Value
 use crate::common::geo::{Coordinate, Rect};
 use crate::layouter::box_model::{BoxModel, Edges};
 use crate::layouter::taffy::TaffyLayouter;
-use crate::layouter::{CollapsedCellBorders, LayoutElementId, LayoutElementNode, LayoutTree};
+use crate::layouter::{CollapsedCellBorders, ElementContext, LayoutElementId, LayoutElementNode, LayoutTree};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -391,7 +391,11 @@ impl TableTree for PipelineTableTree<'_> {
                     "top" => return VerticalAlign::Top,
                     "middle" => return VerticalAlign::Middle,
                     "bottom" => return VerticalAlign::Bottom,
-                    "baseline" | "text-top" | "text-bottom" | "sub" | "super" => return VerticalAlign::Top,
+                    // CSS 2 §17.5.3: cell values other than top/middle/bottom behave
+                    // as baseline.
+                    "baseline" | "text-top" | "text-bottom" | "sub" | "super" => {
+                        return VerticalAlign::Baseline
+                    }
                     // "inherit" (or anything unrecognised): keep walking.
                     _ => {}
                 }
@@ -402,6 +406,39 @@ impl TableTree for PipelineTableTree<'_> {
             cur = self.doc.parent(node);
         }
         VerticalAlign::Top
+    }
+
+    fn cell_baseline(&mut self, id: DomNodeId) -> Option<f32> {
+        let &layout_id = self.dom_to_layout.get(&id)?;
+        let cell_top = self.layout_tree.arena.get(&layout_id)?.box_model.border_box.y;
+
+        // First text element in the cell's subtree, in tree order = the first in-flow
+        // line box (nested tables excluded - their baselines don't propagate here).
+        fn first_text(tree: &LayoutTree, id: LayoutElementId, doc: &dyn PipelineDocument) -> Option<LayoutElementId> {
+            let el = tree.arena.get(&id)?;
+            if matches!(el.context, ElementContext::Text(_)) {
+                return Some(id);
+            }
+            if matches!(
+                doc.get_own_style(el.dom_node_id, &StyleProperty::Display),
+                Some(Value::Display(Display::Table))
+            ) {
+                return None;
+            }
+            for &c in &el.children {
+                if let Some(hit) = first_text(tree, c, doc) {
+                    return Some(hit);
+                }
+            }
+            None
+        }
+        let text_id = first_text(self.layout_tree, layout_id, self.doc)?;
+        let text_el = self.layout_tree.arena.get(&text_id)?;
+        let ElementContext::Text(ref ctx) = text_el.context else {
+            return None;
+        };
+        let ascent = self.layouter.first_line_ascent(&ctx.text, &ctx.font_info)?;
+        Some((text_el.box_model.content_box.y - cell_top) as f32 + ascent)
     }
 
     fn cell_intrinsic_widths(&mut self, id: DomNodeId) -> (f32, f32) {

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -79,7 +79,9 @@ impl<'a> PipelineTableTree<'a> {
             );
             if is_table {
                 // Self-contained nested table - stop here, don't double-count its inner tables.
-                total += child.box_model.border_box.height as f32;
+                // MARGIN box: the table's margins are part of the content extent it occupies
+                // in the cell (negative margins can collapse it out entirely).
+                total += child.box_model.margin_box.height.max(0.0) as f32;
             } else {
                 // The table may be wrapped (e.g. in an anonymous box); keep descending.
                 total += self.nested_table_height(child_id);
@@ -90,7 +92,7 @@ impl<'a> PipelineTableTree<'a> {
 
     /// Convert pending relative positions to absolute `BoxModel`s in the arena.
     /// Must be called after `compute_table_layout` returns.
-    pub fn apply_positions(&mut self, table_dom_id: DomNodeId) {
+    pub fn apply_positions(&mut self, table_dom_id: DomNodeId, border_corrected: &mut HashSet<DomNodeId>) {
         // Under border-collapse the grid (incl. the perimeter border halves) starts at
         // the table's BORDER box origin - the table's own border joined the conflict
         // inside lattice and no longer insets the content. The box model read here is
@@ -122,6 +124,7 @@ impl<'a> PipelineTableTree<'a> {
             &pending,
             &self.edge_owners,
             &self.relaid,
+            border_corrected,
             self.dom_to_layout,
             &mut self.layout_tree.arena,
         );
@@ -140,6 +143,9 @@ fn apply_recursive(
     pending: &HashMap<DomNodeId, CellLayout>,
     edge_owners: &HashMap<DomNodeId, [Option<DomNodeId>; 4]>,
     relaid: &HashSet<DomNodeId>,
+    // Cells whose skipped-relayout subtree already received the raw-vs-collapsed border
+    // shift; the correction is a one-time conversion, not a per-pass translation.
+    border_corrected: &mut HashSet<DomNodeId>,
     dom_to_layout: &HashMap<DomNodeId, LayoutElementId>,
     arena: &mut HashMap<LayoutElementId, LayoutElementNode>,
 ) {
@@ -153,7 +159,7 @@ fn apply_recursive(
                         translate_box_model(&mut element.box_model, offset);
                     }
                 }
-                apply_recursive(doc, child_id, parent_abs, offset, pending, edge_owners, relaid, dom_to_layout, arena);
+                apply_recursive(doc, child_id, parent_abs, offset, pending, edge_owners, relaid, border_corrected, dom_to_layout, arena);
             }
             Some(cell_layout) => {
                 let abs = Coordinate::new(
@@ -189,8 +195,28 @@ fn apply_recursive(
                 } else {
                     0.0
                 };
-                let child_offset = Coordinate::new(abs.x - old_abs.x, abs.y - old_abs.y + valign_shift);
-                apply_recursive(doc, child_id, abs, child_offset, pending, edge_owners, relaid, dom_to_layout, arena);
+                // Skipped-relayout collapsed cells (nested-table guard): their children were
+                // positioned by the FIRST taffy pass with the raw CSS border widths, but the
+                // collapse geometry replaced those with half the resolved boundary. Shift the
+                // subtree by the difference so content sits at the collapsed content origin.
+                let border_delta = if !relaid.contains(&child_id) && border_corrected.insert(child_id) {
+                    let raw_left = doc.get_style_f32(child_id, &StyleProperty::BorderLeftWidth) as f64;
+                    let raw_top = doc.get_style_f32(child_id, &StyleProperty::BorderTopWidth) as f64;
+                    let dl = cell_layout.border.left as f64 - raw_left;
+                    let dt = cell_layout.border.top as f64 - raw_top;
+                    if dl != 0.0 || dt != 0.0 {
+                        Coordinate::new(dl, dt)
+                    } else {
+                        Coordinate::ZERO
+                    }
+                } else {
+                    Coordinate::ZERO
+                };
+                let child_offset = Coordinate::new(
+                    abs.x - old_abs.x + border_delta.x,
+                    abs.y - old_abs.y + valign_shift + border_delta.y,
+                );
+                apply_recursive(doc, child_id, abs, child_offset, pending, edge_owners, relaid, border_corrected, dom_to_layout, arena);
             }
         }
     }
@@ -492,6 +518,9 @@ pub fn post_process_tables(layouter: &mut TaffyLayouter, layout_tree: &mut Layou
     // A nested table's surrounding geometry is owned by its outer table, so
     // only top-level tables push the document flow around when they resize.
     let table_dom_ids: HashSet<DomNodeId> = table_nodes.iter().map(|&(d, _)| d).collect();
+    // One-time raw-vs-collapsed border corrections for skipped-relayout cells,
+    // persistent across both passes (see apply_recursive).
+    let mut border_corrected: HashSet<DomNodeId> = HashSet::new();
     let is_nested = |dom_id: DomNodeId| -> bool {
         let mut cur = doc.parent(dom_id);
         while let Some(p) = cur {
@@ -519,6 +548,7 @@ pub fn post_process_tables(layouter: &mut TaffyLayouter, layout_tree: &mut Layou
                 table_dom_id,
                 table_layout_id,
                 nested.contains(&table_dom_id),
+                &mut border_corrected,
             );
         }
     }
@@ -599,6 +629,7 @@ fn lay_out_one_table(
     table_dom_id: DomNodeId,
     table_layout_id: LayoutElementId,
     is_nested: bool,
+    border_corrected: &mut HashSet<DomNodeId>,
 ) {
     // Use the parent element's content width as available_width. For nested
     // tables the parent is a table cell whose box model was already updated
@@ -635,7 +666,7 @@ fn lay_out_one_table(
 
     match gosub_lattice::compute_table_layout(&mut tree, table_dom_id, available_width, None) {
         Ok((table_width, table_height)) => {
-            tree.apply_positions(table_dom_id);
+            tree.apply_positions(table_dom_id, border_corrected);
             // Write back both dimensions so deeply-nested tables can read the
             // correct width from this table's box model via their parent lookup.
             // Lattice returns the GRID extents (content box); the table's own border

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -5,6 +5,7 @@ use crate::common::document::pipeline_doc::PipelineDocument;
 use crate::common::document::style::{Display, StyleProperty, Unit, Value};
 use crate::common::geo::{Coordinate, Rect};
 use crate::layouter::box_model::{BoxModel, Edges};
+use crate::layouter::taffy::TaffyLayouter;
 use crate::layouter::{ElementContext, LayoutElementId, LayoutElementNode, LayoutTree};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -15,6 +16,7 @@ use std::sync::Arc;
 /// `compute_table_layout` returns.
 pub struct PipelineTableTree<'a> {
     doc: &'a dyn PipelineDocument,
+    layouter: &'a mut TaffyLayouter,
     layout_tree: &'a mut LayoutTree,
     dom_to_layout: &'a HashMap<DomNodeId, LayoutElementId>,
     /// Relative CellLayouts written by `compute_table_layout`.
@@ -24,15 +26,29 @@ pub struct PipelineTableTree<'a> {
 impl<'a> PipelineTableTree<'a> {
     pub fn new(
         doc: &'a dyn PipelineDocument,
+        layouter: &'a mut TaffyLayouter,
         layout_tree: &'a mut LayoutTree,
         dom_to_layout: &'a HashMap<DomNodeId, LayoutElementId>,
     ) -> Self {
         Self {
             doc,
+            layouter,
             layout_tree,
             dom_to_layout,
             pending: HashMap::new(),
         }
+    }
+
+    /// True when the DOM subtree under `id` contains a `display: table` node.
+    /// Such cells keep the first-pass height approximation: re-running taffy on
+    /// them would clobber the box models lattice computed for the inner table.
+    fn subtree_contains_table(&self, id: DomNodeId) -> bool {
+        self.doc.children(id).iter().any(|&child| {
+            matches!(
+                self.doc.get_own_style(child, &StyleProperty::Display),
+                Some(Value::Display(Display::Table))
+            ) || self.subtree_contains_table(child)
+        })
     }
 
     /// Sum of the border-box heights of the nested tables directly contained in a cell (not
@@ -261,21 +277,50 @@ impl TableTree for PipelineTableTree<'_> {
         self.pending.insert(id, layout);
     }
 
-    fn layout_cell(&mut self, id: DomNodeId, _available_width: f32) -> f32 {
-        // Re-use the content height from the Taffy first pass, which correctly
-        // measured text via Parley. This is an approximation - cell content
-        // was measured in a flex context rather than block - but it is far better
-        // than 0 and covers the most common case (single column of text).
-        if let Some(&layout_id) = self.dom_to_layout.get(&id) {
+    fn layout_cell(&mut self, id: DomNodeId, available_width: f32) -> f32 {
+        let Some(&layout_id) = self.dom_to_layout.get(&id) else {
+            return 0.0;
+        };
+
+        // Cells hosting a nested table re-use the first-pass height instead of
+        // re-laying-out: the nested table's real height is only known after
+        // lattice lays it out, and the second (bottom-up) pass in
+        // `post_process_tables` propagates it up here.
+        if self.subtree_contains_table(id) {
             if let Some(element) = self.layout_tree.arena.get(&layout_id) {
                 let taffy_h = element.box_model.content_box.height as f32;
-                // A cell containing a nested table must be at least as tall as that table.
-                // The nested table's real height is only known after lattice lays it out, so
-                // the second (bottom-up) pass in `post_process_tables` propagates it up here.
                 return taffy_h.max(self.nested_table_height(layout_id));
             }
+            return 0.0;
         }
-        0.0
+
+        // Re-run taffy on the cell subtree at the lattice column width so the
+        // content (wrapping, alignment, stacked blocks) is laid out against the
+        // real cell geometry instead of the first pass's equal-share width.
+        // `available_width` is the inner (content) width; taffy sizes the cell's
+        // border box, so add the cell's own border and padding back.
+        let extras = self
+            .layout_tree
+            .arena
+            .get(&layout_id)
+            .map(|el| {
+                (el.box_model.border.left + el.box_model.border.right + el.box_model.padding.left
+                    + el.box_model.padding.right) as f32
+            })
+            .unwrap_or(0.0);
+        if let Some(content_h) = self
+            .layouter
+            .relayout_cell(self.layout_tree, layout_id, available_width + extras)
+        {
+            return content_h;
+        }
+
+        // Fallback: the content height from the taffy first pass.
+        self.layout_tree
+            .arena
+            .get(&layout_id)
+            .map(|el| el.box_model.content_box.height as f32)
+            .unwrap_or(0.0)
     }
 
     fn cell_content_width(&self, id: DomNodeId) -> f32 {
@@ -293,7 +338,11 @@ impl TableTree for PipelineTableTree<'_> {
 
 /// Post-process all `display: table` nodes in the layout tree after the
 /// Taffy first pass. Correct positions are written back via `gosub_lattice`.
-pub fn post_process_tables(layout_tree: &mut LayoutTree, dom_to_layout: &HashMap<DomNodeId, LayoutElementId>) {
+/// Needs the layouter itself (not just the mapping) so cells can be re-laid-out
+/// at their final lattice widths via `relayout_cell`.
+pub fn post_process_tables(layouter: &mut TaffyLayouter, layout_tree: &mut LayoutTree) {
+    // Clone the mapping so `layouter` can be borrowed mutably per table below.
+    let dom_to_layout = layouter.dom_to_layout_mapping().clone();
     // Clone the doc Arc up front so we don't hold a borrow on layout_tree
     // when we later pass it mutably to PipelineTableTree.
     let doc: Arc<dyn PipelineDocument> = Arc::clone(&layout_tree.render_tree.doc);
@@ -304,7 +353,7 @@ pub fn post_process_tables(layout_tree: &mut LayoutTree, dom_to_layout: &HashMap
     // been updated by the outer table's apply_positions call.
     let mut table_nodes: Vec<(DomNodeId, LayoutElementId)> = Vec::new();
     if let Some(root_dom_id) = doc.root() {
-        collect_tables_preorder(&*doc, root_dom_id, dom_to_layout, &mut table_nodes);
+        collect_tables_preorder(&*doc, root_dom_id, &dom_to_layout, &mut table_nodes);
     }
 
     log::info!("lattice: post_process_tables found {} table node(s)", table_nodes.len());
@@ -321,7 +370,7 @@ pub fn post_process_tables(layout_tree: &mut LayoutTree, dom_to_layout: &HashMap
             table_nodes.iter().rev().copied().collect()
         };
         for (table_dom_id, table_layout_id) in order {
-            lay_out_one_table(&*doc, layout_tree, dom_to_layout, table_dom_id, table_layout_id);
+            lay_out_one_table(&*doc, layouter, layout_tree, &dom_to_layout, table_dom_id, table_layout_id);
         }
     }
 }
@@ -330,6 +379,7 @@ pub fn post_process_tables(layout_tree: &mut LayoutTree, dom_to_layout: &HashMap
 /// own size back into the layout tree.
 fn lay_out_one_table(
     doc: &dyn PipelineDocument,
+    layouter: &mut TaffyLayouter,
     layout_tree: &mut LayoutTree,
     dom_to_layout: &HashMap<DomNodeId, LayoutElementId>,
     table_dom_id: DomNodeId,
@@ -352,7 +402,7 @@ fn lay_out_one_table(
                 .unwrap_or(0.0)
         });
 
-    let mut tree = PipelineTableTree::new(doc, layout_tree, dom_to_layout);
+    let mut tree = PipelineTableTree::new(doc, layouter, layout_tree, dom_to_layout);
 
     match gosub_lattice::compute_table_layout(&mut tree, table_dom_id, available_width, None) {
         Ok((table_width, table_height)) => {

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -1,4 +1,4 @@
-use gosub_lattice::{CellLayout, CssLength, CssProp, TableRole, TableTree, VerticalAlign};
+use gosub_lattice::{BoxEdges, CellLayout, CssLength, CssProp, TableRole, TableTree, VerticalAlign};
 
 use crate::common::document::node::{NodeId as DomNodeId, NodeType};
 use crate::common::document::pipeline_doc::PipelineDocument;
@@ -6,7 +6,7 @@ use crate::common::document::style::{lookup, Display, StyleProperty, Unit, Value
 use crate::common::geo::{Coordinate, Rect};
 use crate::layouter::box_model::{BoxModel, Edges};
 use crate::layouter::taffy::TaffyLayouter;
-use crate::layouter::{LayoutElementId, LayoutElementNode, LayoutTree};
+use crate::layouter::{CollapsedCellBorders, LayoutElementId, LayoutElementNode, LayoutTree};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -21,6 +21,10 @@ pub struct PipelineTableTree<'a> {
     dom_to_layout: &'a HashMap<DomNodeId, LayoutElementId>,
     /// Relative CellLayouts written by `compute_table_layout`.
     pending: HashMap<DomNodeId, CellLayout>,
+    /// Per collapsed cell, the node whose CSS border style paints each edge
+    /// (`[top, right, bottom, left]`; `None` = the cell's own border). Only
+    /// populated for cells of `border-collapse` tables.
+    edge_owners: HashMap<DomNodeId, [Option<DomNodeId>; 4]>,
     /// Cells whose subtree was re-laid-out via `relayout_cell` this pass. Only
     /// these get the `content_offset_y` vertical-align shift: their children
     /// are freshly anchored at the cell top, so the shift applies exactly once.
@@ -40,6 +44,7 @@ impl<'a> PipelineTableTree<'a> {
             layout_tree,
             dom_to_layout,
             pending: HashMap::new(),
+            edge_owners: HashMap::new(),
             relaid: HashSet::new(),
         }
     }
@@ -100,6 +105,7 @@ impl<'a> PipelineTableTree<'a> {
             table_abs,
             Coordinate::ZERO,
             &pending,
+            &self.edge_owners,
             &self.relaid,
             self.dom_to_layout,
             &mut self.layout_tree.arena,
@@ -117,6 +123,7 @@ fn apply_recursive(
     // the cell's vertical-align shift when its subtree was re-anchored.
     offset: Coordinate,
     pending: &HashMap<DomNodeId, CellLayout>,
+    edge_owners: &HashMap<DomNodeId, [Option<DomNodeId>; 4]>,
     relaid: &HashSet<DomNodeId>,
     dom_to_layout: &HashMap<DomNodeId, LayoutElementId>,
     arena: &mut HashMap<LayoutElementId, LayoutElementNode>,
@@ -131,7 +138,7 @@ fn apply_recursive(
                         translate_box_model(&mut element.box_model, offset);
                     }
                 }
-                apply_recursive(doc, child_id, parent_abs, offset, pending, relaid, dom_to_layout, arena);
+                apply_recursive(doc, child_id, parent_abs, offset, pending, edge_owners, relaid, dom_to_layout, arena);
             }
             Some(cell_layout) => {
                 let abs = Coordinate::new(
@@ -148,7 +155,16 @@ fn apply_recursive(
                 if let Some(&layout_id) = dom_to_layout.get(&child_id) {
                     if let Some(element) = arena.get_mut(&layout_id) {
                         element.box_model = cell_layout_to_box_model(cell_layout, abs);
-                        element.suppressed_borders = cell_layout.suppressed_borders;
+                        element.collapsed_borders = edge_owners.get(&child_id).map(|&owners| CollapsedCellBorders {
+                            widths: [
+                                cell_layout.border.top,
+                                cell_layout.border.right,
+                                cell_layout.border.bottom,
+                                cell_layout.border.left,
+                            ],
+                            outsets: cell_layout.border_outsets,
+                            owners,
+                        });
                     }
                 }
                 // vertical-align: only cells whose subtree was re-anchored at the
@@ -159,7 +175,7 @@ fn apply_recursive(
                     0.0
                 };
                 let child_offset = Coordinate::new(abs.x - old_abs.x, abs.y - old_abs.y + valign_shift);
-                apply_recursive(doc, child_id, abs, child_offset, pending, relaid, dom_to_layout, arena);
+                apply_recursive(doc, child_id, abs, child_offset, pending, edge_owners, relaid, dom_to_layout, arena);
             }
         }
     }
@@ -294,9 +310,10 @@ impl TableTree for PipelineTableTree<'_> {
         self.pending.insert(id, layout);
     }
 
-    fn suppress_cell_borders(&mut self, id: DomNodeId, edges: [bool; 4]) {
+    fn set_collapsed_cell_borders(&mut self, id: DomNodeId, layout: BoxEdges, edge_owners: [Option<DomNodeId>; 4]) {
+        self.edge_owners.insert(id, edge_owners);
         if let Some(&layout_id) = self.dom_to_layout.get(&id) {
-            self.layouter.zero_cell_borders(layout_id, edges);
+            self.layouter.set_cell_borders(layout_id, layout);
         }
     }
 

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -248,13 +248,14 @@ impl TableTree for PipelineTableTree<'_> {
             CssProp::PaddingRight => StyleProperty::PaddingRight,
             CssProp::PaddingBottom => StyleProperty::PaddingBottom,
             CssProp::PaddingLeft => StyleProperty::PaddingLeft,
-            // Keyword-only properties: map via get_style to get inherited value
-            CssProp::BorderCollapse
-            | CssProp::BorderSpacingX
-            | CssProp::BorderSpacingY
-            | CssProp::TableLayout
-            | CssProp::VerticalAlign
-            | CssProp::CaptionSide => return CssLength::Auto,
+            // border-spacing is inherited, so get_style (below) resolves it through
+            // the cascade down to the UA default (`table { border-spacing: 2px }`).
+            CssProp::BorderSpacingX => StyleProperty::BorderSpacingX,
+            CssProp::BorderSpacingY => StyleProperty::BorderSpacingY,
+            // Keyword-only properties not wired up yet.
+            CssProp::BorderCollapse | CssProp::TableLayout | CssProp::VerticalAlign | CssProp::CaptionSide => {
+                return CssLength::Auto
+            }
         };
 
         match self.doc.get_style(id, &style_prop) {

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -7,6 +7,7 @@ use crate::common::geo::{Coordinate, Rect};
 use crate::layouter::box_model::{BoxModel, Edges};
 use crate::layouter::taffy::TaffyLayouter;
 use crate::layouter::{CollapsedCellBorders, ElementContext, LayoutElementId, LayoutElementNode, LayoutTree};
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -29,6 +30,9 @@ pub struct PipelineTableTree<'a> {
     /// these get the `content_offset_y` vertical-align shift: their children
     /// are freshly anchored at the cell top, so the shift applies exactly once.
     relaid: HashSet<DomNodeId>,
+    /// Memo for `subtree_contains_table`: `layout_cell` asks per cell per pass, and each
+    /// walk re-materializes anonymous wrappers, so uncached it is superlinear in table size.
+    contains_table_cache: RefCell<HashMap<DomNodeId, bool>>,
 }
 
 impl<'a> PipelineTableTree<'a> {
@@ -46,6 +50,7 @@ impl<'a> PipelineTableTree<'a> {
             pending: HashMap::new(),
             edge_owners: HashMap::new(),
             relaid: HashSet::new(),
+            contains_table_cache: RefCell::new(HashMap::new()),
         }
     }
 
@@ -53,12 +58,17 @@ impl<'a> PipelineTableTree<'a> {
     /// Such cells keep the first-pass height approximation: re-running taffy on
     /// them would clobber the box models lattice computed for the inner table.
     fn subtree_contains_table(&self, id: DomNodeId) -> bool {
-        self.doc.children(id).iter().any(|&child| {
+        if let Some(&hit) = self.contains_table_cache.borrow().get(&id) {
+            return hit;
+        }
+        let hit = self.doc.children(id).iter().any(|&child| {
             matches!(
                 self.doc.get_own_style(child, &StyleProperty::Display),
                 Some(Value::Display(Display::Table | Display::InlineTable))
             ) || self.subtree_contains_table(child)
-        })
+        });
+        self.contains_table_cache.borrow_mut().insert(id, hit);
+        hit
     }
 
     /// Sum of the border-box heights of the nested tables directly contained in a cell (not
@@ -210,7 +220,12 @@ fn apply_recursive(
                 // positioned by the FIRST taffy pass with the raw CSS border widths, but the
                 // collapse geometry replaced those with half the resolved boundary. Shift the
                 // subtree by the difference so content sits at the collapsed content origin.
-                let border_delta = if !relaid.contains(&child_id) && border_corrected.insert(child_id) {
+                // Rows are in `pending` too but never collapsed cells; `edge_owners` is the
+                // exact "collapsed cell" predicate.
+                let border_delta = if !relaid.contains(&child_id)
+                    && edge_owners.contains_key(&child_id)
+                    && border_corrected.insert(child_id)
+                {
                     let raw_left = doc.get_style_f32(child_id, &StyleProperty::BorderLeftWidth) as f64;
                     let raw_top = doc.get_style_f32(child_id, &StyleProperty::BorderTopWidth) as f64;
                     let dl = cell_layout.border.left as f64 - raw_left;

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -148,6 +148,7 @@ fn apply_recursive(
                 if let Some(&layout_id) = dom_to_layout.get(&child_id) {
                     if let Some(element) = arena.get_mut(&layout_id) {
                         element.box_model = cell_layout_to_box_model(cell_layout, abs);
+                        element.suppressed_borders = cell_layout.suppressed_borders;
                     }
                 }
                 // vertical-align: only cells whose subtree was re-anchored at the

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -294,6 +294,12 @@ impl TableTree for PipelineTableTree<'_> {
         self.pending.insert(id, layout);
     }
 
+    fn suppress_cell_borders(&mut self, id: DomNodeId, edges: [bool; 4]) {
+        if let Some(&layout_id) = self.dom_to_layout.get(&id) {
+            self.layouter.zero_cell_borders(layout_id, edges);
+        }
+    }
+
     fn layout_cell(&mut self, id: DomNodeId, available_width: f32) -> f32 {
         let Some(&layout_id) = self.dom_to_layout.get(&id) else {
             return 0.0;
@@ -401,6 +407,21 @@ pub fn post_process_tables(layouter: &mut TaffyLayouter, layout_tree: &mut Layou
     // post-order (inner→outer): each table is re-laid-out *after* the tables nested inside its
     // cells, so an outer cell's height now reflects its nested table's true height - height
     // flows bottom-up. A single reverse pass propagates through any table-nesting depth.
+    // A nested table's surrounding geometry is owned by its outer table, so
+    // only top-level tables push the document flow around when they resize.
+    let table_dom_ids: HashSet<DomNodeId> = table_nodes.iter().map(|&(d, _)| d).collect();
+    let is_nested = |dom_id: DomNodeId| -> bool {
+        let mut cur = doc.parent(dom_id);
+        while let Some(p) = cur {
+            if table_dom_ids.contains(&p) {
+                return true;
+            }
+            cur = doc.parent(p);
+        }
+        false
+    };
+    let nested: HashSet<DomNodeId> = table_nodes.iter().map(|&(d, _)| d).filter(|&d| is_nested(d)).collect();
+
     for pass in 0..2 {
         let order: Vec<(DomNodeId, LayoutElementId)> = if pass == 0 {
             table_nodes.clone()
@@ -408,13 +429,22 @@ pub fn post_process_tables(layouter: &mut TaffyLayouter, layout_tree: &mut Layou
             table_nodes.iter().rev().copied().collect()
         };
         for (table_dom_id, table_layout_id) in order {
-            lay_out_one_table(&*doc, layouter, layout_tree, &dom_to_layout, table_dom_id, table_layout_id);
+            lay_out_one_table(
+                &*doc,
+                layouter,
+                layout_tree,
+                &dom_to_layout,
+                table_dom_id,
+                table_layout_id,
+                nested.contains(&table_dom_id),
+            );
         }
     }
 }
 
 /// Run lattice for a single table node and write the computed cell positions and the table's
 /// own size back into the layout tree.
+#[allow(clippy::too_many_arguments)]
 fn lay_out_one_table(
     doc: &dyn PipelineDocument,
     layouter: &mut TaffyLayouter,
@@ -422,6 +452,7 @@ fn lay_out_one_table(
     dom_to_layout: &HashMap<DomNodeId, LayoutElementId>,
     table_dom_id: DomNodeId,
     table_layout_id: LayoutElementId,
+    is_nested: bool,
 ) {
     // Use the parent element's content width as available_width. For nested
     // tables the parent is a table cell whose box model was already updated
@@ -440,6 +471,8 @@ fn lay_out_one_table(
                 .unwrap_or(0.0)
         });
 
+    let old_box = layout_tree.arena.get(&table_layout_id).map(|e| e.box_model.border_box);
+
     let mut tree = PipelineTableTree::new(doc, layouter, layout_tree, dom_to_layout);
 
     match gosub_lattice::compute_table_layout(&mut tree, table_dom_id, available_width, None) {
@@ -456,10 +489,73 @@ fn lay_out_one_table(
                     el.box_model.margin,
                 );
             }
+            // The first taffy pass only approximated the table's height; when
+            // lattice's real height differs, the rest of the document flow
+            // still sits at the old positions. Shift everything below the
+            // table down (or up) by the delta and grow the ancestor chain, so
+            // following siblings and the page height stay correct. Nested
+            // tables skip this - the outer table's own lattice pass owns the
+            // geometry around them.
+            if !is_nested {
+                if let Some(old) = old_box {
+                    let delta = table_height as f64 - old.height;
+                    if delta.abs() > 0.5 {
+                        shift_flow_below(layout_tree, table_layout_id, old.y + old.height, delta);
+                    }
+                }
+            }
         }
         Err(e) => {
             log::warn!("lattice: table layout failed for node {:?}: {:?}", table_dom_id, e);
         }
+    }
+}
+
+/// Translate every layout element that sits below `old_bottom` by `delta` and
+/// grow the resized table's ancestors, approximating the block reflow that the
+/// table's new height would cause. The table's own subtree is exempt (lattice
+/// already positioned it), as are its ancestors (they grow instead of moving).
+fn shift_flow_below(layout_tree: &mut LayoutTree, table_layout_id: LayoutElementId, old_bottom: f64, delta: f64) {
+    let mut exempt: HashSet<LayoutElementId> = HashSet::new();
+    collect_subtree(layout_tree, table_layout_id, &mut exempt);
+
+    let mut ancestors: Vec<LayoutElementId> = Vec::new();
+    let mut cur = layout_tree.arena.get(&table_layout_id).and_then(|e| e.parent);
+    while let Some(id) = cur {
+        ancestors.push(id);
+        cur = layout_tree.arena.get(&id).and_then(|e| e.parent);
+    }
+    exempt.extend(ancestors.iter().copied());
+
+    let ids: Vec<LayoutElementId> = layout_tree.arena.keys().copied().collect();
+    for id in ids {
+        if exempt.contains(&id) {
+            continue;
+        }
+        if let Some(el) = layout_tree.arena.get_mut(&id) {
+            if el.box_model.border_box.y >= old_bottom - 0.5 {
+                translate_box_model(&mut el.box_model, Coordinate::new(0.0, delta));
+            }
+        }
+    }
+
+    for id in ancestors {
+        if let Some(el) = layout_tree.arena.get_mut(&id) {
+            el.box_model.border_box.height += delta;
+            el.box_model.padding_box.height += delta;
+            el.box_model.content_box.height += delta;
+            el.box_model.margin_box.height += delta;
+        }
+    }
+}
+
+fn collect_subtree(layout_tree: &LayoutTree, id: LayoutElementId, out: &mut HashSet<LayoutElementId>) {
+    if !out.insert(id) {
+        return;
+    }
+    let children = layout_tree.arena.get(&id).map(|e| e.children.clone()).unwrap_or_default();
+    for child in children {
+        collect_subtree(layout_tree, child, out);
     }
 }
 

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -532,9 +532,9 @@ pub fn post_process_tables(layouter: &mut TaffyLayouter, layout_tree: &mut Layou
 
     log::info!("lattice: post_process_tables found {} table node(s)", table_nodes.len());
 
-    // Two passes. Pass 1 is pre-order (outer→inner): it establishes column widths, which flow
+    // Two passes. Pass 1 is pre-order (outer->inner): it establishes column widths, which flow
     // top-down (a nested table reads its width from its already-sized parent cell). Pass 2 is
-    // post-order (inner→outer): each table is re-laid-out *after* the tables nested inside its
+    // post-order (inner->outer): each table is re-laid-out *after* the tables nested inside its
     // cells, so an outer cell's height now reflects its nested table's true height - height
     // flows bottom-up. A single reverse pass propagates through any table-nesting depth.
     // A nested table's surrounding geometry is owned by its outer table, so

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -301,6 +301,29 @@ impl TaffyLayouter {
     /// available space; box models in the LayoutTree are untouched (the
     /// subsequent `relayout_cell` at the final width rewrites taffy's internal
     /// layout anyway).
+    /// Ascent of `text`'s first line under `font_info` - the distance from the line-box
+    /// top to the first baseline, as the font system will paint it (half-leading included
+    /// for an explicit line-height). Used for table-cell baseline alignment.
+    pub(super) fn first_line_ascent(&self, text: &str, font_info: &crate::common::font::FontInfo) -> Option<f32> {
+        if text.is_empty() {
+            return None;
+        }
+        let style = gosub_interface::font_system::TextStyle {
+            family: font_info.family.clone(),
+            size: font_info.size as f32,
+            weight: gosub_interface::font_system::FontWeight(font_info.weight.clamp(1, 1000) as u16),
+            style: gosub_interface::font::FontStyle::Normal,
+            stretch: gosub_interface::font_system::FontStretch::NORMAL,
+            line_height: font_info.line_height.map(|v| v as f32),
+            letter_spacing: font_info.letter_spacing as f32,
+            max_width: None,
+            align: gosub_interface::font_system::TextAlign::Start,
+            display_scale: 1.0,
+        };
+        let shaped = self.font_system.lock().shape(text, &style);
+        (shaped.ascent > 0.0).then_some(shaped.ascent)
+    }
+
     pub(super) fn measure_intrinsic_widths(&mut self, cell_layout_id: LayoutElementId) -> Option<(f32, f32)> {
         let &taffy_id = self.layout_taffy_mapping.get(&cell_layout_id)?;
 

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -1175,18 +1175,16 @@ impl TaffyLayouter {
                 };
 
                 let line_height = match doc.get_style(dom_node.node_id, &StyleProperty::LineHeight) {
-                    Value::Unit(value, Unit::Px) => value as f64,
-                    Value::Number(ratio) => font_size * ratio as f64,
-                    // CSS "normal" line-height. We use 1.4 instead of the CSS-spec minimum of
-                    // ~1.2 because pango and parley use different font metrics tables. Parley
-                    // (layout) may return a smaller height than pango (raster), so without this
-                    // buffer the rendered text surface can exceed the span's background
-                    // rectangle, making descenders (e.g. "p") appear to overflow the colored box.
-                    _ => font_size * 1.4,
+                    Value::Unit(value, Unit::Px) => Some(value as f64),
+                    Value::Number(ratio) => Some(font_size * ratio as f64),
+                    // CSS `normal`: no exact height - the font system sizes line boxes from the
+                    // font's natural metrics, which is also what the rasterizer paints.
+                    _ => None,
                 };
 
-                // Calculate vertical offset for centering based on the line height.
-                let text_offset = Coordinate::new(0.0, (line_height - font_size) / 2.0);
+                // Half-leading now lives in the shaped glyph positions (the font system places
+                // baselines inside each line box), so the box itself needs no extra offset.
+                let text_offset = Coordinate::new(0.0, 0.0);
 
                 // Apply CSS white-space: normal - collapse newlines/runs of whitespace to a
                 // single space and strip leading/trailing whitespace.  Raw HTML text nodes
@@ -1384,7 +1382,8 @@ fn measure_node(
                 text_ctx.text.clone(),
                 text_ctx.font_info.family.clone(),
                 (text_ctx.font_info.size as f32).to_bits(),
-                (text_ctx.font_info.line_height as f32).to_bits(),
+                // `normal` (None) hashes as a bit pattern no real px value produces.
+                text_ctx.font_info.line_height.map_or(u32::MAX, |v| (v as f32).to_bits()),
                 text_ctx.font_info.weight,
                 (max_width as f32).to_bits(),
                 (text_ctx.font_info.letter_spacing as f32).to_bits(),

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -1528,7 +1528,7 @@ fn measure_node(
                     // available_width, parley re-measures with slightly less space than
                     // the text requires and wraps. Ceiling ensures allocated width >=
                     // natural text width, preventing spurious wrapping at the boundary.
-                    let mut width = text_layout.width.ceil() as f32;
+                    let width = text_layout.width.ceil() as f32;
 
                     let result = Size {
                         width,

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -327,11 +327,11 @@ impl TaffyLayouter {
         Some((results[0], results[1].max(results[0])))
     }
 
-    /// Zero the given border edges (`[top, right, bottom, left]`) in the cell's
-    /// taffy style. Under `border-collapse`, edges that lost their boundary
-    /// conflict take no layout space - every later measure/re-layout of the
-    /// cell then agrees with lattice's effective borders.
-    pub(super) fn zero_cell_borders(&mut self, cell_layout_id: LayoutElementId, edges: [bool; 4]) {
+    /// Override the cell's border widths in its taffy style with the collapse
+    /// layout borders (half the resolved boundary width per edge) - every
+    /// later measure/re-layout of the cell then agrees with lattice's
+    /// collapse geometry.
+    pub(super) fn set_cell_borders(&mut self, cell_layout_id: LayoutElementId, borders: gosub_lattice::BoxEdges) {
         let Some(&taffy_id) = self.layout_taffy_mapping.get(&cell_layout_id) else {
             return;
         };
@@ -339,20 +339,12 @@ impl TaffyLayouter {
             return;
         };
         let mut style = style.clone();
-        if edges[0] {
-            style.border.top = LengthPercentage::length(0.0);
-        }
-        if edges[1] {
-            style.border.right = LengthPercentage::length(0.0);
-        }
-        if edges[2] {
-            style.border.bottom = LengthPercentage::length(0.0);
-        }
-        if edges[3] {
-            style.border.left = LengthPercentage::length(0.0);
-        }
+        style.border.top = LengthPercentage::length(borders.top);
+        style.border.right = LengthPercentage::length(borders.right);
+        style.border.bottom = LengthPercentage::length(borders.bottom);
+        style.border.left = LengthPercentage::length(borders.left);
         if let Err(e) = self.tree.set_style(taffy_id, style) {
-            log::warn!("lattice: failed to zero collapsed borders for {:?}: {:?}", cell_layout_id, e);
+            log::warn!("lattice: failed to set collapsed borders for {:?}: {:?}", cell_layout_id, e);
         }
     }
 
@@ -690,7 +682,7 @@ impl TaffyLayouter {
             children: vec![],
             context: element_context,
             background_media: None,
-            suppressed_borders: [false; 4],
+            collapsed_borders: None,
         };
         let layout_element_id = element_node.id;
         layout_tree.arena.insert(layout_element_id, element_node);
@@ -754,7 +746,7 @@ impl TaffyLayouter {
             children: vec![],
             context: element_context,
             background_media,
-            suppressed_borders: [false; 4],
+            collapsed_borders: None,
         };
 
         // Children are tracked in both the taffy tree and the element_node's children vec.

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -84,7 +84,7 @@ pub struct TaffyLayouter {
     /// threads (e.g. the rasterizer) can access the font collection between calls. `dyn` so the
     /// same instance can be shared with the rasterizer and swapped for a non-Parley impl.
     font_system: Arc<Mutex<dyn FontSystem>>,
-    /// Taffy calls the measure function 2-4× per node (MinContent, MaxContent, actual width);
+    /// Taffy calls the measure function 2-4x per node (MinContent, MaxContent, actual width);
     /// memoizing eliminates the redundant Parley shaping calls.
     measure_cache: HashMap<MeasureKey, Size<f32>>,
     /// Reverse index used by the table post-processing pass.
@@ -503,7 +503,7 @@ impl TaffyLayouter {
         self.measure_cache.clear();
         self.tree = TaffyTree::new();
         // Taffy's built-in rounding snaps layout values to integer CSS pixels, which causes
-        // text containers to lose sub-pixel width (e.g. 52.344 → 52.0). This makes pango
+        // text containers to lose sub-pixel width (e.g. 52.344 -> 52.0). This makes pango
         // render at a surface too narrow for the text and produces spurious line wraps.
         // Our renderer handles DPR scaling itself via ceil(width) * dpr, so we disable
         // taffy's rounding here.
@@ -666,7 +666,7 @@ impl TaffyLayouter {
             return;
         }
 
-        // Interleave words with single-space tokens: [ ]? w0 [ ] w1 [ ] … [ ]?
+        // Interleave words with single-space tokens: [ ]? w0 [ ] w1 [ ] ... [ ]?
         let mut tokens: Vec<String> = Vec::with_capacity(words.len() * 2 + 1);
         if had_leading {
             tokens.push(" ".to_string());
@@ -992,7 +992,7 @@ impl TaffyLayouter {
         // tile at a box-independent size (its intrinsic size, or an explicit `background-size`
         // length) so it reuses the single raster path for repeat / cover / contain; `compute_bg_tiling`
         // then scales that raster for cover/contain once the box is known. (An SVG intrinsic size is
-        // typically large - e.g. 400×300 - so cover/contain downscale and stay crisp.)
+        // typically large - e.g. 400x300 - so cover/contain downscale and stay crisp.)
         match &*self.media_store.get(media_id, MediaType::Image) {
             Media::Image(mi) => Some(BackgroundMedia::Image {
                 media_id,
@@ -1044,7 +1044,7 @@ impl TaffyLayouter {
 
                     // Non-blocking: an uncached image kicks off a background fetch and returns
                     // Pending without stalling layout. The element is kept with a placeholder size
-                    // (HTML width/height attrs if present, else 0×0); a reflow lands once the fetch
+                    // (HTML width/height attrs if present, else 0x0); a reflow lands once the fetch
                     // completes and installs the real intrinsic size.
                     match self.media_store.request_media(src.as_str()) {
                         MediaRequest::Ready(media_id) => {
@@ -1147,7 +1147,7 @@ impl TaffyLayouter {
                         }
                         MediaRequest::Pending => {
                             // Placeholder size: honour the HTML width/height attributes if present,
-                            // otherwise leave whatever CSS sizing convert() produced (0×0 for a bare
+                            // otherwise leave whatever CSS sizing convert() produced (0x0 for a bare
                             // <img>). The reflow after the fetch completes installs the real size.
                             if let Some(w) = data.get_attribute("width").and_then(|s| parse_px_attr(s)) {
                                 taffy_style.size.width = Dimension::from_length(w);
@@ -1256,7 +1256,7 @@ impl TaffyLayouter {
 
                 // Apply CSS white-space: normal - collapse newlines/runs of whitespace to a
                 // single space and strip leading/trailing whitespace.  Raw HTML text nodes
-                // contain the literal source indentation (e.g. "\n    Red box…\n  ") which
+                // contain the literal source indentation (e.g. "\n    Red box...\n  ") which
                 // pango would render as a blank first line if left untouched.
                 // Whitespace-only source nodes (e.g. "\n  " between </span><span>) collapse
                 // to a single space so they produce an inter-element gap when kept.
@@ -1358,7 +1358,7 @@ impl TaffyLayouter {
 
 // Convert a URI to an absolute URL based on the base URL if this is needed
 fn to_absolute_url(uri: &str, base_uri: &str) -> String {
-    // Already-absolute references (http(s)://, file://, data:, blob:, …) are returned as-is.
+    // Already-absolute references (http(s)://, file://, data:, blob:, ...) are returned as-is.
     if let Ok(parsed) = url::Url::parse(uri) {
         return parsed.to_string();
     }

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -330,7 +330,10 @@ impl TaffyLayouter {
         let font_system = Arc::clone(&self.font_system);
         let mut measure_cache: HashMap<MeasureKey, Size<f32>> = std::mem::take(&mut self.measure_cache);
         let mut results = [0.0_f32; 2];
-        for (i, avail) in [AvailableSpace::MinContent, AvailableSpace::MaxContent].into_iter().enumerate() {
+        for (i, avail) in [AvailableSpace::MinContent, AvailableSpace::MaxContent]
+            .into_iter()
+            .enumerate()
+        {
             let size = Size {
                 width: avail,
                 height: AvailableSpace::MaxContent,
@@ -367,7 +370,11 @@ impl TaffyLayouter {
         style.border.bottom = LengthPercentage::length(borders.bottom);
         style.border.left = LengthPercentage::length(borders.left);
         if let Err(e) = self.tree.set_style(taffy_id, style) {
-            log::warn!("lattice: failed to set collapsed borders for {:?}: {:?}", cell_layout_id, e);
+            log::warn!(
+                "lattice: failed to set collapsed borders for {:?}: {:?}",
+                cell_layout_id,
+                e
+            );
         }
     }
 
@@ -1259,7 +1266,7 @@ impl TaffyLayouter {
                 let mut text: String = if preserve_spaces {
                     // Spaces are significant; substitute NBSP so Pango never elides them at
                     // line-box edges (same advance width as a regular space).
-                    text.replace(' ', "\u{00A0}")
+                    text.cow_replace(' ', "\u{00A0}").into_owned()
                 } else {
                     // Preserve one leading/trailing inter-element gap as NBSP (non-breaking) so
                     // pango does not wrap at the boundary space, while still rendering a visible
@@ -1424,7 +1431,11 @@ fn to_element_context(taffy_context: Option<&TaffyContext>) -> ElementContext {
 /// drops whitespace at line-box edges; a single gap survives BETWEEN inline content).
 /// Ascends through inline ancestors while the text sits at their edge: the space at the
 /// end of `<span>a </span><span>b</span>` separates the SPANS.
-fn text_has_inline_neighbor(doc: &Arc<dyn crate::common::document::pipeline_doc::PipelineDocument>, id: gosub_shared::node::NodeId, forward: bool) -> bool {
+fn text_has_inline_neighbor(
+    doc: &Arc<dyn crate::common::document::pipeline_doc::PipelineDocument>,
+    id: gosub_shared::node::NodeId,
+    forward: bool,
+) -> bool {
     // The same classification the tree build uses, so anonymous inline-tables (marked
     // inline-block on their synthetic Node) keep the whitespace next to them.
     let inline_level = |n: &Node| n.is_inline_element() || n.is_inline_block_element();
@@ -1505,7 +1516,10 @@ fn measure_node(
                 text_ctx.font_info.family.clone(),
                 (text_ctx.font_info.size as f32).to_bits(),
                 // `normal` (None) hashes as a bit pattern no real px value produces.
-                text_ctx.font_info.line_height.map_or(u32::MAX, |v| (v as f32).to_bits()),
+                text_ctx
+                    .font_info
+                    .line_height
+                    .map_or(u32::MAX, |v| (v as f32).to_bits()),
                 text_ctx.font_info.weight,
                 (max_width as f32).to_bits(),
                 (text_ctx.font_info.letter_spacing as f32).to_bits(),

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -623,9 +623,12 @@ impl TaffyLayouter {
             let NodeType::Text(full) = &text_node.node_type else {
                 return;
             };
+            let doc = &layout_tree.render_tree.doc;
             (
-                full.starts_with(|c: char| c.is_ascii_whitespace()),
-                full.ends_with(|c: char| c.is_ascii_whitespace()),
+                full.starts_with(|c: char| c.is_ascii_whitespace())
+                    && text_has_inline_neighbor(doc, text_node.node_id, false),
+                full.ends_with(|c: char| c.is_ascii_whitespace())
+                    && text_has_inline_neighbor(doc, text_node.node_id, true),
                 full.split_whitespace().map(str::to_string).collect::<Vec<_>>(),
             )
         };
@@ -717,7 +720,18 @@ impl TaffyLayouter {
         // Flex and grid containers are formatting contexts where ALL children - inline or block -
         // are direct layout participants. Wrapping inline children in an anonymous flex container
         // would insert an extra level that breaks the parent's `gap`, `align-items`, etc.
-        let parent_is_flex_or_grid = matches!(taffy_style.display, Display::Flex | Display::Grid);
+        // INLINE elements also map to taffy Flex, but their children are inline CONTENT: they
+        // must go through the line-grouping path or inter-element whitespace (which real flex
+        // containers rightly drop) would vanish between nested spans.
+        let is_inline_container = matches!(
+            layout_tree
+                .render_tree
+                .doc
+                .get_own_style(dom_node.node_id, &StyleProperty::Display),
+            None | Some(Value::Display(crate::common::document::style::Display::Inline))
+        ) && matches!(dom_node.node_type, NodeType::Element(_));
+        let parent_is_flex_or_grid =
+            matches!(taffy_style.display, Display::Flex | Display::Grid) && !is_inline_container;
 
         // The context will be moved to the taffy tree, so we need to convert it before that happens.
         let element_context = match taffy_context {
@@ -1195,8 +1209,13 @@ impl TaffyLayouter {
                 let is_whitespace_only = !text.is_empty() && text.chars().all(|c: char| c.is_ascii_whitespace());
                 // Preserve one leading/trailing inter-element gap as NBSP (non-breaking) so
                 // pango does not wrap at the boundary space, while still rendering a visible gap.
-                let had_leading_space = text.starts_with(|c: char| c.is_ascii_whitespace());
-                let had_trailing_space = text.ends_with(|c: char| c.is_ascii_whitespace());
+                // The gap only survives when an inline sibling exists on that side: whitespace at
+                // the very start or end of a block's inline content is removed entirely by CSS
+                // white-space collapsing, so "\n      Row 1..." in a div must not indent the line.
+                let had_leading_space = text.starts_with(|c: char| c.is_ascii_whitespace())
+                    && text_has_inline_neighbor(doc, dom_node.node_id, false);
+                let had_trailing_space = text.ends_with(|c: char| c.is_ascii_whitespace())
+                    && text_has_inline_neighbor(doc, dom_node.node_id, true);
                 let mut text: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
                 if !is_whitespace_only {
                     if had_leading_space && !text.is_empty() {
@@ -1208,13 +1227,10 @@ impl TaffyLayouter {
                 }
                 if is_whitespace_only {
                     // Inter-element whitespace (e.g. between </span><span>). Collapse to a single
-                    // NBSP so the text context is non-empty. We bypass parley measurement entirely
-                    // by setting an explicit taffy width (~0.3em), because parley returns 0 for
-                    // spaces when called with MinContent (max_advance=0), causing the flex item to
-                    // collapse. flex_shrink=0 prevents the space from being squeezed away.
+                    // NBSP so the text context is non-empty and measures at the font's real space
+                    // advance (Pango includes NBSP in the logical extents). flex_shrink=0 prevents
+                    // the gap from being squeezed away when the line is tight.
                     text = "\u{00A0}".to_string();
-                    let space_width = (font_size * 0.3) as f32;
-                    taffy_style.size.width = Dimension::from_length(space_width);
                     taffy_style.flex_shrink = 0.0;
                 }
                 // if inline_element_counter > 0 {
@@ -1349,6 +1365,58 @@ fn to_element_context(taffy_context: Option<&TaffyContext>) -> ElementContext {
     }
 }
 
+/// Does the text node `id` share its line box with an inline-level sibling on the given
+/// side? Decides whether edge whitespace survives collapsing (CSS `white-space: normal`
+/// drops whitespace at line-box edges; a single gap survives BETWEEN inline content).
+/// Ascends through inline ancestors while the text sits at their edge: the space at the
+/// end of `<span>a </span><span>b</span>` separates the SPANS.
+fn text_has_inline_neighbor(doc: &Arc<dyn crate::common::document::pipeline_doc::PipelineDocument>, id: gosub_shared::node::NodeId, forward: bool) -> bool {
+    // The same classification the tree build uses, so anonymous inline-tables (marked
+    // inline-block on their synthetic Node) keep the whitespace next to them.
+    let inline_level = |n: &Node| n.is_inline_element() || n.is_inline_block_element();
+    let mut node = id;
+    loop {
+        let Some(parent) = doc.parent(node) else {
+            return false;
+        };
+        let siblings = doc.children(parent);
+        let Some(pos) = siblings.iter().position(|&s| s == node) else {
+            return false;
+        };
+        let neighbors: Box<dyn Iterator<Item = &gosub_shared::node::NodeId>> = if forward {
+            Box::new(siblings[pos + 1..].iter())
+        } else {
+            Box::new(siblings[..pos].iter().rev())
+        };
+        for &sib in neighbors {
+            let Some(n) = doc.get_node_by_id(sib) else { continue };
+            match &n.node_type {
+                NodeType::Text(t) => {
+                    if t.trim().is_empty() {
+                        continue; // whitespace-only sibling: look further
+                    }
+                    return true;
+                }
+                NodeType::Element(_) => {
+                    // A block-level sibling starts/ends its own line box; only an inline
+                    // one shares it.
+                    return inline_level(&n);
+                }
+                _ => continue, // comments etc.
+            }
+        }
+        // No deciding sibling at this level: an inline parent's own siblings continue the
+        // same line box - keep ascending. A block-level parent ends the line.
+        let parent_inline = doc
+            .get_node_by_id(parent)
+            .is_some_and(|n| matches!(n.node_type, NodeType::Element(_)) && inline_level(&n));
+        if !parent_inline {
+            return false;
+        }
+        node = parent;
+    }
+}
+
 /// Converts a taffy layout to our own BoxModel structure
 /// Measure callback shared by the full first pass and per-cell table re-layout
 /// (`relayout_cell`). Text is shaped through the font system with memoization;
@@ -1407,17 +1475,6 @@ fn measure_node(
                     // the text requires and wraps. Ceiling ensures allocated width >=
                     // natural text width, preventing spurious wrapping at the boundary.
                     let mut width = text_layout.width.ceil() as f32;
-
-                    // Parley strips trailing whitespace (including NBSP) from the line-box
-                    // advance width. When we appended U+00A0 as a trailing-space marker
-                    // for a text node that ended with whitespace, that NBSP is never
-                    // counted by parley, so taffy under-allocates and pango clips it.
-                    // Detect the marker and add the missing space width manually.
-                    // Whitespace-only nodes ("\u{00A0}") have their width fixed explicitly
-                    // in the taffy style, so the measure callback is not invoked for them.
-                    if text_ctx.text.ends_with('\u{00A0}') && text_ctx.text != "\u{00A0}" {
-                        width += (text_ctx.font_info.size * 0.3) as f32;
-                    }
 
                     let result = Size {
                         width,

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -327,6 +327,35 @@ impl TaffyLayouter {
         Some((results[0], results[1].max(results[0])))
     }
 
+    /// Zero the given border edges (`[top, right, bottom, left]`) in the cell's
+    /// taffy style. Under `border-collapse`, edges that lost their boundary
+    /// conflict take no layout space - every later measure/re-layout of the
+    /// cell then agrees with lattice's effective borders.
+    pub(super) fn zero_cell_borders(&mut self, cell_layout_id: LayoutElementId, edges: [bool; 4]) {
+        let Some(&taffy_id) = self.layout_taffy_mapping.get(&cell_layout_id) else {
+            return;
+        };
+        let Ok(style) = self.tree.style(taffy_id) else {
+            return;
+        };
+        let mut style = style.clone();
+        if edges[0] {
+            style.border.top = LengthPercentage::length(0.0);
+        }
+        if edges[1] {
+            style.border.right = LengthPercentage::length(0.0);
+        }
+        if edges[2] {
+            style.border.bottom = LengthPercentage::length(0.0);
+        }
+        if edges[3] {
+            style.border.left = LengthPercentage::length(0.0);
+        }
+        if let Err(e) = self.tree.set_style(taffy_id, style) {
+            log::warn!("lattice: failed to zero collapsed borders for {:?}: {:?}", cell_layout_id, e);
+        }
+    }
+
     /// Re-run taffy layout for a single table-cell subtree at the border-box
     /// width lattice assigned to it, then rewrite the subtree's box models
     /// anchored at the cell's current absolute position (lattice repositions the

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -661,6 +661,7 @@ impl TaffyLayouter {
             children: vec![],
             context: element_context,
             background_media: None,
+            suppressed_borders: [false; 4],
         };
         let layout_element_id = element_node.id;
         layout_tree.arena.insert(layout_element_id, element_node);
@@ -724,6 +725,7 @@ impl TaffyLayouter {
             children: vec![],
             context: element_context,
             background_media,
+            suppressed_borders: [false; 4],
         };
 
         // Children are tracked in both the taffy tree and the element_node's children vec.

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -296,6 +296,37 @@ impl TaffyLayouter {
         &self.dom_to_layout_mapping
     }
 
+    /// Measure a cell subtree's intrinsic border-box widths: `(min_content,
+    /// max_content)`. Runs two taffy computes with MinContent/MaxContent
+    /// available space; box models in the LayoutTree are untouched (the
+    /// subsequent `relayout_cell` at the final width rewrites taffy's internal
+    /// layout anyway).
+    pub(super) fn measure_intrinsic_widths(&mut self, cell_layout_id: LayoutElementId) -> Option<(f32, f32)> {
+        let &taffy_id = self.layout_taffy_mapping.get(&cell_layout_id)?;
+
+        let font_system = Arc::clone(&self.font_system);
+        let mut measure_cache: HashMap<MeasureKey, Size<f32>> = std::mem::take(&mut self.measure_cache);
+        let mut results = [0.0_f32; 2];
+        for (i, avail) in [AvailableSpace::MinContent, AvailableSpace::MaxContent].into_iter().enumerate() {
+            let size = Size {
+                width: avail,
+                height: AvailableSpace::MaxContent,
+            };
+            let computed = self
+                .tree
+                .compute_layout_with_measure(taffy_id, size, |v_kd, v_as, _v_ni, v_nc, _v_s| {
+                    measure_node(&font_system, &mut measure_cache, v_kd, v_as, v_nc)
+                });
+            if computed.is_err() {
+                self.measure_cache = measure_cache;
+                return None;
+            }
+            results[i] = self.tree.layout(taffy_id).map(|l| l.size.width).unwrap_or(0.0);
+        }
+        self.measure_cache = measure_cache;
+        Some((results[0], results[1].max(results[0])))
+    }
+
     /// Re-run taffy layout for a single table-cell subtree at the border-box
     /// width lattice assigned to it, then rewrite the subtree's box models
     /// anchored at the cell's current absolute position (lattice repositions the

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -794,9 +794,18 @@ impl TaffyLayouter {
 
             // In a mixed inline run, split text into per-word inline boxes (see push_text_words).
             // Whitespace-only nodes fall through to the normal NBSP-separator path below.
+            // Preserved text (`white-space: pre`/`pre-wrap`) is never word-split - its spaces
+            // are significant and `pre` forbids wrapping anyway, so it stays one atomic box.
             if has_inline_element_child {
                 if let NodeType::Text(text) = &child_node.node_type {
-                    if !text.trim().is_empty() {
+                    let preserved = matches!(
+                        layout_tree
+                            .render_tree
+                            .doc
+                            .get_style(child_node.node_id, &StyleProperty::WhiteSpace),
+                        Value::Keyword(id) if matches!(lookup(id).as_str(), "pre" | "pre-wrap")
+                    );
+                    if !text.trim().is_empty() && !preserved {
                         self.push_text_words(layout_tree, &child_node, *child_id, &mut current_inline_group);
                         trailing_ws_count = 0;
                         continue;
@@ -853,13 +862,22 @@ impl TaffyLayouter {
                 }
                 let is_ws = if let NodeType::Text(text) = &child_node.node_type {
                     if text.trim().is_empty() {
+                        // Under `white-space: pre`/`pre-wrap` whitespace is content: it is
+                        // never dropped as leading nor stripped as trailing.
+                        let preserved = matches!(
+                            layout_tree
+                                .render_tree
+                                .doc
+                                .get_style(child_node.node_id, &StyleProperty::WhiteSpace),
+                            Value::Keyword(id) if matches!(lookup(id).as_str(), "pre" | "pre-wrap")
+                        );
                         // Drop leading whitespace (before any inline sibling). Keep inter-element
                         // whitespace - it collapses to a single space in extract_taffy_data and
                         // visually separates adjacent inline elements (e.g. between </span><span>).
-                        if current_inline_group.is_empty() {
+                        if current_inline_group.is_empty() && !preserved {
                             continue;
                         }
-                        true
+                        !preserved
                     } else {
                         false
                     }
@@ -1200,32 +1218,48 @@ impl TaffyLayouter {
                 // baselines inside each line box), so the box itself needs no extra offset.
                 let text_offset = Coordinate::new(0.0, 0.0);
 
+                let white_space = match doc.get_style(dom_node.node_id, &StyleProperty::WhiteSpace) {
+                    Value::Keyword(id) => lookup(id),
+                    _ => String::new(),
+                };
+                let preserve_spaces = matches!(white_space.as_str(), "pre" | "pre-wrap");
+
                 // Apply CSS white-space: normal - collapse newlines/runs of whitespace to a
                 // single space and strip leading/trailing whitespace.  Raw HTML text nodes
                 // contain the literal source indentation (e.g. "\n    Red box…\n  ") which
                 // pango would render as a blank first line if left untouched.
                 // Whitespace-only source nodes (e.g. "\n  " between </span><span>) collapse
                 // to a single space so they produce an inter-element gap when kept.
+                // `white-space: pre`/`pre-wrap` skip collapsing: the text keeps its spaces
+                // and newlines verbatim (Pango honors \n as line breaks natively).
                 let is_whitespace_only = !text.is_empty() && text.chars().all(|c: char| c.is_ascii_whitespace());
-                // Preserve one leading/trailing inter-element gap as NBSP (non-breaking) so
-                // pango does not wrap at the boundary space, while still rendering a visible gap.
-                // The gap only survives when an inline sibling exists on that side: whitespace at
-                // the very start or end of a block's inline content is removed entirely by CSS
-                // white-space collapsing, so "\n      Row 1..." in a div must not indent the line.
-                let had_leading_space = text.starts_with(|c: char| c.is_ascii_whitespace())
-                    && text_has_inline_neighbor(doc, dom_node.node_id, false);
-                let had_trailing_space = text.ends_with(|c: char| c.is_ascii_whitespace())
-                    && text_has_inline_neighbor(doc, dom_node.node_id, true);
-                let mut text: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
-                if !is_whitespace_only {
-                    if had_leading_space && !text.is_empty() {
-                        text.insert(0, '\u{00A0}');
+                let mut text: String = if preserve_spaces {
+                    // Spaces are significant; substitute NBSP so Pango never elides them at
+                    // line-box edges (same advance width as a regular space).
+                    text.replace(' ', "\u{00A0}")
+                } else {
+                    // Preserve one leading/trailing inter-element gap as NBSP (non-breaking) so
+                    // pango does not wrap at the boundary space, while still rendering a visible
+                    // gap. The gap only survives when an inline sibling exists on that side:
+                    // whitespace at the very start or end of a block's inline content is removed
+                    // entirely by CSS white-space collapsing, so "\n      Row 1..." in a div must
+                    // not indent the line.
+                    let had_leading_space = text.starts_with(|c: char| c.is_ascii_whitespace())
+                        && text_has_inline_neighbor(doc, dom_node.node_id, false);
+                    let had_trailing_space = text.ends_with(|c: char| c.is_ascii_whitespace())
+                        && text_has_inline_neighbor(doc, dom_node.node_id, true);
+                    let mut collapsed: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
+                    if !is_whitespace_only {
+                        if had_leading_space && !collapsed.is_empty() {
+                            collapsed.insert(0, '\u{00A0}');
+                        }
+                        if had_trailing_space && !collapsed.is_empty() {
+                            collapsed.push('\u{00A0}');
+                        }
                     }
-                    if had_trailing_space && !text.is_empty() {
-                        text.push('\u{00A0}');
-                    }
-                }
-                if is_whitespace_only {
+                    collapsed
+                };
+                if is_whitespace_only && !preserve_spaces {
                     // Inter-element whitespace (e.g. between </span><span>). Collapse to a single
                     // NBSP so the text context is non-empty and measures at the font's real space
                     // advance (Pango includes NBSP in the logical extents). flex_shrink=0 prevents
@@ -1233,15 +1267,12 @@ impl TaffyLayouter {
                     text = "\u{00A0}".to_string();
                     taffy_style.flex_shrink = 0.0;
                 }
-                // if inline_element_counter > 0 {
-                //     // If we are in an inline container, we need to add a space between the text nodes
-                //     text = format!(" {}", text).clone()
-                // }
+                if is_whitespace_only && preserve_spaces {
+                    taffy_style.flex_shrink = 0.0;
+                }
 
-                let no_wrap = matches!(
-                    doc.get_style(dom_node.node_id, &StyleProperty::WhiteSpace),
-                    Value::Keyword(id) if lookup(id) == "nowrap"
-                );
+                // `pre` and `nowrap` both forbid wrapping (`pre-wrap` keeps it).
+                let no_wrap = matches!(white_space.as_str(), "nowrap" | "pre");
                 if no_wrap {
                     taffy_style.flex_shrink = 0.0;
                 }

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -264,86 +264,7 @@ impl CanLayout for TaffyLayouter {
         if let Err(e) = self
             .tree
             .compute_layout_with_measure(self.root_id, size, |v_kd, v_as, _v_ni, v_nc, _v_s| {
-                // If taffy already knows both dimensions, no measurement needed.
-                if let (Some(w), Some(h)) = (v_kd.width, v_kd.height) {
-                    return Size { width: w, height: h };
-                }
-
-                match v_nc {
-                    Some(TaffyContext::Text(text_ctx)) => {
-                        let max_width = if text_ctx.no_wrap {
-                            // white-space: nowrap - measure at unlimited width so text never wraps
-                            1_000_000_000.0_f64
-                        } else {
-                            match v_as.width {
-                                AvailableSpace::Definite(width) => width as f64,
-                                AvailableSpace::MaxContent => 1_000_000_000.0, // f64::MAX doesn't work. Seems some kind of overflow. Same goes for f32::MAX
-                                AvailableSpace::MinContent => 0.0,
-                            }
-                        };
-
-                        let cache_key: MeasureKey = (
-                            text_ctx.text.clone(),
-                            text_ctx.font_info.family.clone(),
-                            (text_ctx.font_info.size as f32).to_bits(),
-                            (text_ctx.font_info.line_height as f32).to_bits(),
-                            text_ctx.font_info.weight,
-                            (max_width as f32).to_bits(),
-                            (text_ctx.font_info.letter_spacing as f32).to_bits(),
-                        );
-                        if let Some(&cached) = measure_cache.get(&cache_key) {
-                            return cached;
-                        }
-
-                        // Measure through the shared font system. The lock is released
-                        // immediately after the call so other callers (e.g. the
-                        // rasterizer) can interleave without contention.
-                        let text_layout = {
-                            let mut fs = font_system.lock();
-                            get_text_layout(text_ctx.text.as_str(), &text_ctx.font_info, max_width, &mut *fs)
-                        };
-                        match text_layout {
-                            Ok(text_layout) => {
-                                // Ceil width to the nearest CSS pixel. Parley returns a fractional
-                                // f64 width; when taffy truncates to f32 and feeds that back as
-                                // available_width, parley re-measures with slightly less space than
-                                // the text requires and wraps. Ceiling ensures allocated width ≥
-                                // natural text width, preventing spurious wrapping at the boundary.
-                                let mut width = text_layout.width.ceil() as f32;
-
-                                // Parley strips trailing whitespace (including NBSP) from the line-box
-                                // advance width. When we appended U+00A0 as a trailing-space marker
-                                // for a text node that ended with whitespace, that NBSP is never
-                                // counted by parley, so taffy under-allocates and pango clips it.
-                                // Detect the marker and add the missing space width manually.
-                                // Whitespace-only nodes ("\u{00A0}") have their width fixed explicitly
-                                // in the taffy style, so the measure callback is not invoked for them.
-                                if text_ctx.text.ends_with('\u{00A0}') && text_ctx.text != "\u{00A0}" {
-                                    width += (text_ctx.font_info.size * 0.3) as f32;
-                                }
-
-                                let result = Size {
-                                    width,
-                                    // Ceil height so the layout height matches the integer-pixel surface
-                                    // that pango creates (prevents descenders from overflowing the box).
-                                    height: text_layout.height.ceil() as f32,
-                                };
-                                measure_cache.insert(cache_key, result);
-                                result
-                            }
-                            Err(_) => Size::ZERO,
-                        }
-                    }
-                    // Replaced elements: honour whichever dimension CSS has constrained and
-                    // derive the other from the intrinsic aspect ratio, so e.g. an
-                    // `height: 30px` logo keeps its shape instead of stretching to its full
-                    // intrinsic width.
-                    Some(TaffyContext::Image(image_ctx)) => measure_replaced(v_kd, image_ctx.dimension),
-                    // SVG-backed <img> elements carry their intrinsic size the same way.
-                    // Without this arm they measured as 0×0 and collapsed (e.g. the HN logo).
-                    Some(TaffyContext::Svg(svg_ctx)) => measure_replaced(v_kd, svg_ctx.dimension),
-                    _ => Size::ZERO,
-                }
+                measure_node(&font_system, &mut measure_cache, v_kd, v_as, v_nc)
             })
         {
             log::error!("Failed to compute taffy layout: {:?}", e);
@@ -358,7 +279,7 @@ impl CanLayout for TaffyLayouter {
         let root_id = layout_tree.root_id;
         let root_width = layout_tree.root_dimension.width;
         self.populate_boxmodel(&mut layout_tree, root_id, Coordinate::ZERO, root_width);
-        post_process_tables(&mut layout_tree, &self.dom_to_layout_mapping);
+        post_process_tables(self, &mut layout_tree);
 
         if let Some(root) = layout_tree.get_node_by_id(root_id) {
             let w = root.box_model.margin_box.width as f32;
@@ -371,6 +292,62 @@ impl CanLayout for TaffyLayouter {
 }
 
 impl TaffyLayouter {
+    pub(super) fn dom_to_layout_mapping(&self) -> &HashMap<DomNodeId, LayoutElementId> {
+        &self.dom_to_layout_mapping
+    }
+
+    /// Re-run taffy layout for a single table-cell subtree at the border-box
+    /// width lattice assigned to it, then rewrite the subtree's box models
+    /// anchored at the cell's current absolute position (lattice repositions the
+    /// cell itself afterwards via `apply_positions`). Returns the cell's
+    /// content-box height at that width, or `None` when the cell is unknown or
+    /// the compute fails.
+    pub(super) fn relayout_cell(
+        &mut self,
+        layout_tree: &mut LayoutTree,
+        cell_layout_id: LayoutElementId,
+        border_box_width: f32,
+    ) -> Option<f32> {
+        let &taffy_id = self.layout_taffy_mapping.get(&cell_layout_id)?;
+        let old_origin = layout_tree
+            .get_node_by_id(cell_layout_id)
+            .map(|el| Coordinate::new(el.box_model.border_box.x, el.box_model.border_box.y))?;
+
+        // Same borrow dance as `layout()`: the closure must not capture `self`
+        // while `self.tree` is mutably borrowed by the compute call.
+        let font_system = Arc::clone(&self.font_system);
+        let mut measure_cache: HashMap<MeasureKey, Size<f32>> = std::mem::take(&mut self.measure_cache);
+        let size = Size {
+            width: AvailableSpace::Definite(border_box_width),
+            height: AvailableSpace::MaxContent,
+        };
+        let result = self
+            .tree
+            .compute_layout_with_measure(taffy_id, size, |v_kd, v_as, _v_ni, v_nc, _v_s| {
+                measure_node(&font_system, &mut measure_cache, v_kd, v_as, v_nc)
+            });
+        self.measure_cache = measure_cache;
+        if let Err(e) = result {
+            log::warn!("lattice: cell re-layout failed for {:?}: {:?}", cell_layout_id, e);
+            return None;
+        }
+
+        // The cell is the computation root, so its taffy location is meaningless
+        // here; cancel it out so the subtree stays anchored at the cell's
+        // current absolute position.
+        let root_location = self
+            .tree
+            .layout(taffy_id)
+            .map(|l| Coordinate::new(l.location.x as f64, l.location.y as f64))
+            .unwrap_or(Coordinate::ZERO);
+        let offset = Coordinate::new(old_origin.x - root_location.x, old_origin.y - root_location.y);
+        self.populate_boxmodel(layout_tree, cell_layout_id, offset, border_box_width as f64);
+
+        layout_tree
+            .get_node_by_id(cell_layout_id)
+            .map(|el| el.box_model.content_box.height as f32)
+    }
+
     fn populate_boxmodel(
         &self,
         layout_tree: &mut LayoutTree,
@@ -1321,6 +1298,98 @@ fn to_element_context(taffy_context: Option<&TaffyContext>) -> ElementContext {
 }
 
 /// Converts a taffy layout to our own BoxModel structure
+/// Measure callback shared by the full first pass and per-cell table re-layout
+/// (`relayout_cell`). Text is shaped through the font system with memoization;
+/// replaced elements resolve against their intrinsic dimensions.
+fn measure_node(
+    font_system: &Arc<Mutex<dyn FontSystem>>,
+    measure_cache: &mut HashMap<MeasureKey, Size<f32>>,
+    known_dimensions: Size<Option<f32>>,
+    available_space: Size<AvailableSpace>,
+    node_context: Option<&mut TaffyContext>,
+) -> Size<f32> {
+    // If taffy already knows both dimensions, no measurement needed.
+    if let (Some(w), Some(h)) = (known_dimensions.width, known_dimensions.height) {
+        return Size { width: w, height: h };
+    }
+
+    match node_context {
+        Some(TaffyContext::Text(text_ctx)) => {
+            let max_width = if text_ctx.no_wrap {
+                // white-space: nowrap - measure at unlimited width so text never wraps
+                1_000_000_000.0_f64
+            } else {
+                match available_space.width {
+                    AvailableSpace::Definite(width) => width as f64,
+                    AvailableSpace::MaxContent => 1_000_000_000.0, // f64::MAX doesn't work. Seems some kind of overflow. Same goes for f32::MAX
+                    AvailableSpace::MinContent => 0.0,
+                }
+            };
+
+            let cache_key: MeasureKey = (
+                text_ctx.text.clone(),
+                text_ctx.font_info.family.clone(),
+                (text_ctx.font_info.size as f32).to_bits(),
+                (text_ctx.font_info.line_height as f32).to_bits(),
+                text_ctx.font_info.weight,
+                (max_width as f32).to_bits(),
+                (text_ctx.font_info.letter_spacing as f32).to_bits(),
+            );
+            if let Some(&cached) = measure_cache.get(&cache_key) {
+                return cached;
+            }
+
+            // Measure through the shared font system. The lock is released
+            // immediately after the call so other callers (e.g. the
+            // rasterizer) can interleave without contention.
+            let text_layout = {
+                let mut fs = font_system.lock();
+                get_text_layout(text_ctx.text.as_str(), &text_ctx.font_info, max_width, &mut *fs)
+            };
+            match text_layout {
+                Ok(text_layout) => {
+                    // Ceil width to the nearest CSS pixel. Parley returns a fractional
+                    // f64 width; when taffy truncates to f32 and feeds that back as
+                    // available_width, parley re-measures with slightly less space than
+                    // the text requires and wraps. Ceiling ensures allocated width >=
+                    // natural text width, preventing spurious wrapping at the boundary.
+                    let mut width = text_layout.width.ceil() as f32;
+
+                    // Parley strips trailing whitespace (including NBSP) from the line-box
+                    // advance width. When we appended U+00A0 as a trailing-space marker
+                    // for a text node that ended with whitespace, that NBSP is never
+                    // counted by parley, so taffy under-allocates and pango clips it.
+                    // Detect the marker and add the missing space width manually.
+                    // Whitespace-only nodes ("\u{00A0}") have their width fixed explicitly
+                    // in the taffy style, so the measure callback is not invoked for them.
+                    if text_ctx.text.ends_with('\u{00A0}') && text_ctx.text != "\u{00A0}" {
+                        width += (text_ctx.font_info.size * 0.3) as f32;
+                    }
+
+                    let result = Size {
+                        width,
+                        // Ceil height so the layout height matches the integer-pixel surface
+                        // that pango creates (prevents descenders from overflowing the box).
+                        height: text_layout.height.ceil() as f32,
+                    };
+                    measure_cache.insert(cache_key, result);
+                    result
+                }
+                Err(_) => Size::ZERO,
+            }
+        }
+        // Replaced elements: honour whichever dimension CSS has constrained and
+        // derive the other from the intrinsic aspect ratio, so e.g. an
+        // `height: 30px` logo keeps its shape instead of stretching to its full
+        // intrinsic width.
+        Some(TaffyContext::Image(image_ctx)) => measure_replaced(known_dimensions, image_ctx.dimension),
+        // SVG-backed <img> elements carry their intrinsic size the same way.
+        // Without this arm they measured as 0x0 and collapsed (e.g. the HN logo).
+        Some(TaffyContext::Svg(svg_ctx)) => measure_replaced(known_dimensions, svg_ctx.dimension),
+        _ => Size::ZERO,
+    }
+}
+
 pub fn taffy_layout_to_boxmodel(layout: &Layout, offset: Coordinate) -> box_model::BoxModel {
     box_model::BoxModel::new(
         // Border box

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -1264,9 +1264,14 @@ impl TaffyLayouter {
                 // and newlines verbatim (Pango honors \n as line breaks natively).
                 let is_whitespace_only = !text.is_empty() && text.chars().all(|c: char| c.is_ascii_whitespace());
                 let mut text: String = if preserve_spaces {
-                    // Spaces are significant; substitute NBSP so Pango never elides them at
-                    // line-box edges (same advance width as a regular space).
-                    text.cow_replace(' ', "\u{00A0}").into_owned()
+                    // Spaces are significant; under `pre` substitute NBSP so Pango never elides
+                    // them at line-box edges (same advance width). `pre-wrap` keeps real spaces:
+                    // they must stay line-break opportunities.
+                    if white_space == "pre" {
+                        text.cow_replace(' ', "\u{00A0}").into_owned()
+                    } else {
+                        text.to_string()
+                    }
                 } else {
                     // Preserve one leading/trailing inter-element gap as NBSP (non-breaking) so
                     // pango does not wrap at the boundary space, while still rendering a visible

--- a/crates/gosub_render_pipeline/src/layouter/text.rs
+++ b/crates/gosub_render_pipeline/src/layouter/text.rs
@@ -17,7 +17,7 @@ pub fn get_text_layout(
         weight: FontWeight(font_info.weight.clamp(1, 1000) as u16),
         style: FontStyle::Normal,
         stretch: FontStretch::NORMAL,
-        line_height: Some(font_info.line_height as f32),
+        line_height: font_info.line_height.map(|v| v as f32),
         letter_spacing: font_info.letter_spacing as f32,
         max_width: Some(max_width as f32),
         // Alignment shifts lines within max_width but never changes the bounding box, so

--- a/crates/gosub_render_pipeline/src/painter.rs
+++ b/crates/gosub_render_pipeline/src/painter.rs
@@ -334,7 +334,7 @@ impl Painter {
     ) -> Vec<PaintCommand> {
         let doc = &self.layer_list.layout_tree.render_tree.doc;
         let color = match doc.get_own_style(dom_node_id, &StyleProperty::Display) {
-            Some(Value::Display(Display::Table)) => Color::from_rgb8(255, 0, 0),
+            Some(Value::Display(Display::Table | Display::InlineTable)) => Color::from_rgb8(255, 0, 0),
             Some(Value::Display(Display::TableCell)) => Color::from_rgb8(0, 180, 0),
             Some(Value::Display(Display::TableRow)) => Color::from_rgb8(0, 0, 255),
             Some(Value::Display(Display::TableRowGroup))
@@ -588,7 +588,7 @@ impl Painter {
             let owner_is_table = |owner: NodeId| {
                 matches!(
                     doc.get_own_style(owner, &StyleProperty::Display),
-                    Some(Value::Display(Display::Table))
+                    Some(Value::Display(Display::Table | Display::InlineTable))
                 )
             };
 
@@ -639,7 +639,7 @@ impl Painter {
         // table's own CSS border as well would double-draw the losing style on top.
         if matches!(
             doc.get_own_style(dom_node_id, &StyleProperty::Display),
-            Some(Value::Display(Display::Table))
+            Some(Value::Display(Display::Table | Display::InlineTable))
         ) && matches!(
             doc.get_style(dom_node_id, &StyleProperty::BorderCollapse),
             Value::Keyword(k) if lookup(k) == "collapse"

--- a/crates/gosub_render_pipeline/src/painter.rs
+++ b/crates/gosub_render_pipeline/src/painter.rs
@@ -59,7 +59,7 @@ fn paint_text_style(font_info: &FontInfo, rect_width: f64, available_width: f64)
             FontStyle::Normal
         },
         stretch: FontStretch::NORMAL,
-        line_height: Some(font_info.line_height as f32),
+        line_height: font_info.line_height.map(|v| v as f32),
         letter_spacing: font_info.letter_spacing as f32,
         max_width: Some(max_width),
         align,
@@ -273,7 +273,7 @@ impl Painter {
             weight: 400,
             width: 100,
             slant: 0,
-            line_height: size * 1.4,
+            line_height: None,
             letter_spacing: 0.0,
             alignment: FontAlignment::Start,
             underline: false,

--- a/crates/gosub_render_pipeline/src/painter.rs
+++ b/crates/gosub_render_pipeline/src/painter.rs
@@ -379,7 +379,12 @@ impl Painter {
                 let r = Rectangle::new(border_box)
                     .with_background(brush)
                     .with_blend_mode(self.mix_blend_mode(dom_node_id));
-                let r = self.decorate_with_border_and_radius(dom_node_id, None, r);
+                // Collapsed cells get their border from the TableBorderOverlay.
+                let r = if layout_element.collapsed_borders.is_some() {
+                    r
+                } else {
+                    self.decorate_with_border_and_radius(dom_node_id, None, r)
+                };
                 vec![PaintCommand::rectangle(r)]
             }
             BackgroundMedia::Svg(media_id) => vec![PaintCommand::svg(media_id, Rectangle::new(border_box))],

--- a/crates/gosub_render_pipeline/src/painter.rs
+++ b/crates/gosub_render_pipeline/src/painter.rs
@@ -436,9 +436,11 @@ impl Painter {
                     let bg_r = Rectangle::new(border_box)
                         .with_background(bg_brush)
                         .with_blend_mode(blend);
-                    commands.push(PaintCommand::rectangle(
-                        self.decorate_with_border_and_radius(dom_node_id, None, bg_r),
-                    ));
+                    commands.push(PaintCommand::rectangle(self.decorate_with_border_and_radius(
+                        dom_node_id,
+                        None,
+                        bg_r,
+                    )));
                 }
 
                 let brush = Brush::image(image_ctx.media_id);

--- a/crates/gosub_render_pipeline/src/painter.rs
+++ b/crates/gosub_render_pipeline/src/painter.rs
@@ -550,7 +550,10 @@ impl Painter {
                 StyleProperty::BorderLeftStyle,
             ];
             // A lost edge renders the winning neighbour's FACING edge: our top
-            // is its bottom, our right is its left, and vice versa.
+            // is its bottom, our right is its left, and vice versa. When the winner
+            // is the TABLE itself (a perimeter boundary the table's border won),
+            // the same side applies - the table's left border faces the same way
+            // as the cell's left border.
             let facing_color = [
                 StyleProperty::BorderBottomColor,
                 StyleProperty::BorderLeftColor,
@@ -563,12 +566,22 @@ impl Painter {
                 StyleProperty::BorderTopStyle,
                 StyleProperty::BorderRightStyle,
             ];
+            let owner_is_table = |owner: NodeId| {
+                matches!(
+                    doc.get_own_style(owner, &StyleProperty::Display),
+                    Some(Value::Display(Display::Table))
+                )
+            };
             let brushes: [Brush; 4] = std::array::from_fn(|e| match cb.owners[e] {
+                Some(owner) if owner_is_table(owner) => {
+                    self.get_brush(owner, &own_color[e], Brush::solid(Color::BLACK))
+                }
                 Some(owner) => self.get_brush(owner, &facing_color[e], Brush::solid(Color::BLACK)),
                 None => self.get_brush(dom_node_id, &own_color[e], Brush::solid(Color::BLACK)),
             });
             let styles: [BorderStyle; 4] = std::array::from_fn(|e| {
                 let (node, prop) = match cb.owners[e] {
+                    Some(owner) if owner_is_table(owner) => (owner, &own_style[e]),
                     Some(owner) => (owner, &facing_style[e]),
                     None => (dom_node_id, &own_style[e]),
                 };
@@ -599,6 +612,19 @@ impl Painter {
             return r
                 .with_rect(Rect::new(left, top, right - left, bottom - top))
                 .with_border(Border::new_per_side(widths, styles, brushes));
+        }
+
+        // A collapsed table's boundary is painted entirely by its perimeter cells
+        // (their halves + outsets, in whatever style won the conflict); painting the
+        // table's own CSS border as well would double-draw the losing style on top.
+        if matches!(
+            doc.get_own_style(dom_node_id, &StyleProperty::Display),
+            Some(Value::Display(Display::Table))
+        ) && matches!(
+            doc.get_style(dom_node_id, &StyleProperty::BorderCollapse),
+            Value::Keyword(k) if lookup(k) == "collapse"
+        ) {
+            return r;
         }
 
         let border_top_width = doc.get_style_f32(dom_node_id, &StyleProperty::BorderTopWidth);

--- a/crates/gosub_render_pipeline/src/painter.rs
+++ b/crates/gosub_render_pipeline/src/painter.rs
@@ -379,7 +379,7 @@ impl Painter {
                 let r = Rectangle::new(border_box)
                     .with_background(brush)
                     .with_blend_mode(self.mix_blend_mode(dom_node_id));
-                let r = self.decorate_with_border_and_radius(dom_node_id, layout_element.collapsed_borders.as_ref(), r);
+                let r = self.decorate_with_border_and_radius(dom_node_id, None, r);
                 vec![PaintCommand::rectangle(r)]
             }
             BackgroundMedia::Svg(media_id) => vec![PaintCommand::svg(media_id, Rectangle::new(border_box))],
@@ -421,7 +421,7 @@ impl Painter {
                 // separate border-only rectangle painted on top of the icon (e.g. the HN logo's
                 // `border:1px white solid`).
                 if self.has_border(dom_node_id) {
-                    let r = self.decorate_with_border_and_radius(dom_node_id, layout_element.collapsed_borders.as_ref(), Rectangle::new(border_box));
+                    let r = self.decorate_with_border_and_radius(dom_node_id, None, Rectangle::new(border_box));
                     commands.push(PaintCommand::rectangle(r));
                 }
             }
@@ -437,7 +437,7 @@ impl Painter {
                         .with_background(bg_brush)
                         .with_blend_mode(blend);
                     commands.push(PaintCommand::rectangle(
-                        self.decorate_with_border_and_radius(dom_node_id, layout_element.collapsed_borders.as_ref(), bg_r),
+                        self.decorate_with_border_and_radius(dom_node_id, None, bg_r),
                     ));
                 }
 
@@ -454,7 +454,7 @@ impl Painter {
                 let r = Rectangle::new(draw_box).with_background(brush).with_blend_mode(blend);
                 // The border/radius belongs to the element box, not the shrunk icon rect.
                 let border_target = if image_ctx.placeholder { border_box } else { draw_box };
-                let border_r = self.decorate_with_border_and_radius(dom_node_id, layout_element.collapsed_borders.as_ref(), Rectangle::new(border_target));
+                let border_r = self.decorate_with_border_and_radius(dom_node_id, None, Rectangle::new(border_target));
                 if image_ctx.placeholder {
                     commands.push(PaintCommand::rectangle(r));
                     // Emit the element border separately so it frames the full reserved box.
@@ -462,7 +462,7 @@ impl Painter {
                         commands.push(PaintCommand::rectangle(border_r));
                     }
                 } else {
-                    let r = self.decorate_with_border_and_radius(dom_node_id, layout_element.collapsed_borders.as_ref(), r);
+                    let r = self.decorate_with_border_and_radius(dom_node_id, None, r);
                     commands.push(PaintCommand::rectangle(r));
                 }
 
@@ -481,7 +481,13 @@ impl Painter {
                 let r = Rectangle::new(border_box)
                     .with_background(brush)
                     .with_blend_mode(self.mix_blend_mode(dom_node_id));
-                let r = self.decorate_with_border_and_radius(dom_node_id, layout_element.collapsed_borders.as_ref(), r);
+                // A collapsed cell paints only its background here; its border strips are
+                // painted by the table's TableBorderOverlay AFTER all table content.
+                let r = if layout_element.collapsed_borders.is_some() {
+                    r
+                } else {
+                    self.decorate_with_border_and_radius(dom_node_id, None, r)
+                };
                 commands.push(PaintCommand::rectangle(r));
 
                 // background-image paints on top of the background-color.
@@ -497,6 +503,19 @@ impl Painter {
                     let r = Rectangle::new(border_box)
                         .with_background(Brush::gradient(layer))
                         .with_blend_mode(blend);
+                    commands.push(PaintCommand::rectangle(r));
+                }
+            }
+            // Collapsed borders of a whole table, painted in front of its content: one
+            // border-only rectangle per collapsed cell, in cell paint order.
+            ElementContext::TableBorderOverlay(cells) => {
+                for &cell_id in cells {
+                    let Some(cell) = self.layer_list.layout_tree.get_node_by_id(cell_id) else {
+                        continue;
+                    };
+                    let Some(ref cb) = cell.collapsed_borders else { continue };
+                    let r = Rectangle::new(cell.box_model.border_box);
+                    let r = self.decorate_with_border_and_radius(cell.dom_node_id, Some(cb), r);
                     commands.push(PaintCommand::rectangle(r));
                 }
             }

--- a/crates/gosub_render_pipeline/src/painter.rs
+++ b/crates/gosub_render_pipeline/src/painter.rs
@@ -379,7 +379,7 @@ impl Painter {
                 let r = Rectangle::new(border_box)
                     .with_background(brush)
                     .with_blend_mode(self.mix_blend_mode(dom_node_id));
-                let r = self.decorate_with_border_and_radius(dom_node_id, r);
+                let r = self.decorate_with_border_and_radius(dom_node_id, layout_element.suppressed_borders, r);
                 vec![PaintCommand::rectangle(r)]
             }
             BackgroundMedia::Svg(media_id) => vec![PaintCommand::svg(media_id, Rectangle::new(border_box))],
@@ -421,7 +421,7 @@ impl Painter {
                 // separate border-only rectangle painted on top of the icon (e.g. the HN logo's
                 // `border:1px white solid`).
                 if self.has_border(dom_node_id) {
-                    let r = self.decorate_with_border_and_radius(dom_node_id, Rectangle::new(border_box));
+                    let r = self.decorate_with_border_and_radius(dom_node_id, layout_element.suppressed_borders, Rectangle::new(border_box));
                     commands.push(PaintCommand::rectangle(r));
                 }
             }
@@ -437,7 +437,7 @@ impl Painter {
                         .with_background(bg_brush)
                         .with_blend_mode(blend);
                     commands.push(PaintCommand::rectangle(
-                        self.decorate_with_border_and_radius(dom_node_id, bg_r),
+                        self.decorate_with_border_and_radius(dom_node_id, layout_element.suppressed_borders, bg_r),
                     ));
                 }
 
@@ -454,7 +454,7 @@ impl Painter {
                 let r = Rectangle::new(draw_box).with_background(brush).with_blend_mode(blend);
                 // The border/radius belongs to the element box, not the shrunk icon rect.
                 let border_target = if image_ctx.placeholder { border_box } else { draw_box };
-                let border_r = self.decorate_with_border_and_radius(dom_node_id, Rectangle::new(border_target));
+                let border_r = self.decorate_with_border_and_radius(dom_node_id, layout_element.suppressed_borders, Rectangle::new(border_target));
                 if image_ctx.placeholder {
                     commands.push(PaintCommand::rectangle(r));
                     // Emit the element border separately so it frames the full reserved box.
@@ -462,7 +462,7 @@ impl Painter {
                         commands.push(PaintCommand::rectangle(border_r));
                     }
                 } else {
-                    let r = self.decorate_with_border_and_radius(dom_node_id, r);
+                    let r = self.decorate_with_border_and_radius(dom_node_id, layout_element.suppressed_borders, r);
                     commands.push(PaintCommand::rectangle(r));
                 }
 
@@ -481,7 +481,7 @@ impl Painter {
                 let r = Rectangle::new(border_box)
                     .with_background(brush)
                     .with_blend_mode(self.mix_blend_mode(dom_node_id));
-                let r = self.decorate_with_border_and_radius(dom_node_id, r);
+                let r = self.decorate_with_border_and_radius(dom_node_id, layout_element.suppressed_borders, r);
                 commands.push(PaintCommand::rectangle(r));
 
                 // background-image paints on top of the background-color.
@@ -515,13 +515,23 @@ impl Painter {
 
     /// Apply the element's computed CSS border and border-radius to `r`. Shared by block,
     /// image and SVG elements so replaced elements (`<img>`) get their borders too.
-    fn decorate_with_border_and_radius(&self, dom_node_id: NodeId, mut r: Rectangle) -> Rectangle {
+    /// `suppressed` edges (`[top, right, bottom, left]`, from `border-collapse`
+    /// conflict resolution) are painted at zero width - the neighbouring cell
+    /// paints the shared border instead.
+    fn decorate_with_border_and_radius(&self, dom_node_id: NodeId, suppressed: [bool; 4], mut r: Rectangle) -> Rectangle {
         let doc = &self.layer_list.layout_tree.render_tree.doc;
 
-        let border_top_width = doc.get_style_f32(dom_node_id, &StyleProperty::BorderTopWidth);
-        let border_right_width = doc.get_style_f32(dom_node_id, &StyleProperty::BorderRightWidth);
-        let border_bottom_width = doc.get_style_f32(dom_node_id, &StyleProperty::BorderBottomWidth);
-        let border_left_width = doc.get_style_f32(dom_node_id, &StyleProperty::BorderLeftWidth);
+        let side_width = |suppress: bool, prop: &StyleProperty| {
+            if suppress {
+                0.0
+            } else {
+                doc.get_style_f32(dom_node_id, prop)
+            }
+        };
+        let border_top_width = side_width(suppressed[0], &StyleProperty::BorderTopWidth);
+        let border_right_width = side_width(suppressed[1], &StyleProperty::BorderRightWidth);
+        let border_bottom_width = side_width(suppressed[2], &StyleProperty::BorderBottomWidth);
+        let border_left_width = side_width(suppressed[3], &StyleProperty::BorderLeftWidth);
 
         if border_top_width != 0.0
             || border_right_width != 0.0

--- a/crates/gosub_render_pipeline/src/painter.rs
+++ b/crates/gosub_render_pipeline/src/painter.rs
@@ -572,6 +572,7 @@ impl Painter {
                     Some(Value::Display(Display::Table))
                 )
             };
+
             let brushes: [Brush; 4] = std::array::from_fn(|e| match cb.owners[e] {
                 Some(owner) if owner_is_table(owner) => {
                     self.get_brush(owner, &own_color[e], Brush::solid(Color::BLACK))

--- a/crates/gosub_render_pipeline/src/painter.rs
+++ b/crates/gosub_render_pipeline/src/painter.rs
@@ -8,7 +8,7 @@ use crate::common::font::{FontAlignment, FontInfo};
 use crate::common::geo::Rect;
 use crate::common::media::MediaStore;
 use crate::layering::layer::LayerList;
-use crate::layouter::{BackgroundMedia, ElementContext, LayoutElementId, LayoutElementNode};
+use crate::layouter::{BackgroundMedia, CollapsedCellBorders, ElementContext, LayoutElementId, LayoutElementNode};
 use crate::painter::commands::border::{Border, BorderStyle};
 use crate::painter::commands::brush::Brush;
 use crate::painter::commands::color::Color;
@@ -379,7 +379,7 @@ impl Painter {
                 let r = Rectangle::new(border_box)
                     .with_background(brush)
                     .with_blend_mode(self.mix_blend_mode(dom_node_id));
-                let r = self.decorate_with_border_and_radius(dom_node_id, layout_element.suppressed_borders, r);
+                let r = self.decorate_with_border_and_radius(dom_node_id, layout_element.collapsed_borders.as_ref(), r);
                 vec![PaintCommand::rectangle(r)]
             }
             BackgroundMedia::Svg(media_id) => vec![PaintCommand::svg(media_id, Rectangle::new(border_box))],
@@ -421,7 +421,7 @@ impl Painter {
                 // separate border-only rectangle painted on top of the icon (e.g. the HN logo's
                 // `border:1px white solid`).
                 if self.has_border(dom_node_id) {
-                    let r = self.decorate_with_border_and_radius(dom_node_id, layout_element.suppressed_borders, Rectangle::new(border_box));
+                    let r = self.decorate_with_border_and_radius(dom_node_id, layout_element.collapsed_borders.as_ref(), Rectangle::new(border_box));
                     commands.push(PaintCommand::rectangle(r));
                 }
             }
@@ -437,7 +437,7 @@ impl Painter {
                         .with_background(bg_brush)
                         .with_blend_mode(blend);
                     commands.push(PaintCommand::rectangle(
-                        self.decorate_with_border_and_radius(dom_node_id, layout_element.suppressed_borders, bg_r),
+                        self.decorate_with_border_and_radius(dom_node_id, layout_element.collapsed_borders.as_ref(), bg_r),
                     ));
                 }
 
@@ -454,7 +454,7 @@ impl Painter {
                 let r = Rectangle::new(draw_box).with_background(brush).with_blend_mode(blend);
                 // The border/radius belongs to the element box, not the shrunk icon rect.
                 let border_target = if image_ctx.placeholder { border_box } else { draw_box };
-                let border_r = self.decorate_with_border_and_radius(dom_node_id, layout_element.suppressed_borders, Rectangle::new(border_target));
+                let border_r = self.decorate_with_border_and_radius(dom_node_id, layout_element.collapsed_borders.as_ref(), Rectangle::new(border_target));
                 if image_ctx.placeholder {
                     commands.push(PaintCommand::rectangle(r));
                     // Emit the element border separately so it frames the full reserved box.
@@ -462,7 +462,7 @@ impl Painter {
                         commands.push(PaintCommand::rectangle(border_r));
                     }
                 } else {
-                    let r = self.decorate_with_border_and_radius(dom_node_id, layout_element.suppressed_borders, r);
+                    let r = self.decorate_with_border_and_radius(dom_node_id, layout_element.collapsed_borders.as_ref(), r);
                     commands.push(PaintCommand::rectangle(r));
                 }
 
@@ -481,7 +481,7 @@ impl Painter {
                 let r = Rectangle::new(border_box)
                     .with_background(brush)
                     .with_blend_mode(self.mix_blend_mode(dom_node_id));
-                let r = self.decorate_with_border_and_radius(dom_node_id, layout_element.suppressed_borders, r);
+                let r = self.decorate_with_border_and_radius(dom_node_id, layout_element.collapsed_borders.as_ref(), r);
                 commands.push(PaintCommand::rectangle(r));
 
                 // background-image paints on top of the background-color.
@@ -518,20 +518,93 @@ impl Painter {
     /// `suppressed` edges (`[top, right, bottom, left]`, from `border-collapse`
     /// conflict resolution) are painted at zero width - the neighbouring cell
     /// paints the shared border instead.
-    fn decorate_with_border_and_radius(&self, dom_node_id: NodeId, suppressed: [bool; 4], mut r: Rectangle) -> Rectangle {
+    fn decorate_with_border_and_radius(
+        &self,
+        dom_node_id: NodeId,
+        collapsed: Option<&CollapsedCellBorders>,
+        mut r: Rectangle,
+    ) -> Rectangle {
         let doc = &self.layer_list.layout_tree.render_tree.doc;
 
-        let side_width = |suppress: bool, prop: &StyleProperty| {
-            if suppress {
-                0.0
-            } else {
-                doc.get_style_f32(dom_node_id, prop)
+        // Table cells under border-collapse paint the collapse geometry, not
+        // their CSS borders: each edge at its layout width (half the resolved
+        // boundary - the adjacent cell paints the other half, so the result is
+        // independent of cell paint order), lost edges in the winning
+        // neighbour's style, and perimeter edges extended outward by the
+        // outset (the border covers the background bleed on those strips).
+        // border-radius does not apply to collapsed cells.
+        if let Some(cb) = collapsed {
+            if (0..4).all(|e| cb.widths[e] + cb.outsets[e] <= 0.0) {
+                return r;
             }
-        };
-        let border_top_width = side_width(suppressed[0], &StyleProperty::BorderTopWidth);
-        let border_right_width = side_width(suppressed[1], &StyleProperty::BorderRightWidth);
-        let border_bottom_width = side_width(suppressed[2], &StyleProperty::BorderBottomWidth);
-        let border_left_width = side_width(suppressed[3], &StyleProperty::BorderLeftWidth);
+            let own_color = [
+                StyleProperty::BorderTopColor,
+                StyleProperty::BorderRightColor,
+                StyleProperty::BorderBottomColor,
+                StyleProperty::BorderLeftColor,
+            ];
+            let own_style = [
+                StyleProperty::BorderTopStyle,
+                StyleProperty::BorderRightStyle,
+                StyleProperty::BorderBottomStyle,
+                StyleProperty::BorderLeftStyle,
+            ];
+            // A lost edge renders the winning neighbour's FACING edge: our top
+            // is its bottom, our right is its left, and vice versa.
+            let facing_color = [
+                StyleProperty::BorderBottomColor,
+                StyleProperty::BorderLeftColor,
+                StyleProperty::BorderTopColor,
+                StyleProperty::BorderRightColor,
+            ];
+            let facing_style = [
+                StyleProperty::BorderBottomStyle,
+                StyleProperty::BorderLeftStyle,
+                StyleProperty::BorderTopStyle,
+                StyleProperty::BorderRightStyle,
+            ];
+            let brushes: [Brush; 4] = std::array::from_fn(|e| match cb.owners[e] {
+                Some(owner) => self.get_brush(owner, &facing_color[e], Brush::solid(Color::BLACK)),
+                None => self.get_brush(dom_node_id, &own_color[e], Brush::solid(Color::BLACK)),
+            });
+            let styles: [BorderStyle; 4] = std::array::from_fn(|e| {
+                let (node, prop) = match cb.owners[e] {
+                    Some(owner) => (owner, &facing_style[e]),
+                    None => (dom_node_id, &own_style[e]),
+                };
+                match doc.get_style(node, prop) {
+                    Value::BorderStyle(s) => css_border_style_to_paint(&s),
+                    _ => BorderStyle::Solid,
+                }
+            });
+            // Snap the box and the strip ends to whole device pixels. The two
+            // cells of a boundary compute their strip ends from the SAME edge
+            // coordinate, so they snap identically and the half-strips abut
+            // without a double-AA seam - and thin borders land on whole
+            // pixels (a fractional 0.5+0.5 split would render as two
+            // half-alpha rows instead of one crisp line).
+            let rect = r.rect();
+            let (x0, y0) = (rect.x, rect.y);
+            let (x1, y1) = (rect.x + rect.width, rect.y + rect.height);
+            let top = (y0 - cb.outsets[0] as f64).round();
+            let right = (x1 + cb.outsets[1] as f64).round();
+            let bottom = (y1 + cb.outsets[2] as f64).round();
+            let left = (x0 - cb.outsets[3] as f64).round();
+            let widths = [
+                ((y0 + cb.widths[0] as f64).round() - top) as f32,
+                (right - (x1 - cb.widths[1] as f64).round()) as f32,
+                (bottom - (y1 - cb.widths[2] as f64).round()) as f32,
+                ((x0 + cb.widths[3] as f64).round() - left) as f32,
+            ];
+            return r
+                .with_rect(Rect::new(left, top, right - left, bottom - top))
+                .with_border(Border::new_per_side(widths, styles, brushes));
+        }
+
+        let border_top_width = doc.get_style_f32(dom_node_id, &StyleProperty::BorderTopWidth);
+        let border_right_width = doc.get_style_f32(dom_node_id, &StyleProperty::BorderRightWidth);
+        let border_bottom_width = doc.get_style_f32(dom_node_id, &StyleProperty::BorderBottomWidth);
+        let border_left_width = doc.get_style_f32(dom_node_id, &StyleProperty::BorderLeftWidth);
 
         if border_top_width != 0.0
             || border_right_width != 0.0

--- a/crates/gosub_render_pipeline/src/painter/commands/border.rs
+++ b/crates/gosub_render_pipeline/src/painter/commands/border.rs
@@ -1,5 +1,64 @@
+use crate::common::geo::Rect;
 use crate::painter::commands::brush::Brush;
 use crate::painter::commands::Trbl;
+
+/// Axis-aligned strips that paint one side of a non-uniform border while keeping its
+/// style: `Double` is two thin strips, `Dashed`/`Dotted` a run of segments along the edge,
+/// everything else (incl. the 3D styles, which have no two-tone rendering yet) one solid
+/// strip. Sides are `[top, right, bottom, left]`; a side with no visible border is empty.
+/// Backends only need a rect fill to consume this, so all three stay in sync.
+pub fn per_side_strips(rect: Rect, widths: [f32; 4], styles: &[BorderStyle; 4]) -> [Vec<Rect>; 4] {
+    let w = |i: usize| widths[i] as f64;
+    let edges = [
+        (rect.x, rect.y, rect.width, w(0), true),
+        (rect.x + rect.width - w(1), rect.y, w(1), rect.height, false),
+        (rect.x, rect.y + rect.height - w(2), rect.width, w(2), true),
+        (rect.x, rect.y, w(3), rect.height, false),
+    ];
+    let mut out: [Vec<Rect>; 4] = Default::default();
+    for (i, &(x, y, width, height, horizontal)) in edges.iter().enumerate() {
+        let thickness = if horizontal { height } else { width };
+        if thickness <= 0.0 || styles[i].is_invisible() {
+            continue;
+        }
+        let strips = &mut out[i];
+        match styles[i] {
+            BorderStyle::Double if thickness >= 3.0 => {
+                let strand = (thickness / 3.0).floor();
+                let inner = thickness - strand;
+                if horizontal {
+                    strips.push(Rect::new(x, y, width, strand));
+                    strips.push(Rect::new(x, y + inner, width, strand));
+                } else {
+                    strips.push(Rect::new(x, y, strand, height));
+                    strips.push(Rect::new(x + inner, y, strand, height));
+                }
+            }
+            BorderStyle::Dashed | BorderStyle::Dotted => {
+                // Same dash rhythm as the uniform stroke paths: dots are `w` on / `w` off,
+                // dashes `3w` (min 3px) on / off.
+                let seg = if styles[i] == BorderStyle::Dotted {
+                    thickness
+                } else {
+                    (thickness * 3.0).max(3.0)
+                };
+                let length = if horizontal { width } else { height };
+                let mut pos = 0.0;
+                while pos < length {
+                    let len = seg.min(length - pos);
+                    strips.push(if horizontal {
+                        Rect::new(x + pos, y, len, thickness)
+                    } else {
+                        Rect::new(x, y + pos, thickness, len)
+                    });
+                    pos += 2.0 * seg;
+                }
+            }
+            _ => strips.push(Rect::new(x, y, width, height)),
+        }
+    }
+    out
+}
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub enum BorderStyle {

--- a/crates/gosub_render_pipeline/src/painter/commands/border.rs
+++ b/crates/gosub_render_pipeline/src/painter/commands/border.rs
@@ -74,7 +74,18 @@ impl Border {
     /// All four sides share width and style, so the whole-rectangle stroke path applies. Per-side
     /// colours are still allowed, but that fast path only uses the first brush.
     pub fn is_uniform(&self) -> bool {
-        self.widths.iter().all(|&w| w == self.widths[0]) && self.styles.iter().all(|s| *s == self.styles[0])
+        self.widths.iter().all(|&w| w == self.widths[0])
+            && self.styles.iter().all(|s| *s == self.styles[0])
+            // Same-width same-style borders can still differ per side in COLOR (collapsed
+            // table boundaries owned by different neighbours) - the single-stroke path
+            // would paint all four sides with one brush. Non-solid brushes conservatively
+            // count as differing.
+            && self.brushes.iter().all(|b| match (b, &self.brushes[0]) {
+                (crate::painter::commands::brush::Brush::Solid(a), crate::painter::commands::brush::Brush::Solid(c)) => {
+                    a.r() == c.r() && a.g() == c.g() && a.b() == c.b() && a.a() == c.a()
+                }
+                _ => false,
+            })
     }
 
     pub fn widths(&self) -> [f32; 4] {

--- a/crates/gosub_render_pipeline/src/painter/commands/gradient.rs
+++ b/crates/gosub_render_pipeline/src/painter/commands/gradient.rs
@@ -31,11 +31,11 @@ pub struct LinearGradient {
 }
 
 impl LinearGradient {
-    /// Gradient line within a `w`×`h` box, relative to the box origin. Per spec the line is
+    /// Gradient line within a `w`x`h` box, relative to the box origin. Per spec the line is
     /// centred and long enough that the `0%`/`100%` stops land on the box's edges/corners.
     pub fn line(&self, w: f32, h: f32) -> ((f32, f32), (f32, f32)) {
         let theta = self.angle_deg.to_radians();
-        // CSS direction vector: 0deg → up (0,-1), 90deg → right (1,0), 180deg → down (0,1).
+        // CSS direction vector: 0deg -> up (0,-1), 90deg -> right (1,0), 180deg -> down (0,1).
         let dx = theta.sin();
         let dy = -theta.cos();
         // Half the length of the gradient line projected onto the box.
@@ -81,7 +81,7 @@ impl LinearGradient {
         }
     }
 
-    /// Rasterize one `tw`×`th` tile into straight-alpha RGBA8 (row-major, 4 bytes per pixel),
+    /// Rasterize one `tw`x`th` tile into straight-alpha RGBA8 (row-major, 4 bytes per pixel),
     /// to be repeated across a tiled `background-image` layer.
     pub fn rasterize_tile(&self, tw: u32, th: u32) -> Vec<u8> {
         let (w, h) = (tw as f32, th as f32);

--- a/crates/gosub_render_pipeline/src/painter/commands/rectangle.rs
+++ b/crates/gosub_render_pipeline/src/painter/commands/rectangle.rs
@@ -154,6 +154,11 @@ impl Rectangle {
         self
     }
 
+    pub fn with_rect(mut self, rect: Rect) -> Self {
+        self.rect = rect;
+        self
+    }
+
     pub fn with_blend_mode(mut self, blend_mode: BlendMode) -> Self {
         self.blend_mode = blend_mode;
         self

--- a/crates/gosub_render_pipeline/src/rasterizer.rs
+++ b/crates/gosub_render_pipeline/src/rasterizer.rs
@@ -265,7 +265,8 @@ fn tile_cache_key(tile: &crate::tiler::Tile) -> TileCacheKey {
                     hstr!(&t.text);
                     hstr!(&t.font_info.family);
                     hf64!(t.font_info.size);
-                    hf64!(t.font_info.line_height);
+                    // `normal` (None) hashes as -1.0, distinct from any real px line-height.
+                    hf64!(t.font_info.line_height.unwrap_or(-1.0));
                     hu64!(t.font_info.weight as u64);
                     hu64!(t.font_info.width as u64);
                     hu64!(t.font_info.slant as u64);

--- a/crates/gosub_render_pipeline/src/render/tile_composite.rs
+++ b/crates/gosub_render_pipeline/src/render/tile_composite.rs
@@ -17,7 +17,7 @@ use crate::render::backend::{anchored_tile_pos, blend_over_argb_u32, scale_premu
 /// A rectangular region of a premultiplied-ARGB (`0xAARRGGBB`) `u32` buffer that tiles composite
 /// into.
 ///
-/// `buf` is row-major with `stride` pixels per row. Tiles are clipped to the `width × height`
+/// `buf` is row-major with `stride` pixels per row. Tiles are clipped to the `width x height`
 /// device-pixel region at (`origin_x`, `origin_y`); the offset lets a host reserve rows for its own
 /// chrome while still handing over the whole window buffer.
 ///
@@ -116,7 +116,7 @@ mod tests {
 
     const WHITE: u32 = 0xFFFF_FFFF;
 
-    /// A 1×1 opaque tile of the given RGBA bytes at page (page_x, page_y).
+    /// A 1x1 opaque tile of the given RGBA bytes at page (page_x, page_y).
     fn tile_rgba(page_x: f32, page_y: f32, rgba: [u8; 4]) -> CachedTile {
         CachedTile {
             page_x,
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn scroll_moves_tiles_up() {
-        // Tile at page y=1, scrolled down by 1 CSS px → lands at viewport (0,0).
+        // Tile at page y=1, scrolled down by 1 CSS px -> lands at viewport (0,0).
         let mut buf = [WHITE; 4];
         composite_tiles(
             &[tile_rgba(0.0, 1.0, [0, 255, 0, 255])],
@@ -202,7 +202,7 @@ mod tests {
 
     #[test]
     fn argb_to_rgba8_channel_order() {
-        // 0xAARRGGBB red → [R,G,B,255].
+        // 0xAARRGGBB red -> [R,G,B,255].
         assert_eq!(argb_u32_to_rgba8(&[0xFF12_3456]), vec![0x12, 0x34, 0x56, 255]);
     }
 }

--- a/crates/gosub_render_pipeline/src/tests.rs
+++ b/crates/gosub_render_pipeline/src/tests.rs
@@ -41,6 +41,77 @@ mod rendertree_from_engine {
         rt
     }
 
+    /// `border-top: 3px dashed red` (a per-side shorthand) must set that side's width, style
+    /// and color - from a stylesheet and from an inline `style=""` alike.
+    #[test]
+    fn border_side_shorthand_sets_width_style_color() {
+        use crate::common::document::pipeline_doc::PipelineDocument as _;
+        use crate::common::document::style::{BorderStyle, StyleProperty, Unit, Value};
+
+        let html = r#"<html><head><style>
+          #sheet { border-top: 3px dashed red }
+          #multi { border-top: 3px dashed #c00; border-bottom: 6px double #06c; border-left: 4px dotted #080; border-right: 2px solid #000 }
+        </style></head>
+        <body><div id="sheet">a</div><div id="multi">m</div><div id="inline" style="border-left: 4px dotted green">b</div></body></html>"#;
+        let mut doc = html_compile::<Config>(html);
+        doc.add_stylesheet(Css3System::load_default_useragent_stylesheet());
+        let adapter = GosubDocumentAdapter::<Config>::new(Arc::new(doc));
+        let root = adapter.doc.root();
+
+        let sheet = find_node_by_id_attr(&adapter.doc, root, "sheet").expect("#sheet");
+        let w = adapter.get_style(sheet, &StyleProperty::BorderTopWidth);
+        assert!(
+            matches!(w, Value::Unit(v, Unit::Px) if (v - 3.0).abs() < 0.01),
+            "sheet width: {w:?}"
+        );
+        let st = adapter.get_style(sheet, &StyleProperty::BorderTopStyle);
+        assert!(
+            matches!(st, Value::BorderStyle(BorderStyle::Dashed)),
+            "sheet style: {st:?}"
+        );
+        let c = adapter.get_style(sheet, &StyleProperty::BorderTopColor);
+        assert!(matches!(c, Value::Color(255, 0, 0, _)), "sheet color: {c:?}");
+        // Untouched sides keep the initial (none -> 0 width).
+        let w = adapter.get_style(sheet, &StyleProperty::BorderLeftWidth);
+        assert!(
+            matches!(w, Value::Unit(v, _) if v == 0.0),
+            "sheet untouched side: {w:?}"
+        );
+
+        let multi = find_node_by_id_attr(&adapter.doc, root, "multi").expect("#multi");
+        for (prop, want) in [
+            (StyleProperty::BorderTopStyle, BorderStyle::Dashed),
+            (StyleProperty::BorderRightStyle, BorderStyle::Solid),
+            (StyleProperty::BorderBottomStyle, BorderStyle::Double),
+            (StyleProperty::BorderLeftStyle, BorderStyle::Dotted),
+        ] {
+            let st = adapter.get_style(multi, &prop);
+            assert!(
+                matches!(&st, Value::BorderStyle(s) if *s == want),
+                "multi {prop:?}: {st:?}"
+            );
+        }
+        let w = adapter.get_style(multi, &StyleProperty::BorderBottomWidth);
+        assert!(
+            matches!(w, Value::Unit(v, Unit::Px) if (v - 6.0).abs() < 0.01),
+            "multi bottom width: {w:?}"
+        );
+
+        let inline = find_node_by_id_attr(&adapter.doc, root, "inline").expect("#inline");
+        let w = adapter.get_style(inline, &StyleProperty::BorderLeftWidth);
+        assert!(
+            matches!(w, Value::Unit(v, Unit::Px) if (v - 4.0).abs() < 0.01),
+            "inline width: {w:?}"
+        );
+        let st = adapter.get_style(inline, &StyleProperty::BorderLeftStyle);
+        assert!(
+            matches!(st, Value::BorderStyle(BorderStyle::Dotted)),
+            "inline style: {st:?}"
+        );
+        let c = adapter.get_style(inline, &StyleProperty::BorderLeftColor);
+        assert!(matches!(c, Value::Color(0, 128, 0, _)), "inline color: {c:?}");
+    }
+
     /// CSS 2 §10.3.7 regression: an absolutely-positioned auto-width box must shrink to fit
     /// but never exceed its containing block - an abs div wrapping a wide table once sized
     /// to the table's raw max-content (812px in an 800px viewport).

--- a/crates/gosub_render_pipeline/src/tests.rs
+++ b/crates/gosub_render_pipeline/src/tests.rs
@@ -91,7 +91,6 @@ mod rendertree_from_engine {
     #[test]
     fn parentless_table_cells_get_anonymous_table() {
         use crate::common::document::node::NodeType;
-        use crate::common::document::pipeline_doc::PipelineDocument;
         use crate::common::geo::Dimension;
         use crate::layouter::taffy::TaffyLayouter;
         use crate::layouter::CanLayout as _;

--- a/crates/gosub_render_pipeline/src/tests.rs
+++ b/crates/gosub_render_pipeline/src/tests.rs
@@ -41,6 +41,97 @@ mod rendertree_from_engine {
         rt
     }
 
+    /// CSS 2 §10.3.7 regression: an absolutely-positioned auto-width box must shrink to fit
+    /// but never exceed its containing block - an abs div wrapping a wide table once sized
+    /// to the table's raw max-content (812px in an 800px viewport).
+    #[test]
+    fn absolute_auto_width_capped_at_containing_block() {
+        use crate::common::geo::Dimension;
+        use crate::layouter::taffy::TaffyLayouter;
+        use crate::layouter::CanLayout as _;
+
+        let html = r#"<html><body style="font-family: monospace; font-size: 16px">
+          <div style="position: relative; font-size: 2em;">
+            <div style="position: relative; padding: 1px;">flow</div>
+            <div id="overlay" style="position: absolute; top: 0; padding: 1px;">
+              <table cellpadding="0" cellspacing="0" style="margin: 0; padding: 0; border: none">
+                <tr><td>Row 1, Col 1</td><td>Row 1, Col 2</td><td>Row 1, Col 3</td></tr>
+                <tr><td>Row 333, Col 1</td><td>Row 333, Col 2</td><td>Row 333, Col 3</td></tr>
+              </table>
+            </div>
+          </div></body></html>"#;
+        let rt = parse_to_rendertree(html);
+        let doc = rt.doc.clone();
+        let mut l = TaffyLayouter::new();
+        let tree = l.layout(rt, Some(Dimension { width: 800.0, height: 600.0 }), 1.0);
+
+        let overlay = tree
+            .arena
+            .values()
+            .find(|el| {
+                doc.get_node_by_id(el.dom_node_id).is_some_and(|n| match n.node_type {
+                    crate::common::document::node::NodeType::Element(ref d) => {
+                        d.attributes.get("id").is_some_and(|v| v == "overlay")
+                    }
+                    _ => false,
+                })
+            })
+            .expect("overlay div in layout tree");
+        // Containing block: body content = 800 - 2x8 margin = 784.
+        assert!(
+            (overlay.box_model.border_box.width - 784.0).abs() < 0.5,
+            "abs overlay must cap at the containing block width, got {}",
+            overlay.box_model.border_box.width
+        );
+    }
+
+    /// CSS 2.1 §17.2.1: consecutive table-internal boxes without a table ancestor get an
+    /// anonymous table wrapper, so bare `display: table-cell` spans lay out side by side
+    /// (WPT table-anonymous-objects-061 and friends).
+    #[test]
+    fn parentless_table_cells_get_anonymous_table() {
+        use crate::common::document::node::NodeType;
+        use crate::common::document::pipeline_doc::PipelineDocument;
+        use crate::common::geo::Dimension;
+        use crate::layouter::taffy::TaffyLayouter;
+        use crate::layouter::CanLayout as _;
+
+        let html = r#"<html><body>
+          <div>
+            <span style="display: table-cell">alpha</span>
+            <span style="display: table-cell">beta</span>
+          </div></body></html>"#;
+        let rt = parse_to_rendertree(html);
+        let doc = rt.doc.clone();
+        let mut l = TaffyLayouter::new();
+        let tree = l.layout(rt, Some(Dimension { width: 800.0, height: 600.0 }), 1.0);
+
+        let cell_boxes: Vec<_> = tree
+            .arena
+            .values()
+            .filter(|el| {
+                doc.get_node_by_id(el.dom_node_id).is_some_and(|n|
+
+                    matches!(n.node_type, NodeType::Element(ref d) if d.tag_name == "span"))
+            })
+            .map(|el| el.box_model.border_box)
+            .collect();
+        assert_eq!(cell_boxes.len(), 2, "both cells reach the layout tree");
+        let (a, b) = (&cell_boxes[0], &cell_boxes[1]);
+        assert!(
+            (a.y - b.y).abs() < 0.5,
+            "cells share a table row: y {} vs {}",
+            a.y,
+            b.y
+        );
+        assert!(
+            (a.x - b.x).abs() > 10.0,
+            "cells occupy adjacent columns: x {} vs {}",
+            a.x,
+            b.x
+        );
+    }
+
     #[test]
     fn minimal_document_has_root() {
         let rt = parse_to_rendertree("<html><body><p>Hello</p></body></html>");

--- a/crates/gosub_render_pipeline/src/tests.rs
+++ b/crates/gosub_render_pipeline/src/tests.rs
@@ -63,7 +63,14 @@ mod rendertree_from_engine {
         let rt = parse_to_rendertree(html);
         let doc = rt.doc.clone();
         let mut l = TaffyLayouter::new();
-        let tree = l.layout(rt, Some(Dimension { width: 800.0, height: 600.0 }), 1.0);
+        let tree = l.layout(
+            rt,
+            Some(Dimension {
+                width: 800.0,
+                height: 600.0,
+            }),
+            1.0,
+        );
 
         let overlay = tree
             .arena
@@ -103,26 +110,27 @@ mod rendertree_from_engine {
         let rt = parse_to_rendertree(html);
         let doc = rt.doc.clone();
         let mut l = TaffyLayouter::new();
-        let tree = l.layout(rt, Some(Dimension { width: 800.0, height: 600.0 }), 1.0);
+        let tree = l.layout(
+            rt,
+            Some(Dimension {
+                width: 800.0,
+                height: 600.0,
+            }),
+            1.0,
+        );
 
         let cell_boxes: Vec<_> = tree
             .arena
             .values()
             .filter(|el| {
-                doc.get_node_by_id(el.dom_node_id).is_some_and(|n|
-
-                    matches!(n.node_type, NodeType::Element(ref d) if d.tag_name == "span"))
+                doc.get_node_by_id(el.dom_node_id)
+                    .is_some_and(|n| matches!(n.node_type, NodeType::Element(ref d) if d.tag_name == "span"))
             })
             .map(|el| el.box_model.border_box)
             .collect();
         assert_eq!(cell_boxes.len(), 2, "both cells reach the layout tree");
         let (a, b) = (&cell_boxes[0], &cell_boxes[1]);
-        assert!(
-            (a.y - b.y).abs() < 0.5,
-            "cells share a table row: y {} vs {}",
-            a.y,
-            b.y
-        );
+        assert!((a.y - b.y).abs() < 0.5, "cells share a table row: y {} vs {}", a.y, b.y);
         assert!(
             (a.x - b.x).abs() > 10.0,
             "cells occupy adjacent columns: x {} vs {}",

--- a/crates/gosub_render_pipeline/src/tiler.rs
+++ b/crates/gosub_render_pipeline/src/tiler.rs
@@ -4,7 +4,7 @@ use crate::common::document::style::{StyleProperty, Value};
 use crate::common::geo::{Coordinate, Dimension, Rect};
 use crate::common::texture::TextureId;
 use crate::layering::layer::{LayerId, LayerList};
-use crate::layouter::LayoutElementId;
+use crate::layouter::{LayoutElementId, LayoutElementNode};
 use crate::painter::commands::PaintCommand;
 use parking_lot::RwLock;
 use rstar::primitives::GeomWithData;
@@ -16,6 +16,19 @@ use std::sync::Arc;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TileId(u64);
+
+/// Tile-coverage extent of an element's paint: the union of margin and border box. Negative
+/// margins shrink the margin box below the painted border box (even to zero area), so the
+/// margin box alone would drop tiles the element actually paints into.
+fn paint_extent(el: &LayoutElementNode) -> Rect {
+    let m = el.box_model.margin_box;
+    let b = el.box_model.border_box;
+    let x = m.x.min(b.x);
+    let y = m.y.min(b.y);
+    let x2 = (m.x + m.width).max(b.x + b.width);
+    let y2 = (m.y + m.height).max(b.y + b.height);
+    Rect::new(x, y, x2 - x, y2 - y)
+}
 
 impl TileId {
     pub const fn new(val: u64) -> Self {
@@ -262,7 +275,7 @@ impl TileList {
                 let mut max_y = f64::MIN;
                 for &eid in &layer.elements {
                     if let Some(el) = self.layer_list.layout_tree.get_node_by_id(eid) {
-                        let m = el.box_model.margin_box;
+                        let m = paint_extent(el);
                         if m.width > 0.0 && m.height > 0.0 {
                             min_x = min_x.min(m.x);
                             min_y = min_y.min(m.y);
@@ -342,7 +355,7 @@ impl TileList {
                     log::warn!("Warning: Element {:?} not found in layout tree!", element_id);
                     continue;
                 };
-                let margin_box = element.box_model.margin_box;
+                let margin_box = paint_extent(element);
 
                 let matching_tile_ids = tile_layer.intersects_with(margin_box);
                 for tile_id in &matching_tile_ids {

--- a/crates/gosub_renderer_cairo/src/rasterizer/rectangle.rs
+++ b/crates/gosub_renderer_cairo/src/rasterizer/rectangle.rs
@@ -1,7 +1,7 @@
 use crate::rasterizer::brush::set_brush;
 use cairo::{Context, Operator};
 use gosub_render_pipeline::common::media::MediaStore;
-use gosub_render_pipeline::painter::commands::border::BorderStyle;
+use gosub_render_pipeline::painter::commands::border::{per_side_strips, BorderStyle};
 use gosub_render_pipeline::painter::commands::rectangle::{BlendMode, Rectangle};
 use gosub_render_pipeline::tiler::Tile;
 
@@ -118,35 +118,17 @@ pub(crate) fn do_paint_rectangle(cr: &Context, tile: &Tile, rectangle: &Rectangl
 /// solid fill per side, which is the common case for single-side borders.
 fn paint_per_side_border(cr: &Context, rectangle: &Rectangle, media_store: &MediaStore) {
     let rect = rectangle.rect();
-    let widths = rectangle.border().widths();
-    let styles = rectangle.border().styles();
     let brushes = rectangle.border().brushes();
+    let strips = per_side_strips(rect, rectangle.border().widths(), &rectangle.border().styles());
 
-    // (x, y, w, h) for each side's edge rectangle.
-    let edges = [
-        (rect.x, rect.y, rect.width, widths[0] as f64), // top
-        (
-            rect.x + rect.width - widths[1] as f64,
-            rect.y,
-            widths[1] as f64,
-            rect.height,
-        ), // right
-        (
-            rect.x,
-            rect.y + rect.height - widths[2] as f64,
-            rect.width,
-            widths[2] as f64,
-        ), // bottom
-        (rect.x, rect.y, widths[3] as f64, rect.height), // left
-    ];
-
-    for i in 0..4 {
-        if widths[i] <= 0.0 || styles[i].is_invisible() {
+    for (i, side) in strips.iter().enumerate() {
+        if side.is_empty() {
             continue;
         }
-        let (x, y, w, h) = edges[i];
         cr.new_path();
-        cr.rectangle(x, y, w, h);
+        for strip in side {
+            cr.rectangle(strip.x, strip.y, strip.width, strip.height);
+        }
         set_brush(cr, &brushes[i], rect, media_store);
         _ = cr.fill();
     }

--- a/crates/gosub_renderer_cairo/src/rasterizer/rectangle.rs
+++ b/crates/gosub_renderer_cairo/src/rasterizer/rectangle.rs
@@ -185,13 +185,31 @@ fn setup_inset_path(cr: &Context, rect: &Rectangle, inset: f64) {
     cr.arc(x + width - r_tr, y + r_tr, r_tr, -0.5 * std::f64::consts::PI, 0.0);
 
     cr.line_to(x + width, y + height - r_br);
-    cr.arc(x + width - r_br, y + height - r_br, r_br, 0.0, 0.5 * std::f64::consts::PI);
+    cr.arc(
+        x + width - r_br,
+        y + height - r_br,
+        r_br,
+        0.0,
+        0.5 * std::f64::consts::PI,
+    );
 
     cr.line_to(x + r_bl, y + height);
-    cr.arc(x + r_bl, y + height - r_bl, r_bl, 0.5 * std::f64::consts::PI, std::f64::consts::PI);
+    cr.arc(
+        x + r_bl,
+        y + height - r_bl,
+        r_bl,
+        0.5 * std::f64::consts::PI,
+        std::f64::consts::PI,
+    );
 
     cr.line_to(x, y + r_tl);
-    cr.arc(x + r_tl, y + r_tl, r_tl, std::f64::consts::PI, 1.5 * std::f64::consts::PI);
+    cr.arc(
+        x + r_tl,
+        y + r_tl,
+        r_tl,
+        std::f64::consts::PI,
+        1.5 * std::f64::consts::PI,
+    );
 
     cr.close_path();
 }

--- a/crates/gosub_renderer_cairo/src/rasterizer/rectangle.rs
+++ b/crates/gosub_renderer_cairo/src/rasterizer/rectangle.rs
@@ -60,7 +60,9 @@ pub(crate) fn do_paint_rectangle(cr: &Context, tile: &Tile, rectangle: &Rectangl
         return;
     }
 
-    setup_rectangle_path(cr, rectangle);
+    // Stroke a path inset by half the border width so the whole border lies
+    // inside the border box (see setup_inset_path).
+    setup_inset_path(cr, rectangle, rectangle.border().width() as f64 / 2.0);
 
     cr.set_line_width(rectangle.border().width() as f64);
     set_brush(cr, &rectangle.border().brush(), rectangle.rect(), media_store);
@@ -152,53 +154,44 @@ fn paint_per_side_border(cr: &Context, rectangle: &Rectangle, media_store: &Medi
 }
 
 fn setup_rectangle_path(cr: &Context, rect: &Rectangle) {
+    setup_inset_path(cr, rect, 0.0);
+}
+
+/// Builds the rectangle path inset by `inset` on every side. Cairo centers a
+/// stroke's pen on the path, so a border of width `w` must stroke a path inset
+/// by `w / 2` to stay entirely inside the border box (CSS borders never paint
+/// outside it - a centered stroke bleeds into the neighbouring element and
+/// gets painted over, which visibly halved collapsed table borders).
+fn setup_inset_path(cr: &Context, rect: &Rectangle, inset: f64) {
     let (r_tl, r_tr, r_br, r_bl) = rect.radius_x();
 
+    let x = rect.rect().x + inset;
+    let y = rect.rect().y + inset;
+    let width = (rect.rect().width - 2.0 * inset).max(0.0);
+    let height = (rect.rect().height - 2.0 * inset).max(0.0);
+    let r_tl = (r_tl - inset).max(0.0);
+    let r_tr = (r_tr - inset).max(0.0);
+    let r_br = (r_br - inset).max(0.0);
+    let r_bl = (r_bl - inset).max(0.0);
+
     if r_tl == 0.0 && r_tr == 0.0 && r_br == 0.0 && r_bl == 0.0 {
-        cr.rectangle(rect.rect().x, rect.rect().y, rect.rect().width, rect.rect().height);
+        cr.rectangle(x, y, width, height);
         return;
     }
 
-    cr.move_to(rect.rect().x + r_tl, rect.rect().y);
+    cr.move_to(x + r_tl, y);
 
-    cr.line_to(rect.rect().x + rect.rect().width - r_tr, rect.rect().y);
-    cr.arc(
-        rect.rect().x + rect.rect().width - r_tr,
-        rect.rect().y + r_tr,
-        r_tr,
-        -0.5 * std::f64::consts::PI,
-        0.0,
-    );
+    cr.line_to(x + width - r_tr, y);
+    cr.arc(x + width - r_tr, y + r_tr, r_tr, -0.5 * std::f64::consts::PI, 0.0);
 
-    cr.line_to(
-        rect.rect().x + rect.rect().width,
-        rect.rect().y + rect.rect().height - r_br,
-    );
-    cr.arc(
-        rect.rect().x + rect.rect().width - r_br,
-        rect.rect().y + rect.rect().height - r_br,
-        r_br,
-        0.0,
-        0.5 * std::f64::consts::PI,
-    );
+    cr.line_to(x + width, y + height - r_br);
+    cr.arc(x + width - r_br, y + height - r_br, r_br, 0.0, 0.5 * std::f64::consts::PI);
 
-    cr.line_to(rect.rect().x + r_bl, rect.rect().y + rect.rect().height);
-    cr.arc(
-        rect.rect().x + r_bl,
-        rect.rect().y + rect.rect().height - r_bl,
-        r_bl,
-        0.5 * std::f64::consts::PI,
-        std::f64::consts::PI,
-    );
+    cr.line_to(x + r_bl, y + height);
+    cr.arc(x + r_bl, y + height - r_bl, r_bl, 0.5 * std::f64::consts::PI, std::f64::consts::PI);
 
-    cr.line_to(rect.rect().x, rect.rect().y + r_tl);
-    cr.arc(
-        rect.rect().x + r_tl,
-        rect.rect().y + r_tl,
-        r_tl,
-        std::f64::consts::PI,
-        1.5 * std::f64::consts::PI,
-    );
+    cr.line_to(x, y + r_tl);
+    cr.arc(x + r_tl, y + r_tl, r_tl, std::f64::consts::PI, 1.5 * std::f64::consts::PI);
 
     cr.close_path();
 }

--- a/crates/gosub_renderer_cairo/src/rasterizer/rectangle.rs
+++ b/crates/gosub_renderer_cairo/src/rasterizer/rectangle.rs
@@ -83,19 +83,18 @@ pub(crate) fn do_paint_rectangle(cr: &Context, tile: &Tile, rectangle: &Rectangl
             _ = cr.stroke();
         }
         BorderStyle::Double => {
-            if rectangle.border().width() >= 3.0 {
-                let width = (rectangle.border().width() / 2.0).floor();
-                cr.set_line_width(width as f64);
+            let total = rectangle.border().width() as f64;
+            if total >= 3.0 {
+                // The path above is inset for the FULL width; each strand needs its own
+                // inset (half its own width) or the outer band stays unpainted. Thirds
+                // split keeps strands + gap within the declared width.
+                let strand = (total / 3.0).floor();
+                let gap = total - 2.0 * strand;
+                cr.new_path();
+                cr.set_line_width(strand);
+                setup_inset_path(cr, rectangle, strand / 2.0);
                 _ = cr.stroke();
-
-                let gap_size = 1.0;
-
-                cr.rectangle(
-                    rectangle.rect().x + width as f64 + gap_size,
-                    rectangle.rect().y + width as f64 + gap_size,
-                    rectangle.rect().width - 2.0 * (width as f64 + gap_size),
-                    rectangle.rect().height - 2.0 * (width as f64 + gap_size),
-                );
+                setup_inset_path(cr, rectangle, strand + gap + strand / 2.0);
                 _ = cr.stroke();
             } else {
                 _ = cr.stroke();

--- a/crates/gosub_renderer_cairo/src/rasterizer/text/glyphs.rs
+++ b/crates/gosub_renderer_cairo/src/rasterizer/text/glyphs.rs
@@ -170,7 +170,7 @@ mod tests {
             weight: 400,
             width: 100,
             slant: 0,
-            line_height: 28.0,
+            line_height: Some(28.0),
             letter_spacing: 0.0,
             alignment: FontAlignment::Start,
             underline: true,

--- a/crates/gosub_renderer_skia/src/rasterizer/rectangle.rs
+++ b/crates/gosub_renderer_skia/src/rasterizer/rectangle.rs
@@ -83,13 +83,18 @@ pub fn do_paint_rectangle(canvas: &Canvas, _tile: &Tile, cmd: &Rectangle, media_
         paint.set_blend_mode(to_skia_blend_mode(cmd.blend_mode()));
         paint.set_stroke_width(border.width());
         paint.set_style(skia_safe::paint::Style::Stroke);
+        // Skia centers a stroke on the path; inset by half the border width so
+        // the whole border lies inside the border box (a centered stroke bleeds
+        // into the neighbouring element and gets painted over - visibly halving
+        // collapsed table borders).
+        let half = border.width() / 2.0;
         draw_rect_or_rounded(
             canvas,
             cmd,
-            r.x as f32,
-            r.y as f32,
-            r.width as f32,
-            r.height as f32,
+            r.x as f32 + half,
+            r.y as f32 + half,
+            (r.width as f32 - border.width()).max(0.0),
+            (r.height as f32 - border.width()).max(0.0),
             &paint,
         );
     }

--- a/crates/gosub_renderer_skia/src/rasterizer/rectangle.rs
+++ b/crates/gosub_renderer_skia/src/rasterizer/rectangle.rs
@@ -1,5 +1,5 @@
 use gosub_render_pipeline::common::media::{MediaId, MediaStore};
-use gosub_render_pipeline::painter::commands::border::BorderStyle;
+use gosub_render_pipeline::painter::commands::border::{per_side_strips, BorderStyle};
 use gosub_render_pipeline::painter::commands::brush::Brush;
 use gosub_render_pipeline::painter::commands::gradient::{Gradient, LinearGradient, Tiling};
 use gosub_render_pipeline::painter::commands::rectangle::{BlendMode as CssBlendMode, Rectangle};
@@ -103,38 +103,23 @@ pub fn do_paint_rectangle(canvas: &Canvas, _tile: &Tile, cmd: &Rectangle, media_
 /// Paints a non-uniform border (e.g. `border-bottom` only) by filling each visible side as a
 /// solid edge rectangle. Side order is `[top, right, bottom, left]`.
 fn paint_per_side_border(canvas: &Canvas, cmd: &Rectangle) {
-    let r = cmd.rect();
-    let widths = cmd.border().widths();
-    let styles = cmd.border().styles();
     let brushes = cmd.border().brushes();
+    let strips = per_side_strips(cmd.rect(), cmd.border().widths(), &cmd.border().styles());
 
-    let edges = [
-        (r.x as f32, r.y as f32, r.width as f32, widths[0]),
-        (
-            r.x as f32 + r.width as f32 - widths[1],
-            r.y as f32,
-            widths[1],
-            r.height as f32,
-        ),
-        (
-            r.x as f32,
-            r.y as f32 + r.height as f32 - widths[2],
-            r.width as f32,
-            widths[2],
-        ),
-        (r.x as f32, r.y as f32, widths[3], r.height as f32),
-    ];
-
-    for i in 0..4 {
-        if widths[i] <= 0.0 || styles[i].is_invisible() {
+    for (i, side) in strips.iter().enumerate() {
+        if side.is_empty() {
             continue;
         }
-        let (x, y, w, h) = edges[i];
         let mut paint = Paint::new(brush_to_color4f(&brushes[i]), None);
         paint.set_anti_alias(true);
         paint.set_blend_mode(to_skia_blend_mode(cmd.blend_mode()));
         paint.set_style(skia_safe::paint::Style::Fill);
-        canvas.draw_rect(Rect::from_xywh(x, y, w, h), &paint);
+        for strip in side {
+            canvas.draw_rect(
+                Rect::from_xywh(strip.x as f32, strip.y as f32, strip.width as f32, strip.height as f32),
+                &paint,
+            );
+        }
     }
 }
 

--- a/crates/gosub_renderer_skia/src/rasterizer/rectangle.rs
+++ b/crates/gosub_renderer_skia/src/rasterizer/rectangle.rs
@@ -140,16 +140,19 @@ fn paint_per_side_border(canvas: &Canvas, cmd: &Rectangle) {
 
 /// `radius_x`/`radius_y` yield corners in CSS order (top-left, top-right, bottom-right,
 /// bottom-left), which is also the order Skia's radii array expects.
-fn rounded_rect(cmd: &Rectangle, rect: Rect) -> RRect {
+/// `inset` is how far `rect` sits inside the CSS border box; the radii shrink by the same
+/// amount so the outer edge of an inset stroke keeps the box's corner curvature.
+fn rounded_rect(cmd: &Rectangle, rect: Rect, inset: f32) -> RRect {
     let (x_tl, x_tr, x_br, x_bl) = cmd.radius_x();
     let (y_tl, y_tr, y_br, y_bl) = cmd.radius_y();
+    let r = |v: f64| (v as f32 - inset).max(0.0);
     RRect::new_rect_radii(
         rect,
         &[
-            Point::new(x_tl as f32, y_tl as f32),
-            Point::new(x_tr as f32, y_tr as f32),
-            Point::new(x_br as f32, y_br as f32),
-            Point::new(x_bl as f32, y_bl as f32),
+            Point::new(r(x_tl), r(y_tl)),
+            Point::new(r(x_tr), r(y_tr)),
+            Point::new(r(x_br), r(y_br)),
+            Point::new(r(x_bl), r(y_bl)),
         ],
     )
 }
@@ -157,7 +160,8 @@ fn rounded_rect(cmd: &Rectangle, rect: Rect) -> RRect {
 fn draw_rect_or_rounded(canvas: &Canvas, cmd: &Rectangle, x: f32, y: f32, w: f32, h: f32, paint: &Paint) {
     let skia_rect = Rect::from_xywh(x, y, w, h);
     if cmd.is_rounded() {
-        canvas.draw_rrect(rounded_rect(cmd, skia_rect), paint);
+        let inset = x - cmd.rect().x as f32;
+        canvas.draw_rrect(rounded_rect(cmd, skia_rect, inset), paint);
     } else {
         canvas.draw_rect(skia_rect, paint);
     }
@@ -221,7 +225,7 @@ fn draw_image_brush(
             paint.set_shader(shader);
         }
         if cmd.is_rounded() {
-            canvas.draw_rrect(rounded_rect(cmd, dest), &paint);
+            canvas.draw_rrect(rounded_rect(cmd, dest, 0.0), &paint);
         } else {
             canvas.draw_rect(dest, &paint);
         }
@@ -231,7 +235,7 @@ fn draw_image_brush(
     let sampling = SamplingOptions::new(FilterMode::Linear, MipmapMode::None);
     if cmd.is_rounded() {
         canvas.save();
-        canvas.clip_rrect(rounded_rect(cmd, dest), None, true);
+        canvas.clip_rrect(rounded_rect(cmd, dest, 0.0), None, true);
         canvas.draw_image_rect_with_sampling_options(&image, None, dest, sampling, &paint);
         canvas.restore();
     } else {

--- a/crates/gosub_renderer_skia/src/rasterizer/text/glyphs.rs
+++ b/crates/gosub_renderer_skia/src/rasterizer/text/glyphs.rs
@@ -118,7 +118,7 @@ mod tests {
             weight: 400,
             width: 100,
             slant: 0,
-            line_height: 28.0,
+            line_height: Some(28.0),
             letter_spacing: 0.0,
             alignment: FontAlignment::Start,
             underline: true,

--- a/crates/gosub_renderer_vello/src/rasterizer/rectangle.rs
+++ b/crates/gosub_renderer_vello/src/rasterizer/rectangle.rs
@@ -144,24 +144,24 @@ fn draw_double_border(scene: &mut vello::Scene, rect: &Rectangle, affine: Affine
         return;
     }
 
-    // Two strands inside the border box: [0, w] outer and [w+gap, 2w+gap]
-    // inner, both stroked centered on paths inset to the strand middles.
-    let width = (rect.border().width() as f64 / 2.0).floor();
+    // Two strands inside the border box, split in thirds so strands + gap never
+    // exceed the declared width (the gap absorbs the rounding remainder).
+    let total = rect.border().width() as f64;
+    let strand = (total / 3.0).floor();
+    let gap = total - 2.0 * strand;
     scene.stroke(
-        &kurbo::Stroke::new(width),
+        &kurbo::Stroke::new(strand),
         affine,
         &vello_brush,
         brush_transform,
-        &setup_inset_path(rect, width / 2.0),
+        &setup_inset_path(rect, strand / 2.0),
     );
-
-    let gap_size = 1.0;
     scene.stroke(
-        &kurbo::Stroke::new(width),
+        &kurbo::Stroke::new(strand),
         affine,
         &vello_brush,
         brush_transform,
-        &setup_inset_path(rect, width + gap_size + width / 2.0),
+        &setup_inset_path(rect, strand + gap + strand / 2.0),
     );
 }
 

--- a/crates/gosub_renderer_vello/src/rasterizer/rectangle.rs
+++ b/crates/gosub_renderer_vello/src/rasterizer/rectangle.rs
@@ -1,6 +1,6 @@
 use crate::rasterizer::brush::set_brush;
 use gosub_render_pipeline::common::media::MediaStore;
-use gosub_render_pipeline::painter::commands::border::BorderStyle;
+use gosub_render_pipeline::painter::commands::border::{per_side_strips, BorderStyle};
 use gosub_render_pipeline::painter::commands::rectangle::{BlendMode, Rectangle};
 use vello::kurbo;
 use vello::kurbo::{Affine, PathEl, Point, Rect, RoundedRect, Shape};
@@ -85,25 +85,18 @@ fn paint_rectangle_content(scene: &mut vello::Scene, rect: &Rectangle, affine: A
 /// Side order is `[top, right, bottom, left]`.
 fn paint_per_side_border(scene: &mut vello::Scene, rect: &Rectangle, affine: Affine, media_store: &MediaStore) {
     let r = rect.rect();
-    let widths = rect.border().widths();
-    let styles = rect.border().styles();
     let brushes = rect.border().brushes();
+    let strips = per_side_strips(r, rect.border().widths(), &rect.border().styles());
 
-    let edges = [
-        (r.x, r.y, r.width, widths[0] as f64),
-        (r.x + r.width - widths[1] as f64, r.y, widths[1] as f64, r.height),
-        (r.x, r.y + r.height - widths[2] as f64, r.width, widths[2] as f64),
-        (r.x, r.y, widths[3] as f64, r.height),
-    ];
-
-    for i in 0..4 {
-        if widths[i] <= 0.0 || styles[i].is_invisible() {
+    for (i, side) in strips.iter().enumerate() {
+        if side.is_empty() {
             continue;
         }
-        let (x, y, w, h) = edges[i];
         let (vello_brush, brush_transform) = set_brush(&brushes[i], r, media_store);
-        let edge = Rect::new(x, y, x + w, y + h);
-        scene.fill(Fill::NonZero, affine, &vello_brush, brush_transform, &edge);
+        for strip in side {
+            let edge = Rect::new(strip.x, strip.y, strip.x + strip.width, strip.y + strip.height);
+            scene.fill(Fill::NonZero, affine, &vello_brush, brush_transform, &edge);
+        }
     }
 }
 

--- a/crates/gosub_renderer_vello/src/rasterizer/rectangle.rs
+++ b/crates/gosub_renderer_vello/src/rasterizer/rectangle.rs
@@ -118,9 +118,10 @@ fn draw_single_border(
     let Some(brush) = binding.first() else {
         return;
     };
-    let vello_shape = setup_rectangle_path(rect);
+    let width = rect.border().width() as f64;
+    let vello_shape = setup_inset_path(rect, width / 2.0);
     let (vello_brush, brush_transform) = set_brush(brush, rect.rect(), media_store);
-    let vello_stroke = kurbo::Stroke::new(rect.border().width() as f64).with_dashes(0.0, dashes);
+    let vello_stroke = kurbo::Stroke::new(width).with_dashes(0.0, dashes);
     scene.stroke(&vello_stroke, affine, &vello_brush, brush_transform, &vello_shape);
 }
 
@@ -129,60 +130,38 @@ fn draw_double_border(scene: &mut vello::Scene, rect: &Rectangle, affine: Affine
     let Some(brush) = binding.first() else {
         return;
     };
-    let vello_shape = setup_rectangle_path(rect);
     let (vello_brush, brush_transform) = set_brush(brush, rect.rect(), media_store);
 
     if rect.border().width() < 3.0 {
+        let width = rect.border().width() as f64;
         scene.stroke(
-            &kurbo::Stroke::new(rect.border().width() as f64),
+            &kurbo::Stroke::new(width),
             affine,
             &vello_brush,
             brush_transform,
-            &vello_shape,
+            &setup_inset_path(rect, width / 2.0),
         );
         return;
     }
 
-    let width = (rect.border().width() / 2.0).floor();
+    // Two strands inside the border box: [0, w] outer and [w+gap, 2w+gap]
+    // inner, both stroked centered on paths inset to the strand middles.
+    let width = (rect.border().width() as f64 / 2.0).floor();
     scene.stroke(
-        &kurbo::Stroke::new(width as f64),
+        &kurbo::Stroke::new(width),
         affine,
         &vello_brush,
         brush_transform,
-        &vello_shape,
+        &setup_inset_path(rect, width / 2.0),
     );
 
     let gap_size = 1.0;
-    let inset = width as f64 + gap_size;
-
-    let inner_border_shape = if rect.is_rounded() {
-        let (r_tl, r_tr, r_br, r_bl) = rect.radius_x();
-        ShapeEnum::RoundedRect(RoundedRect::new(
-            rect.rect().x + inset,
-            rect.rect().y + inset,
-            rect.rect().x + rect.rect().width - inset,
-            rect.rect().y + rect.rect().height - inset,
-            (
-                (r_tl - inset).max(0.0),
-                (r_tr - inset).max(0.0),
-                (r_br - inset).max(0.0),
-                (r_bl - inset).max(0.0),
-            ),
-        ))
-    } else {
-        ShapeEnum::Rect(Rect::new(
-            rect.rect().x + inset,
-            rect.rect().y + inset,
-            rect.rect().x + rect.rect().width - inset,
-            rect.rect().y + rect.rect().height - inset,
-        ))
-    };
     scene.stroke(
-        &kurbo::Stroke::new(width as f64),
+        &kurbo::Stroke::new(width),
         affine,
         &vello_brush,
         brush_transform,
-        &inner_border_shape,
+        &setup_inset_path(rect, width + gap_size + width / 2.0),
     );
 }
 
@@ -231,21 +210,35 @@ impl Shape for ShapeEnum {
 }
 
 fn setup_rectangle_path(rect: &Rectangle) -> ShapeEnum {
+    setup_inset_path(rect, 0.0)
+}
+
+/// Builds the rectangle path inset by `inset` on every side. Strokes are
+/// centered on the path, so a border of width `w` must stroke a path inset by
+/// `w / 2` to stay entirely inside the border box (CSS borders never paint
+/// outside it - a centered stroke bleeds into the neighbouring element and
+/// gets painted over, which visibly halves adjacent borders).
+fn setup_inset_path(rect: &Rectangle, inset: f64) -> ShapeEnum {
+    let x0 = rect.rect().x + inset;
+    let y0 = rect.rect().y + inset;
+    let x1 = (rect.rect().x + rect.rect().width - inset).max(x0);
+    let y1 = (rect.rect().y + rect.rect().height - inset).max(y0);
+
     if rect.is_rounded() {
         let (r_tl, r_tr, r_br, r_bl) = rect.radius_x();
         return ShapeEnum::RoundedRect(RoundedRect::new(
-            rect.rect().x,
-            rect.rect().y,
-            rect.rect().x + rect.rect().width,
-            rect.rect().y + rect.rect().height,
-            (r_tl, r_tr, r_br, r_bl),
+            x0,
+            y0,
+            x1,
+            y1,
+            (
+                (r_tl - inset).max(0.0),
+                (r_tr - inset).max(0.0),
+                (r_br - inset).max(0.0),
+                (r_bl - inset).max(0.0),
+            ),
         ));
     }
 
-    ShapeEnum::Rect(Rect::new(
-        rect.rect().x,
-        rect.rect().y,
-        rect.rect().x + rect.rect().width,
-        rect.rect().y + rect.rect().height,
-    ))
+    ShapeEnum::Rect(Rect::new(x0, y0, x1, y1))
 }

--- a/crates/gosub_renderer_vello/src/rasterizer/text/glyphs.rs
+++ b/crates/gosub_renderer_vello/src/rasterizer/text/glyphs.rs
@@ -91,7 +91,7 @@ mod tests {
             weight: 400,
             width: 100,
             slant: 0,
-            line_height: 28.0,
+            line_height: Some(28.0),
             letter_spacing: 0.0,
             alignment: FontAlignment::Start,
             underline: true,

--- a/scripts/table-compare.sh
+++ b/scripts/table-compare.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Renders every table fixture with gosub-screenshot (Cairo) AND headless
+# Chromium, then writes an HTML page showing the pairs side by side.
+#
+# Usage: scripts/table-compare.sh [output-dir]   (default: target/table-compare)
+# Open <output-dir>/compare.html in a browser afterwards.
+#
+# Notes:
+# - Fixtures are served over HTTP because the engine refuses file:// URLs.
+# - Snap-confined Chromium can only write inside $HOME (not dot-dirs), so its
+#   screenshots go to a temp file in $HOME and are moved into place.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+OUT="${1:-target/table-compare}"
+PORT=8734
+VIEWPORT=1280
+SHOT=target/release/gosub-screenshot
+CHROME_BIN="${CHROME_BIN:-chromium}"
+
+mkdir -p "$OUT"
+
+if [ ! -x "$SHOT" ]; then
+    echo "building gosub-screenshot (cairo)..."
+    cargo build --release -p gosub-screenshot --no-default-features --features backend_cairo
+fi
+
+python3 -m http.server "$PORT" --directory tests/data/tables >/dev/null 2>&1 &
+SERVER_PID=$!
+trap 'kill $SERVER_PID 2>/dev/null || true' EXIT
+sleep 0.5
+
+HTML="$OUT/compare.html"
+cat > "$HTML" <<'EOF'
+<!doctype html><meta charset="utf-8"><title>gosub vs Chrome - table fixtures</title>
+<style>
+body { font-family: sans-serif; margin: 1rem; background: #f4f4f4; }
+h2 { margin: 2rem 0 0.5rem; font-size: 1rem; }
+.pair { display: flex; gap: 8px; }
+.pair figure { margin: 0; flex: 1; min-width: 0; }
+.pair figcaption { font-size: 0.75rem; color: #555; padding: 2px 0; }
+.pair img { width: 100%; border: 1px solid #ccc; background: #fff; }
+</style>
+<h1 style="font-size:1.2rem">gosub_lattice (Cairo) vs Chromium - tests/data/tables</h1>
+EOF
+
+CHROME_TMP="$HOME/gosub-table-compare-tmp.png"
+find tests/data/tables -name '[0-9][0-9]-*.html' | sort | while read -r fixture; do
+    name=$(basename "$fixture" .html)
+    echo "== $name"
+    "$SHOT" "http://127.0.0.1:$PORT/$name.html" "$OUT/gosub-$name.png" "$VIEWPORT" >/dev/null
+    "$CHROME_BIN" --headless --disable-gpu --hide-scrollbars \
+        --force-device-scale-factor=1 --window-size="$VIEWPORT,800" \
+        --screenshot="$CHROME_TMP" "http://127.0.0.1:$PORT/$name.html" >/dev/null 2>&1
+    mv "$CHROME_TMP" "$OUT/chrome-$name.png"
+    {
+        echo "<h2>$name</h2><div class=\"pair\">"
+        echo "<figure><figcaption>gosub</figcaption><img src=\"gosub-$name.png\"></figure>"
+        echo "<figure><figcaption>Chrome</figcaption><img src=\"chrome-$name.png\"></figure>"
+        echo "</div>"
+    } >> "$HTML"
+done
+
+echo "wrote $HTML"

--- a/scripts/wpt-fonts.conf
+++ b/scripts/wpt-fonts.conf
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<!--
+  Deterministic generic-family mapping for WPT reftests (used via FONTCONFIG_FILE by
+  scripts/wpt-reftest.py). Pins the generics to the same fonts snap Chromium resolves
+  (Liberation Serif/Sans, DejaVu Sans Mono) so gosub and the report's Chrome column
+  shape identical glyphs - and so `serif` has Times-class metrics (ascent+descent
+  ~1.11em): many CSS2 tests put 20px text in a 24px line box and assume the descender
+  fits, which Noto Serif's 1.36em metrics cannot satisfy.
+-->
+<fontconfig>
+  <include ignore_missing="yes">/etc/fonts/fonts.conf</include>
+
+  <match target="pattern">
+    <test qual="any" name="family"><string>serif</string></test>
+    <edit name="family" mode="prepend" binding="strong"><string>Liberation Serif</string></edit>
+  </match>
+  <match target="pattern">
+    <test qual="any" name="family"><string>sans-serif</string></test>
+    <edit name="family" mode="prepend" binding="strong"><string>Liberation Sans</string></edit>
+  </match>
+  <match target="pattern">
+    <test qual="any" name="family"><string>monospace</string></test>
+    <edit name="family" mode="prepend" binding="strong"><string>DejaVu Sans Mono</string></edit>
+  </match>
+</fontconfig>

--- a/scripts/wpt-reftest.py
+++ b/scripts/wpt-reftest.py
@@ -183,11 +183,15 @@ class Renderer:
             rel = page.relative_to(self.root).as_posix()
             out = self.out_dir / (rel.replace("/", "__") + ".png")
             url = f"http://127.0.0.1:{self.port}/{rel}"
+            # Pin the generic font families (see wpt-fonts.conf) so results don't depend on
+            # the distro's fontconfig defaults.
+            env = dict(os.environ,
+                       FONTCONFIG_FILE=str(Path(__file__).resolve().parent / "wpt-fonts.conf"))
             with self.sem:
                 proc = subprocess.run(
                     [self.shot_bin, url, str(out), str(VIEWPORT_W),
                      "--nav-timeout", "20", "--render-timeout", "30"],
-                    capture_output=True, timeout=90)
+                    capture_output=True, timeout=90, env=env)
             if proc.returncode != 0 or not out.exists():
                 raise RuntimeError(
                     f"render failed: {proc.stderr.decode(errors='replace')[-200:]}")

--- a/scripts/wpt-reftest.py
+++ b/scripts/wpt-reftest.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""WPT reftest runner for the gosub engine.
+
+Discovers reftests (<link rel="match"/"mismatch">) under a WPT subtree,
+renders test and reference pages with gosub-screenshot (Cairo backend), and
+pixel-compares them on a WPT-style 800x600 canvas.
+
+Usage:
+  scripts/wpt-reftest.py --wpt-root ~/code/gosub/wpt css/CSS2/tables
+  scripts/wpt-reftest.py --wpt-root ~/code/gosub/wpt css/CSS2/tables/table-anonymous-objects-001.xht
+
+Outputs a summary, a JSON results file, and (with --report) an HTML report of
+failures with test/ref/diff images side by side.
+
+Requirements: the Ahem font must be installed (fc-match Ahem), and
+target/release/gosub-screenshot must be built with the Cairo backend:
+  cargo build --release -p gosub-screenshot --no-default-features --features backend_cairo
+"""
+
+import argparse
+import base64
+import concurrent.futures
+import functools
+import html
+import http.server
+import io
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+from PIL import Image, ImageChops
+
+VIEWPORT_W = 800
+VIEWPORT_H = 600
+
+LINK_RE = re.compile(
+    r'<link[^>]+rel=["\']?(match|mismatch)["\']?[^>]*>', re.I)
+HREF_RE = re.compile(r'href=["\']?([^"\'\s>]+)', re.I)
+FUZZY_RE = re.compile(
+    r'<meta[^>]+name=["\']?fuzzy["\']?[^>]+content=["\']([^"\']+)["\']', re.I)
+WAIT_RE = re.compile(r'class=["\'][^"\']*reftest-wait', re.I)
+SCRIPT_RE = re.compile(r'<script\b', re.I)
+
+
+def parse_fuzzy(content):
+    """Parse a WPT fuzzy annotation into (max_channel_diff, max_pixel_count).
+
+    Content looks like "maxDifference=0-2;totalPixels=0-300", optionally
+    prefixed with "ref-name.html:". We take the upper bounds and, with
+    multiple annotations, the loosest.
+    """
+    spec = content.split(":", 1)[-1] if ("=" in content.split(":", 1)[-1]) else content
+    max_diff = pixels = 0
+    for part in spec.split(";"):
+        part = part.strip()
+        m = re.match(r'(maxDifference|totalPixels)\s*=\s*(?:\d+-)?(\d+)', part)
+        if not m:
+            continue
+        if m.group(1) == "maxDifference":
+            max_diff = int(m.group(2))
+        else:
+            pixels = int(m.group(2))
+    return max_diff, pixels
+
+
+def discover(root, target):
+    """Yield (test_path, [(rel, ref_path)], fuzzy, skip_reason) tuples."""
+    target_path = root / target
+    files = [target_path] if target_path.is_file() else sorted(
+        p for p in target_path.rglob("*")
+        if p.suffix in (".html", ".htm", ".xht", ".xhtml")
+    )
+    for f in files:
+        try:
+            text = f.read_text(errors="replace")
+        except OSError:
+            continue
+        refs = []
+        for link in LINK_RE.finditer(text):
+            href = HREF_RE.search(link.group(0))
+            if href:
+                rel = link.group(1).lower()
+                ref = (f.parent / href.group(1)).resolve()
+                refs.append((rel, ref))
+        if not refs:
+            continue
+        skip = None
+        if WAIT_RE.search(text):
+            skip = "reftest-wait (needs script support)"
+        elif SCRIPT_RE.search(text):
+            skip = "uses <script>"
+        fuzzy = (0, 0)
+        fm = FUZZY_RE.search(text)
+        if fm:
+            fuzzy = parse_fuzzy(fm.group(1))
+        yield f, refs, fuzzy, skip
+
+
+class WptHandler(http.server.SimpleHTTPRequestHandler):
+    """Serves the WPT tree; XHTML goes out as text/html for the engine.
+
+    The engine has no XML parser, so XHTML gets the HTML treatment. That
+    breaks `<![CDATA[ ... ]]>`-wrapped stylesheets (the markers become
+    stylesheet text and poison rule parsing), so those markers are stripped
+    on the way out.
+    """
+    extensions_map = {
+        **http.server.SimpleHTTPRequestHandler.extensions_map,
+        ".xht": "text/html",
+        ".xhtml": "text/html",
+        ".htm": "text/html",
+    }
+
+    def do_GET(self):
+        path = Path(self.translate_path(self.path))
+        if path.suffix not in (".xht", ".xhtml", ".html", ".htm") or not path.is_file():
+            return super().do_GET()
+        data = path.read_bytes().replace(b"<![CDATA[", b"").replace(b"]]>", b"")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, *args):
+        pass
+
+
+def start_server(root):
+    handler = functools.partial(WptHandler, directory=str(root))
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, server.server_address[1]
+
+
+def to_canvas(png_bytes):
+    """Place a full-page render on a white WPT viewport canvas (800x600)."""
+    img = Image.open(io.BytesIO(png_bytes)).convert("RGB")
+    canvas = Image.new("RGB", (VIEWPORT_W, VIEWPORT_H), "white")
+    canvas.paste(img.crop((0, 0, min(img.width, VIEWPORT_W),
+                           min(img.height, VIEWPORT_H))), (0, 0))
+    return canvas
+
+
+def images_match(a, b, fuzzy):
+    diff = ImageChops.difference(a, b)
+    bbox = diff.getbbox()
+    if bbox is None:
+        return True, 0, 0
+    max_diff, pixel_budget = fuzzy
+    hist_max = max(ch.getextrema()[1] for ch in diff.split())
+    differing = sum(1 for px in diff.getdata() if px != (0, 0, 0))
+    ok = hist_max <= max_diff and differing <= pixel_budget
+    return ok, hist_max, differing
+
+
+class Renderer:
+    def __init__(self, shot_bin, root, port, out_dir, jobs):
+        self.shot_bin, self.root, self.port = shot_bin, root, port
+        self.out_dir = out_dir
+        self.cache = {}
+        self.lock = threading.Lock()
+        self.sem = threading.Semaphore(jobs)
+
+    def render(self, page: Path):
+        """Render one page, cached by path. Returns PNG bytes or raises."""
+        key = str(page)
+        with self.lock:
+            fut = self.cache.get(key)
+            if fut is None:
+                fut = self.cache[key] = concurrent.futures.Future()
+                owner = True
+            else:
+                owner = False
+        if not owner:
+            return fut.result()
+        try:
+            rel = page.relative_to(self.root).as_posix()
+            out = self.out_dir / (rel.replace("/", "__") + ".png")
+            url = f"http://127.0.0.1:{self.port}/{rel}"
+            with self.sem:
+                proc = subprocess.run(
+                    [self.shot_bin, url, str(out), str(VIEWPORT_W),
+                     "--nav-timeout", "20", "--render-timeout", "30"],
+                    capture_output=True, timeout=90)
+            if proc.returncode != 0 or not out.exists():
+                raise RuntimeError(
+                    f"render failed: {proc.stderr.decode(errors='replace')[-200:]}")
+            data = out.read_bytes()
+            fut.set_result(data)
+            return data
+        except BaseException as e:
+            fut.set_exception(e)
+            raise
+
+
+def run_test(renderer, test, refs, fuzzy):
+    try:
+        test_img = to_canvas(renderer.render(test))
+    except Exception as e:
+        return "ERROR", f"test render: {e}", None
+
+    match_results, detail = [], []
+    for rel, ref in refs:
+        if not ref.exists():
+            return "ERROR", f"missing ref {ref.name}", None
+        try:
+            ref_img = to_canvas(renderer.render(ref))
+        except Exception as e:
+            return "ERROR", f"ref render: {e}", None
+        equal, max_d, n_px = images_match(test_img, ref_img, fuzzy)
+        detail.append(f"{rel} {ref.name}: maxdiff={max_d} pixels={n_px}")
+        if rel == "match":
+            match_results.append(equal)
+        elif equal:  # mismatch ref that matched
+            return "FAIL", "; ".join(detail), refs[0][1]
+    # Multiple match refs are alternates: any one passing suffices.
+    if match_results and not any(match_results):
+        return "FAIL", "; ".join(detail), refs[0][1]
+    return "PASS", "; ".join(detail), None
+
+
+def chrome_shot(url, chrome_bin="chromium"):
+    """Render `url` with headless Chromium (writes inside $HOME: snap)."""
+    tmp = Path.home() / f"gosub-wpt-chrome-{os.getpid()}.png"
+    try:
+        subprocess.run(
+            [chrome_bin, "--headless", "--disable-gpu", "--hide-scrollbars",
+             "--force-device-scale-factor=1",
+             f"--window-size={VIEWPORT_W},{VIEWPORT_H}",
+             f"--screenshot={tmp}", url],
+            capture_output=True, timeout=60)
+        return tmp.read_bytes()
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def write_report(path, failures, renderer, with_chrome=False):
+    rows = []
+    for test, refs, note in failures:
+        try:
+            t64 = base64.b64encode(renderer.render(test)).decode()
+            r64 = base64.b64encode(renderer.render(refs[0][1])).decode()
+        except Exception:
+            continue
+        chrome_fig = ""
+        if with_chrome:
+            try:
+                rel = test.relative_to(renderer.root).as_posix()
+                c64 = base64.b64encode(
+                    chrome_shot(f"http://127.0.0.1:{renderer.port}/{rel}")).decode()
+                chrome_fig = (f'<figure><figcaption>chrome (test)</figcaption>'
+                              f'<img src="data:image/png;base64,{c64}"></figure>')
+            except Exception:
+                pass
+        rows.append(f"""
+<section><h2>{html.escape(str(test.relative_to(renderer.root)))}</h2>
+<p>{html.escape(note)}</p>
+<div class="pair">
+<figure><figcaption>gosub (test)</figcaption><img src="data:image/png;base64,{t64}"></figure>
+<figure><figcaption>gosub (ref, {html.escape(refs[0][0])})</figcaption><img src="data:image/png;base64,{r64}"></figure>
+{chrome_fig}
+</div></section>""")
+    path.write_text(f"""<!doctype html><meta charset="utf-8">
+<title>gosub WPT reftest failures</title>
+<style>body{{font:14px sans-serif;margin:1rem;background:#f4f4f4;color:#222}}
+.pair{{display:flex;gap:8px}} figure{{flex:1;margin:0;min-width:0}}
+img{{width:100%;border:1px solid #ccc;background:#fff}}
+figcaption{{font-size:.75rem;color:#555}}
+h2{{font-size:1rem;margin:1.5rem 0 .3rem;font-family:monospace}}
+p{{font-size:.8rem;color:#666;margin:.2rem 0}}</style>
+<h1 style="font-size:1.2rem">{len(rows)} failures shown</h1>{''.join(rows)}""")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("target", help="path under the WPT root, dir or file")
+    ap.add_argument("--wpt-root", default=os.path.expanduser("~/code/gosub/wpt"))
+    ap.add_argument("--shot-bin", default="target/release/gosub-screenshot")
+    ap.add_argument("--jobs", type=int, default=max(2, (os.cpu_count() or 4) // 2))
+    ap.add_argument("--out", default="target/wpt-reftest")
+    ap.add_argument("--report", action="store_true",
+                    help="write failures.html with side-by-side images")
+    ap.add_argument("--max-report", type=int, default=80)
+    ap.add_argument("--chrome", action="store_true",
+                    help="add a headless-Chromium render of each failing test to the report")
+    ap.add_argument("--filter", default="",
+                    help="only run tests whose filename contains this substring")
+    args = ap.parse_args()
+
+    root = Path(args.wpt_root).resolve()
+    out_dir = Path(args.out)
+    (out_dir / "shots").mkdir(parents=True, exist_ok=True)
+
+    if subprocess.run(["fc-match", "Ahem"], capture_output=True,
+                      text=True).stdout.split(":")[0] != "Ahem.ttf":
+        print("warning: Ahem font not resolved - expect bogus failures", file=sys.stderr)
+
+    tests = [t for t in discover(root, args.target) if args.filter in t[0].name]
+    if not tests:
+        sys.exit(f"no reftests found under {args.target}")
+
+    server, port = start_server(root)
+    renderer = Renderer(args.shot_bin, root, port, out_dir / "shots", args.jobs)
+
+    results, failures = {}, []
+    done = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:
+        futs = {}
+        for test, refs, fuzzy, skip in tests:
+            name = str(test.relative_to(root))
+            if skip:
+                results[name] = {"status": "SKIP", "note": skip}
+                continue
+            futs[pool.submit(run_test, renderer, test, refs, fuzzy)] = (test, refs, name)
+        for fut in concurrent.futures.as_completed(futs):
+            test, refs, name = futs[fut]
+            status, note, _ = fut.result()
+            results[name] = {"status": status, "note": note}
+            if status == "FAIL":
+                failures.append((test, refs, note))
+            done += 1
+            if done % 25 == 0:
+                print(f"  ...{done}/{len(futs)}", file=sys.stderr)
+
+    counts = {}
+    for r in results.values():
+        counts[r["status"]] = counts.get(r["status"], 0) + 1
+    (out_dir / "results.json").write_text(json.dumps(results, indent=1, sort_keys=True))
+
+    total_run = counts.get("PASS", 0) + counts.get("FAIL", 0) + counts.get("ERROR", 0)
+    print(f"\n{args.target}: {counts.get('PASS', 0)}/{total_run} pass "
+          f"({counts.get('FAIL', 0)} fail, {counts.get('ERROR', 0)} error, "
+          f"{counts.get('SKIP', 0)} skipped)")
+    print(f"results: {out_dir}/results.json")
+
+    if args.report and failures:
+        failures.sort(key=lambda f: str(f[0]))
+        write_report(out_dir / "failures.html", failures[:args.max_report],
+                     renderer, with_chrome=args.chrome)
+        print(f"report:  {out_dir}/failures.html")
+
+    server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/wpt-reftest.py
+++ b/scripts/wpt-reftest.py
@@ -48,17 +48,14 @@ SCRIPT_RE = re.compile(r'<script\b', re.I)
 
 
 def parse_fuzzy(content):
-    """Parse a WPT fuzzy annotation into (max_channel_diff, max_pixel_count).
+    """Parse one WPT fuzzy annotation into (max_channel_diff, max_pixel_count).
 
-    Content looks like "maxDifference=0-2;totalPixels=0-300", optionally
-    prefixed with "ref-name.html:". We take the upper bounds and, with
-    multiple annotations, the loosest.
+    Content looks like "maxDifference=0-2;totalPixels=0-300"; ranges keep their
+    upper bound. Explicit zeros stay zero: they demand an exact match.
     """
-    spec = content.split(":", 1)[-1] if ("=" in content.split(":", 1)[-1]) else content
     max_diff = pixels = 0
-    for part in spec.split(";"):
-        part = part.strip()
-        m = re.match(r'(maxDifference|totalPixels)\s*=\s*(?:\d+-)?(\d+)', part)
+    for part in content.split(";"):
+        m = re.match(r'(maxDifference|totalPixels)\s*=\s*(?:\d+-)?(\d+)', part.strip())
         if not m:
             continue
         if m.group(1) == "maxDifference":
@@ -66,6 +63,28 @@ def parse_fuzzy(content):
         else:
             pixels = int(m.group(2))
     return max_diff, pixels
+
+
+def parse_fuzzy_meta(text):
+    """Collect every fuzzy annotation in a test: {ref_name_or_None: (max_diff, pixels)}.
+
+    A "ref.html:maxDifference=..." annotation applies only to that reference; an
+    unprefixed one is the default for the rest. Absent metadata means exact match.
+    """
+    out = {}
+    for fm in FUZZY_RE.finditer(text):
+        content = fm.group(1)
+        head, sep, tail = content.partition(":")
+        if sep and "=" in tail and "=" not in head:
+            out[Path(head.strip()).name] = parse_fuzzy(tail)
+        else:
+            out[None] = parse_fuzzy(content)
+    return out
+
+
+def fuzzy_for(fuzzy_meta, ref):
+    """Tolerance for `ref`: its own annotation, else the unprefixed default, else exact."""
+    return fuzzy_meta.get(ref.name, fuzzy_meta.get(None, (0, 0)))
 
 
 def discover(root, target):
@@ -98,11 +117,7 @@ def discover(root, target):
             skip = "reftest-wait (needs script support)"
         elif SCRIPT_RE.search(text):
             skip = "uses <script>"
-        fuzzy = (0, 0)
-        fm = FUZZY_RE.search(text)
-        if fm:
-            fuzzy = parse_fuzzy(fm.group(1))
-        yield f, refs, fuzzy, skip
+        yield f, refs, parse_fuzzy_meta(text), skip
 
 
 class WptHandler(http.server.SimpleHTTPRequestHandler):
@@ -156,14 +171,16 @@ def images_match(a, b, fuzzy):
     bbox = diff.getbbox()
     if bbox is None:
         return True, 0, 0
-    max_diff, pixel_budget = fuzzy
-    # Baseline tolerance: channel differences of 1 are sub-antialiasing rounding noise
-    # (two float layout paths landing 1e-4 apart blend fringes +/-1). The old CSS2 tests
-    # predate WPT fuzzy metadata and say "except for antialiasing issues" in prose.
-    max_diff = max(max_diff, 1)
     hist_max = max(ch.getextrema()[1] for ch in diff.split())
     differing = sum(1 for px in diff.getdata() if px != (0, 0, 0))
-    ok = hist_max <= max_diff and (pixel_budget == 0 or differing <= pixel_budget)
+    if fuzzy is None:
+        # No metadata at all. The old CSS2 tests predate WPT fuzzy annotations and say
+        # "except for antialiasing issues" in prose, so channel differences of 1
+        # (sub-antialiasing rounding noise between two float layout paths) pass.
+        return hist_max <= 1, hist_max, differing
+    # Explicit metadata is taken literally: maxDifference=0;totalPixels=0 is exact.
+    max_diff, pixel_budget = fuzzy
+    ok = hist_max <= max_diff and differing <= pixel_budget
     return ok, hist_max, differing
 
 
@@ -214,7 +231,7 @@ class Renderer:
             raise
 
 
-def run_test(renderer, test, refs, fuzzy):
+def run_test(renderer, test, refs, fuzzy_meta):
     try:
         test_img = to_canvas(renderer.render(test))
     except Exception as e:
@@ -228,6 +245,7 @@ def run_test(renderer, test, refs, fuzzy):
             ref_img = to_canvas(renderer.render(ref))
         except Exception as e:
             return "ERROR", f"ref render: {e}", None
+        fuzzy = fuzzy_for(fuzzy_meta, ref) if fuzzy_meta else None
         equal, max_d, n_px = images_match(test_img, ref_img, fuzzy)
         detail.append(f"{rel} {ref.name}: maxdiff={max_d} pixels={n_px}")
         if rel == "match":

--- a/scripts/wpt-reftest.py
+++ b/scripts/wpt-reftest.py
@@ -153,9 +153,13 @@ def images_match(a, b, fuzzy):
     if bbox is None:
         return True, 0, 0
     max_diff, pixel_budget = fuzzy
+    # Baseline tolerance: channel differences of 1 are sub-antialiasing rounding noise
+    # (two float layout paths landing 1e-4 apart blend fringes +/-1). The old CSS2 tests
+    # predate WPT fuzzy metadata and say "except for antialiasing issues" in prose.
+    max_diff = max(max_diff, 1)
     hist_max = max(ch.getextrema()[1] for ch in diff.split())
     differing = sum(1 for px in diff.getdata() if px != (0, 0, 0))
-    ok = hist_max <= max_diff and differing <= pixel_budget
+    ok = hist_max <= max_diff and (pixel_budget == 0 or differing <= pixel_budget)
     return ok, hist_max, differing
 
 
@@ -190,6 +194,9 @@ class Renderer:
             with self.sem:
                 proc = subprocess.run(
                     [self.shot_bin, url, str(out), str(VIEWPORT_W),
+                     # Min capture height = comparison canvas: abs-positioned reference
+                     # content below the page's flow height must not be cut off.
+                     "--min-height", str(VIEWPORT_H),
                      "--nav-timeout", "20", "--render-timeout", "30"],
                     capture_output=True, timeout=90, env=env)
             if proc.returncode != 0 or not out.exists():

--- a/scripts/wpt-reftest.py
+++ b/scripts/wpt-reftest.py
@@ -85,7 +85,11 @@ def discover(root, target):
             href = HREF_RE.search(link.group(0))
             if href:
                 rel = link.group(1).lower()
-                ref = (f.parent / href.group(1)).resolve()
+                h = href.group(1)
+                # WPT-root-absolute hrefs ("/css/reference/...") resolve against the
+                # checkout root, not the test's directory.
+                base = root if h.startswith("/") else f.parent
+                ref = (base / h.lstrip("/")).resolve()
                 refs.append((rel, ref))
         if not refs:
             continue

--- a/tests/data/tables/01-basic-grid.html
+++ b/tests/data/tables/01-basic-grid.html
@@ -9,8 +9,10 @@
 </style>
 </head>
 <body>
-<h3>Basic 3x3 grid - equal auto columns, uniform content</h3>
-<p>Expected: three equal-width columns, three equal-height rows, 2px gutters.</p>
+<h3>Basic 3x3 grid - auto columns, uniform content</h3>
+<p>Expected: the table shrinks to fit its content (auto width); each column is
+as wide as its widest word ("seven" &gt; "one"); three equal-height rows, 2px
+gutters.</p>
 <table>
   <tr><td>one</td><td>two</td><td>three</td></tr>
   <tr><td>four</td><td>five</td><td>six</td></tr>

--- a/tests/data/tables/01-basic-grid.html
+++ b/tests/data/tables/01-basic-grid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>01 - basic 3x3 grid</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  table { border-spacing: 2px; }
+  td { border: 1px solid #999; padding: 6px; background-color: #e8f0fe; }
+</style>
+</head>
+<body>
+<h3>Basic 3x3 grid - equal auto columns, uniform content</h3>
+<p>Expected: three equal-width columns, three equal-height rows, 2px gutters.</p>
+<table>
+  <tr><td>one</td><td>two</td><td>three</td></tr>
+  <tr><td>four</td><td>five</td><td>six</td></tr>
+  <tr><td>seven</td><td>eight</td><td>nine</td></tr>
+</table>
+</body>
+</html>

--- a/tests/data/tables/02-ragged-rows.html
+++ b/tests/data/tables/02-ragged-rows.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>02 - ragged rows and empty cells</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  table { border-spacing: 2px; }
+  td { border: 1px solid #999; padding: 6px; background-color: #e8f0fe; }
+  .empty { background-color: #fce8e8; }
+</style>
+</head>
+<body>
+<h3>Ragged rows - rows with 4, 2, and 3 cells; one fully empty cell</h3>
+<p>Expected: table is 4 columns wide (widest row wins); short rows leave
+missing slots blank at the right; the empty cell still gets its column's
+width and the row's height.</p>
+<table>
+  <tr><td>r1c1</td><td>r1c2</td><td>r1c3</td><td>r1c4</td></tr>
+  <tr><td>r2c1</td><td>r2c2</td></tr>
+  <tr><td>r3c1</td><td class="empty"></td><td>r3c3</td></tr>
+</table>
+</body>
+</html>

--- a/tests/data/tables/03-sections.html
+++ b/tests/data/tables/03-sections.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>03 - thead/tfoot ordering and multiple tbodies</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  table { border-spacing: 2px; }
+  td, th { border: 1px solid #999; padding: 6px; }
+  thead th { background-color: #d0e2ff; }
+  tfoot td { background-color: #ffe2d0; }
+  .b1 td { background-color: #e8f6e8; }
+  .b2 td { background-color: #f6f0e0; }
+</style>
+</head>
+<body>
+<h3>Sections - tfoot written before thead, two tbodies</h3>
+<p>Expected render order top-to-bottom: blue header, green body, tan body,
+orange footer - regardless of source order (tfoot appears first in the
+source here).</p>
+<table>
+  <tfoot>
+    <tr><td>footer 1</td><td>footer 2</td></tr>
+  </tfoot>
+  <thead>
+    <tr><th>Head A</th><th>Head B</th></tr>
+  </thead>
+  <tbody class="b1">
+    <tr><td>body1 r1a</td><td>body1 r1b</td></tr>
+    <tr><td>body1 r2a</td><td>body1 r2b</td></tr>
+  </tbody>
+  <tbody class="b2">
+    <tr><td>body2 r1a</td><td>body2 r1b</td></tr>
+  </tbody>
+</table>
+</body>
+</html>

--- a/tests/data/tables/04-anonymous-boxes.html
+++ b/tests/data/tables/04-anonymous-boxes.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>04 - anonymous table boxes</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  .tbl { display: table; border-spacing: 2px; }
+  .row { display: table-row; }
+  .cell { display: table-cell; border: 1px solid #999; padding: 6px; background-color: #e8f0fe; }
+  .bare-cells { display: table; }
+  .bare-cells .cell { background-color: #e8f6e8; }
+</style>
+</head>
+<body>
+<h3>CSS display:table on divs + anonymous box generation</h3>
+<p>Expected: first block renders as a normal 2x2 table. Second block has
+cells directly under the table (no row) - an anonymous row must be
+generated, producing one row of two cells.</p>
+
+<div class="tbl">
+  <div class="row"><div class="cell">a1</div><div class="cell">a2</div></div>
+  <div class="row"><div class="cell">b1</div><div class="cell">b2</div></div>
+</div>
+
+<br>
+
+<div class="bare-cells">
+  <div class="cell">bare 1</div>
+  <div class="cell">bare 2</div>
+</div>
+</body>
+</html>

--- a/tests/data/tables/05-caption.html
+++ b/tests/data/tables/05-caption.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>05 - captions</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  table { border-spacing: 2px; }
+  td { border: 1px solid #999; padding: 6px; background-color: #e8f0fe; }
+  caption { background-color: #fff3c4; padding: 4px; }
+  .bottom caption { caption-side: bottom; }
+</style>
+</head>
+<body>
+<h3>Captions - default (top) and caption-side: bottom</h3>
+<p>Expected: first table shows the yellow caption above the grid, second
+shows it below. The caption spans the table width and is part of the
+table's total height.</p>
+
+<table>
+  <caption>Caption on top (default)</caption>
+  <tr><td>one</td><td>two</td></tr>
+  <tr><td>three</td><td>four</td></tr>
+</table>
+
+<br>
+
+<table class="bottom">
+  <caption>Caption on the bottom</caption>
+  <tr><td>one</td><td>two</td></tr>
+  <tr><td>three</td><td>four</td></tr>
+</table>
+</body>
+</html>

--- a/tests/data/tables/06-colspan.html
+++ b/tests/data/tables/06-colspan.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>06 - colspan</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  table { border-spacing: 2px; }
+  td { border: 1px solid #999; padding: 6px; background-color: #e8f0fe; }
+  .span { background-color: #ffd9b3; }
+</style>
+</head>
+<body>
+<h3>Colspan - spans of 2, 3, full width, and overflowing</h3>
+<p>Expected: orange cells span the stated columns; the width of a spanning
+cell equals the sum of its columns plus the gutters between them. The last
+row's colspan=9 exceeds the 4-column grid and must not widen the table.</p>
+<table>
+  <tr><td>c1</td><td>c2</td><td>c3</td><td>c4</td></tr>
+  <tr><td class="span" colspan="2">span 2</td><td>c3</td><td>c4</td></tr>
+  <tr><td>c1</td><td class="span" colspan="3">span 3</td></tr>
+  <tr><td class="span" colspan="4">span all 4</td></tr>
+  <tr><td class="span" colspan="9">colspan 9 (clamped)</td></tr>
+</table>
+</body>
+</html>

--- a/tests/data/tables/06-colspan.html
+++ b/tests/data/tables/06-colspan.html
@@ -13,13 +13,15 @@
 <h3>Colspan - spans of 2, 3, full width, and overflowing</h3>
 <p>Expected: orange cells span the stated columns; the width of a spanning
 cell equals the sum of its columns plus the gutters between them. The last
-row's colspan=9 exceeds the 4-column grid and must not widen the table.</p>
+row's colspan=9 nominally widens the HTML grid to 9 columns, but no cell
+originates in columns 5-9, so those columns get no width or gutters and the
+table stays as wide as 4 columns (this is what Chrome and Firefox render).</p>
 <table>
   <tr><td>c1</td><td>c2</td><td>c3</td><td>c4</td></tr>
   <tr><td class="span" colspan="2">span 2</td><td>c3</td><td>c4</td></tr>
   <tr><td>c1</td><td class="span" colspan="3">span 3</td></tr>
   <tr><td class="span" colspan="4">span all 4</td></tr>
-  <tr><td class="span" colspan="9">colspan 9 (clamped)</td></tr>
+  <tr><td class="span" colspan="9">colspan 9 (trailing empty columns truncated)</td></tr>
 </table>
 </body>
 </html>

--- a/tests/data/tables/07-rowspan.html
+++ b/tests/data/tables/07-rowspan.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>07 - rowspan</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  table { border-spacing: 2px; }
+  td { border: 1px solid #999; padding: 6px; background-color: #e8f0fe; }
+  .span { background-color: #ffd9b3; }
+  .tall { background-color: #d9ffb3; }
+</style>
+</head>
+<body>
+<h3>Rowspan - spanning cells, tall spanner, span past the last row</h3>
+<p>Expected: the first orange cell covers rows 1-2 of column 1; later cells
+in those rows shift right. The green cell has tall content spanning rows
+3-4 - those two rows together must be tall enough to contain it. The final
+rowspan=5 is clamped to the remaining single row.</p>
+<table>
+  <tr><td class="span" rowspan="2">rows 1-2</td><td>r1c2</td><td>r1c3</td></tr>
+  <tr><td>r2c2</td><td>r2c3</td></tr>
+  <tr><td>r3c1</td><td class="tall" rowspan="2"><div>tall content</div><div>line 2</div><div>line 3</div><div>line 4</div><div>line 5</div></td><td>r3c3</td></tr>
+  <tr><td>r4c1</td><td>r4c3</td></tr>
+  <tr><td>r5c1</td><td class="span" rowspan="5">rowspan 5 (clamped)</td><td>r5c3</td></tr>
+</table>
+</body>
+</html>

--- a/tests/data/tables/08-span-mix.html
+++ b/tests/data/tables/08-span-mix.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>08 - colspan + rowspan combined</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  table { border-spacing: 2px; }
+  td { border: 1px solid #999; padding: 6px; background-color: #e8f0fe; }
+  .big { background-color: #ffd9b3; }
+  .wide { background-color: #d9ffb3; }
+  .tall { background-color: #f0d9ff; }
+</style>
+</head>
+<body>
+<h3>Combined spans - a 2x2 block, plus interlocking spans</h3>
+<p>Expected: the orange cell occupies a 2-column-by-2-row block in the top
+left; the purple cell spans rows 1-3 in the last column; the green cell
+spans columns 1-3 in row 4. Slot-filling must route the smaller cells
+around all three without overlap.</p>
+<table>
+  <tr><td class="big" colspan="2" rowspan="2">2x2 block</td><td>r1c3</td><td class="tall" rowspan="3">rows 1-3</td></tr>
+  <tr><td>r2c3</td></tr>
+  <tr><td>r3c1</td><td>r3c2</td><td>r3c3</td></tr>
+  <tr><td class="wide" colspan="3">columns 1-3</td><td>r4c4</td></tr>
+</table>
+</body>
+</html>

--- a/tests/data/tables/09-widths-explicit.html
+++ b/tests/data/tables/09-widths-explicit.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>09 - explicit cell widths</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  table { border-spacing: 2px; width: 600px; }
+  td { border: 1px solid #999; padding: 6px; background-color: #e8f0fe; }
+  .w100 { width: 100px; background-color: #ffd9b3; }
+  .w25p { width: 25%; background-color: #d9ffb3; }
+  .late { background-color: #f0d9ff; width: 320px; }
+</style>
+</head>
+<body>
+<h3>Explicit widths - px, %, auto mixed in a 600px table</h3>
+<p>Expected: column 1 is 100px (orange), column 2 is 25% of 600px = 150px
+(green), columns 3 and 4 share the rest. Second table: the explicit width
+sits on a <em>second-row</em> cell (purple, 320px) - it must still win the
+column width (320px is deliberately not the equal share, so a failure is
+visible).</p>
+<table>
+  <tr><td class="w100">100px</td><td class="w25p">25%</td><td>auto</td><td>auto</td></tr>
+  <tr><td>x</td><td>x</td><td>x</td><td>x</td></tr>
+</table>
+
+<br>
+
+<table>
+  <tr><td>auto</td><td>auto</td><td>auto</td></tr>
+  <tr><td class="late">320px on row 2</td><td>x</td><td>x</td></tr>
+</table>
+</body>
+</html>

--- a/tests/data/tables/10-table-width.html
+++ b/tests/data/tables/10-table-width.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>10 - table width resolution</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  table { border-spacing: 2px; }
+  td { border: 1px solid #999; padding: 6px; background-color: #e8f0fe; }
+  .px { width: 400px; }
+  .pct { width: 50%; }
+  .full { width: 100%; }
+</style>
+</head>
+<body>
+<h3>Table width - auto (shrink-to-fit), 400px, 50%, 100%</h3>
+<p>Expected: the auto table is only as wide as its content needs (it must
+NOT stretch to the viewport). Then: exactly 400px, half the body width,
+and full body width.</p>
+
+<p>auto:</p>
+<table>
+  <tr><td>short</td><td>content</td></tr>
+</table>
+
+<p>400px:</p>
+<table class="px">
+  <tr><td>short</td><td>content</td></tr>
+</table>
+
+<p>50%:</p>
+<table class="pct">
+  <tr><td>short</td><td>content</td></tr>
+</table>
+
+<p>100%:</p>
+<table class="full">
+  <tr><td>short</td><td>content</td></tr>
+</table>
+</body>
+</html>

--- a/tests/data/tables/11-fixed-layout.html
+++ b/tests/data/tables/11-fixed-layout.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>11 - table-layout: fixed</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  table { border-spacing: 2px; table-layout: fixed; width: 600px; }
+  td { border: 1px solid #999; padding: 6px; background-color: #e8f0fe; }
+  .w150 { width: 150px; background-color: #ffd9b3; }
+</style>
+</head>
+<body>
+<h3>table-layout: fixed - widths from row 1 only, content ignored</h3>
+<p>Expected: column 1 is 150px, columns 2 and 3 split the remaining space
+equally. The very long word in row 2 must NOT widen its column (it
+overflows or clips instead) - under fixed layout content never affects
+column width. The 900px width on the row-2 cell must be ignored (only row
+1 counts).</p>
+<table>
+  <tr><td class="w150">150px</td><td>auto</td><td>auto</td></tr>
+  <tr>
+    <td>short</td>
+    <td>Supercalifragilisticexpialidocious-antidisestablishmentarianism</td>
+    <td style="width: 900px;">900px here is ignored</td>
+  </tr>
+</table>
+</body>
+</html>

--- a/tests/data/tables/12-colgroup.html
+++ b/tests/data/tables/12-colgroup.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>12 - colgroup and col widths</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  table { border-spacing: 2px; width: 600px; }
+  td { border: 1px solid #999; padding: 6px; background-color: #e8f0fe; }
+  .c1 { width: 80px; background-color: #ffe9d9; }
+  .c2 { width: 40%; background-color: #e2ffd9; }
+</style>
+</head>
+<body>
+<h3>&lt;colgroup&gt;/&lt;col&gt; widths - 80px, 40%, auto in a 600px table</h3>
+<p>Expected: column 1 is 80px, column 2 is 40% of 600px = 240px, column 3
+takes the rest. No cell carries a width - everything comes from the col
+elements. (Col background colors are a bonus check; width is the real
+test.)</p>
+<table>
+  <colgroup>
+    <col class="c1">
+    <col class="c2">
+    <col>
+  </colgroup>
+  <tr><td>a</td><td>b</td><td>c</td></tr>
+  <tr><td>d</td><td>e</td><td>f</td></tr>
+</table>
+</body>
+</html>

--- a/tests/data/tables/13-content-extremes.html
+++ b/tests/data/tables/13-content-extremes.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>13 - content extremes</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  table { border-spacing: 2px; width: 500px; }
+  td { border: 1px solid #999; padding: 6px; background-color: #e8f0fe; }
+  .block { width: 350px; height: 40px; background-color: #b46ad4; }
+</style>
+</head>
+<body>
+<h3>Content extremes - unbreakable word and an over-wide block, 500px table</h3>
+<p>Expected: the long unbreakable word forces its column to at least the
+word's width (min-content), squeezing the neighbors. In the second table a
+350px fixed block sits in one of three columns of a 500px table - its
+column must be at least 350px wide.</p>
+<table>
+  <tr>
+    <td>normal words that wrap fine</td>
+    <td>Donaudampfschifffahrtsgesellschaftskapitaenswitwenrente</td>
+    <td>more normal text</td>
+  </tr>
+</table>
+
+<br>
+
+<table>
+  <tr>
+    <td>text</td>
+    <td><div class="block"></div></td>
+    <td>text</td>
+  </tr>
+</table>
+</body>
+</html>

--- a/tests/data/tables/14-border-spacing.html
+++ b/tests/data/tables/14-border-spacing.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>14 - border-spacing and padding</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  table { background-color: #ffe9a8; }
+  td { border: 1px solid #999; background-color: #e8f0fe; }
+  .s0 { border-spacing: 0; }
+  .s10 { border-spacing: 10px; }
+  .sxy { border-spacing: 20px 4px; }
+  .pad td { padding: 15px; }
+</style>
+</head>
+<body>
+<h3>border-spacing - 0, 10px, asymmetric 20px/4px, and heavy padding</h3>
+<p>Expected: the yellow table background shows through the gutters. First
+table has no gutters at all (borders touch), second has 10px everywhere
+(including around the outside), third has 20px horizontal but only 4px
+vertical gutters. Fourth: 15px padding inside every cell.</p>
+
+<table class="s0">
+  <tr><td>a</td><td>b</td></tr>
+  <tr><td>c</td><td>d</td></tr>
+</table>
+<br>
+<table class="s10">
+  <tr><td>a</td><td>b</td></tr>
+  <tr><td>c</td><td>d</td></tr>
+</table>
+<br>
+<table class="sxy">
+  <tr><td>a</td><td>b</td></tr>
+  <tr><td>c</td><td>d</td></tr>
+</table>
+<br>
+<table class="s10 pad">
+  <tr><td>padded</td><td>cells</td></tr>
+</table>
+</body>
+</html>

--- a/tests/data/tables/15-border-collapse.html
+++ b/tests/data/tables/15-border-collapse.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>15 - border-collapse</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  td { padding: 6px; background-color: #e8f0fe; }
+  .sep { border-collapse: separate; border-spacing: 4px; }
+  .sep td { border: 2px solid #999; }
+  .col { border-collapse: collapse; }
+  .col td { border: 2px solid #999; }
+  .col td.thick { border: 6px solid #c0392b; }
+</style>
+</head>
+<body>
+<h3>border-collapse - separate vs collapse, plus a conflict</h3>
+<p>Expected: first table shows double lines between cells (each cell keeps
+its own 2px border, 4px apart). Second table shows single 2px lines -
+adjacent borders merge. Third table: the middle cell declares a 6px red
+border, which must win the conflict against its neighbors' thin grey
+borders on all four shared edges.</p>
+
+<table class="sep">
+  <tr><td>a</td><td>b</td><td>c</td></tr>
+  <tr><td>d</td><td>e</td><td>f</td></tr>
+</table>
+<br>
+<table class="col">
+  <tr><td>a</td><td>b</td><td>c</td></tr>
+  <tr><td>d</td><td>e</td><td>f</td></tr>
+</table>
+<br>
+<table class="col">
+  <tr><td>a</td><td>b</td><td>c</td></tr>
+  <tr><td>d</td><td class="thick">thick wins</td><td>f</td></tr>
+  <tr><td>g</td><td>h</td><td>i</td></tr>
+</table>
+</body>
+</html>

--- a/tests/data/tables/16-nested-layout.html
+++ b/tests/data/tables/16-nested-layout.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>16 - block and flex layout inside cells</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  table { border-spacing: 2px; width: 640px; }
+  td { border: 1px solid #999; padding: 6px; background-color: #e8f0fe; vertical-align: top; }
+  .flex { display: flex; }
+  .flex div { flex: 1; padding: 4px; }
+  .f1 { background-color: #ffd9b3; }
+  .f2 { background-color: #d9ffb3; }
+  .f3 { background-color: #f0d9ff; }
+  .stack div { padding: 4px; margin-bottom: 4px; background-color: #ffd9b3; }
+</style>
+</head>
+<body>
+<h3>Other layout inside cells - flex row, block stack, wrapping text</h3>
+<p>Expected: cell 1 holds a flex row of three equal boxes filling the cell
+width. Cell 2 holds three stacked blocks with margins; the row grows to
+fit them. Cell 3 holds a paragraph that wraps within its column width; the
+whole row takes the tallest cell's height.</p>
+<table>
+  <tr>
+    <td>
+      <div class="flex"><div class="f1">one</div><div class="f2">two</div><div class="f3">three</div></div>
+    </td>
+    <td class="stack">
+      <div>first block</div>
+      <div>second block</div>
+      <div>third block</div>
+    </td>
+    <td>
+      This paragraph of text is long enough that it will need to wrap onto
+      several lines inside its table cell, which makes this row taller than
+      a single line of text.
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/tests/data/tables/17-nested-table.html
+++ b/tests/data/tables/17-nested-table.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>17 - table inside a table cell</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  table { border-spacing: 2px; }
+  td { border: 1px solid #999; padding: 6px; background-color: #e8f0fe; }
+  .outer { width: 600px; }
+  .inner td { background-color: #ffd9b3; }
+</style>
+</head>
+<body>
+<h3>Nested tables - a 2x2 table inside a cell of a 2x2 table</h3>
+<p>Expected: the inner orange table lays out independently inside its cell,
+sized by the cell's available width. Its host row grows to contain it. The
+inner table's cells must not be captured by the outer table's grid.</p>
+<table class="outer">
+  <tr>
+    <td>plain cell</td>
+    <td>
+      <table class="inner">
+        <tr><td>i-a</td><td>i-b</td></tr>
+        <tr><td>i-c</td><td>i-d</td></tr>
+      </table>
+    </td>
+  </tr>
+  <tr><td>bottom left</td><td>bottom right</td></tr>
+</table>
+</body>
+</html>

--- a/tests/data/tables/18-vertical-align.html
+++ b/tests/data/tables/18-vertical-align.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>18 - vertical-align in cells</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  table { border-spacing: 2px; }
+  td { border: 1px solid #999; padding: 6px; background-color: #e8f0fe; }
+  .tall { background-color: #d9ffb3; }
+  .top { vertical-align: top; }
+  .mid { vertical-align: middle; }
+  .bot { vertical-align: bottom; }
+  .base { vertical-align: baseline; font-size: 28px; }
+</style>
+</head>
+<body>
+<h3>vertical-align - top / middle / bottom / baseline in a tall row</h3>
+<p>Expected: the green cell makes the row tall. "top" hugs the top edge,
+"middle" centers vertically, "bottom" hugs the bottom edge. In the second
+table, the large-font cell and the small-font cell must share one text
+baseline for their first lines.</p>
+<table>
+  <tr>
+    <td class="tall"><div>tall</div><div>cell</div><div>with</div><div>five</div><div>lines</div></td>
+    <td class="top">top</td>
+    <td class="mid">middle</td>
+    <td class="bot">bottom</td>
+  </tr>
+</table>
+
+<br>
+
+<table>
+  <tr>
+    <td class="base">Big text</td>
+    <td>small text on the same baseline</td>
+  </tr>
+</table>
+</body>
+</html>

--- a/tests/data/tables/19-infobox.html
+++ b/tests/data/tables/19-infobox.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>19 - wikipedia-style infobox</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; font-size: 14px; }
+  .infobox {
+    width: 300px;
+    border: 1px solid #a2a9b1;
+    background-color: #f8f9fa;
+    border-spacing: 3px;
+    font-size: 12px;
+  }
+  .infobox th { background-color: #cedff2; padding: 4px; text-align: center; }
+  .infobox td { padding: 3px; vertical-align: top; }
+  .infobox .label { font-weight: bold; width: 90px; }
+  .infobox .imgcell { text-align: center; }
+  .infobox .img { width: 260px; height: 140px; background-color: #b0c4d8; margin: 0 auto; }
+</style>
+</head>
+<body>
+<h3>Real-world: infobox - fixed 300px table, label/value pairs, full-width rows</h3>
+<p>Expected: a 300px-wide box. The title and image rows span both columns;
+label/value rows below have a narrow bold label column (90px) and a value
+column that wraps. Long values wrap rather than widen the box.</p>
+<table class="infobox">
+  <tr><th colspan="2">Gosub Engine</th></tr>
+  <tr><td colspan="2" class="imgcell"><div class="img"></div></td></tr>
+  <tr><td class="label">Developer</td><td>Gosub Community</td></tr>
+  <tr><td class="label">Written in</td><td>Rust</td></tr>
+  <tr><td class="label">Type</td><td>Browser engine with a very long description that needs to wrap across multiple lines</td></tr>
+  <tr><td class="label">License</td><td>MIT</td></tr>
+</table>
+</body>
+</html>

--- a/tests/data/tables/20-data-table.html
+++ b/tests/data/tables/20-data-table.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>20 - realistic data table</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  table { border-collapse: collapse; width: 100%; }
+  th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+  th { background-color: #2c3e50; color: #ffffff; }
+  .num { text-align: right; }
+  .alt td { background-color: #f2f2f2; }
+  tfoot td { font-weight: bold; background-color: #eaf2f8; }
+</style>
+</head>
+<body>
+<h3>Real-world: full-width data table - header, zebra rows, numeric columns, footer</h3>
+<p>Expected: table fills the viewport width; the name column is widest
+(most content), numeric columns are right-aligned; alternating rows are
+grey; the footer row is bold on light blue. Collapsed 1px grid lines
+throughout.</p>
+<table>
+  <thead>
+    <tr><th>#</th><th>Crate</th><th>Description</th><th class="num">Lines</th><th class="num">Tests</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>1</td><td>gosub_lattice</td><td>CSS table layout engine</td><td class="num">1,842</td><td class="num">27</td></tr>
+    <tr class="alt"><td>2</td><td>gosub_css3</td><td>CSS parser and matcher with a longer description that stretches this column</td><td class="num">24,610</td><td class="num">312</td></tr>
+    <tr><td>3</td><td>gosub_html5</td><td>HTML5 tokenizer and tree builder</td><td class="num">31,077</td><td class="num">508</td></tr>
+    <tr class="alt"><td>4</td><td>gosub_render_pipeline</td><td>Layout and paint</td><td class="num">12,395</td><td class="num">96</td></tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="3">Total</td><td class="num">69,924</td><td class="num">943</td></tr>
+  </tfoot>
+</table>
+</body>
+</html>

--- a/tests/data/tables/21-section-spans.html
+++ b/tests/data/tables/21-section-spans.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>21 - section-crossing spans</title>
+<style>
+  body { font-family: sans-serif; margin: 16px; }
+  table { border-collapse: collapse; }
+  td, th { border: 1px solid #999; padding: 4px 10px; }
+  thead th { background: #dbe6f4; }
+  tfoot td { background: #f4e9d2; font-weight: bold; }
+  .span { background: #e2efe4; }
+</style>
+</head>
+<body>
+<h3>spans vs section boundaries</h3>
+<p>Expected: spans never cross out of their row group. First table: the tbody
+cell declares rowspan=5 but the body only has 2 rows - the span is clipped at
+the tbody and the footer keeps its own row. Second table: rowspan=0 is HTML for
+"all remaining rows of the row group" - it spans both body rows, footer
+untouched. Third table: the tfoot is written BEFORE the tbody in source but
+must still render at the bottom, and the body span must not reach it.</p>
+
+<table>
+  <thead><tr><th>head A</th><th>head B</th></tr></thead>
+  <tbody>
+    <tr><td class="span" rowspan="5">rowspan 5 (clipped at tbody)</td><td>b1</td></tr>
+    <tr><td>b2</td></tr>
+  </tbody>
+  <tfoot><tr><td>foot A</td><td>foot B</td></tr></tfoot>
+</table>
+<br>
+<table>
+  <thead><tr><th>head A</th><th>head B</th></tr></thead>
+  <tbody>
+    <tr><td class="span" rowspan="0">rowspan 0 (rest of group)</td><td>b1</td></tr>
+    <tr><td>b2</td></tr>
+  </tbody>
+  <tfoot><tr><td>foot A</td><td>foot B</td></tr></tfoot>
+</table>
+<br>
+<table>
+  <thead><tr><th>head A</th><th>head B</th></tr></thead>
+  <tfoot><tr><td>foot A</td><td>foot B</td></tr></tfoot>
+  <tbody>
+    <tr><td class="span" rowspan="3">rowspan 3 (clipped at tbody)</td><td>b1</td></tr>
+    <tr><td>b2</td></tr>
+  </tbody>
+</table>
+</body>
+</html>

--- a/tests/data/tables/README.md
+++ b/tests/data/tables/README.md
@@ -20,7 +20,7 @@ cargo run -p gosub-screenshot -- file://$PWD/tests/data/tables/01-basic-grid.htm
 | `03-sections.html` | tfoot before thead in source, multiple tbodies | header->body->footer ordering |
 | `04-anonymous-boxes.html` | `display: table` divs, cells without a row | anonymous box generation |
 | `05-caption.html` | `<caption>`, `caption-side: bottom` | caption layout (done 2026-08-08) |
-| `06-colspan.html` | colspan 2/3/full/overflowing | slot filling, span clamping |
+| `06-colspan.html` | colspan 2/3/full/overflowing | slot filling, trailing empty-column truncation |
 | `07-rowspan.html` | rowspan, tall spanning content, span past last row | rowspan height distribution (done 2026-08-08) |
 | `08-span-mix.html` | interlocking colspan+rowspan block puzzle | slot filling |
 | `09-widths-explicit.html` | px/% cell widths; explicit width on a row-2 cell | column algorithm beyond first row (**gap**) |
@@ -43,7 +43,7 @@ and double as acceptance tests for the corresponding roadmap item.
 
 ## Findings from the first render pass (2026-08-06, Cairo backend)
 
-Solid: slot filling (02, 06, 08 place every span correctly, clamped spans
+Solid: slot filling (02, 06, 08 place every span correctly, overflowing spans
 included), section reordering (03), anonymous boxes (04), first-row px/%
 widths (09, table 1), table width px/%/100% (10), separate borders with
 per-cell overrides (15), and both real-world pages (19, 20) are close.

--- a/tests/data/tables/README.md
+++ b/tests/data/tables/README.md
@@ -21,7 +21,7 @@ cargo run -p gosub-screenshot -- file://$PWD/tests/data/tables/01-basic-grid.htm
 | `04-anonymous-boxes.html` | `display: table` divs, cells without a row | anonymous box generation |
 | `05-caption.html` | `<caption>`, `caption-side: bottom` | caption layout (**gap**) |
 | `06-colspan.html` | colspan 2/3/full/overflowing | slot filling, span clamping |
-| `07-rowspan.html` | rowspan, tall spanning content, span past last row | rowspan height distribution (**gap**) |
+| `07-rowspan.html` | rowspan, tall spanning content, span past last row | rowspan height distribution (done 2026-08-08) |
 | `08-span-mix.html` | interlocking colspan+rowspan block puzzle | slot filling |
 | `09-widths-explicit.html` | px/% cell widths; explicit width on a row-2 cell | column algorithm beyond first row (**gap**) |
 | `10-table-width.html` | table width auto/px/%/100% | shrink-to-fit for auto (**gap**) |
@@ -32,7 +32,7 @@ cargo run -p gosub-screenshot -- file://$PWD/tests/data/tables/01-basic-grid.htm
 | `15-border-collapse.html` | separate vs collapse, border conflict | border-collapse (**gap**) |
 | `16-nested-layout.html` | flex + block stacks + wrapping text in cells | `layout_cell` callback |
 | `17-nested-table.html` | table inside a table cell | nested `compute_table_layout` |
-| `18-vertical-align.html` | top/middle/bottom/baseline | vertical-align (**gap**) |
+| `18-vertical-align.html` | top/middle/bottom/baseline | vertical-align (done 2026-08-08; baseline ~ top) |
 | `19-infobox.html` | wikipedia-style infobox (fixed width, spans, label col) | several combined |
 | `20-data-table.html` | full-width data table, zebra, collapse, tfoot | several combined |
 
@@ -68,9 +68,16 @@ Broken or missing, beyond the known compute gaps:
   `PipelineTableTree` adapter. 14 renders 0 / 10px / 20px 4px correctly.
 - **Nested tables collapse to a sliver** (17).
 - **`text-align` on cells ignored** (20, numeric columns).
-- Confirmed compute gaps as expected: captions absent (05), rowspan height
-  not distributed (07), later-row explicit widths ignored (09 table 2),
-  no shrink-to-fit auto width (10), border-collapse (15), vertical-align (18).
+- Confirmed compute gaps as expected: captions absent (05), later-row
+  explicit widths ignored (09 table 2), no shrink-to-fit auto width (10),
+  border-collapse (15).
+- **Fixed 2026-08-08**: rowspan height distribution (07) - spanning cells are
+  measured and their deficit spreads equally over the spanned rows - and
+  vertical-align (18) - lattice emits a `content_offset_y` per cell, the
+  pipeline shifts re-anchored cell subtrees by it; alignment resolves by
+  walking cell->row->section (HTML-spec `inherit`-on-cells pattern), so the
+  browser's `middle` default falls out of the UA stylesheet. `baseline` is
+  approximated as `top` until real first-line metrics exist.
 - **Fixed 2026-08-07**: `table-layout: fixed` (11) and `<col>`/`<colgroup>`
   widths (12) - new `TableSizing::Fixed` path in `sizing/columns.rs`
   (col elements -> first-row cells with colspan division -> equal split of the

--- a/tests/data/tables/README.md
+++ b/tests/data/tables/README.md
@@ -25,8 +25,8 @@ cargo run -p gosub-screenshot -- file://$PWD/tests/data/tables/01-basic-grid.htm
 | `08-span-mix.html` | interlocking colspan+rowspan block puzzle | slot filling |
 | `09-widths-explicit.html` | px/% cell widths; explicit width on a row-2 cell | column algorithm beyond first row (**gap**) |
 | `10-table-width.html` | table width auto/px/%/100% | shrink-to-fit for auto (**gap**) |
-| `11-fixed-layout.html` | `table-layout: fixed` semantics | fixed layout (**gap**) |
-| `12-colgroup.html` | widths from `<col>`/`<colgroup>` | col widths (**gap**) |
+| `11-fixed-layout.html` | `table-layout: fixed` semantics | fixed layout (done 2026-08-07) |
+| `12-colgroup.html` | widths from `<col>`/`<colgroup>` | col widths (done 2026-08-07) |
 | `13-content-extremes.html` | unbreakable word, over-wide block | min-content column floors (**gap**) |
 | `14-border-spacing.html` | spacing 0 / 10px / asymmetric; padding | separate border model |
 | `15-border-collapse.html` | separate vs collapse, border conflict | border-collapse (**gap**) |
@@ -70,5 +70,10 @@ Broken or missing, beyond the known compute gaps:
 - **`text-align` on cells ignored** (20, numeric columns).
 - Confirmed compute gaps as expected: captions absent (05), rowspan height
   not distributed (07), later-row explicit widths ignored (09 table 2),
-  no shrink-to-fit auto width (10), `<col>` widths ignored (12),
-  border-collapse (15), vertical-align (18).
+  no shrink-to-fit auto width (10), border-collapse (15), vertical-align (18).
+- **Fixed 2026-08-07**: `table-layout: fixed` (11) and `<col>`/`<colgroup>`
+  widths (12) - new `TableSizing::Fixed` path in `sizing/columns.rs`
+  (col elements -> first-row cells with colspan division -> equal split of the
+  remainder; content never measured), col widths also seed auto layout;
+  pipeline grew `Display::TableColumn(Group)` (no box generated) and the
+  `table-layout` style property (Px(1.0) sentinel to lattice).

--- a/tests/data/tables/README.md
+++ b/tests/data/tables/README.md
@@ -51,11 +51,13 @@ Broken or missing, beyond the known compute gaps:
 
 - **Auto columns sized from row 1 only** - in 01, "seven"/"eight" clip
   because rows 2+ never influence the natural width; 08 degenerates badly.
-- **Block children in cells lay out horizontally** - stacked `<div>`s
-  render side by side on one line (07, 16, 18); `<br>` adds no height
-  either. This is in the cell-content callback path
-  (`layout_cell`/`gosub_render_pipeline`), not the table algorithm, and it
-  masks the row-height logic.
+- ~~**Block children in cells lay out horizontally**~~ - **fixed
+  2026-08-07**: cells now use block inner layout in the first pass
+  (`css_taffy_converter.rs`), and `layout_cell` re-runs taffy on the cell
+  subtree at the final lattice width (`TaffyLayouter::relayout_cell`), so
+  stacked blocks, wrapping, and `text-align` all resolve against real cell
+  geometry. Cells hosting nested tables keep the first-pass approximation
+  (re-layout would clobber the inner table's lattice output).
 - **No min-content floor** - 13: an unbreakable word squeezes neighbors
   into clipping; a 350px block overflows its column instead of widening it.
 - **`border-spacing` CSS never reaches the algorithm** - 14 renders

--- a/tests/data/tables/README.md
+++ b/tests/data/tables/README.md
@@ -29,7 +29,7 @@ cargo run -p gosub-screenshot -- file://$PWD/tests/data/tables/01-basic-grid.htm
 | `12-colgroup.html` | widths from `<col>`/`<colgroup>` | col widths (done 2026-08-07) |
 | `13-content-extremes.html` | unbreakable word, over-wide block | min-content column floors (**gap**) |
 | `14-border-spacing.html` | spacing 0 / 10px / asymmetric; padding | separate border model |
-| `15-border-collapse.html` | separate vs collapse, border conflict | border-collapse (done 2026-08-08; conflicts by paint order) |
+| `15-border-collapse.html` | separate vs collapse, border conflict | border-collapse + conflict resolution (done 2026-08-09) |
 | `16-nested-layout.html` | flex + block stacks + wrapping text in cells | `layout_cell` callback |
 | `17-nested-table.html` | table inside a table cell | nested `compute_table_layout` |
 | `18-vertical-align.html` | top/middle/bottom/baseline | vertical-align (done 2026-08-08; baseline ~ top) |
@@ -72,12 +72,16 @@ Broken or missing, beyond the known compute gaps:
   cell-content block layout + per-cell re-layout change.
 - **Fixed 2026-08-08 (captions + border-collapse)** - the last two compute
   gaps. Captions (05): measured like a full-width cell, placed above or below
-  the grid per `caption-side`. Border-collapse (15, 20): spacing forced to 0
-  and adjacent cells overlap by their shared border width so equal borders
-  coincide as a single line; border *conflicts* resolve by paint order (the
-  later-painted cell wins), not by the CSS wider-border-wins rules - the 6px
-  conflict in 15 only wins its top/left edges. Every fixture gap is now
-  closed.
+  the grid per `caption-side`. Border-collapse (15, 20): spacing forced to 0;
+  cells sit flush.
+- **Fixed 2026-08-09 (border-conflict resolution)**: every shared boundary is
+  painted by exactly one cell - lattice resolves the winner (wider border
+  wins; ties go to the left/top cell, per CSS 2 §17.6.2.1 for same-style
+  borders) and flags the loser's edge in `CellLayout.suppressed_borders`;
+  the painter skips suppressed edges. The 6px red conflict in 15 now wins all
+  four edges. Not implemented: the border-style rank tiebreak (double >
+  solid > ...) and row/rowgroup/table borders as conflict participants.
+  Every fixture gap is now closed.
 - **Fixed 2026-08-08 (min/max-content auto columns)**: the heuristic column
   algorithm was replaced with the CSS 2 §17.5.2.2 algorithm. Every cell
   contributes real min/max-content widths (`TableTree::cell_intrinsic_widths`,

--- a/tests/data/tables/README.md
+++ b/tests/data/tables/README.md
@@ -74,6 +74,15 @@ Broken or missing, beyond the known compute gaps:
   gaps. Captions (05): measured like a full-width cell, placed above or below
   the grid per `caption-side`. Border-collapse (15, 20): spacing forced to 0;
   cells sit flush.
+- **Fixed 2026-08-11 (Chrome side-by-side review)**: (1) trailing columns no
+  cell originates in are truncated, so an overflowing colspan no longer
+  manufactures phantom gutter-bearing columns (06); (2) when lattice's table
+  height differs from the first-pass estimate, the document flow below shifts
+  and ancestors grow - restoring `<br>` gaps between tables (04, 14), fixing
+  sibling overlap and the clipped page bottom (05, 19); (3) collapse-suppressed
+  border edges take no layout space, so every collapsed boundary is exactly
+  one border wide like a browser (15, 20); (4) `text-align: -webkit-center`
+  (the UA caption rule) now centers captions (05).
 - **Fixed 2026-08-09 (border-conflict resolution)**: every shared boundary is
   painted by exactly one cell - lattice resolves the winner (wider border
   wins; ties go to the left/top cell, per CSS 2 §17.6.2.1 for same-style

--- a/tests/data/tables/README.md
+++ b/tests/data/tables/README.md
@@ -1,0 +1,69 @@
+# Table layout fixture pages
+
+Small, single-purpose HTML pages for exercising `gosub_lattice` (the CSS
+table layout engine) through the full render pipeline. Each page states in
+its intro paragraph what the correct rendering looks like, so a screenshot
+can be judged on its own.
+
+Render one headlessly (no window) with:
+
+```
+cargo run -p gosub-screenshot -- file://$PWD/tests/data/tables/01-basic-grid.html out.png
+```
+
+## Pages
+
+| Page | Exercises | Depends on |
+|------|-----------|------------|
+| `01-basic-grid.html` | 3x3 grid, auto columns, border-spacing | core grid + auto widths |
+| `02-ragged-rows.html` | rows of unequal length, empty cells | slot filling |
+| `03-sections.html` | tfoot before thead in source, multiple tbodies | header->body->footer ordering |
+| `04-anonymous-boxes.html` | `display: table` divs, cells without a row | anonymous box generation |
+| `05-caption.html` | `<caption>`, `caption-side: bottom` | caption layout (**gap**) |
+| `06-colspan.html` | colspan 2/3/full/overflowing | slot filling, span clamping |
+| `07-rowspan.html` | rowspan, tall spanning content, span past last row | rowspan height distribution (**gap**) |
+| `08-span-mix.html` | interlocking colspan+rowspan block puzzle | slot filling |
+| `09-widths-explicit.html` | px/% cell widths; explicit width on a row-2 cell | column algorithm beyond first row (**gap**) |
+| `10-table-width.html` | table width auto/px/%/100% | shrink-to-fit for auto (**gap**) |
+| `11-fixed-layout.html` | `table-layout: fixed` semantics | fixed layout (**gap**) |
+| `12-colgroup.html` | widths from `<col>`/`<colgroup>` | col widths (**gap**) |
+| `13-content-extremes.html` | unbreakable word, over-wide block | min-content column floors (**gap**) |
+| `14-border-spacing.html` | spacing 0 / 10px / asymmetric; padding | separate border model |
+| `15-border-collapse.html` | separate vs collapse, border conflict | border-collapse (**gap**) |
+| `16-nested-layout.html` | flex + block stacks + wrapping text in cells | `layout_cell` callback |
+| `17-nested-table.html` | table inside a table cell | nested `compute_table_layout` |
+| `18-vertical-align.html` | top/middle/bottom/baseline | vertical-align (**gap**) |
+| `19-infobox.html` | wikipedia-style infobox (fixed width, spans, label col) | several combined |
+| `20-data-table.html` | full-width data table, zebra, collapse, tfoot | several combined |
+
+Pages marked **gap** exercise features `compute.rs` does not implement yet
+(they parse into the model but are ignored); they document target behavior
+and double as acceptance tests for the corresponding roadmap item.
+
+## Findings from the first render pass (2026-08-06, Cairo backend)
+
+Solid: slot filling (02, 06, 08 place every span correctly, clamped spans
+included), section reordering (03), anonymous boxes (04), first-row px/%
+widths (09, table 1), table width px/%/100% (10), separate borders with
+per-cell overrides (15), and both real-world pages (19, 20) are close.
+
+Broken or missing, beyond the known compute gaps:
+
+- **Auto columns sized from row 1 only** - in 01, "seven"/"eight" clip
+  because rows 2+ never influence the natural width; 08 degenerates badly.
+- **Block children in cells lay out horizontally** - stacked `<div>`s
+  render side by side on one line (07, 16, 18); `<br>` adds no height
+  either. This is in the cell-content callback path
+  (`layout_cell`/`gosub_render_pipeline`), not the table algorithm, and it
+  masks the row-height logic.
+- **No min-content floor** - 13: an unbreakable word squeezes neighbors
+  into clipping; a 350px block overflows its column instead of widening it.
+- **`border-spacing` CSS never reaches the algorithm** - 14 renders
+  identical gutters for 0 / 10px / 20px 4px (the mock-tree tests pass
+  because they inject spacing directly).
+- **Nested tables collapse to a sliver** (17).
+- **`text-align` on cells ignored** (20, numeric columns).
+- Confirmed compute gaps as expected: captions absent (05), rowspan height
+  not distributed (07), later-row explicit widths ignored (09 table 2),
+  no shrink-to-fit auto width (10), `<col>` widths ignored (12),
+  border-collapse (15), vertical-align (18).

--- a/tests/data/tables/README.md
+++ b/tests/data/tables/README.md
@@ -35,6 +35,7 @@ cargo run -p gosub-screenshot -- file://$PWD/tests/data/tables/01-basic-grid.htm
 | `18-vertical-align.html` | top/middle/bottom/baseline | vertical-align (done 2026-08-08; baseline ~ top) |
 | `19-infobox.html` | wikipedia-style infobox (fixed width, spans, label col) | several combined |
 | `20-data-table.html` | full-width data table, zebra, collapse, tfoot | several combined |
+| `21-section-spans.html` | rowspan overrun + rowspan=0 vs thead/tbody/tfoot | section clamping, HTML rowspan=0 (done 2026-08-12) |
 
 Pages marked **gap** exercise features `compute.rs` does not implement yet
 (they parse into the model but are ignored); they document target behavior

--- a/tests/data/tables/README.md
+++ b/tests/data/tables/README.md
@@ -19,7 +19,7 @@ cargo run -p gosub-screenshot -- file://$PWD/tests/data/tables/01-basic-grid.htm
 | `02-ragged-rows.html` | rows of unequal length, empty cells | slot filling |
 | `03-sections.html` | tfoot before thead in source, multiple tbodies | header->body->footer ordering |
 | `04-anonymous-boxes.html` | `display: table` divs, cells without a row | anonymous box generation |
-| `05-caption.html` | `<caption>`, `caption-side: bottom` | caption layout (**gap**) |
+| `05-caption.html` | `<caption>`, `caption-side: bottom` | caption layout (done 2026-08-08) |
 | `06-colspan.html` | colspan 2/3/full/overflowing | slot filling, span clamping |
 | `07-rowspan.html` | rowspan, tall spanning content, span past last row | rowspan height distribution (done 2026-08-08) |
 | `08-span-mix.html` | interlocking colspan+rowspan block puzzle | slot filling |
@@ -29,7 +29,7 @@ cargo run -p gosub-screenshot -- file://$PWD/tests/data/tables/01-basic-grid.htm
 | `12-colgroup.html` | widths from `<col>`/`<colgroup>` | col widths (done 2026-08-07) |
 | `13-content-extremes.html` | unbreakable word, over-wide block | min-content column floors (**gap**) |
 | `14-border-spacing.html` | spacing 0 / 10px / asymmetric; padding | separate border model |
-| `15-border-collapse.html` | separate vs collapse, border conflict | border-collapse (**gap**) |
+| `15-border-collapse.html` | separate vs collapse, border conflict | border-collapse (done 2026-08-08; conflicts by paint order) |
 | `16-nested-layout.html` | flex + block stacks + wrapping text in cells | `layout_cell` callback |
 | `17-nested-table.html` | table inside a table cell | nested `compute_table_layout` |
 | `18-vertical-align.html` | top/middle/bottom/baseline | vertical-align (done 2026-08-08; baseline ~ top) |
@@ -70,8 +70,14 @@ Broken or missing, beyond the known compute gaps:
   side effect of intrinsic column sizing.
 - ~~**`text-align` on cells ignored**~~ (20) - fixed 2026-08-07 by the
   cell-content block layout + per-cell re-layout change.
-- Confirmed compute gaps as expected: captions absent (05), border-collapse
-  (15) - the only remaining compute gaps.
+- **Fixed 2026-08-08 (captions + border-collapse)** - the last two compute
+  gaps. Captions (05): measured like a full-width cell, placed above or below
+  the grid per `caption-side`. Border-collapse (15, 20): spacing forced to 0
+  and adjacent cells overlap by their shared border width so equal borders
+  coincide as a single line; border *conflicts* resolve by paint order (the
+  later-painted cell wins), not by the CSS wider-border-wins rules - the 6px
+  conflict in 15 only wins its top/left edges. Every fixture gap is now
+  closed.
 - **Fixed 2026-08-08 (min/max-content auto columns)**: the heuristic column
   algorithm was replaced with the CSS 2 §17.5.2.2 algorithm. Every cell
   contributes real min/max-content widths (`TableTree::cell_intrinsic_widths`,

--- a/tests/data/tables/README.md
+++ b/tests/data/tables/README.md
@@ -60,9 +60,12 @@ Broken or missing, beyond the known compute gaps:
   (re-layout would clobber the inner table's lattice output).
 - **No min-content floor** - 13: an unbreakable word squeezes neighbors
   into clipping; a 350px block overflows its column instead of widening it.
-- **`border-spacing` CSS never reaches the algorithm** - 14 renders
-  identical gutters for 0 / 10px / 20px 4px (the mock-tree tests pass
-  because they inject spacing directly).
+- ~~**`border-spacing` CSS never reaches the algorithm**~~ - **fixed
+  2026-08-07**: `StyleProperty::BorderSpacingX/Y` added (two internal
+  longhands over the one `border-spacing` declaration; X = first length,
+  Y = second), wired through the cascade (inherited, UA default
+  `table { border-spacing: 2px }`), inline styles, and the
+  `PipelineTableTree` adapter. 14 renders 0 / 10px / 20px 4px correctly.
 - **Nested tables collapse to a sliver** (17).
 - **`text-align` on cells ignored** (20, numeric columns).
 - Confirmed compute gaps as expected: captions absent (05), rowspan height

--- a/tests/data/tables/README.md
+++ b/tests/data/tables/README.md
@@ -49,8 +49,8 @@ per-cell overrides (15), and both real-world pages (19, 20) are close.
 
 Broken or missing, beyond the known compute gaps:
 
-- **Auto columns sized from row 1 only** - in 01, "seven"/"eight" clip
-  because rows 2+ never influence the natural width; 08 degenerates badly.
+- ~~**Auto columns sized from row 1 only**~~ - fixed 2026-08-08 by the real
+  min/max-content algorithm (see below).
 - ~~**Block children in cells lay out horizontally**~~ - **fixed
   2026-08-07**: cells now use block inner layout in the first pass
   (`css_taffy_converter.rs`), and `layout_cell` re-runs taffy on the cell
@@ -58,19 +58,29 @@ Broken or missing, beyond the known compute gaps:
   stacked blocks, wrapping, and `text-align` all resolve against real cell
   geometry. Cells hosting nested tables keep the first-pass approximation
   (re-layout would clobber the inner table's lattice output).
-- **No min-content floor** - 13: an unbreakable word squeezes neighbors
-  into clipping; a 350px block overflows its column instead of widening it.
+- ~~**No min-content floor**~~ - fixed 2026-08-08 (min/max-content
+  algorithm, see below).
 - ~~**`border-spacing` CSS never reaches the algorithm**~~ - **fixed
   2026-08-07**: `StyleProperty::BorderSpacingX/Y` added (two internal
   longhands over the one `border-spacing` declaration; X = first length,
   Y = second), wired through the cascade (inherited, UA default
   `table { border-spacing: 2px }`), inline styles, and the
   `PipelineTableTree` adapter. 14 renders 0 / 10px / 20px 4px correctly.
-- **Nested tables collapse to a sliver** (17).
-- **`text-align` on cells ignored** (20, numeric columns).
-- Confirmed compute gaps as expected: captions absent (05), later-row
-  explicit widths ignored (09 table 2), no shrink-to-fit auto width (10),
-  border-collapse (15).
+- ~~**Nested tables collapse to a sliver**~~ (17) - fixed 2026-08-08 as a
+  side effect of intrinsic column sizing.
+- ~~**`text-align` on cells ignored**~~ (20) - fixed 2026-08-07 by the
+  cell-content block layout + per-cell re-layout change.
+- Confirmed compute gaps as expected: captions absent (05), border-collapse
+  (15) - the only remaining compute gaps.
+- **Fixed 2026-08-08 (min/max-content auto columns)**: the heuristic column
+  algorithm was replaced with the CSS 2 §17.5.2.2 algorithm. Every cell
+  contributes real min/max-content widths (`TableTree::cell_intrinsic_widths`,
+  measured by taffy at MinContent/MaxContent), specified widths are read from
+  **all** rows (09), colspan cells distribute their requirement over spanned
+  columns weighted by content, auto tables shrink-to-fit (01, 08, 10),
+  min-content floors prevent clipping (13), and nested tables (17) now render
+  correctly because the host column sizes to the inner table's needs. 19/20
+  are essentially browser-accurate.
 - **Fixed 2026-08-08**: rowspan height distribution (07) - spanning cells are
   measured and their deficit spreads equally over the spanned rows - and
   vertical-align (18) - lattice emits a `content_offset_y` per cell, the


### PR DESCRIPTION
This PR adds more updates to the table layouter and tests them through the WPT tests. This is still ongoing functionality, but a good first batch of functionality to submit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved HTML table rendering, including sizing, captions, column groups, spanning cells, nested tables, alignment, and border collapsing.
  * Added support for additional table-related CSS properties and display modes.
  * Added screenshot minimum-height handling and more reliable settling for asynchronous page updates.
  * Added CSS `:focus` and `:focus-visible` matching.
  * Added explicit CSS line-height support for text measurement and rendering.

* **Bug Fixes**
  * Improved border placement and double-border rendering across supported rendering backends.
  * Preserved whitespace and line breaks more accurately in preformatted and inline text.

* **Testing**
  * Added extensive table layout fixtures, rendering comparisons, and web-platform regression tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->