### PR TITLE
Network process: the network stack in its own sandboxed child

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,9 +3032,9 @@ dependencies = [
 
 [[package]]
 name = "gosub-sonar"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680c8da58b4a9f5ac7b1f822c88c3fad564acb695c7a040581f3b5d905318c41"
+checksum = "4ee39d8a24112d929543f3e9d1fab83abf8fb718c48f512f87c99ce5ff36290a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3047,7 +3047,11 @@ dependencies = [
  "http",
  "log",
  "parking_lot",
+ "psl",
  "reqwest",
+ "rustls",
+ "rustls-platform-verifier",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.20",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ gosub_v8 = { version = "0.1.1", path = "./crates/gosub_v8", features = [], regis
 gosub_webexecutor = { version = "0.1.1", path = "./crates/gosub_webexecutor", features = [], registry = "gosub" }
 gosub_config = { version = "0.1.1", path = "./crates/gosub_config", features = [], registry = "gosub" }
 gosub_jsapi = { version = "0.1.1", path = "./crates/gosub_jsapi", features = [], registry = "gosub" }
-gosub-sonar = "0.2.0"
+gosub-sonar = "0.4.0"
 futures = { workspace = true }
 cookie = { workspace = true, features = ["secure", "private"] }
 clap = { workspace = true, features = ["derive"] }

--- a/crates/gosub_engine/Cargo.toml
+++ b/crates/gosub_engine/Cargo.toml
@@ -9,7 +9,7 @@ name = "gosub_engine"
 crate-type = ["rlib"]
 
 [dependencies]
-gosub-sonar = "0.2.0"
+gosub-sonar = "0.4.0"
 gosub_shared = { version = "0.1.1", path = "../gosub_shared" }
 gosub_config = { version = "0.1.1", path = "../gosub_config" }
 gosub_html5 = { version = "0.1.1", path = "../gosub_html5" }
@@ -60,6 +60,14 @@ mimetype-detector = "0.3.11"
 image = { workspace = true }
 async-trait = "0.1.89"
 allsorts = "0.17"
+
+# Exercises the isolated components from a binary that dispatches child roles the
+# way an embedder must; `tests/process_isolation.rs` runs it. Pointless without
+# the machinery it drives.
+[[bin]]
+name = "isolation-harness"
+path = "src/bin/isolation-harness.rs"
+required-features = ["process-isolation"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/gosub_engine/src/bin/isolation-harness.rs
+++ b/crates/gosub_engine/src/bin/isolation-harness.rs
@@ -1,0 +1,328 @@
+//! Drives the network process end to end, from a binary that dispatches child
+//! roles the way a real embedder does.
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::Arc;
+
+const BODY: &str = "<html><head><title>through the net process</title></head>\
+<body style=\"margin:0\"><a href=\"https://example.test/target\" \
+style=\"display:block;width:400px;height:200px\">a link to hover</a></body></html>";
+
+/// The harness's render configuration: null backend and compositor, nothing
+/// composites here.
+#[derive(Clone, Debug, PartialEq)]
+struct TileConfig;
+
+impl gosub_interface::config::ModuleConfiguration for TileConfig {
+    type CssSystem = gosub_css3::system::Css3System;
+    type Document = gosub_html5::document::document_impl::DocumentImpl<Self>;
+    type HtmlParser = gosub_html5::parser::Html5Parser<'static, Self>;
+}
+
+impl gosub_engine::html::RenderConfiguration for TileConfig {
+    type RenderBackend = gosub_render_pipeline::render::backends::null::NullBackend;
+    type CompositorSink = gosub_render_pipeline::render::DefaultCompositor;
+    type FontSystem = gosub_fontmanager::ParleyFontSystem;
+}
+
+fn main() {
+    // First statement, exactly as the docs require of an embedder: in a child
+    // this runs the role and exits, so nothing below executes there. Skipping it
+    // is the mistake the `guard` scenario reproduces.
+    if std::env::var_os("GOSUB_HARNESS_SKIP_DISPATCH").is_none() {
+        gosub_engine::child_process::dispatch_with::<TileConfig>();
+    }
+
+    let scenario = std::env::args().nth(1).unwrap_or_default();
+    let code = match scenario.as_str() {
+        "direct" => direct(),
+        "resolve" => resolve(),
+        "engine" => engine(),
+        "guard" => guard(),
+        other => {
+            eprintln!("unknown scenario {other:?}; expected 'direct', 'resolve', 'engine' or 'guard'");
+            2
+        }
+    };
+    std::process::exit(code);
+}
+
+fn guard() -> i32 {
+    use gosub_engine::net::process::client::NetProcess;
+
+    if !gosub_engine::child_process::is_child_process() {
+        eprintln!("the guard scenario must be run with the child-role flag");
+        return 2;
+    }
+
+    match NetProcess::spawn() {
+        Ok(_) => {
+            eprintln!("spawning should have been refused: an undispatched child must not spawn more");
+            1
+        }
+        Err(e) => {
+            // The message has to name the omission, or whoever hits this cannot
+            // act on it.
+            if e.to_string().contains("dispatch()") {
+                0
+            } else {
+                eprintln!("refused, but not for the documented reason: {e}");
+                1
+            }
+        }
+    }
+}
+
+fn serve_once() -> std::io::Result<(u16, std::thread::JoinHandle<()>)> {
+    serve_once_with(BODY)
+}
+
+/// A one-shot HTTP server on an ephemeral port, serving `body`.
+fn serve_once_with(body: &'static str) -> std::io::Result<(u16, std::thread::JoinHandle<()>)> {
+    serve_once_bytes(body.as_bytes().to_vec(), "text/html")
+}
+
+/// A one-shot HTTP server on an ephemeral port, serving `body` in small
+/// writes with pauses, the way a body arrives over a real network.
+fn serve_once_bytes(body: Vec<u8>, content_type: &'static str) -> std::io::Result<(u16, std::thread::JoinHandle<()>)> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+
+    let handle = std::thread::spawn(move || {
+        let Ok((mut stream, _)) = listener.accept() else {
+            return;
+        };
+        let mut buf = [0u8; 4096];
+        let _ = stream.read(&mut buf);
+        let head = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        let _ = stream.write_all(head.as_bytes());
+        for chunk in body.chunks(32 * 1024) {
+            if stream.write_all(chunk).is_err() {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+    });
+
+    Ok((port, handle))
+}
+
+fn resolve() -> i32 {
+    use gosub_engine::net::process::client::NetProcess;
+    use gosub_engine::net::process::protocol::FetchOutcome;
+
+    let Ok((port, server)) = serve_once() else {
+        eprintln!("could not start the test server");
+        return 1;
+    };
+    let net = match NetProcess::spawn() {
+        Ok(n) => n,
+        Err(e) => {
+            eprintln!("could not spawn the network process: {e}");
+            return 1;
+        }
+    };
+    let Ok(runtime) = tokio::runtime::Builder::new_current_thread().enable_all().build() else {
+        eprintln!("could not start a runtime");
+        return 1;
+    };
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let fetch = |url: String| {
+        let out = gosub_engine::net::process::client::Outbound::get(url);
+        runtime.block_on(net.fetch(out, &cancel)).outcome
+    };
+
+    // 1. A name that cannot exist (RFC 2606).
+    match fetch("http://gosub-hostname-probe.invalid/".into()) {
+        FetchOutcome::Ok { status, .. } => {
+            eprintln!("a .invalid name must not resolve, got status {status}");
+            net.shutdown();
+            return 1;
+        }
+        FetchOutcome::Error(e) => println!("resolution failed as it should: {e}"),
+    }
+
+    // 2. The process is still alive and serving.
+    let outcome = fetch(format!("http://127.0.0.1:{port}/"));
+    net.shutdown();
+    drop(server);
+    match outcome {
+        FetchOutcome::Ok { status: 200, body, .. } if body == BODY.as_bytes() => {
+            println!("network process survived resolution and still serves");
+            0
+        }
+        other => {
+            eprintln!("the network process did not survive: {other:?}");
+            1
+        }
+    }
+}
+
+/// The transport on its own: does a request survive the round trip through a
+/// separate, sandboxed process and come back intact?
+fn direct() -> i32 {
+    use gosub_engine::net::process::client::NetProcess;
+    use gosub_engine::net::process::protocol::FetchOutcome;
+
+    let Ok((port, server)) = serve_once() else {
+        eprintln!("could not start the test server");
+        return 1;
+    };
+
+    let net = match NetProcess::spawn() {
+        Ok(n) => n,
+        Err(e) => {
+            eprintln!("could not spawn the network process: {e}");
+            return 1;
+        }
+    };
+
+    // `fetch` is async (the broker awaits it on its I/O runtime); the harness
+    // has no runtime of its own, so give it a small one.
+    let Ok(runtime) = tokio::runtime::Builder::new_current_thread().enable_all().build() else {
+        eprintln!("could not start a runtime");
+        return 1;
+    };
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let out = gosub_engine::net::process::client::Outbound {
+        headers: vec![("accept".into(), "text/html".into())],
+        ..gosub_engine::net::process::client::Outbound::get(format!("http://127.0.0.1:{port}/"))
+    };
+    let outcome = runtime.block_on(net.fetch(out, &cancel)).outcome;
+    net.shutdown();
+    drop(server);
+
+    match outcome {
+        FetchOutcome::Ok { status, body, .. } => {
+            if status != 200 {
+                eprintln!("expected status 200, got {status}");
+                return 1;
+            }
+            if body != BODY.as_bytes() {
+                eprintln!(
+                    "body did not survive the round trip: {:?}",
+                    String::from_utf8_lossy(&body)
+                );
+                return 1;
+            }
+            0
+        }
+        FetchOutcome::Error(e) => {
+            eprintln!("fetch through the network process failed: {e}");
+            1
+        }
+    }
+}
+
+/// The wiring: with isolation on, does an ordinary navigation still resolve -
+/// through the child process rather than an in-process fetcher?
+fn engine() -> i32 {
+    use gosub_config::settings::Setting;
+    use gosub_engine::events::{EngineEvent, NavigationEvent};
+    use gosub_engine::storage::{InMemoryLocalStore, InMemorySessionStore, PartitionPolicy, StorageService};
+    use gosub_engine::zone::ZoneServices;
+    use gosub_engine::GosubEngine;
+    use gosub_render_pipeline::render::backends::null::NullBackend;
+    use gosub_render_pipeline::render::DefaultCompositor;
+
+    let Ok((port, server)) = serve_once() else {
+        eprintln!("could not start the test server");
+        return 1;
+    };
+
+    let runtime = match tokio::runtime::Builder::new_multi_thread().enable_all().build() {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("could not build a runtime: {e}");
+            return 1;
+        }
+    };
+
+    let code = runtime.block_on(async move {
+        let mut engine: GosubEngine = GosubEngine::new(
+            None,
+            Arc::new(NullBackend::new()),
+            Arc::new(DefaultCompositor::default()),
+        );
+
+        // Read once when the I/O runtime starts, so it must be set before start().
+        if let Err(e) = engine.settings().set("security.network_process", Setting::Bool(true)) {
+            eprintln!("could not enable process isolation: {e}");
+            return 1;
+        }
+
+        let mut events = engine.subscribe_events();
+        let Ok(run) = engine.start() else {
+            eprintln!("engine failed to start");
+            return 1;
+        };
+        tokio::spawn(run);
+
+        let services = ZoneServices {
+            storage: Arc::new(StorageService::new(
+                Arc::new(InMemoryLocalStore::new()),
+                Arc::new(InMemorySessionStore::new()),
+            )),
+            cookie_store: None,
+            cookie_jar: None,
+            partition_policy: PartitionPolicy::None,
+            places: None,
+        };
+        let Ok(mut zone) = engine.create_zone(None, services, None) else {
+            eprintln!("could not create a zone");
+            return 1;
+        };
+        let Ok(tab) = zone.create_tab(Default::default(), None).await else {
+            eprintln!("could not create a tab");
+            return 1;
+        };
+        if tab.navigate(format!("http://127.0.0.1:{port}/")).await.is_err() {
+            eprintln!("navigate failed");
+            return 1;
+        }
+
+        // The navigation is only meaningful if it *finished*: a failure would
+        // also end the wait, so the variant is what is asserted.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                eprintln!("timed out waiting for the navigation to finish");
+                return 1;
+            }
+            match tokio::time::timeout(remaining, events.recv()).await {
+                Ok(Ok(EngineEvent::Navigation {
+                    event: NavigationEvent::Finished { .. },
+                    ..
+                })) => break,
+                Ok(Ok(EngineEvent::Navigation {
+                    event: NavigationEvent::Failed { error, .. },
+                    ..
+                })) => {
+                    eprintln!("navigation failed: {error}");
+                    return 1;
+                }
+                Ok(Ok(_)) => continue,
+                Ok(Err(e)) => {
+                    eprintln!("event channel closed: {e}");
+                    return 1;
+                }
+                Err(_) => {
+                    eprintln!("timed out waiting for the navigation to finish");
+                    return 1;
+                }
+            }
+        }
+
+        engine.close_zone(zone).await;
+        let _ = engine.shutdown().await;
+        0
+    });
+
+    drop(server);
+    code
+}

--- a/crates/gosub_engine/src/child_process.rs
+++ b/crates/gosub_engine/src/child_process.rs
@@ -77,6 +77,7 @@ pub fn dispatch_with<C: crate::html::RenderConfiguration>() {
 
 /// Roles that need `C` (a renderer) dispatch here; every other role behaves
 /// exactly as under [`dispatch`].
+#[allow(clippy::extra_unused_type_parameters)]
 fn run_role_with<C: crate::html::RenderConfiguration>(role: &str, args: &[String]) -> i32 {
     run_role(role, args)
 }
@@ -86,11 +87,36 @@ pub fn is_child_process() -> bool {
     std::env::args().any(|a| a == ROLE_FLAG)
 }
 
-fn run_role(role: &str, _args: &[String]) -> i32 {
+fn run_role(role: &str, args: &[String]) -> i32 {
+    use crate::net::process::client::NET_ROLE;
+
     // Every child is non-dumpable: a role holds cookies or page content in its
     // address space, and another process running as the same user must not be
     // able to attach and read it.
     gosub_sandbox::deny_debugger_attach();
-    eprintln!("[gosub] unknown child role '{role}'");
-    2
+
+    match role {
+        NET_ROLE => match adopt_link(role, args) {
+            Ok(endpoint) => crate::net::process::child::serve(endpoint),
+            Err(code) => code,
+        },
+        other => {
+            eprintln!("[gosub] unknown child role '{other}'");
+            2
+        }
+    }
+}
+
+/// Take over the link this child inherited, or report why it could not.
+fn adopt_link(role: &str, args: &[String]) -> Result<gosub_ipc::Endpoint, i32> {
+    // `spawn` appends the primary link last; anything before it is a further
+    // inherited channel the role knows what to do with.
+    let Some(link) = args.last() else {
+        eprintln!("[gosub] child role '{role}' needs an IPC link argument");
+        return Err(2);
+    };
+    gosub_ipc::Endpoint::adopt_inherited(link).map_err(|e| {
+        eprintln!("[gosub] child role '{role}' could not adopt its link: {e}");
+        2
+    })
 }

--- a/crates/gosub_engine/src/engine/cookies.rs
+++ b/crates/gosub_engine/src/engine/cookies.rs
@@ -119,6 +119,8 @@ pub use cookie_jar::SameSiteContext;
 pub use cookie_jar::ThirdPartyCookiePolicy;
 pub use persistent_cookie_jar::PersistentCookieJar;
 
+/// Registrable-domain comparison, for the I/O side's SameSite decisions.
+pub(crate) use cookie_jar::same_site;
 pub use store::CookieStore;
 pub use store::InMemoryCookieStore;
 pub use store::JsonCookieStore;

--- a/crates/gosub_engine/src/engine/cookies/cookie_jar.rs
+++ b/crates/gosub_engine/src/engine/cookies/cookie_jar.rs
@@ -103,7 +103,7 @@ fn parse_http_date(s: &str) -> Option<i64> {
 /// Uses the compile-time embedded Mozilla Public Suffix List (`psl` crate) for
 /// accurate comparison. Falls back to exact hostname equality for IP addresses,
 /// `localhost`, and other labels not present in the PSL.
-fn same_site(host_a: &str, host_b: &str) -> bool {
+pub(crate) fn same_site(host_a: &str, host_b: &str) -> bool {
     let registrable = |host: &str| -> Option<String> {
         let d = psl::List.domain(host.as_bytes())?;
         std::str::from_utf8(d.as_bytes()).ok().map(str::to_owned)

--- a/crates/gosub_engine/src/engine/engine.rs
+++ b/crates/gosub_engine/src/engine/engine.rs
@@ -154,6 +154,11 @@ impl<C: RenderConfiguration> GosubEngine<C> {
 
         // Start I/O thread, building the fetcher config from the settings store.
         let io_cfg = fetcher_config_from(&self.context.config_store);
+        // Isolation needs the embedder's cooperation and a platform that has
+        // it; decided before the I/O thread, which spawns the network process.
+        #[cfg(feature = "process-isolation")]
+        self.resolve_isolation_settings();
+
         let io_handle = spawn_io_thread(io_cfg, self.context.clone());
         // Set once; `start()` already refuses to run twice, so this never races or overwrites.
         let _ = self.context.io_tx.set(io_handle.subscribe());
@@ -183,6 +188,73 @@ impl<C: RenderConfiguration> GosubEngine<C> {
     /// The engine's settings store, for reading or overriding settings (e.g.
     /// `net.user_agent`). Network settings are read once when [`start`](Self::start)
     /// builds the I/O runtime, so overrides must land before then.
+    /// Whether `key` still holds its schema default, i.e. the embedder never
+    /// chose it. A default that cannot apply here is dropped quietly; an
+    /// explicit choice that cannot apply gets a warning.
+    #[cfg(feature = "process-isolation")]
+    fn setting_at_default(&self, key: &str) -> bool {
+        let store = &self.context.config_store;
+        match (store.get_info(key), store.get(key)) {
+            (Some(info), Ok(Some(value))) => info.default == value,
+            _ => false,
+        }
+    }
+
+    #[cfg(feature = "process-isolation")]
+    fn turn_off(&self, key: &str) {
+        let _ = self
+            .context
+            .config_store
+            .set(key, gosub_config::settings::Setting::Bool(false));
+    }
+
+    /// The `security.*` process settings default to on; here the defaults meet
+    /// this process and platform. Without the embedder's
+    /// `child_process::dispatch()` nothing may spawn (a child is this binary
+    /// re-exec'd, and would run the embedder's own `main()` - for a GUI
+    /// embedder, a phantom window per spawn); the network process is on by
+    /// default on Linux only, until the macOS and Windows backends have run
+    /// in CI.
+    #[cfg(feature = "process-isolation")]
+    fn resolve_isolation_settings(&self) {
+        const PROCESS_SETTINGS: [&str; 1] = ["security.network_process"];
+        let store = &self.context.config_store;
+
+        if !crate::child_process::was_dispatched() {
+            let requested: Vec<&str> = PROCESS_SETTINGS.into_iter().filter(|key| store.get_bool(key)).collect();
+            if requested.is_empty() {
+                return;
+            }
+            if requested.iter().any(|key| !self.setting_at_default(key)) {
+                log::warn!(
+                    "{} requested, but gosub_engine::child_process::dispatch() was not called at the \
+                     top of main(); running without process isolation",
+                    requested.join(", ")
+                );
+            } else {
+                log::info!(
+                    "process isolation is off: this embedder does not call \
+                     gosub_engine::child_process::dispatch() at the top of main()"
+                );
+            }
+            for key in requested {
+                self.turn_off(key);
+            }
+            return;
+        }
+
+        if !cfg!(target_os = "linux") {
+            for key in PROCESS_SETTINGS {
+                if store.get_bool(key) && self.setting_at_default(key) {
+                    self.turn_off(key);
+                }
+            }
+            if PROCESS_SETTINGS.iter().any(|key| store.get_bool(key)) {
+                log::info!("process isolation was requested explicitly on a platform where it is not on by default");
+            }
+        }
+    }
+
     pub fn settings(&self) -> &Config {
         &self.context.config_store
     }

--- a/crates/gosub_engine/src/engine/resource_pipeline/html.rs
+++ b/crates/gosub_engine/src/engine/resource_pipeline/html.rs
@@ -267,6 +267,7 @@ mod tests {
             content_length: None,
             content_type: None,
             has_body: true,
+            tainting: gosub_sonar::ResponseTainting::Basic,
         }
     }
 

--- a/crates/gosub_engine/src/engine/settings.json
+++ b/crates/gosub_engine/src/engine/settings.json
@@ -429,6 +429,12 @@
       "values": "off,balanced,strict",
       "default": "s:balanced",
       "description": "Sandboxing level applied to zones."
+    },
+    {
+      "key": "network_process",
+      "type": "b",
+      "default": "b:true",
+      "description": "Run the network stack in a sandboxed child process. Needs the embedder to dispatch child roles; turned off at start when it cannot apply."
     }
   ],
   "telemetry": [

--- a/crates/gosub_engine/src/engine/tab/worker.rs
+++ b/crates/gosub_engine/src/engine/tab/worker.rs
@@ -1792,6 +1792,7 @@ impl<C: RenderConfiguration> TabWorker<C> {
             content_length: Some(html.len() as u64),
             content_type: Some("text/html".into()),
             has_body: true,
+            tainting: gosub_sonar::ResponseTainting::Basic,
         };
 
         spawn_named("tab-load-html", async move {

--- a/crates/gosub_engine/src/net.rs
+++ b/crates/gosub_engine/src/net.rs
@@ -58,6 +58,9 @@ pub mod events;
 mod fetcher;
 mod file_loader;
 mod io_runtime;
+/// The network stack running as a separate, sandboxed process.
+#[cfg(feature = "process-isolation")]
+pub mod process;
 pub mod req_ref_tracker;
 mod router;
 mod shared_body;

--- a/crates/gosub_engine/src/net/emitter/engine_event_emitter.rs
+++ b/crates/gosub_engine/src/net/emitter/engine_event_emitter.rs
@@ -187,6 +187,13 @@ impl NetObserver for EngineEventEmitter {
                     error: error.into(),
                 });
             }
+            NetEvent::TlsFailed { url, error } => {
+                log::debug!("TLS handshake failed for {url}: {error}");
+            }
+            // A preflight is an internal hop of a CORS request, not a resource.
+            NetEvent::CorsPreflight { url } => {
+                log::trace!("CORS preflight for {url}");
+            }
             NetEvent::Cancelled { url, reason } => {
                 REF_REGISTRY.forget_request(self.req_id);
                 self.emit(ResourceEvent::Cancelled {

--- a/crates/gosub_engine/src/net/file_loader.rs
+++ b/crates/gosub_engine/src/net/file_loader.rs
@@ -115,6 +115,7 @@ pub async fn serve(req: &FetchRequest, enabled: bool, observer: Arc<dyn NetObser
                     content_length: Some(len),
                     content_type: Some(content_type.to_string()),
                     has_body: len > 0,
+                    tainting: gosub_sonar::ResponseTainting::Basic,
                 },
                 body,
             }

--- a/crates/gosub_engine/src/net/io_runtime.rs
+++ b/crates/gosub_engine/src/net/io_runtime.rs
@@ -50,7 +50,7 @@ impl IoHandle {
         log::trace!("signal: global shutdown -> I/O thread");
         shutdown_token.cancel();
 
-        // Note: subscribers hold clones of this sender, so the channel only fully
+        // Subscribers hold clones of this sender, so the channel only fully
         // closes once they drop theirs; the cancellation token is the real signal.
         log::trace!("signal: dropping our submit channel handle");
         drop(tx_submit);
@@ -98,6 +98,11 @@ pub struct IoRouter {
     /// Observer factory for requests the engine serves itself (the `file://` scheme),
     /// so they emit the same resource events a gosub-sonar fetch would.
     local_ctx: EngineNetContext,
+    /// The network process, if `security.network_process` is on and it started.
+    /// One for the whole engine: it holds no per-zone state, and the connection
+    /// pooling that *is* per-zone lives inside it.
+    #[cfg(feature = "process-isolation")]
+    net_process: Option<Arc<crate::net::process::client::NetProcess>>,
 }
 
 impl IoRouter {
@@ -107,12 +112,17 @@ impl IoRouter {
             request_reference_map: engine_ctx.request_reference_map.clone(),
             request_ref_tracker: Arc::new(RequestRefTracker::new()),
         };
+        #[cfg(feature = "process-isolation")]
+        let net_process = start_net_process(&engine_ctx);
+
         Self {
             zones: DashMap::new(),
             cfg,
             engine_ctx,
             decision_hub: Arc::new(DecisionHub::new()),
             local_ctx,
+            #[cfg(feature = "process-isolation")]
+            net_process,
         }
     }
 
@@ -135,20 +145,31 @@ impl IoRouter {
         &self.engine_ctx.tab_identities
     }
 
+    /// The network process, when this engine is running one.
+    #[cfg(feature = "process-isolation")]
+    pub fn net_process(&self) -> Option<Arc<crate::net::process::client::NetProcess>> {
+        self.net_process.clone()
+    }
+
+    #[cfg(not(feature = "process-isolation"))]
+    pub fn net_process(&self) -> Option<std::convert::Infallible> {
+        None
+    }
+
+    /// The zone's fetcher, spawned on first use.
     pub fn get_or_spawn_zone_fetcher(&self, zone_id: ZoneId) -> Result<Arc<Fetcher>, EngineError> {
-        if let Some(f) = self.zones.get(&zone_id) {
-            return Ok(f.fetcher.clone());
+        if let Some(entry) = self.zones.get(&zone_id) {
+            return Ok(entry.fetcher.clone());
         }
 
         let zone_shutdown = CancellationToken::new();
-
-        let engine_ctx = Arc::new(EngineNetContext {
+        let context = Arc::new(EngineNetContext {
             event_tx: self.engine_ctx.event_tx.clone(),
             request_reference_map: self.engine_ctx.request_reference_map.clone(),
             request_ref_tracker: Arc::new(RequestRefTracker::new()),
         });
         let f =
-            Arc::new(Fetcher::new(self.cfg.clone(), engine_ctx).map_err(|e| EngineError::NetworkError(e.to_string()))?);
+            Arc::new(Fetcher::new(self.cfg.clone(), context).map_err(|e| EngineError::NetworkError(e.to_string()))?);
 
         let f_run = f.clone();
         let cancel = zone_shutdown.clone();
@@ -165,7 +186,6 @@ impl IoRouter {
                 join: join_handle,
             },
         );
-
         Ok(f)
     }
 
@@ -211,19 +231,118 @@ impl IoRouter {
     }
 }
 
-/// Put the requesting tab's cookies on an outbound request.
-fn attach_request_cookies(req: &mut FetchRequest, identity: Option<&TabIdentity>) {
+/// Start the network process if the setting asks for one.
+#[cfg(feature = "process-isolation")]
+fn start_net_process(engine_ctx: &Arc<EngineContext>) -> Option<Arc<crate::net::process::client::NetProcess>> {
+    if !engine_ctx.config_store.get_bool("security.network_process") {
+        return None;
+    }
+
+    match crate::net::process::client::NetProcess::spawn() {
+        Ok(net) => {
+            log::info!("network stack running in a separate, sandboxed process");
+            Some(Arc::new(net))
+        }
+        Err(e) => {
+            log::error!(
+                "security.network_process is on but the network process could not start ({e}); \
+                 falling back to in-process networking. Does this embedder call \
+                 gosub_engine::child_process::dispatch() at the top of main()?"
+            );
+            None
+        }
+    }
+}
+
+/// Hand a request to the network process and answer the caller when it replies.
+/// The wait runs as a task, not a thread, and follows `cancel`: an abandoned
+/// navigation frees its slot and tells the child to drop the request.
+#[cfg(feature = "process-isolation")]
+fn dispatch_to_net_process(
+    net: Arc<crate::net::process::client::NetProcess>,
+    req: FetchRequest,
+    cancel: tokio_util::sync::CancellationToken,
+    reply_tx: oneshot::Sender<FetchResult>,
+) {
+    use crate::net::process::client::net_error;
+    use crate::net::process::protocol::FetchOutcome;
+
+    let url = req.url.to_string();
+    let method = req.method.as_str().to_string();
+    // No in-process fetcher emits the terminal event that would drop this.
+    let req_id = req.req_id;
+    let mut headers: Vec<(String, String)> = req
+        .headers
+        .iter()
+        .filter_map(|(n, v)| v.to_str().ok().map(|v| (n.as_str().to_string(), v.to_string())))
+        .collect();
+
+    // The body crosses the link as plain bytes. Its Content-Type is folded into
+    // the headers here, mirroring what gosub-sonar would inject at send time.
+    let body = match req.body.as_ref() {
+        None => None,
+        Some(body) => match body.as_bytes() {
+            Some(bytes) => {
+                if !req.headers.contains_key(http::header::CONTENT_TYPE) {
+                    if let Some(ct) = &body.content_type {
+                        headers.push((http::header::CONTENT_TYPE.as_str().to_string(), ct.clone()));
+                    }
+                }
+                Some(bytes.to_vec())
+            }
+            // A streaming body cannot cross the link; refuse rather than send
+            // the request without it.
+            None => {
+                let _ = reply_tx.send(FetchResult::Error(net_error(format!(
+                    "cannot send a streaming request body to the network process ({url})"
+                ))));
+                return;
+            }
+        },
+    };
+
+    spawn_named("net-process-request", async move {
+        let out = crate::net::process::client::Outbound {
+            url,
+            method,
+            headers,
+            body,
+        };
+        let reply = net.fetch(out, &cancel).await;
+        crate::net::req_ref_tracker::REF_REGISTRY.forget_request(req_id);
+        let _ = reply_tx.send(match reply.outcome {
+            FetchOutcome::Error(e) => FetchResult::Error(net_error(e)),
+            _ => match crate::net::process::client::outcome_to_result(reply) {
+                Ok(result) => result,
+                Err(e) => FetchResult::Error(e),
+            },
+        });
+    });
+}
+
+#[cfg(not(feature = "process-isolation"))]
+fn dispatch_to_net_process(
+    _net: std::convert::Infallible,
+    _req: FetchRequest,
+    _cancel: tokio_util::sync::CancellationToken,
+    _reply_tx: oneshot::Sender<FetchResult>,
+) {
+}
+
+/// A vault jar answers over IPC, so the lookup runs on a blocking thread.
+async fn attach_request_cookies(req: &mut FetchRequest, identity: Option<&TabIdentity>) {
     req.headers.remove(http::header::COOKIE);
 
     let Some(identity) = identity else {
         return;
     };
     let context = same_site_context(identity.top_level.as_ref(), &req.url);
-    let Some(cookies) = identity
-        .cookie_jar
-        .read()
-        .get_request_cookies(&req.url, identity.top_level.as_ref(), context)
-    else {
+    let jar = identity.cookie_jar.clone();
+    let url = req.url.clone();
+    let top_level = identity.top_level.clone();
+    let cookies =
+        tokio::task::spawn_blocking(move || jar.read().get_request_cookies(&url, top_level.as_ref(), context)).await;
+    let Ok(Some(cookies)) = cookies else {
         return;
     };
     if let Ok(value) = cookies.parse() {
@@ -232,12 +351,18 @@ fn attach_request_cookies(req: &mut FetchRequest, identity: Option<&TabIdentity>
 }
 
 /// Classify a request against the document that caused it, so `SameSite`
-/// cookies are withheld from genuinely cross-site loads.
+/// cookies are withheld from genuinely cross-site loads. "Site" is the
+/// registrable domain (eTLD+1), not the exact host: `api.example.com` under a
+/// `example.com` document is same-site, per the jar's own matching.
 fn same_site_context(top_level: Option<&url::Url>, url: &url::Url) -> SameSiteContext {
+    let hosts_same_site = |top: &url::Url| match (top.host_str(), url.host_str()) {
+        (Some(a), Some(b)) => crate::engine::cookies::same_site(a, b),
+        _ => false,
+    };
     match top_level {
         // A request with no document behind it is the document load itself.
         None => SameSiteContext::SameSite,
-        Some(top) if top.host_str() == url.host_str() && top.scheme() == url.scheme() => SameSiteContext::SameSite,
+        Some(top) if top.scheme() == url.scheme() && hosts_same_site(top) => SameSiteContext::SameSite,
         Some(_) => SameSiteContext::CrossSite,
     }
 }
@@ -302,9 +427,7 @@ pub async fn submit_to_io(
     Ok((handle, reply_rx))
 }
 
-/// Spawns the IO thread and runs a single fetcher on top. If needed, we can expand this system to
-/// run multiple fetchers on different OS threads for instance, but most likely the fetching itself
-/// isn't the biggest bottleneck.
+/// Spawns the IO thread and runs a single fetcher on top.
 pub fn spawn_io_thread(cfg: FetcherConfig, engine_ctx: Arc<EngineContext>) -> IoHandle {
     let (tx_submit, mut rx_submit) = mpsc::unbounded_channel::<IoCommand>();
     let shutdown_token = CancellationToken::new();
@@ -329,24 +452,43 @@ pub fn spawn_io_thread(cfg: FetcherConfig, engine_ctx: Arc<EngineContext>) -> Io
                                 router.serve_file_request(req, reply_tx);
                                 continue;
                             }
-                            // Cookies are attached here, never by the requester: see
-                            // `net::tab_identity`. `identity` is None for a tab that has
-                            // closed or never registered, which sends no cookies.
+                            // `identity` is None for a tab that has closed or never
+                            // registered, which sends no cookies (see `net::tab_identity`).
                             let identity = tab_id.and_then(|id| router.tab_identities().get(id));
-                            attach_request_cookies(&mut req, identity.as_ref());
-
-                            // The reply is intercepted so `Set-Cookie` is stored on this
-                            // side too; the requester still receives the untouched result.
-                            let reply_tx = match identity {
-                                Some(id) => store_response_cookies_then_forward(id, reply_tx),
-                                None => reply_tx,
+                            let net = router.net_process();
+                            let fetcher = match &net {
+                                Some(_) => None,
+                                None => match router.get_or_spawn_zone_fetcher(zone_id) {
+                                    Ok(fetcher) => Some(fetcher),
+                                    Err(e) => {
+                                        log::error!("Failed to create fetcher for zone {zone_id}: {e}");
+                                        continue;
+                                    }
+                                },
                             };
 
-                            // The I/O thread must keep running; drop the request on fetcher failure.
-                            match router.get_or_spawn_zone_fetcher(zone_id) {
-                                Ok(fetcher) => fetcher.submit(req, handle.cancel.clone(), reply_tx).await,
-                                Err(e) => log::error!("Failed to create fetcher for zone {zone_id}: {e}"),
-                            }
+                            // The cookie lookup may block, so it runs off this loop,
+                            // which must stay free for every other tab's requests.
+                            spawn_named("io-fetch", async move {
+                                attach_request_cookies(&mut req, identity.as_ref()).await;
+
+                                // The reply is intercepted so `Set-Cookie` is stored on this
+                                // side too; the requester still receives the untouched result.
+                                let reply_tx = match identity {
+                                    Some(id) => store_response_cookies_then_forward(id, reply_tx),
+                                    None => reply_tx,
+                                };
+
+                                match (net, fetcher) {
+                                    (Some(net), _) => {
+                                        dispatch_to_net_process(net, req, handle.cancel.clone(), reply_tx)
+                                    }
+                                    (None, Some(fetcher)) => {
+                                        fetcher.submit(req, handle.cancel.clone(), reply_tx).await;
+                                    }
+                                    (None, None) => {}
+                                }
+                            });
                         }
                         Some(IoCommand::Decision { token, action }) => {
                             // Decisions are engine-owned (gosub-sonar has no decision hub);
@@ -407,29 +549,29 @@ mod tests {
             })
         }
 
-        #[test]
-        fn a_tab_gets_its_own_cookies() {
+        #[tokio::test]
+        async fn a_tab_gets_its_own_cookies() {
             let identity = TabIdentity {
                 cookie_jar: jar_with("https://example.com/", "sid=abc; Path=/"),
                 top_level: Some(Url::parse("https://example.com/page").unwrap()),
             };
             let mut req = request_to("https://example.com/api");
-            attach_request_cookies(&mut req, Some(&identity));
+            attach_request_cookies(&mut req, Some(&identity)).await;
 
             assert_eq!(cookie_header(&req), Some("sid=abc"));
         }
 
-        #[test]
-        fn no_identity_means_no_cookies() {
+        #[tokio::test]
+        async fn no_identity_means_no_cookies() {
             // A closed or unregistered tab must not borrow anyone else's jar.
             let mut req = request_to("https://example.com/api");
-            attach_request_cookies(&mut req, None);
+            attach_request_cookies(&mut req, None).await;
 
             assert_eq!(cookie_header(&req), None);
         }
 
-        #[test]
-        fn a_cookie_header_from_the_requester_is_discarded() {
+        #[tokio::test]
+        async fn a_cookie_header_from_the_requester_is_discarded() {
             // The property the whole inversion rests on: a compromised tab cannot
             // send cookies of its own choosing, not even for its own origin.
             let identity = TabIdentity {
@@ -440,17 +582,17 @@ mod tests {
             req.headers
                 .insert(http::header::COOKIE, "sid=forged; admin=1".parse().unwrap());
 
-            attach_request_cookies(&mut req, Some(&identity));
+            attach_request_cookies(&mut req, Some(&identity)).await;
 
             assert_eq!(cookie_header(&req), Some("sid=real"));
         }
 
-        #[test]
-        fn a_forged_header_is_dropped_even_with_no_identity() {
+        #[tokio::test]
+        async fn a_forged_header_is_dropped_even_with_no_identity() {
             let mut req = request_to("https://example.com/api");
             req.headers.insert(http::header::COOKIE, "sid=forged".parse().unwrap());
 
-            attach_request_cookies(&mut req, None);
+            attach_request_cookies(&mut req, None).await;
 
             assert_eq!(cookie_header(&req), None, "an unidentified tab must send nothing");
         }
@@ -475,6 +617,19 @@ mod tests {
             );
             // The document load itself has no document behind it.
             assert_eq!(same_site_context(None, &page), SameSiteContext::SameSite);
+            // A subdomain shares the page's registrable domain: still same-site.
+            assert_eq!(
+                same_site_context(Some(&page), &Url::parse("https://api.example.com/x").unwrap()),
+                SameSiteContext::SameSite
+            );
+            // A shared eTLD is not a shared site.
+            assert_eq!(
+                same_site_context(
+                    Some(&Url::parse("https://a.github.io/").unwrap()),
+                    &Url::parse("https://b.github.io/x").unwrap()
+                ),
+                SameSiteContext::CrossSite
+            );
         }
     }
 
@@ -511,7 +666,6 @@ mod tests {
         // Let the driver spin up
         sleep(Duration::from_millis(10)).await;
 
-        // Global shutdown should complete promptly
         timeout(Duration::from_secs(2), handle.shutdown())
             .await
             .expect("global shutdown timed out");
@@ -524,13 +678,11 @@ mod tests {
         let handle = spawn_io_thread(test_cfg(), ctx);
 
         let z = ZoneId::new();
-        // Should ACK even if the zone was never created
         timeout(Duration::from_secs(2), handle.shutdown_zone(z))
             .await
             .expect("zone shutdown ack timed out")
             .expect("zone shutdown returned error");
 
-        // Cleanly stop IO
         timeout(Duration::from_secs(2), handle.shutdown())
             .await
             .expect("global shutdown timed out");
@@ -547,11 +699,9 @@ mod tests {
         let router = IoRouter::new(cfg, ctx);
         let z = ZoneId::new();
 
-        // Lazily create fetcher for zone z
         let f = router.get_or_spawn_zone_fetcher(z).unwrap();
         assert!(Arc::strong_count(&f) >= 1, "fetcher Arc should be alive");
 
-        // Shut down zone z; should return true (existed)
         let stopped = router.shutdown_zone(z).await;
         assert!(stopped, "zone should have existed and been stopped");
     }
@@ -566,15 +716,12 @@ mod tests {
         let z1 = ZoneId::new();
         let z2 = ZoneId::new();
 
-        // Spawn both zones
         let _f1 = router.get_or_spawn_zone_fetcher(z1).unwrap();
         let f2 = router.get_or_spawn_zone_fetcher(z2).unwrap();
 
-        // Shut down z1 only
         let stopped = router.shutdown_zone(z1).await;
         assert!(stopped, "z1 should have been stopped");
 
-        // z2 should still have a running fetcher; get_or_spawn must return the same Arc ptr
         let f2_again = router.get_or_spawn_zone_fetcher(z2).unwrap();
         assert!(Arc::ptr_eq(&f2, &f2_again), "z2 fetcher must remain the same instance");
 
@@ -594,7 +741,6 @@ mod tests {
         let stopped = router.shutdown_zone(z_never_spawned).await;
         assert!(!stopped, "unknown zone should return false on shutdown");
 
-        // Clean (no zones to stop)
         router.shutdown_all().await;
     }
 }

--- a/crates/gosub_engine/src/net/process.rs
+++ b/crates/gosub_engine/src/net/process.rs
@@ -1,0 +1,5 @@
+//! Running the network stack in its own process.
+
+pub mod child;
+pub mod client;
+pub mod protocol;

--- a/crates/gosub_engine/src/net/process/child.rs
+++ b/crates/gosub_engine/src/net/process/child.rs
@@ -1,0 +1,216 @@
+//! The network process: the only part of the engine that may open a socket.
+//!
+
+use crate::net::fetcher::{Fetcher, FetcherConfig};
+use crate::net::process::protocol::{FetchOutcome, FromNet, NetFetch, RequestTag, ToNet};
+use crate::net::types::{FetchRequest, FetchResult, RequestBody};
+use gosub_ipc::Endpoint;
+use http::Method;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+use url::Url;
+
+/// How long a shutdown drain waits for in-flight requests before giving up.
+/// Shorter than the broker's `SHUTDOWN_GRACE`, so a draining child exits on
+/// its own rather than being killed mid-drain.
+const DRAIN_GRACE: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Run as the network process until the broker disconnects or says to stop.
+pub fn serve(link: Endpoint) -> i32 {
+    gosub_sandbox::capture_process_title_region();
+    gosub_sandbox::set_process_title("gosub-net", "gosub: network process");
+
+    // Built before lockdown: spawning threads is not on the allowlist, so a
+    // runtime created afterwards could not start its workers.
+    let runtime = match tokio::runtime::Builder::new_multi_thread().enable_all().build() {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("[net] could not start a runtime: {e}");
+            return 1;
+        }
+    };
+
+    // Force glibc to load its NSS resolver modules *now*, while this process
+    // may still map executable pages. `getaddrinfo` `dlopen`s `libnss_dns.so`
+    // on first use, and the sandbox denies `mmap(PROT_EXEC)` - so a name
+    // resolved after the lockdown kills the process on a syscall that looks
+    // nothing like DNS. The name deliberately does not resolve: what matters
+    // is the module load, not the answer. Same shape as the font warm-up in
+    // the renderer: do the thing that needs the privilege before dropping it.
+    {
+        use std::net::ToSocketAddrs;
+        let _ = "gosub-resolver-warmup.invalid:80".to_socket_addrs();
+    }
+
+    // Read-only, and only these: the resolver configuration and the trust store.
+    // A network stack that cannot read them cannot resolve a name or verify a
+    // certificate, so denying files outright (as a renderer is) is not an option
+    // here - the paths are scoped instead.
+    let paths = gosub_sandbox::net_filesystem_paths();
+    let fs_allow: Vec<(&std::path::Path, bool)> = paths.iter().map(|p| (p.as_path(), false)).collect();
+    gosub_sandbox::lock_down_net(&fs_allow);
+
+    // No hooks: in-process, `EngineNetContext` turns these into engine events and
+    // resolves request references against engine state. Here there is no engine to
+    // resolve against - this process holds no tab map, no jar, no event bus - so
+    // progress reporting stays the broker's job. `cookies_for` in particular must
+    // stay silent: answering it would mean this process kept a jar.
+    let fetcher = match Fetcher::new(FetcherConfig::default(), Arc::new(NetProcessContext)) {
+        Ok(f) => Arc::new(f),
+        Err(e) => {
+            eprintln!("[net] could not build the fetcher: {e}");
+            return 1;
+        }
+    };
+
+    let shutdown = CancellationToken::new();
+    let fetcher_run = fetcher.clone();
+    let cancel = shutdown.clone();
+    runtime.spawn(async move {
+        fetcher_run.run(cancel).await;
+    });
+
+    // Requests run concurrently: each Fetch is spawned onto the runtime and
+    // replies through the shared writer, tagged, so a slow response never
+    // holds up the ones behind it. The broker bounds how many are in flight.
+    let (link_tx, mut link_rx) = link.split();
+    let link_tx = Arc::new(Mutex::new(link_tx));
+    let cancels: Arc<Mutex<HashMap<RequestTag, CancellationToken>>> = Arc::new(Mutex::new(HashMap::new()));
+    let tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>> = Arc::new(Mutex::new(Vec::new()));
+
+    // A read error ends the loop: it means the broker went away, which is a
+    // normal end - the network process exists only to serve it.
+    let mut drain = false;
+    while let Ok(msg) = link_rx.recv::<ToNet>() {
+        match msg {
+            ToNet::Ping => {
+                if link_tx.lock().send(&FromNet::Pong).is_err() {
+                    break;
+                }
+            }
+            ToNet::Shutdown => {
+                drain = true;
+                break;
+            }
+            ToNet::Cancel(tag) => {
+                if let Some(token) = cancels.lock().remove(&tag) {
+                    token.cancel();
+                }
+            }
+            ToNet::Fetch(fetch) => {
+                let tag = fetch.tag;
+                let token = CancellationToken::new();
+                cancels.lock().insert(tag, token.clone());
+                let fetcher = fetcher.clone();
+                let link_tx = link_tx.clone();
+                let cancels = cancels.clone();
+                let handle = runtime.spawn(async move {
+                    let outcome = perform(&fetcher, fetch, token).await;
+                    cancels.lock().remove(&tag);
+                    // A write error means the broker went away; the recv loop
+                    // notices the same and ends the process.
+                    let _ = link_tx.lock().send(&FromNet::Reply { tag, outcome });
+                });
+                let mut tasks = tasks.lock();
+                tasks.retain(|h| !h.is_finished());
+                tasks.push(handle);
+            }
+        }
+    }
+
+    // Shutdown promises to finish in-flight work (see `ToNet::Shutdown`): stop
+    // reading (done - the loop ended), then flush what is still running so its
+    // replies reach the broker. Bounded: the broker kills a child that lingers.
+    if drain {
+        let pending: Vec<_> = std::mem::take(&mut *tasks.lock());
+        runtime.block_on(async {
+            let _ = tokio::time::timeout(DRAIN_GRACE, futures_util::future::join_all(pending)).await;
+        });
+    }
+
+    shutdown.cancel();
+    0
+}
+
+/// The network process has no engine around it: no events, no cookies (the
+/// broker attaches those).
+struct NetProcessContext;
+
+impl gosub_sonar::net::fetcher_context::FetcherContext for NetProcessContext {
+    fn observer_for(
+        &self,
+        _: gosub_sonar::RequestReference,
+        _: gosub_sonar::types::RequestId,
+        _: gosub_sonar::net::types::ResourceKind,
+        _: gosub_sonar::net::types::Initiator,
+    ) -> Arc<dyn gosub_sonar::net::observer::NetObserver + Send + Sync> {
+        Arc::new(crate::net::emitter::null_emitter::NullEmitter)
+    }
+    fn on_ref_active(&self, _: gosub_sonar::RequestReference) {}
+    fn on_ref_done(&self, _: gosub_sonar::RequestReference) {}
+    fn is_url_allowed(&self, _url: &Url) -> bool {
+        true
+    }
+}
+
+fn flat_headers(headers: &http::HeaderMap) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .filter_map(|(n, v)| v.to_str().ok().map(|v| (n.as_str().to_string(), v.to_string())))
+        .collect()
+}
+
+/// Perform one request and flatten the result to something that can travel.
+async fn perform(fetcher: &Arc<Fetcher>, fetch: NetFetch, cancel: CancellationToken) -> FetchOutcome {
+    let done = |o: FetchOutcome| o;
+    let url = match Url::parse(&fetch.url) {
+        Ok(u) => u,
+        Err(e) => return done(FetchOutcome::Error(format!("bad url {}: {e}", fetch.url))),
+    };
+    let method = match Method::from_str(&fetch.method) {
+        Ok(m) => m,
+        Err(e) => return done(FetchOutcome::Error(format!("bad method {}: {e}", fetch.method))),
+    };
+
+    let mut headers = http::HeaderMap::new();
+    for (name, value) in &fetch.headers {
+        let parsed = http::header::HeaderName::from_str(name).ok().zip(value.parse().ok());
+        if let Some((name, value)) = parsed {
+            headers.insert(name, value);
+        }
+    }
+
+    let mut builder = FetchRequest::builder(method, url)
+        .with_headers(headers)
+        .with_streaming(false)
+        .with_auto_decode(true);
+    if let Some(body) = fetch.body {
+        // Plain bytes: the Content-Type already travelled in the headers.
+        builder = builder.with_body(RequestBody::bytes(body));
+    }
+    let req = builder.build();
+
+    let (tx, rx) = tokio::sync::oneshot::channel::<FetchResult>();
+    fetcher.submit(req, cancel.clone(), tx).await;
+
+    let result = tokio::select! {
+        _ = cancel.cancelled() => return done(FetchOutcome::Error("cancelled by the broker".into())),
+        r = rx => r,
+    };
+    match result {
+        Ok(FetchResult::Buffered { meta, body }) => done(FetchOutcome::Ok {
+            status: meta.status,
+            status_text: meta.status_text,
+            final_url: meta.final_url.to_string(),
+            headers: flat_headers(&meta.headers),
+            body: body.to_vec(),
+        }),
+        // Never streamed: the request asked for a buffered body.
+        Ok(FetchResult::Stream { .. }) => done(FetchOutcome::Error("unexpected streamed body".into())),
+        Ok(FetchResult::Error(e)) => done(FetchOutcome::Error(e.to_string())),
+        Err(_) => done(FetchOutcome::Error("the fetcher dropped the request".into())),
+    }
+}

--- a/crates/gosub_engine/src/net/process/client.rs
+++ b/crates/gosub_engine/src/net/process/client.rs
@@ -1,0 +1,377 @@
+//! The broker's side of the network process: spawn it, talk to it, notice when
+//! it dies.
+
+use crate::net::process::protocol::{FetchOutcome, FromNet, NetFetch, RequestTag, ToNet};
+use crate::net::types::NetError;
+use gosub_ipc::{Endpoint, EndpointTx};
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+/// One request for the network process, as the broker hands it over.
+#[derive(Debug)]
+pub struct Outbound {
+    pub url: String,
+    pub method: String,
+    pub headers: Vec<(String, String)>,
+    pub body: Option<Vec<u8>>,
+}
+
+impl Outbound {
+    /// A plain GET with no body and no special handling.
+    pub fn get(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            method: "GET".into(),
+            headers: Vec::new(),
+            body: None,
+        }
+    }
+}
+
+/// A reply as the broker sees it: the wire outcome.
+#[derive(Debug)]
+pub struct NetReply {
+    pub outcome: FetchOutcome,
+}
+
+impl NetReply {
+    fn error(msg: impl Into<String>) -> Self {
+        Self {
+            outcome: FetchOutcome::Error(msg.into()),
+        }
+    }
+}
+
+/// The argv role name the broker re-execs itself with.
+pub const NET_ROLE: &str = "net";
+
+/// How long a caller waits for a reply before giving up on the network process.
+const REPLY_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// How many requests may be in flight in the network process at once. Callers
+/// past this bound wait for a slot rather than being refused: subresource
+/// bursts are the normal case, and backpressure degrades better than errors.
+const MAX_INFLIGHT: usize = 16;
+
+/// How long to wait for the child to identify itself. Short: it answers before
+/// doing any work, so anything slower means it is not a network process at all.
+const READY_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How long shutdown waits for the child to finish in-flight work and exit on
+/// its own before killing it. A little longer than the child's own drain grace,
+/// so a well-behaved child is never killed mid-drain.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+
+/// A running network process and the link to it.
+pub struct NetProcess {
+    tx: Arc<Mutex<EndpointTx>>,
+    pending: Arc<Mutex<HashMap<RequestTag, tokio::sync::oneshot::Sender<NetReply>>>>,
+    next_tag: AtomicU64,
+    child: Mutex<Option<gosub_sandbox::spawn::Child>>,
+    /// Bounds concurrent requests (see [`MAX_INFLIGHT`]).
+    inflight: Arc<tokio::sync::Semaphore>,
+}
+
+impl std::fmt::Debug for NetProcess {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NetProcess").finish_non_exhaustive()
+    }
+}
+
+impl NetProcess {
+    /// Re-exec this binary as the network process and connect to it.
+    pub fn spawn() -> anyhow::Result<Self> {
+        // A process that carries a child role but is running broker code got here
+        // because the embedder never dispatched, so re-exec put it into its own
+        // `main`. Spawning from here would do the same thing again, and again:
+        // an unbounded chain of processes, each opening whatever the embedder
+        // opens. Refuse, and name the omission.
+        if crate::child_process::is_child_process() {
+            anyhow::bail!(
+                "this process was started as an engine child role but is running embedder startup, \
+                 which means gosub_engine::child_process::dispatch() was not called at the top of \
+                 main(); refusing to spawn further processes"
+            );
+        }
+
+        let exe = std::env::current_exe()?;
+        let (ours, theirs) = gosub_ipc::channel::Channel::pair()?;
+        let args: [&str; 2] = [crate::child_process::ROLE_FLAG, NET_ROLE];
+
+        let child = gosub_sandbox::spawn::spawn(
+            &exe,
+            &args,
+            theirs,
+            // The one component that keeps its network namespace.
+            gosub_sandbox::NamespaceIsolation::KeepNetwork,
+            gosub_sandbox::spawn::ContainerProfile {
+                name: "gosub-net",
+                internet: true,
+                fs_grant: None,
+                data_limit: None,
+                extra_fds: &[],
+                // A multi-thread runtime plus its blocking pool.
+                max_tasks: 1024,
+                file_size_limit: None,
+            },
+        )?;
+        if let Err(e) = gosub_sandbox::confine_spawned_child(&child) {
+            log::warn!("could not apply parent-side confinement to the network process: {e}");
+        }
+
+        let mut endpoint = Endpoint::from_channel(ours)?;
+        // A child that stops reading must not pin blocking-pool threads forever.
+        let _ = endpoint.tx.set_write_timeout(Some(REPLY_TIMEOUT));
+        let (tx, mut rx) = endpoint.split();
+
+        let pending: Arc<Mutex<HashMap<RequestTag, tokio::sync::oneshot::Sender<NetReply>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel::<()>(1);
+
+        // A plain thread, not a task: it blocks on the link, and must keep
+        // draining even when every runtime worker is busy waiting on a reply.
+        let waiters = pending.clone();
+        std::thread::Builder::new()
+            .name("net-process-reader".into())
+            .spawn(move || {
+                while let Ok(msg) = rx.recv::<FromNet>() {
+                    match msg {
+                        FromNet::Pong => {
+                            let _ = ready_tx.send(());
+                        }
+                        FromNet::Reply { tag, outcome } => {
+                            if let Some(waiter) = waiters.lock().remove(&tag) {
+                                let _ = waiter.send(NetReply { outcome });
+                            }
+                        }
+                    }
+                }
+                // The link is gone, so no reply will ever arrive. Dropping the
+                // senders wakes every waiter with a disconnect instead of leaving
+                // them to time out one by one.
+                waiters.lock().clear();
+            })?;
+
+        let net = Self {
+            tx: Arc::new(Mutex::new(tx)),
+            pending,
+            next_tag: AtomicU64::new(1),
+            child: Mutex::new(Some(child)),
+            inflight: Arc::new(tokio::sync::Semaphore::new(MAX_INFLIGHT)),
+        };
+
+        // Confirm the child really is a network process before returning it as
+        // one. Without this, a child that answers nothing (see `ToNet::Ping`)
+        // would only be noticed when the first request timed out.
+        net.tx.lock().send(&ToNet::Ping)?;
+        match ready_rx.recv_timeout(READY_TIMEOUT) {
+            Ok(()) => {}
+            // The reader thread ended, so the link is gone: the child died
+            // rather than went quiet. Report how it died, not a bogus timeout.
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                let fate = net
+                    .child
+                    .lock()
+                    .take()
+                    .map_or_else(|| "already reaped".to_string(), |mut c| c.wait_describe());
+                anyhow::bail!("the network process died before answering ({fate})");
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                net.shutdown();
+                anyhow::bail!("the spawned process did not answer as a network process within {READY_TIMEOUT:?}");
+            }
+        }
+
+        Ok(net)
+    }
+
+    /// Send a request and wait for the network process to answer. Bounded by
+    /// [`MAX_INFLIGHT`]; a caller past the bound waits for a slot. Cancelling
+    /// `cancel` abandons the wait and tells the child to drop the request.
+    pub async fn fetch(&self, out: Outbound, cancel: &CancellationToken) -> NetReply {
+        let Outbound {
+            url,
+            method,
+            headers,
+            body,
+        } = out;
+        let permit = tokio::select! {
+            _ = cancel.cancelled() => return NetReply::error("cancelled"),
+            p = self.inflight.clone().acquire_owned() => p,
+        };
+        let Ok(_permit) = permit else {
+            return NetReply::error("the network process is shutting down");
+        };
+
+        let tag = self.next_tag.fetch_add(1, Ordering::Relaxed);
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel::<NetReply>();
+        self.pending.lock().insert(tag, reply_tx);
+        let requested = url.clone();
+
+        let msg = ToNet::Fetch(NetFetch {
+            tag,
+            url,
+            method,
+            headers,
+            body,
+        });
+        // The link write can block on a full pipe (bodies can be large), so it
+        // runs on a blocking thread rather than a runtime worker.
+        let tx = self.tx.clone();
+        let sent = tokio::task::spawn_blocking(move || tx.lock().send(&msg)).await;
+        match sent {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                self.pending.lock().remove(&tag);
+                return NetReply::error(format!("could not reach the network process: {e}"));
+            }
+            Err(e) => {
+                self.pending.lock().remove(&tag);
+                return NetReply::error(format!("could not dispatch to the network process: {e}"));
+            }
+        }
+
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                self.pending.lock().remove(&tag);
+                self.send_cancel(tag);
+                NetReply::error("cancelled")
+            }
+            reply = tokio::time::timeout(REPLY_TIMEOUT, reply_rx) => match reply {
+                Ok(Ok(reply)) => Self::plausible_reply(reply, &requested),
+                Ok(Err(_)) => NetReply::error("the network process exited"),
+                Err(_) => {
+                    self.pending.lock().remove(&tag);
+                    // Without this the child would keep working the request (and
+                    // holding its resources) long after anyone cared.
+                    self.send_cancel(tag);
+                    NetReply::error("the network process did not answer")
+                }
+            },
+        }
+    }
+
+    /// The child's word on where a request ended is checked against what was
+    /// asked: a `final_url` must be a web URL, and stay on the requested URL's
+    /// scheme family - a redirect chain cannot land on `file:` or an internal
+    /// page, whatever the child reports. Where it landed within the web is still
+    /// the child's word; only the broker following redirects itself could fix that.
+    fn plausible_reply(reply: NetReply, requested: &str) -> NetReply {
+        let final_url = match &reply.outcome {
+            FetchOutcome::Ok { final_url, .. } => final_url,
+            FetchOutcome::Error(_) => return reply,
+        };
+        let Ok(parsed) = url::Url::parse(final_url) else {
+            return NetReply::error(format!(
+                "the network process reported an unparsable final url for {requested}"
+            ));
+        };
+        if !matches!(parsed.scheme(), "http" | "https") {
+            return NetReply::error(format!(
+                "the network process reported a non-web final url ({}) for {requested}",
+                parsed.scheme()
+            ));
+        }
+        reply
+    }
+
+    /// Tell the child to drop a request nobody is waiting for anymore.
+    /// Best-effort, on a blocking thread: the pipe write may block, and there
+    /// is no reply to wait for - a child that already answered simply finds no
+    /// waiter.
+    fn send_cancel(&self, tag: RequestTag) {
+        let tx = self.tx.clone();
+        tokio::task::spawn_blocking(move || {
+            let _ = tx.lock().send(&ToNet::Cancel(tag));
+        });
+    }
+
+    /// Ask the process to stop, then make sure it has. The child drains its
+    /// in-flight requests before exiting (see [`ToNet::Shutdown`]), so give it
+    /// [`SHUTDOWN_GRACE`] to do that; kill only one that fails to.
+    pub fn shutdown(&self) {
+        let _ = self.tx.lock().send(&ToNet::Shutdown);
+
+        let Some(mut child) = self.child.lock().take() else {
+            return;
+        };
+        let deadline = std::time::Instant::now() + SHUTDOWN_GRACE;
+        while std::time::Instant::now() < deadline {
+            match child.try_wait() {
+                Ok(true) => return,
+                Ok(false) => std::thread::sleep(Duration::from_millis(50)),
+                // The child cannot be observed; fall through to the kill.
+                Err(_) => break,
+            }
+        }
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+impl Drop for NetProcess {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// Rebuild the engine's own result type from what came back over the wire.
+pub fn outcome_to_result(reply: NetReply) -> Result<crate::net::types::FetchResult, NetError> {
+    let (status, status_text, final_url, headers, body) = match reply.outcome {
+        FetchOutcome::Ok {
+            status,
+            status_text,
+            final_url,
+            headers,
+            body,
+        } => (status, status_text, final_url, headers, body),
+        FetchOutcome::Error(e) => return Err(net_error(e)),
+    };
+
+    let final_url = url::Url::parse(&final_url).map_err(|e| net_error(format!("bad final url: {e}")))?;
+
+    let mut header_map = http::HeaderMap::new();
+    for (name, value) in &headers {
+        let parsed = http::header::HeaderName::from_bytes(name.as_bytes())
+            .ok()
+            .zip(value.parse().ok());
+        if let Some((name, value)) = parsed {
+            header_map.append(name, value);
+        }
+    }
+
+    let content_type = header_map
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+    let content_length = header_map
+        .get(http::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse().ok());
+
+    let meta = |has_body: bool| crate::net::types::FetchResultMeta {
+        final_url,
+        status,
+        status_text,
+        headers: header_map,
+        content_length,
+        content_type,
+        has_body,
+        tainting: gosub_sonar::ResponseTainting::Basic,
+    };
+    Ok(crate::net::types::FetchResult::Buffered {
+        meta: meta(!body.is_empty()),
+        body: bytes::Bytes::from(body),
+    })
+}
+
+/// A failure that came from (or about) the network process, as the engine's own
+/// error type. `Other` because the cause is a broker↔child protocol problem
+/// rather than any of the transport-specific variants.
+pub fn net_error(msg: impl Into<String>) -> NetError {
+    NetError::Other(std::sync::Arc::new(anyhow::anyhow!(msg.into())))
+}

--- a/crates/gosub_engine/src/net/process/protocol.rs
+++ b/crates/gosub_engine/src/net/process/protocol.rs
@@ -1,0 +1,71 @@
+//! The broker↔network-process wire vocabulary.
+
+use serde::{Deserialize, Serialize};
+
+/// Correlates a reply with the request that caused it. Assigned by the broker;
+/// the network process only echoes it back, so a confused or hostile child can
+/// misroute its *own* replies and nothing else.
+pub type RequestTag = u64;
+
+/// Broker → network process.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ToNet {
+    /// Prove the child is a network process before anything is entrusted to it.
+    Ping,
+    Fetch(NetFetch),
+    /// Abandon the request with this tag: the navigation that wanted it is gone.
+    /// Best-effort - a reply already in flight simply finds no waiter.
+    Cancel(RequestTag),
+    /// Finish in-flight work and exit. The broker still waits for the process to
+    /// go away and kills it if it does not.
+    Shutdown,
+}
+
+/// One request, flattened to what actually has to travel.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NetFetch {
+    pub tag: RequestTag,
+    pub url: String,
+    pub method: String,
+    /// Includes the `Cookie` header the broker attached (see
+    /// [`crate::net::tab_identity`]). The network process is trusted with cookie
+    /// *values* because it must put them on the wire; the renderer is not, and
+    /// that is the boundary this whole exercise is about. A cookie vault that
+    /// keeps values out of the broker→net hop too is a later refinement - see
+    /// the PoC's `vault` component.
+    pub headers: Vec<(String, String)>,
+    pub body: Option<Vec<u8>>,
+    // Only these cross. `FetchRequest::origin` / `referrer` / `mixed_content`
+    // (sonar 0.2.0) do not: the engine sets none of them yet. When it does, add
+    // them here - otherwise the network process rebuilds the request without
+    // them and mixed-content blocking silently disappears out-of-process.
+}
+
+/// Network process → broker.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum FromNet {
+    /// Answer to [`ToNet::Ping`]: this really is a network process.
+    Pong,
+    Reply {
+        tag: RequestTag,
+        outcome: FetchOutcome,
+    },
+}
+
+/// What became of a request.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum FetchOutcome {
+    Ok {
+        status: u16,
+        status_text: String,
+        /// After redirects - the broker needs this to attribute `Set-Cookie`
+        /// correctly, so it must come from the process that followed them.
+        final_url: String,
+        headers: Vec<(String, String)>,
+        body: Vec<u8>,
+    },
+    /// The request failed. A string rather than a typed error: the broker only
+    /// reports it, and a rich error type would be one more thing whose
+    /// deserialization a compromised child could exercise.
+    Error(String),
+}

--- a/crates/gosub_engine/src/net/types.rs
+++ b/crates/gosub_engine/src/net/types.rs
@@ -128,6 +128,7 @@ mod tests {
             content_length: None,
             content_type: None,
             has_body: true,
+            tainting: gosub_sonar::ResponseTainting::Basic,
         }
     }
 

--- a/crates/gosub_engine/tests/process_isolation.rs
+++ b/crates/gosub_engine/tests/process_isolation.rs
@@ -1,0 +1,104 @@
+//! Process isolation, exercised for real: the network stack and the image
+//! decoder each running in their own sandboxed process, plus the font property a
+//! future renderer process depends on.
+
+// Nothing here exists without the machinery it drives; the single-process build
+// has no child roles to test.
+#![cfg(feature = "process-isolation")]
+#![allow(clippy::expect_used)] // a harness that will not start must fail the test loudly
+
+use std::process::Command;
+
+fn harness() -> &'static str {
+    env!("CARGO_BIN_EXE_isolation-harness")
+}
+
+fn run(scenario: &str) -> std::process::Output {
+    Command::new(harness())
+        .arg(scenario)
+        .output()
+        .expect("spawn isolation-harness")
+}
+
+/// The boundary itself: a request crosses into a separate, sandboxed process and
+/// the response comes back byte-for-byte.
+///
+/// This is also the sandbox's own regression test. A real network stack needs
+/// syscalls the synthetic one in the proof of concept never made - reading the
+/// trust store, resolving names, driving an async reactor - so a filter that is
+/// too tight shows up here as a `SIGSYS` rather than as a mysteriously failing
+/// page much later.
+#[test]
+fn a_request_completes_through_the_network_process() {
+    let out = run("direct");
+    assert!(
+        out.status.success(),
+        "fetch through the network process failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Resolving a real hostname inside the sandboxed network process: a
+/// reserved `.invalid` name must fail to resolve without taking the process
+/// down (the NSS `dlopen` and resolver syscalls that `127.0.0.1` never
+/// exercises), the strict fetcher must refuse loopback, and the process must
+/// still serve afterwards.
+#[test]
+fn the_network_process_survives_hostname_resolution() {
+    let out = run("resolve");
+    assert!(
+        out.status.success(),
+        "hostname resolution scenario failed:\n{}\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The wiring: an ordinary navigation with `security.network_process` on resolves
+/// through the child rather than an in-process fetcher.
+#[test]
+fn a_navigation_resolves_with_process_isolation_enabled() {
+    let out = run("engine");
+    assert!(
+        out.status.success(),
+        "navigation under process isolation failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// An embedder that enables isolation without dispatching must be stopped, not
+/// merely warned.
+#[test]
+fn an_undispatched_embedder_cannot_spawn_further_processes() {
+    let out = Command::new(harness())
+        .args(["guard", gosub_engine::child_process::ROLE_FLAG, "net"])
+        .env("GOSUB_HARNESS_SKIP_DISPATCH", "1")
+        .output()
+        .expect("spawn isolation-harness");
+
+    assert!(
+        out.status.success(),
+        "spawning should have been refused with a message naming dispatch():\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// An embedder that does not dispatch child roles must not silently run the
+/// engine's startup in what was supposed to be a network process.
+#[test]
+fn an_unknown_child_role_is_refused() {
+    let out = Command::new(harness())
+        .args([gosub_engine::child_process::ROLE_FLAG, "no-such-role"])
+        .output()
+        .expect("spawn isolation-harness");
+
+    assert!(
+        !out.status.success(),
+        "an unknown role should not be treated as success"
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("unknown child role"),
+        "expected the refusal to name the problem, got: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/crates/gosub_html5/Cargo.toml
+++ b/crates/gosub_html5/Cargo.toml
@@ -24,7 +24,7 @@ serde = { workspace = true, features = ["derive"] }
 cow-utils = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-gosub-sonar = "0.2.0"
+gosub-sonar = "0.4.0"
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/crates/gosub_render_pipeline/Cargo.toml
+++ b/crates/gosub_render_pipeline/Cargo.toml
@@ -14,7 +14,7 @@ sha2 = "0.11.0"
 serde_json = { workspace = true }
 csscolorparser = "0.8.3"
 rstar = "0.13.0"
-gosub-sonar = "0.2.0"
+gosub-sonar = "0.4.0"
 url = { workspace = true }
 resvg = { workspace = true }
 bytes = { workspace = true }


### PR DESCRIPTION

Base: `02-contract`. The first real role: with `security.network_process` on,
the gosub-sonar stack runs in a re-exec'd child whose only privilege is the
network.

### What is in here

- `net::process` — protocol (`ToNet`/`FromNet`, tagged replies), client
  (`NetProcess`: spawn, ping-before-trust, bounded in-flight requests,
  cancellation forwarded to the child, reply timeouts, kill-then-reap
  shutdown, `plausible_reply` refusing non-web `final_url`s), and the child
  (`serve`: resolver warm-up before lockdown, Landlock scoped to resolver and
  CA paths, `lock_down_net`, one fetcher, drain grace on shutdown).
- The I/O runtime dispatches every fetch to the process when it runs, with
  request metadata forgotten on reply so nothing leaks; in-process fetcher
  otherwise. Bodies are buffered at this layer (streaming comes in a later PR).
- `child_process::run_role` gains the `net` role; the engine resolves
  `security.network_process` at `start()`: dropped quietly when the embedder
  never dispatched or on a non-Linux platform, with a warning when the setting
  was explicit.
- The `isolation-harness` binary (an embedder that dispatches) and the
  `process_isolation` suite: `direct` (round trip through the sandboxed
  process, intact body), `resolve` (a `.invalid` name resolves inside the
  sandbox without killing the process), `engine` (a navigation resolves through
  the child), `guard` (an undispatched embedder cannot spawn further processes).
- gosub-sonar 0.4 (additive: `FetchResultMeta.tainting`, two `NetEvent`s).

### Testing

```
cargo test -p gosub_engine --test process_isolation      # 5
cargo test -p gosub_engine --lib net::
./target/debug/isolation-harness {direct,resolve,engine}
```

### Deliberate limits

Buffered bodies only; no cookie vault, no private-network policy yet (later
PRs). The child is trusted with cookie values because it must put them on the
wire.