### PR TITLE
Beacon backmerge into main

### DIFF
--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -567,6 +567,24 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
         Some(node.box_model.border_box.y)
     }
 
+    /// Tile-cache statistics for diagnostics (`gosub://stats`): `(tile count, CPU pixel
+    /// bytes)`. Bytes sum each baked tile's buffer, so shared buffers count once per tile
+    /// (an upper bound, cheap to compute).
+    pub fn tile_stats(&self) -> (usize, usize) {
+        let Some(cache) = self.pipeline_cache.as_ref() else {
+            return (0, 0);
+        };
+        let bytes = cache
+            .tiles
+            .iter()
+            .map(|t| match &t.pixels {
+                TilePixels::Cpu(data) => data.len(),
+                _ => 0,
+            })
+            .sum();
+        (cache.tiles.len(), bytes)
+    }
+
     /// The active full-page height, from whichever cache this tab populates.
     fn active_page_height(&self) -> Option<f64> {
         self.scene_cache

--- a/crates/gosub_engine/src/engine/engine.rs
+++ b/crates/gosub_engine/src/engine/engine.rs
@@ -522,14 +522,20 @@ mod tests {
             .await
             .expect("navigate");
         let offer = tokio::time::timeout(Duration::from_secs(10), async {
+            let mut nav_progress = false;
             loop {
                 match event_rx.recv().await {
+                    // The document fetch of the navigation reports load progress.
+                    Ok(EngineEvent::Navigation {
+                        event: crate::events::NavigationEvent::Progress { .. },
+                        ..
+                    }) => nav_progress = true,
                     Ok(EngineEvent::DownloadRequested {
                         url,
                         suggested_filename,
                         total_bytes,
                         ..
-                    }) => return (url, suggested_filename, total_bytes),
+                    }) => return (url, suggested_filename, total_bytes, nav_progress),
                     Ok(_) => continue,
                     Err(e) => panic!("event stream closed: {e}"),
                 }
@@ -537,6 +543,7 @@ mod tests {
         })
         .await
         .expect("timed out waiting for DownloadRequested");
+        assert!(offer.3, "expected NavigationEvent::Progress during the document fetch");
         assert_eq!(offer.1, "pretty.bin", "Content-Disposition filename wins");
         assert_eq!(offer.2, Some(payload.len() as u64));
 
@@ -551,11 +558,24 @@ mod tests {
         .await
         .expect("start download");
 
-        let (progress_seen, received) = tokio::time::timeout(Duration::from_secs(10), async {
+        let (progress_seen, partial_seen, received) = tokio::time::timeout(Duration::from_secs(10), async {
             let mut progress_seen = false;
+            let mut partial_seen = false;
             loop {
                 match event_rx.recv().await {
-                    Ok(EngineEvent::DownloadProgress { id: DownloadId(7), .. }) => progress_seen = true,
+                    Ok(EngineEvent::DownloadProgress {
+                        id: DownloadId(7),
+                        received_bytes,
+                        total_bytes,
+                        ..
+                    }) => {
+                        progress_seen = true;
+                        // Granular progress: at least one event mid-transfer, not only the
+                        // final full-size report.
+                        if total_bytes.is_some_and(|t| received_bytes < t) {
+                            partial_seen = true;
+                        }
+                    }
                     Ok(EngineEvent::DownloadFinished {
                         id: DownloadId(7),
                         received_bytes,
@@ -563,7 +583,7 @@ mod tests {
                         ..
                     }) => {
                         assert_eq!(path, target);
-                        return (progress_seen, received_bytes);
+                        return (progress_seen, partial_seen, received_bytes);
                     }
                     Ok(EngineEvent::DownloadFailed { error, .. }) => panic!("download failed: {error}"),
                     Ok(_) => continue,
@@ -574,6 +594,10 @@ mod tests {
         .await
         .expect("timed out waiting for DownloadFinished");
         assert!(progress_seen, "expected at least one progress event");
+        assert!(
+            partial_seen,
+            "expected granular mid-transfer progress, not only the final report"
+        );
         assert_eq!(received, payload.len() as u64);
         assert_eq!(std::fs::read(&target).unwrap(), payload, "file content must match");
 

--- a/crates/gosub_engine/src/engine/internal_pages.rs
+++ b/crates/gosub_engine/src/engine/internal_pages.rs
@@ -39,6 +39,22 @@ pub struct TabView {
     pub history: HistorySnapshot,
     /// Name of the active render backend (`RenderBackend::name`).
     pub render_backend: &'static str,
+    /// Rendering diagnostics (drives `gosub://stats`).
+    pub stats: TabStats,
+}
+
+/// Rendering/layout diagnostics for one tab, as of the moment the page was requested.
+#[derive(Debug, Clone, Default)]
+pub struct TabStats {
+    pub viewport_width: u32,
+    pub viewport_height: u32,
+    pub scroll_x: f64,
+    pub scroll_y: f64,
+    pub page_height: f64,
+    pub tile_count: usize,
+    pub tile_bytes: usize,
+    pub scene_epoch: u64,
+    pub raster_dpr: u32,
 }
 
 /// A rendered internal page. Only HTML for now; a `content_type` field is the obvious
@@ -158,6 +174,7 @@ pub mod builtins {
             ("help", Arc::new(|r| Some(help(r)))),
             ("version", Arc::new(|r| Some(version(r)))),
             ("history", Arc::new(|r| Some(history(r)))),
+            ("stats", Arc::new(|r| Some(stats(r)))),
             ("config", Arc::new(|r| Some(config(r)))),
         ]
     }
@@ -183,13 +200,30 @@ pub mod builtins {
              body{{margin:0;padding:32px 40px;font-family:sans-serif;font-size:14px;color:#1c2333;background:#ffffff}}\
              h1{{font-size:24px;margin:0 0 4px 0}} h2{{font-size:16px;margin:24px 0 8px 0}}\
              .sub{{color:#5c6675;margin:0 0 20px 0}}\
-             table{{border-collapse:collapse}} td,th{{text-align:left;padding:3px 14px 3px 0;vertical-align:top}}\
-             th{{color:#5c6675;font-weight:normal}} code{{font-family:monospace;font-size:13px}}\
+             .gr span{{display:inline-block;padding:3px 14px 3px 0;vertical-align:top;overflow:hidden}}\
+             .hd span,.k{{color:#5c6675}} code{{font-family:monospace;font-size:13px}}\
              a{{color:#1d5fd1}} .muted{{color:#8a94a6}} .cur{{font-weight:bold}}\
              </style></head><body>{}</body></html>",
             escape(title),
             body
         ))
+    }
+
+    /// One row of tabular data. `<table>` markup is avoided for now: the
+    /// current auto table layout misplaces columns (tables are being reworked
+    /// on the lattice branch), so rows are fixed-width inline-block cells
+    /// instead. A width of 0 gives the cell its natural size.
+    fn grid_row(cls: &str, cells: &[(u32, String)]) -> String {
+        let mut row = format!("<div class=\"gr{cls}\">");
+        for (w, html) in cells {
+            if *w == 0 {
+                row.push_str(&format!("<span>{html}</span>"));
+            } else {
+                row.push_str(&format!("<span style=\"width:{w}px\">{html}</span>"));
+            }
+        }
+        row.push_str("</div>");
+        row
     }
 
     const BLANK: &str =
@@ -209,17 +243,24 @@ pub mod builtins {
             ("help", "This page"),
             ("version", "Engine build, render backend, settings of note"),
             ("history", "This tab's session history tree"),
+            ("stats", "Rendering diagnostics and engine timings"),
             ("config", "Engine settings (read-only dump)"),
         ];
         let mut body = String::from(
-            "<h1>Internal pages</h1><p class=\"sub\">Also reachable as <code>about:&lt;name&gt;</code>.</p><table>",
+            "<h1>Internal pages</h1><p class=\"sub\">Also reachable as <code>about:&lt;name&gt;</code>.</p>",
         );
         for (name, desc) in items {
-            body.push_str(&format!(
-                "<tr><td><a href=\"gosub://{name}\"><code>gosub://{name}</code></a></td><td>{desc}</td></tr>"
+            body.push_str(&grid_row(
+                "",
+                &[
+                    (
+                        170,
+                        format!("<a href=\"gosub://{name}\"><code>gosub://{name}</code></a>"),
+                    ),
+                    (0, desc.to_string()),
+                ],
             ));
         }
-        body.push_str("</table>");
         let _ = r;
         page("Help", &body)
     }
@@ -234,15 +275,16 @@ pub mod builtins {
                 format!("{} / {}", std::env::consts::OS, std::env::consts::ARCH),
             ),
         ];
-        let mut body = String::from("<h1>Version</h1><table>");
+        let mut body = String::from("<h1>Version</h1>");
         for (k, v) in rows {
-            body.push_str(&format!(
-                "<tr><th>{}</th><td><code>{}</code></td></tr>",
-                escape(k),
-                escape(&v)
+            body.push_str(&grid_row(
+                "",
+                &[
+                    (150, format!("<span class=\"k\">{}</span>", escape(k))),
+                    (0, format!("<code>{}</code>", escape(&v))),
+                ],
             ));
         }
-        body.push_str("</table>");
         page("Version", &body)
     }
 
@@ -252,28 +294,122 @@ pub mod builtins {
         if h.entries.is_empty() {
             body.push_str("<p class=\"muted\">No entries yet.</p>");
         } else {
-            body.push_str("<table><tr><th>#</th><th>Parent</th><th>Title</th><th>URL</th></tr>");
+            body.push_str(&grid_row(
+                " hd",
+                &[
+                    (40, "#".into()),
+                    (70, "Parent".into()),
+                    (280, "Title".into()),
+                    (0, "URL".into()),
+                ],
+            ));
             for e in &h.entries {
-                let cls = if Some(e.id) == h.current { " class=\"cur\"" } else { "" };
+                let cls = if Some(e.id) == h.current { " cur" } else { "" };
                 let title = e.title.as_deref().unwrap_or("");
                 let parent = e.parent.map(|p| p.0.to_string()).unwrap_or_else(|| "–".to_string());
-                body.push_str(&format!(
-                    "<tr{cls}><td>{}</td><td>{parent}</td><td>{}</td><td><a href=\"{}\"><code>{}</code></a></td></tr>",
-                    e.id.0,
-                    escape(title),
-                    escape(e.url.as_str()),
-                    escape(e.url.as_str()),
+                body.push_str(&grid_row(
+                    cls,
+                    &[
+                        (40, e.id.0.to_string()),
+                        (70, parent),
+                        (280, escape(title)),
+                        (
+                            0,
+                            format!(
+                                "<a href=\"{}\"><code>{}</code></a>",
+                                escape(e.url.as_str()),
+                                escape(e.url.as_str())
+                            ),
+                        ),
+                    ],
                 ));
             }
-            body.push_str("</table>");
         }
         page("Session history", &body)
+    }
+
+    fn stats(r: &PageRequest<'_>) -> PageResponse {
+        let s = &r.tab.stats;
+        let mut body = String::from("<h1>Stats</h1><p class=\"sub\">This tab's rendering state, and process-wide engine timings since start.</p>");
+
+        body.push_str("<h2>Tab</h2>");
+        for (k, v) in [
+            (
+                "Viewport",
+                format!("{} × {} CSS px", s.viewport_width, s.viewport_height),
+            ),
+            ("Scroll", format!("{:.0}, {:.0}", s.scroll_x, s.scroll_y)),
+            ("Page height", format!("{:.0} px", s.page_height)),
+            ("Raster DPR", format!("{}", s.raster_dpr)),
+            (
+                "Tile cache",
+                format!(
+                    "{} tiles, {:.1} MiB",
+                    s.tile_count,
+                    s.tile_bytes as f64 / (1024.0 * 1024.0)
+                ),
+            ),
+            ("Scene epoch", format!("{}", s.scene_epoch)),
+            ("Render backend", r.tab.render_backend.to_string()),
+        ] {
+            body.push_str(&grid_row(
+                "",
+                &[
+                    (150, format!("<span class=\"k\">{}</span>", escape(k))),
+                    (0, escape(&v)),
+                ],
+            ));
+        }
+
+        let mut timings = gosub_shared::timing::snapshot_stats();
+        timings.sort_by_key(|t| std::cmp::Reverse(t.total_us));
+        timings.truncate(30);
+        body.push_str("<h2>Timings</h2>");
+        if timings.is_empty() {
+            body.push_str("<p class=\"muted\">No timing data collected.</p>");
+        } else {
+            body.push_str(&grid_row(
+                " hd",
+                &[
+                    (340, "Namespace".into()),
+                    (70, "Count".into()),
+                    (90, "Avg".into()),
+                    (90, "p95".into()),
+                    (90, "Max".into()),
+                    (0, "Total".into()),
+                ],
+            ));
+            let ms = |us: u64| format!("{:.2} ms", us as f64 / 1000.0);
+            for t in timings {
+                body.push_str(&grid_row(
+                    "",
+                    &[
+                        (340, format!("<code>{}</code>", escape(&t.namespace))),
+                        (70, t.count.to_string()),
+                        (90, ms(t.avg_us)),
+                        (90, ms(t.p95_us)),
+                        (90, ms(t.max_us)),
+                        (0, ms(t.total_us)),
+                    ],
+                ));
+            }
+        }
+        page("Stats", &body)
     }
 
     fn config(r: &PageRequest<'_>) -> PageResponse {
         let mut keys = r.settings.find("*");
         keys.sort();
-        let mut body = String::from("<h1>Engine settings</h1><p class=\"sub\">Read-only dump of the settings store; bold rows differ from their default.</p><table><tr><th>Key</th><th>Value</th><th>Default</th><th>Description</th></tr>");
+        let mut body = String::from("<h1>Engine settings</h1><p class=\"sub\">Read-only dump of the settings store; bold rows differ from their default.</p>");
+        body.push_str(&grid_row(
+            " hd",
+            &[
+                (260, "Key".into()),
+                (150, "Value".into()),
+                (150, "Default".into()),
+                (0, "Description".into()),
+            ],
+        ));
         for key in keys {
             let Some(info) = r.settings.get_info(&key) else {
                 continue;
@@ -284,16 +420,23 @@ pub mod builtins {
                 .ok()
                 .flatten()
                 .unwrap_or_else(|| info.default.clone());
-            let cls = if current != info.default { " class=\"cur\"" } else { "" };
-            body.push_str(&format!(
-                "<tr{cls}><td><code>{}</code></td><td><code>{}</code></td><td class=\"muted\"><code>{}</code></td><td>{}</td></tr>",
-                escape(&key),
-                escape(&current.value_string()),
-                escape(&info.default.value_string()),
-                escape(&info.description),
+            let cls = if current != info.default { " cur" } else { "" };
+            body.push_str(&grid_row(
+                cls,
+                &[
+                    (260, format!("<code>{}</code>", escape(&key))),
+                    (150, format!("<code>{}</code>", escape(&current.value_string()))),
+                    (
+                        150,
+                        format!(
+                            "<span class=\"muted\"><code>{}</code></span>",
+                            escape(&info.default.value_string())
+                        ),
+                    ),
+                    (0, escape(&info.description)),
+                ],
             ));
         }
-        body.push_str("</table>");
         page("Engine settings", &body)
     }
 
@@ -371,6 +514,7 @@ mod tests {
         let tab = TabView {
             history: h.snapshot(),
             render_backend: "test",
+            ..Default::default()
         };
         let pages = InternalPages::with_builtins();
         let html = pages
@@ -383,6 +527,34 @@ mod tests {
         assert!(html.contains("https://a.example/"));
         assert!(html.contains("https://b.example/"));
         assert!(html.contains(">A<"));
+    }
+
+    #[test]
+    fn stats_page_renders_tab_diagnostics() {
+        let tab = TabView {
+            render_backend: "test-backend",
+            stats: TabStats {
+                viewport_width: 1024,
+                viewport_height: 768,
+                page_height: 4321.0,
+                tile_count: 12,
+                tile_bytes: 3 * 1024 * 1024,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let pages = InternalPages::with_builtins();
+        let html = pages
+            .resolve(
+                &Url::parse("gosub://stats").unwrap(),
+                &settings_store::default_config(),
+                &tab,
+            )
+            .html;
+        assert!(html.contains("1024 × 768"));
+        assert!(html.contains("4321 px"));
+        assert!(html.contains("12 tiles, 3.0 MiB"));
+        assert!(html.contains("test-backend"));
     }
 
     #[test]

--- a/crates/gosub_engine/src/engine/resource_pipeline/html.rs
+++ b/crates/gosub_engine/src/engine/resource_pipeline/html.rs
@@ -89,13 +89,27 @@ impl HtmlPipelineImpl {
             }
         }
 
+        let doc_url = meta.final_url.clone();
         let mut on_discover = |hint: ResourceHint| {
+            // A remote document must never pull file:// subresources; don't even submit
+            // them (the file loader refuses them again as defense in depth).
+            if hint.url.scheme() == "file" && doc_url.scheme() != "file" {
+                log::warn!(
+                    "refusing file:// subresource {} for remote document {}",
+                    hint.url,
+                    doc_url
+                );
+                return;
+            }
             let sub_req_id = RequestId::new();
             REF_REGISTRY.register_request(sub_req_id, hint.kind, Initiator::Parser);
             let mut headers = sub_headers.clone();
             if let Ok(val) = hint.kind.accept_header().parse() {
                 headers.insert(http::header::ACCEPT, val);
             }
+            // The referrer serves double duty: gosub-sonar computes the Referer header from
+            // it (never for non-http(s) referrers), and the file loader uses it to accept
+            // subresources of file:// documents.
             let sub_req = FetchRequest::builder(Method::GET, hint.url)
                 .with_req_id(sub_req_id)
                 .with_reference(parent_ref)
@@ -103,6 +117,7 @@ impl HtmlPipelineImpl {
                 .with_initiator(Initiator::Parser.to_net())
                 .with_kind(hint.kind.to_net())
                 .with_headers(headers)
+                .with_referrer(doc_url.clone())
                 .with_streaming(true)
                 .with_auto_decode(true)
                 .build();

--- a/crates/gosub_engine/src/engine/settings.json
+++ b/crates/gosub_engine/src/engine/settings.json
@@ -81,6 +81,12 @@
       "description": "User-Agent string sent with outgoing HTTP requests. Empty (the default) sends the computed compat UA (see net::default_user_agent); embedders set this key to add their product token or send a fully custom UA."
     },
     {
+      "key": "file.enabled",
+      "type": "b",
+      "default": "b:true",
+      "description": "Serve file:// URLs from the local filesystem (navigations, downloads, and subresources of file:// documents only; remote pages can never reference local files). Embedders rendering untrusted content in a non-browser setting may want this off."
+    },
+    {
       "key": "timeout.connect_secs",
       "type": "u",
       "default": "u:5",

--- a/crates/gosub_engine/src/engine/tab/worker.rs
+++ b/crates/gosub_engine/src/engine/tab/worker.rs
@@ -633,12 +633,15 @@ impl<C: RenderConfiguration> TabWorker<C> {
         if let Ok(val) = ResourceKind::Image.accept_header().parse() {
             headers.insert(http::header::ACCEPT, val);
         }
+        // The referrer marks the requesting document; it lets file:// pages load their
+        // own icons (the file loader gates subresources on it).
         let req = FetchRequest::builder(Method::GET, icon_url.clone())
             .with_req_id(req_id)
             .with_headers(headers)
             .with_priority(Priority::Low)
             .with_kind(ResourceKind::Image.to_net())
             .with_initiator(Initiator::Other.to_net())
+            .with_referrer(base_url.clone())
             .with_streaming(false)
             .with_auto_decode(true)
             .build();

--- a/crates/gosub_engine/src/engine/tab/worker.rs
+++ b/crates/gosub_engine/src/engine/tab/worker.rs
@@ -123,6 +123,18 @@ async fn stream_to_file(
     Ok(())
 }
 
+/// Minimal scope guard: runs `f` on drop. Used where a task must clean up on every exit
+/// path without pulling in a dependency.
+fn scopeguard<F: FnMut()>(f: F) -> impl Drop {
+    struct Guard<F: FnMut()>(F);
+    impl<F: FnMut()> Drop for Guard<F> {
+        fn drop(&mut self) {
+            (self.0)();
+        }
+    }
+    Guard(f)
+}
+
 /// Fallback URL used when a navigation has no usable URL.
 fn about_blank() -> Url {
     #[allow(clippy::unwrap_used)] // PANIC-SAFE: literal URL
@@ -934,8 +946,16 @@ impl<C: RenderConfiguration> TabWorker<C> {
 
         let req_id = RequestId::new();
         REF_REGISTRY.register_request(req_id, ResourceKind::Other, Initiator::Other);
+        // A Download reference routes the transport's per-chunk progress to the shell as
+        // DownloadProgress events while the (buffered) fetch is still receiving.
+        let reference = RequestReference::Download(id.0);
+        self.zone_context
+            .request_reference_map
+            .write()
+            .insert(reference, self.tab_id);
         let req = FetchRequest::builder(Method::GET, url.clone())
             .with_req_id(req_id)
+            .with_reference(REF_REGISTRY.to_net(reference))
             .with_priority(Priority::Low)
             .with_kind(ResourceKind::Other.to_net())
             .with_initiator(Initiator::Other.to_net())
@@ -947,7 +967,13 @@ impl<C: RenderConfiguration> TabWorker<C> {
         let zone_id = self.zone_id;
         let io_tx = self.zone_context.io_tx.clone();
         let event_tx = self.zone_context.event_tx.clone();
+        let reference_map = self.zone_context.request_reference_map.clone();
         spawn_named("tab-download", async move {
+            // Remove the routing entry however the download ends.
+            let _cleanup = scopeguard(move || {
+                reference_map.write().remove(&reference);
+            });
+
             let fail = |error: String| {
                 let _ = event_tx.send(EngineEvent::DownloadFailed { tab_id, id, error });
             };

--- a/crates/gosub_engine/src/engine/tab/worker.rs
+++ b/crates/gosub_engine/src/engine/tab/worker.rs
@@ -1395,9 +1395,21 @@ impl<C: RenderConfiguration> TabWorker<C> {
 
         // gosub:// and about: pages are served by the engine's page registry, never fetched.
         if InternalPages::handles(&url) {
+            let (tile_count, tile_bytes) = self.context.tile_stats();
             let tab_view = TabView {
                 history: self.history.snapshot(),
                 render_backend: self.zone_context.render_backend.name(),
+                stats: crate::engine::internal_pages::TabStats {
+                    viewport_width: self.desired_viewport.width,
+                    viewport_height: self.desired_viewport.height,
+                    scroll_x: self.scroll_x as f64,
+                    scroll_y: self.scroll_y as f64,
+                    page_height: self.context.page_height(),
+                    tile_count,
+                    tile_bytes,
+                    scene_epoch: self.context.scene_epoch(),
+                    raster_dpr: self.zone_context.render_backend.device_pixel_ratio(),
+                },
             };
             let page = self
                 .zone_context

--- a/crates/gosub_engine/src/engine/useragent-settings.json
+++ b/crates/gosub_engine/src/engine/useragent-settings.json
@@ -12,7 +12,7 @@
       "key": "close_button",
       "type": "m",
       "values": "left,right",
-      "default": "m:left",
+      "default": "m:right",
       "description": "Defines where the close button on tabs is located"
     },
     {

--- a/crates/gosub_engine/src/net.rs
+++ b/crates/gosub_engine/src/net.rs
@@ -55,6 +55,7 @@ mod decision_hub;
 mod emitter;
 pub mod events;
 mod fetcher;
+mod file_loader;
 mod io_runtime;
 pub mod req_ref_tracker;
 mod router;

--- a/crates/gosub_engine/src/net/emitter/engine_event_emitter.rs
+++ b/crates/gosub_engine/src/net/emitter/engine_event_emitter.rs
@@ -22,6 +22,9 @@ pub struct EngineEventEmitter {
     kind: ResourceKind,
     /// The initiator of the request
     initiator: Initiator,
+    /// Bytes at the last forwarded progress event (progress arrives per read chunk from
+    /// the transport, which is too chatty for the event bus).
+    last_progress: std::sync::atomic::AtomicU64,
 }
 
 impl EngineEventEmitter {
@@ -43,6 +46,21 @@ impl EngineEventEmitter {
             event_tx,
             kind,
             initiator,
+            last_progress: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    /// Forward at most one progress event per `STEP` bytes received (always forwarding
+    /// the final one that reaches `expected`).
+    fn should_report_progress(&self, received: u64, expected: Option<u64>) -> bool {
+        use std::sync::atomic::Ordering;
+        const STEP: u64 = 64 * 1024;
+        let last = self.last_progress.load(Ordering::Relaxed);
+        if received.saturating_sub(last) >= STEP || Some(received) == expected {
+            self.last_progress.store(received, Ordering::Relaxed);
+            true
+        } else {
+            false
         }
     }
 
@@ -101,6 +119,34 @@ impl NetObserver for EngineEventEmitter {
                 expected_length,
                 elapsed,
             } => {
+                if !self.should_report_progress(received_bytes, expected_length) {
+                    return;
+                }
+                match self.reference {
+                    // Document fetch of a navigation: the shell's load-progress signal.
+                    RequestReference::Navigation(nav_id) => {
+                        let _ = self.event_tx.send(EngineEvent::Navigation {
+                            tab_id: self.tab_id,
+                            event: crate::engine::events::NavigationEvent::Progress {
+                                nav_id,
+                                received_bytes,
+                                expected_length,
+                                elapsed,
+                            },
+                        });
+                    }
+                    // A download: granular per-chunk progress for the shell's downloads UI.
+                    RequestReference::Download(id) => {
+                        let _ = self.event_tx.send(EngineEvent::DownloadProgress {
+                            tab_id: self.tab_id,
+                            id: crate::engine::events::DownloadId(id),
+                            received_bytes,
+                            total_bytes: expected_length,
+                        });
+                        return; // not a page resource
+                    }
+                    _ => {}
+                }
                 self.emit(ResourceEvent::Progress {
                     request_id: self.req_id,
                     reference: self.reference,

--- a/crates/gosub_engine/src/net/file_loader.rs
+++ b/crates/gosub_engine/src/net/file_loader.rs
@@ -1,0 +1,424 @@
+//! Serving `file://` URLs from the local filesystem.
+//!
+//! gosub-sonar only speaks http(s) (anything else is `BlockReason::UnsupportedScheme`), so
+//! the engine serves the file scheme itself: the I/O thread intercepts file requests before
+//! they reach the zone fetcher and answers them from disk with a synthesized buffered
+//! response. The rest of the pipeline (content routing, parsing, subresource discovery,
+//! download offers) treats the result like any other fetch.
+//!
+//! Access policy — enforced per request in [`refusal`]:
+//! - `net.file.enabled` (settings store) turns the scheme off entirely.
+//! - Top-level navigations (`ResourceKind::Primary`) are always served. Note this is laxer
+//!   than mainstream browsers, which also refuse file links *clicked from* remote pages;
+//!   the request does not carry enough context to tell a typed URL from a clicked link.
+//! - User downloads (`RequestReference::Download`) are served.
+//! - Subresources are served only when the initiating document is itself `file://` (the
+//!   engine stamps `FetchRequest::referrer` with the document URL; gosub-sonar never turns
+//!   a non-http(s) referrer into a `Referer` header, so this cannot leak local paths).
+//! - Everything else is refused: a remote page can never read local files.
+//!
+//! Directories render as a generated listing page; unknown file types are served as
+//! `application/octet-stream`, which flows into the regular download offer.
+
+use crate::net::req_ref_tracker::{RequestReference, REF_REGISTRY};
+use crate::net::types::{FetchRequest, FetchResult, FetchResultMeta, NetError};
+use bytes::Bytes;
+use cow_utils::CowUtils;
+use gosub_sonar::net::events::NetEvent;
+use gosub_sonar::net::observer::NetObserver;
+use gosub_sonar::net::types::{BlockReason, ResourceKind as NetResourceKind};
+use http::HeaderMap;
+use std::path::Path;
+use std::sync::Arc;
+use url::Url;
+
+/// Whether this request is for the engine-served `file://` scheme.
+pub fn handles(req: &FetchRequest) -> bool {
+    req.url.scheme() == "file"
+}
+
+/// Why a file request is refused, if it is.
+fn refusal(req: &FetchRequest, enabled: bool) -> Option<BlockReason> {
+    if !enabled {
+        return Some(BlockReason::UrlPolicy);
+    }
+    // Top-level navigation (address bar, link click).
+    if req.kind == NetResourceKind::Primary {
+        return None;
+    }
+    // A user-initiated download ("save link as" on a file link).
+    if matches!(
+        REF_REGISTRY.from_net(req.reference),
+        Some(RequestReference::Download(_))
+    ) {
+        return None;
+    }
+    // Subresource of a document that is itself served from disk.
+    if req.referrer.as_ref().is_some_and(|r| r.scheme() == "file") {
+        return None;
+    }
+    Some(BlockReason::UrlPolicy)
+}
+
+/// Serve a `file://` request, emitting the same observer events a network fetch would, and
+/// returning the buffered response (or error) for the reply channel.
+pub async fn serve(req: &FetchRequest, enabled: bool, observer: Arc<dyn NetObserver + Send + Sync>) -> FetchResult {
+    let url = req.url.clone();
+
+    if let Some(reason) = refusal(req, enabled) {
+        log::warn!(
+            "refusing file:// request for {url} (kind {:?}, referrer {:?})",
+            req.kind,
+            req.referrer
+        );
+        observer.on_event(NetEvent::Blocked {
+            url: url.clone(),
+            reason,
+        });
+        return FetchResult::Error(NetError::Blocked { reason, url });
+    }
+
+    observer.on_event(NetEvent::Started { url: url.clone() });
+    let started = std::time::Instant::now();
+
+    match load(&url).await {
+        Ok((content_type, body)) => {
+            let mut headers = HeaderMap::new();
+            if let Ok(v) = content_type.parse() {
+                headers.insert(http::header::CONTENT_TYPE, v);
+            }
+            if let Ok(v) = body.len().to_string().parse() {
+                headers.insert(http::header::CONTENT_LENGTH, v);
+            }
+            observer.on_event(NetEvent::ResponseHeaders {
+                url: url.clone(),
+                status: 200,
+                headers: headers.clone(),
+            });
+            let len = body.len() as u64;
+            observer.on_event(NetEvent::Progress {
+                received_bytes: len,
+                expected_length: Some(len),
+                elapsed: started.elapsed(),
+            });
+            observer.on_event(NetEvent::Finished {
+                received_bytes: len,
+                elapsed: started.elapsed(),
+                url: url.clone(),
+            });
+            FetchResult::Buffered {
+                meta: FetchResultMeta {
+                    final_url: url,
+                    status: 200,
+                    status_text: "OK".into(),
+                    headers,
+                    content_length: Some(len),
+                    content_type: Some(content_type.to_string()),
+                    has_body: len > 0,
+                },
+                body,
+            }
+        }
+        Err(e) => {
+            let err = NetError::Io(Arc::new(e));
+            observer.on_event(NetEvent::Failed {
+                url,
+                error: anyhow::anyhow!(err.clone()),
+            });
+            FetchResult::Error(err)
+        }
+    }
+}
+
+/// Read the URL's path from disk: file contents, or a generated listing for a directory.
+async fn load(url: &Url) -> std::io::Result<(&'static str, Bytes)> {
+    let path = url
+        .to_file_path()
+        .map_err(|()| std::io::Error::new(std::io::ErrorKind::InvalidInput, "not a local file path"))?;
+    let meta = tokio::fs::metadata(&path).await?;
+    if meta.is_dir() {
+        let listing = directory_listing(&path).await?;
+        Ok(("text/html; charset=utf-8", Bytes::from(listing)))
+    } else {
+        let body = tokio::fs::read(&path).await?;
+        Ok((content_type_for(&path), Bytes::from(body)))
+    }
+}
+
+/// `Content-Type` by file extension. `application/octet-stream` for anything unknown,
+/// which routes into the download offer like a server would trigger it.
+fn content_type_for(path: &Path) -> &'static str {
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    let ext = ext.cow_to_ascii_lowercase();
+    match ext.as_ref() {
+        "html" | "htm" | "xhtml" => "text/html; charset=utf-8",
+        "css" => "text/css; charset=utf-8",
+        "js" | "mjs" => "text/javascript; charset=utf-8",
+        "json" => "application/json",
+        "txt" | "text" | "log" | "md" | "rs" | "toml" | "yaml" | "yml" | "ini" | "csv" => "text/plain; charset=utf-8",
+        "xml" => "application/xml",
+        "pdf" => "application/pdf",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "avif" => "image/avif",
+        "svg" => "image/svg+xml",
+        "ico" => "image/x-icon",
+        "bmp" => "image/bmp",
+        "woff" => "font/woff",
+        "woff2" => "font/woff2",
+        "ttf" => "font/ttf",
+        "otf" => "font/otf",
+        "mp4" => "video/mp4",
+        "webm" => "video/webm",
+        "mp3" => "audio/mpeg",
+        "wav" => "audio/wav",
+        "ogg" | "oga" => "audio/ogg",
+        "wasm" => "application/wasm",
+        "zip" => "application/zip",
+        "gz" => "application/gzip",
+        _ => "application/octet-stream",
+    }
+}
+
+fn escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+fn human_size(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    let b = bytes as f64;
+    if b >= KIB * KIB * KIB {
+        format!("{:.1} GiB", b / (KIB * KIB * KIB))
+    } else if b >= KIB * KIB {
+        format!("{:.1} MiB", b / (KIB * KIB))
+    } else if b >= KIB {
+        format!("{:.1} KiB", b / KIB)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+/// A generated index page for a directory, in the internal-pages house style.
+/// Tabular data is inline-block rows, not `<table>` (see the internal_pages module:
+/// the current auto table layout misplaces columns until the lattice work merges).
+async fn directory_listing(path: &Path) -> std::io::Result<String> {
+    struct Entry {
+        name: String,
+        href: Option<Url>,
+        is_dir: bool,
+        size: u64,
+    }
+
+    let mut entries = Vec::new();
+    let mut rd = tokio::fs::read_dir(path).await?;
+    while let Some(item) = rd.next_entry().await? {
+        let name = item.file_name().to_string_lossy().into_owned();
+        let meta = item.metadata().await;
+        let is_dir = meta.as_ref().map(|m| m.is_dir()).unwrap_or(false);
+        let size = meta.map(|m| m.len()).unwrap_or(0);
+        let href = if is_dir {
+            Url::from_directory_path(item.path()).ok()
+        } else {
+            Url::from_file_path(item.path()).ok()
+        };
+        entries.push(Entry {
+            name,
+            href,
+            is_dir,
+            size,
+        });
+    }
+    entries.sort_by(|a, b| {
+        b.is_dir
+            .cmp(&a.is_dir)
+            .then_with(|| a.name.cow_to_lowercase().cmp(&b.name.cow_to_lowercase()))
+    });
+
+    let shown = escape(&path.to_string_lossy());
+    let mut rows = String::new();
+    if let Some(parent) = path.parent() {
+        if let Ok(up) = Url::from_directory_path(parent) {
+            rows.push_str(&format!(
+                "<div class=\"gr\"><span style=\"width:420px\"><a href=\"{up}\">..</a></span><span></span></div>"
+            ));
+        }
+    }
+    for e in entries {
+        let label = if e.is_dir {
+            format!("{}/", e.name)
+        } else {
+            e.name.clone()
+        };
+        let cell = match &e.href {
+            Some(href) => format!("<a href=\"{href}\">{}</a>", escape(&label)),
+            None => escape(&label),
+        };
+        let size = if e.is_dir { String::new() } else { human_size(e.size) };
+        rows.push_str(&format!(
+            "<div class=\"gr\"><span style=\"width:420px\">{cell}</span><span class=\"muted\">{size}</span></div>"
+        ));
+    }
+
+    Ok(format!(
+        "<!DOCTYPE html><html><head><meta charset=\"utf-8\"><title>Index of {shown}</title><style>\
+         body{{margin:0;padding:32px 40px;font-family:sans-serif;font-size:14px;color:#1c2333;background:#ffffff}}\
+         h1{{font-size:20px;margin:0 0 16px 0}}\
+         .gr span{{display:inline-block;padding:3px 14px 3px 0;vertical-align:top}}\
+         a{{color:#1d5fd1;text-decoration:none}} .muted{{color:#8a94a6}}\
+         </style></head><body><h1>Index of {shown}</h1>{rows}</body></html>"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gosub_sonar::net::null_emitter::NullEmitter;
+    use gosub_sonar::net::types::FetchRequestBuilder;
+    use gosub_sonar::types::RequestId;
+    use http::Method;
+
+    fn observer() -> Arc<dyn NetObserver + Send + Sync> {
+        Arc::new(NullEmitter)
+    }
+
+    fn request(url: &Url) -> FetchRequestBuilder {
+        FetchRequest::builder(Method::GET, url.clone()).with_req_id(RequestId::new())
+    }
+
+    fn nav_request(url: &Url) -> FetchRequest {
+        request(url).with_kind(NetResourceKind::Primary).build()
+    }
+
+    fn temp_dir() -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("gosub-file-loader-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[tokio::test]
+    async fn navigation_serves_a_local_file_with_content_type() {
+        let dir = temp_dir();
+        let file = dir.join("page.html");
+        std::fs::write(&file, "<html><body>hello</body></html>").unwrap();
+
+        let url = Url::from_file_path(&file).unwrap();
+        let result = serve(&nav_request(&url), true, observer()).await;
+        match result {
+            FetchResult::Buffered { meta, body } => {
+                assert_eq!(meta.status, 200);
+                assert_eq!(meta.content_type.as_deref(), Some("text/html; charset=utf-8"));
+                assert!(std::str::from_utf8(&body).unwrap().contains("hello"));
+            }
+            other => panic!("expected buffered response, got {other:?}"),
+        }
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn directory_navigation_renders_a_listing() {
+        let dir = temp_dir();
+        std::fs::write(dir.join("a.txt"), "x").unwrap();
+        std::fs::create_dir(dir.join("sub")).unwrap();
+
+        let url = Url::from_directory_path(&dir).unwrap();
+        let result = serve(&nav_request(&url), true, observer()).await;
+        match result {
+            FetchResult::Buffered { meta, body } => {
+                let html = std::str::from_utf8(&body).unwrap();
+                assert_eq!(meta.content_type.as_deref(), Some("text/html; charset=utf-8"));
+                assert!(html.contains("a.txt"));
+                assert!(html.contains("sub/"));
+                assert!(html.contains("Index of"));
+            }
+            other => panic!("expected listing, got {other:?}"),
+        }
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn missing_file_is_an_io_error() {
+        let url = Url::parse("file:///definitely/not/a/real/path/x.html").unwrap();
+        let result = serve(&nav_request(&url), true, observer()).await;
+        assert!(matches!(result, FetchResult::Error(NetError::Io(_))));
+    }
+
+    #[tokio::test]
+    async fn disabled_setting_blocks_even_navigations() {
+        let url = Url::parse("file:///etc/hostname").unwrap();
+        let result = serve(&nav_request(&url), false, observer()).await;
+        assert!(matches!(
+            result,
+            FetchResult::Error(NetError::Blocked {
+                reason: BlockReason::UrlPolicy,
+                ..
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn remote_page_cannot_pull_local_subresources() {
+        let dir = temp_dir();
+        let file = dir.join("secret.txt");
+        std::fs::write(&file, "s3cr3t").unwrap();
+        let url = Url::from_file_path(&file).unwrap();
+
+        // Subresource (Asset) with a remote referrer: refused.
+        let req = request(&url)
+            .with_kind(NetResourceKind::Asset)
+            .with_referrer(Url::parse("https://evil.example/").unwrap())
+            .build();
+        assert!(matches!(
+            serve(&req, true, observer()).await,
+            FetchResult::Error(NetError::Blocked { .. })
+        ));
+
+        // Subresource with no referrer at all: refused too.
+        let req = request(&url).with_kind(NetResourceKind::Asset).build();
+        assert!(matches!(
+            serve(&req, true, observer()).await,
+            FetchResult::Error(NetError::Blocked { .. })
+        ));
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn file_page_subresources_are_served() {
+        let dir = temp_dir();
+        let css = dir.join("style.css");
+        std::fs::write(&css, "body{color:red}").unwrap();
+        let url = Url::from_file_path(&css).unwrap();
+
+        let doc = Url::from_file_path(dir.join("index.html")).unwrap();
+        let req = request(&url)
+            .with_kind(NetResourceKind::Asset)
+            .with_referrer(doc)
+            .build();
+        match serve(&req, true, observer()).await {
+            FetchResult::Buffered { meta, .. } => {
+                assert_eq!(meta.content_type.as_deref(), Some("text/css; charset=utf-8"));
+            }
+            other => panic!("expected buffered response, got {other:?}"),
+        }
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn content_types_cover_the_common_cases() {
+        assert_eq!(content_type_for(Path::new("x.html")), "text/html; charset=utf-8");
+        assert_eq!(content_type_for(Path::new("x.PNG")), "image/png");
+        assert_eq!(content_type_for(Path::new("x.unknown")), "application/octet-stream");
+        assert_eq!(content_type_for(Path::new("no-extension")), "application/octet-stream");
+    }
+}

--- a/crates/gosub_engine/src/net/io_runtime.rs
+++ b/crates/gosub_engine/src/net/io_runtime.rs
@@ -92,16 +92,39 @@ pub struct IoRouter {
     /// Pending UA decisions (render/download/...) keyed by decision token.
     /// Tokens are process-wide unique, so one hub serves all zones.
     decision_hub: Arc<DecisionHub>,
+    /// Observer factory for requests the engine serves itself (the `file://` scheme),
+    /// so they emit the same resource events a gosub-sonar fetch would.
+    local_ctx: EngineNetContext,
 }
 
 impl IoRouter {
     pub fn new(cfg: FetcherConfig, engine_ctx: Arc<EngineContext>) -> Self {
+        let local_ctx = EngineNetContext {
+            event_tx: engine_ctx.event_tx.clone(),
+            request_reference_map: engine_ctx.request_reference_map.clone(),
+            request_ref_tracker: Arc::new(RequestRefTracker::new()),
+        };
         Self {
             zones: DashMap::new(),
             cfg,
             engine_ctx,
             decision_hub: Arc::new(DecisionHub::new()),
+            local_ctx,
         }
+    }
+
+    /// Serve a `file://` request from disk on its own task (never through gosub-sonar,
+    /// which only speaks http(s)). Policy lives in [`crate::net::file_loader`].
+    fn serve_file_request(&self, req: FetchRequest, reply_tx: oneshot::Sender<crate::net::types::FetchResult>) {
+        use gosub_sonar::net::fetcher_context::FetcherContext;
+        let enabled = self.engine_ctx.config_store.get_bool("net.file.enabled");
+        let observer = self
+            .local_ctx
+            .observer_for(req.reference, req.req_id, req.kind, req.initiator);
+        spawn_named("file-loader", async move {
+            let result = crate::net::file_loader::serve(&req, enabled, observer).await;
+            let _ = reply_tx.send(result);
+        });
     }
 
     pub fn get_or_spawn_zone_fetcher(&self, zone_id: ZoneId) -> Result<Arc<Fetcher>, EngineError> {
@@ -231,6 +254,12 @@ pub fn spawn_io_thread(cfg: FetcherConfig, engine_ctx: Arc<EngineContext>) -> Io
                 maybe_req = rx_submit.recv() => {
                     match maybe_req {
                         Some(IoCommand::Fetch { zone_id, req, handle, reply_tx }) => {
+                            // The engine serves file:// itself; everything else goes to the
+                            // zone's gosub-sonar fetcher.
+                            if crate::net::file_loader::handles(&req) {
+                                router.serve_file_request(req, reply_tx);
+                                continue;
+                            }
                             // The I/O thread must keep running; drop the request on fetcher failure.
                             match router.get_or_spawn_zone_fetcher(zone_id) {
                                 Ok(fetcher) => fetcher.submit(req, handle.cancel.clone(), reply_tx).await,

--- a/crates/gosub_engine/src/net/req_ref_tracker.rs
+++ b/crates/gosub_engine/src/net/req_ref_tracker.rs
@@ -31,6 +31,8 @@ pub enum RequestReference {
     Document(DocumentId),
     /// Background prefetches
     Prefetch(PrefetchId),
+    /// A user-initiated download (the inner value is the embedder-minted `DownloadId`)
+    Download(u64),
     /// Misc/system
     Background(TaskId),
 }
@@ -42,6 +44,7 @@ impl Display for RequestReference {
             RequestReference::Document(id) => write!(f, "Doc({})", id),
             RequestReference::Prefetch(id) => write!(f, "Prefetch({})", id),
             RequestReference::Background(id) => write!(f, "BG({})", id),
+            RequestReference::Download(id) => write!(f, "DL({})", id),
         }
     }
 }

--- a/crates/gosub_renderer_vello/src/lib.rs
+++ b/crates/gosub_renderer_vello/src/lib.rs
@@ -1,3 +1,7 @@
+// wgpu's deeply nested generic types push auto-trait (`Send`/`Sync`) solving past the default
+// limit of 128; nightly's `recursion_depth_exceeding_limit` lint makes that a hard error.
+#![recursion_limit = "256"]
+
 pub mod backend;
 pub(crate) mod gpu_tiles;
 pub mod rasterizer;

--- a/crates/gosub_winit/src/lib.rs
+++ b/crates/gosub_winit/src/lib.rs
@@ -12,6 +12,10 @@
 //! selects an adapter that is compatible with the window's surface (see its docs for the Wayland
 //! trap) and a non-sRGB swap-chain format, so the embedder just creates a window and calls it.
 
+// wgpu's deeply nested generic types push auto-trait (`Send`/`Sync`) solving past the default
+// limit of 128; nightly's `recursion_depth_exceeding_limit` lint makes that a hard error.
+#![recursion_limit = "256"]
+
 use gosub_renderer_vello::WgpuContextProvider;
 use parking_lot::RwLock;
 use std::collections::HashMap;

--- a/examples/egui-vello/main.rs
+++ b/examples/egui-vello/main.rs
@@ -4,6 +4,10 @@
 //!
 //! No GTK dependency - pure egui + wgpu.
 
+// wgpu's deeply nested generic types push auto-trait (`Send`/`Sync`) solving past the default
+// limit of 128; nightly's `recursion_depth_exceeding_limit` lint makes that a hard error.
+#![recursion_limit = "256"]
+
 use eframe::{egui, CreationContext};
 use gosub_engine::events::{EngineEvent, NavigationEvent, TabCommand};
 use gosub_engine::storage::{InMemorySessionStore, PartitionPolicy, SqliteLocalStore, StorageService};

--- a/examples/winit-vello/main.rs
+++ b/examples/winit-vello/main.rs
@@ -10,6 +10,10 @@
 //! On Wayland an incompatible adapter causes `get_current_texture()` to silently fail
 //! every frame, keeping the surface un-committed and the window invisible.
 
+// wgpu's deeply nested generic types push auto-trait (`Send`/`Sync`) solving past the default
+// limit of 128; nightly's `recursion_depth_exceeding_limit` lint makes that a hard error.
+#![recursion_limit = "256"]
+
 use gosub_engine::events::{EngineEvent, MouseButton, NavigationEvent, TabCommand};
 use gosub_engine::storage::{InMemorySessionStore, PartitionPolicy, SqliteLocalStore, StorageService};
 use gosub_engine::tab::{TabDefaults, TabHandle, TabId};


### PR DESCRIPTION
The "beacon" branch is currently long-living and holds new code to support the Beacon browser. From time to time, we need to merge back this code into the main branch.

This way, the Beacon browser can always compile the "beacon" engine branch, without relying on the main branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a built-in statistics page showing tab rendering, tile, viewport, and performance details.
  * Added support for browsing local `file://` files and directories, controlled by a new setting.
  * Added progress updates for navigation and downloads.
* **Bug Fixes**
  * Improved local-resource access controls and referrer handling.
  * Improved download and favicon request tracking.
* **UI Improvements**
  * Updated built-in page layouts and moved the tab close button to the right.
* **Tests**
  * Expanded coverage for downloads, local files, directories, progress events, and statistics display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->