### PR TITLE
Decoder process: raster images decoded in a throwaway sandboxed child

### DIFF
--- a/crates/gosub_engine/src/bin/isolation-harness.rs
+++ b/crates/gosub_engine/src/bin/isolation-harness.rs
@@ -38,10 +38,13 @@ fn main() {
     let code = match scenario.as_str() {
         "direct" => direct(),
         "resolve" => resolve(),
+        "decode" => decode(),
+        "decode-garbage" => decode_garbage(),
+        "decode-many" => decode_many(),
         "engine" => engine(),
         "guard" => guard(),
         other => {
-            eprintln!("unknown scenario {other:?}; expected 'direct', 'resolve', 'engine' or 'guard'");
+            eprintln!("unknown scenario {other:?}; expected 'direct', 'resolve', 'engine', 'guard' or 'decode[-garbage|-many]'");
             2
         }
     };
@@ -159,6 +162,112 @@ fn resolve() -> i32 {
             eprintln!("the network process did not survive: {other:?}");
             1
         }
+    }
+}
+
+/// A 2x2 RGBA PNG: red, green, blue, white.
+const SAMPLE_PNG: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00,
+    0x02, 0x00, 0x00, 0x00, 0x02, 0x08, 0x06, 0x00, 0x00, 0x00, 0x72, 0xB6, 0x0D, 0x24, 0x00, 0x00, 0x00, 0x12, 0x49,
+    0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0xF0, 0x1F, 0x0C, 0x81, 0x34, 0x18, 0x00, 0x00, 0x49, 0xC8,
+    0x09, 0xF7, 0xF9, 0xAB, 0xB6, 0x0D, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+];
+
+/// The decode boundary: real image bytes go into a throwaway process and the
+/// exact pixels come back.
+fn decode() -> i32 {
+    use gosub_engine::decoder_process::client::ProcessImageDecoder;
+    use gosub_interface::media_decoder::{BrokeredDecode, ImageDecoder};
+
+    match ProcessImageDecoder.decode(Some("image/png"), SAMPLE_PNG) {
+        Ok(BrokeredDecode::Raster(image)) => {
+            if (image.width, image.height) != (2, 2) {
+                eprintln!("expected a 2x2 image, got {}x{}", image.width, image.height);
+                return 1;
+            }
+            let expected: &[u8] = &[255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255, 255];
+            if image.rgba.as_ref() != expected {
+                eprintln!("pixels did not survive the boundary: {:?}", image.rgba.as_ref());
+                return 1;
+            }
+        }
+        Err(e) => {
+            eprintln!("decode in a separate process failed: {e}");
+            return 1;
+        }
+    }
+
+    // Header parsing runs in the child too.
+    match ProcessImageDecoder.dimensions(Some("image/png"), SAMPLE_PNG) {
+        Ok((2, 2)) => {}
+        other => {
+            eprintln!("expected 2x2 from the decoder's header parse, got {other:?}");
+            return 1;
+        }
+    }
+
+    // SVG comes back rasterized at its intrinsic size: the tree never leaves
+    // the child. A logo-sized SVG (with text) must produce pixels, not a
+    // dead decoder.
+    match ProcessImageDecoder.decode(Some("image/svg+xml"), SAMPLE_SVG) {
+        Ok(BrokeredDecode::Raster(image)) if image.width > 1 && image.height > 1 => 0,
+        Ok(BrokeredDecode::Raster(image)) => {
+            eprintln!("an SVG rasterized to {}x{}", image.width, image.height);
+            1
+        }
+        Err(e) => {
+            eprintln!("SVG decode in a separate process failed: {e}");
+            1
+        }
+    }
+}
+
+/// A small SVG with a `<text>` element, so decoding it consults the fontdb.
+const SAMPLE_SVG: &[u8] = br##"<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18"><rect width="18" height="18" fill="#f60"/><text x="4" y="13" font-family="serif" font-size="10">Y</text></svg>"##;
+
+/// Decode the sample image repeatedly and report the wall-clock cost per image,
+/// so the price of a process per decode is a measured number rather than a
+/// guess. Count comes from argv[2], default 20.
+fn decode_many() -> i32 {
+    use gosub_engine::decoder_process::client::ProcessImageDecoder;
+    use gosub_interface::media_decoder::ImageDecoder;
+
+    let count: u32 = std::env::args().nth(2).and_then(|a| a.parse().ok()).unwrap_or(20);
+
+    let start = std::time::Instant::now();
+    for _ in 0..count {
+        if ProcessImageDecoder.decode(Some("image/png"), SAMPLE_PNG).is_err() {
+            eprintln!("decode failed during timing run");
+            return 1;
+        }
+    }
+    let elapsed = start.elapsed();
+    println!(
+        "{count} decodes in {:?} ({:.2} ms each)",
+        elapsed,
+        elapsed.as_secs_f64() * 1000.0 / f64::from(count)
+    );
+    0
+}
+
+/// Malformed input must come back as a refusal. This is the common case in the
+/// wild - a truncated or hostile image - and it must not hang or crash the
+/// broker.
+fn decode_garbage() -> i32 {
+    use gosub_engine::decoder_process::client::ProcessImageDecoder;
+    use gosub_interface::media_decoder::ImageDecoder;
+
+    // A PNG magic number followed by nonsense: it gets past a magic-byte sniff
+    // and dies inside the decoder, which is where the danger actually lives.
+    let mut bytes = vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+    bytes.extend(std::iter::repeat_n(0xA5, 4096));
+
+    match ProcessImageDecoder.decode(Some("image/png"), &bytes) {
+        Ok(other) => {
+            eprintln!("garbage should not have decoded, got {other:?}");
+            1
+        }
+        Err(_) => 0,
     }
 }
 

--- a/crates/gosub_engine/src/child_process.rs
+++ b/crates/gosub_engine/src/child_process.rs
@@ -95,7 +95,13 @@ fn run_role(role: &str, args: &[String]) -> i32 {
     // able to attach and read it.
     gosub_sandbox::deny_debugger_attach();
 
+    use crate::decoder_process::client::DECODER_ROLE;
+
     match role {
+        DECODER_ROLE => match adopt_link(role, args) {
+            Ok(endpoint) => crate::decoder_process::child::serve(endpoint),
+            Err(code) => code,
+        },
         NET_ROLE => match adopt_link(role, args) {
             Ok(endpoint) => crate::net::process::child::serve(endpoint),
             Err(code) => code,

--- a/crates/gosub_engine/src/decoder_process.rs
+++ b/crates/gosub_engine/src/decoder_process.rs
@@ -1,0 +1,5 @@
+//! Decoding images in a throwaway, sandboxed process.
+
+pub mod child;
+pub mod client;
+pub mod protocol;

--- a/crates/gosub_engine/src/decoder_process/child.rs
+++ b/crates/gosub_engine/src/decoder_process/child.rs
@@ -1,0 +1,88 @@
+//! The image decoder process: one image, then gone.
+
+use crate::decoder_process::protocol::{FromDecoder, ToDecoder, CHUNK_BYTES};
+use gosub_ipc::Endpoint;
+use gosub_render_pipeline::common::media::{
+    render_svg_tree_to_image, DecodedMedia, MediaDecoderRegistry, RasterDecoder, SvgDecoder,
+};
+
+/// An SVG is rasterized at its intrinsic size, scaled down to fit this.
+const MAX_SVG_SIDE: f32 = 4096.0;
+
+/// Decode one image for the broker, then return the process exit code.
+pub fn serve(mut link: Endpoint) -> i32 {
+    // Renamed before the lockdown takes /proc away; there is no per-image
+    // identity to show - this process decodes exactly one and exits.
+    gosub_sandbox::capture_process_title_region();
+    gosub_sandbox::set_process_title("gosub-decoder", "gosub: image decoder");
+
+    // The default set, minus system fonts for SVG: discovering and lazily
+    // loading them walks the filesystem, which the lockdown below forbids.
+    // SVG text therefore renders without fonts here; the alternative is
+    // parsing untrusted SVG in the caller. Nothing here opens a file, a
+    // socket or a program, so the tightest profile applies, installed before
+    // the untrusted bytes are so much as read.
+    let mut registry = MediaDecoderRegistry::new();
+    registry.register(Box::new(SvgDecoder::without_system_fonts()));
+    registry.register(Box::new(RasterDecoder));
+
+    gosub_sandbox::lock_down_decoder();
+
+    let (mime, bytes) = match link.recv::<ToDecoder>() {
+        Ok(ToDecoder::Decode { mime, bytes }) => (mime, bytes),
+        Ok(ToDecoder::Dimensions { mime, bytes }) => {
+            let reply = match registry.dimensions(mime.as_deref(), &bytes) {
+                Some((width, height)) => FromDecoder::Dimensions { width, height },
+                None => FromDecoder::Failed("not an image".into()),
+            };
+            return if link.send(&reply).is_ok() { 0 } else { 1 };
+        }
+        // The broker went away before asking for anything; nothing to do.
+        Err(_) => return 0,
+    };
+    let reply = match registry.decode(mime.as_deref(), &bytes) {
+        // Already normalised to RGBA8 by the decoder, so this is the layout the
+        // broker expects and no conversion is needed here.
+        Ok(DecodedMedia::Raster(image)) => {
+            return send_raster(&mut link, image.width(), image.height(), image.as_raw());
+        }
+        // A tree cannot cross the boundary: pixels at the intrinsic size do.
+        Ok(DecodedMedia::Vector(tree)) => {
+            let size = tree.size();
+            let (w, h) = (size.width().max(1.0), size.height().max(1.0));
+            let scale = (MAX_SVG_SIDE / w).min(MAX_SVG_SIDE / h).min(1.0);
+            let (w, h) = ((w * scale).round().max(1.0) as u32, (h * scale).round().max(1.0) as u32);
+            match render_svg_tree_to_image(&tree, w, h) {
+                Some(image) => return send_raster(&mut link, image.width(), image.height(), image.as_raw()),
+                None => FromDecoder::Failed("could not rasterize the SVG".into()),
+            }
+        }
+        Err(e) => FromDecoder::Failed(e.to_string()),
+    };
+
+    if link.send(&reply).is_err() {
+        return 1;
+    }
+    0
+}
+
+/// Send dimensions, then the pixels in bounded pieces, then the terminator.
+fn send_raster(link: &mut Endpoint, width: u32, height: u32, rgba: &[u8]) -> i32 {
+    let header = FromDecoder::RasterHeader {
+        width,
+        height,
+        len: rgba.len() as u64,
+    };
+    if link.send(&header).is_err() {
+        return 1;
+    }
+    for chunk in rgba.chunks(CHUNK_BYTES) {
+        if link.send(&FromDecoder::Chunk(chunk.to_vec())).is_err() {
+            return 1;
+        }
+    }
+    if link.send(&FromDecoder::RasterEnd).is_err() {
+        return 1;
+    }
+    0
+}

--- a/crates/gosub_engine/src/decoder_process/client.rs
+++ b/crates/gosub_engine/src/decoder_process/client.rs
@@ -1,0 +1,194 @@
+//! The broker's side of image decoding: one throwaway process per image.
+
+use crate::decoder_process::protocol::{FromDecoder, ToDecoder};
+use gosub_interface::media_decoder::{BrokeredDecode, DecodeError, ImageDecoder, RasterImage};
+use std::time::{Duration, Instant};
+
+/// The argv role name the broker re-execs itself with.
+pub const DECODER_ROLE: &str = "decoder";
+
+/// How long one image may take, start to finish.
+const DECODE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Largest decoded image accepted, as raw RGBA.
+///
+/// 256 MiB is about 8000×8000 - beyond any plausible page image, and far below
+/// what a decompression bomb would ask for. The cap is enforced while
+/// accumulating, so an over-large claim costs nothing to reject.
+const MAX_DECODED_BYTES: u64 = 256 * 1024 * 1024;
+
+/// The largest dimension accepted in a header, so an absurd claim is rejected
+/// before it is multiplied out.
+const MAX_DIMENSION: u32 = 32_768;
+
+/// Decodes each image in its own short-lived, sandboxed process.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ProcessImageDecoder;
+
+impl ImageDecoder for ProcessImageDecoder {
+    fn decode(&self, mime: Option<&str>, bytes: &[u8]) -> Result<BrokeredDecode, DecodeError> {
+        match ask_child(ToDecoder::Decode {
+            mime: mime.map(str::to_string),
+            bytes: bytes.to_vec(),
+        })? {
+            Answer::Raster(image) => Ok(BrokeredDecode::Raster(image)),
+            _ => Err(DecodeError::Failed("the decoder answered the wrong question".into())),
+        }
+    }
+
+    fn dimensions(&self, mime: Option<&str>, bytes: &[u8]) -> Result<(u32, u32), DecodeError> {
+        match ask_child(ToDecoder::Dimensions {
+            mime: mime.map(str::to_string),
+            bytes: bytes.to_vec(),
+        })? {
+            Answer::Dimensions(width, height) => Ok((width, height)),
+            _ => Err(DecodeError::Failed("the decoder answered the wrong question".into())),
+        }
+    }
+}
+
+/// What one decoder process answered.
+enum Answer {
+    Raster(RasterImage),
+    Dimensions(u32, u32),
+}
+
+fn ask_child(request: ToDecoder) -> Result<Answer, DecodeError> {
+    // Same guard as the network process: a child that never dispatched is
+    // running embedder startup, and spawning from there would repeat forever.
+    if crate::child_process::is_child_process() {
+        return Err(DecodeError::Failed(
+            "refusing to spawn a decoder from an undispatched child process".into(),
+        ));
+    }
+
+    let exe = std::env::current_exe().map_err(|e| DecodeError::Failed(e.to_string()))?;
+    let (ours, theirs) = gosub_ipc::channel::Channel::pair().map_err(|e| DecodeError::Failed(e.to_string()))?;
+
+    let mut child = gosub_sandbox::spawn::spawn(
+        &exe,
+        &[crate::child_process::ROLE_FLAG, DECODER_ROLE],
+        theirs,
+        // Nothing to reach: a decoder has no business on the network, so it goes
+        // in an empty namespace as well as being denied the syscalls.
+        gosub_sandbox::NamespaceIsolation::Full,
+        gosub_sandbox::spawn::ContainerProfile {
+            name: "gosub-decoder",
+            internet: false,
+            fs_grant: None,
+            data_limit: None,
+            extra_fds: &[],
+            max_tasks: 16,
+            file_size_limit: None,
+        },
+    )
+    .map_err(|e| DecodeError::Failed(format!("could not spawn a decoder: {e}")))?;
+
+    if let Err(e) = gosub_sandbox::confine_spawned_child(&child) {
+        log::warn!("could not apply parent-side confinement to the decoder: {e}");
+    }
+
+    let result = exchange(ours, request);
+
+    // Kill before reaping, on every path: a decoder that will not exit - wedged
+    // or hostile - must not be able to hold this thread open.
+    let _ = child.kill();
+    let _ = child.wait();
+
+    result
+}
+
+/// Send the image and read back what the decoder makes of it.
+fn exchange(channel: gosub_ipc::channel::Channel, request: ToDecoder) -> Result<Answer, DecodeError> {
+    let mut link = gosub_ipc::Endpoint::from_channel(channel).map_err(|e| DecodeError::Failed(e.to_string()))?;
+
+    let deadline = Instant::now() + DECODE_TIMEOUT;
+    // The socket timeouts are what make the deadline real: without them a
+    // decoder that simply stops talking would block this thread forever.
+    let _ = link.tx.set_write_timeout(Some(DECODE_TIMEOUT));
+    let _ = link.rx.set_read_timeout(Some(DECODE_TIMEOUT));
+
+    link.send(&request)
+        .map_err(|e| DecodeError::Failed(format!("could not hand the image to the decoder: {e}")))?;
+
+    let mut pending: Option<(u32, u32, u64, Vec<u8>)> = None;
+    loop {
+        if Instant::now() >= deadline {
+            return Err(DecodeError::TimedOut);
+        }
+        let msg = link.recv::<FromDecoder>().map_err(|e| {
+            if e.kind() == std::io::ErrorKind::WouldBlock || e.kind() == std::io::ErrorKind::TimedOut {
+                DecodeError::TimedOut
+            } else {
+                DecodeError::Failed(format!("the decoder stopped responding: {e}"))
+            }
+        })?;
+
+        match msg {
+            FromDecoder::Failed(why) => return Err(DecodeError::Unsupported(why)),
+            FromDecoder::Dimensions { width, height } => {
+                if width == 0 || height == 0 || width > MAX_DIMENSION || height > MAX_DIMENSION {
+                    return Err(DecodeError::Failed(format!(
+                        "implausible image dimensions {width}x{height}"
+                    )));
+                }
+                return Ok(Answer::Dimensions(width, height));
+            }
+            FromDecoder::RasterHeader { width, height, len } => {
+                if pending.is_some() {
+                    return Err(DecodeError::Failed("the decoder sent two headers".into()));
+                }
+                // Bound the claim before it is multiplied out or used to size
+                // anything: every value here came from the untrusted side.
+                if width == 0 || height == 0 || width > MAX_DIMENSION || height > MAX_DIMENSION {
+                    return Err(DecodeError::Failed(format!(
+                        "implausible image dimensions {width}x{height}"
+                    )));
+                }
+                let expected = u64::from(width) * u64::from(height) * 4;
+                if len != expected {
+                    return Err(DecodeError::Failed(format!(
+                        "the decoder claimed {len} bytes for a {width}x{height} image, expected {expected}"
+                    )));
+                }
+                if len > MAX_DECODED_BYTES {
+                    return Err(DecodeError::Failed(format!(
+                        "decoded image of {len} bytes is too large"
+                    )));
+                }
+                pending = Some((width, height, len, Vec::with_capacity(len as usize)));
+            }
+            FromDecoder::Chunk(chunk) => {
+                let Some((_, _, len, buffer)) = pending.as_mut() else {
+                    return Err(DecodeError::Failed("the decoder sent pixels before a header".into()));
+                };
+                // Checked per chunk, so a flood is cut off at the first byte past
+                // the agreed size rather than after it has been buffered.
+                if buffer.len() as u64 + chunk.len() as u64 > *len {
+                    return Err(DecodeError::Failed(
+                        "the decoder sent more pixels than it announced".into(),
+                    ));
+                }
+                buffer.extend_from_slice(&chunk);
+            }
+            FromDecoder::RasterEnd => {
+                let Some((width, height, len, buffer)) = pending.take() else {
+                    return Err(DecodeError::Failed(
+                        "the decoder ended a transfer it never started".into(),
+                    ));
+                };
+                if buffer.len() as u64 != len {
+                    return Err(DecodeError::Failed(format!(
+                        "the decoder sent {} of {len} announced bytes",
+                        buffer.len()
+                    )));
+                }
+                return Ok(Answer::Raster(RasterImage {
+                    width,
+                    height,
+                    rgba: bytes::Bytes::from(buffer),
+                }));
+            }
+        }
+    }
+}

--- a/crates/gosub_engine/src/decoder_process/protocol.rs
+++ b/crates/gosub_engine/src/decoder_process/protocol.rs
@@ -1,0 +1,53 @@
+//! The broker↔decoder wire vocabulary.
+//!
+//! ## Why pixels arrive in pieces
+//!
+//! A decoded image is far larger than its encoded form: a 4000×3000 photo is
+//! 48 MiB of RGBA, well past the 16 MiB cap that keeps a corrupt length prefix
+//! from forcing a huge allocation. Rather than raise that cap for every link in
+//! the engine, the pixels are sent as bounded chunks and the receiver accumulates
+//! them against its own total limit. The zero-copy alternative - a sealed
+//! shared-memory buffer, `gosub_ipc::shm` - is already imported and is the
+//! natural upgrade; chunking keeps this portable in the meantime.
+
+use serde::{Deserialize, Serialize};
+
+/// Largest chunk of pixel data in one frame, comfortably inside the transport's
+/// frame cap with room for the enum's own encoding.
+pub const CHUNK_BYTES: usize = 4 * 1024 * 1024;
+
+/// Broker → decoder. Exactly one of these is ever sent: the process handles a
+/// single image and exits.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ToDecoder {
+    Decode {
+        /// The `Content-Type` the response claimed, if any. A hint only - the
+        /// decoder sniffs the bytes, since this comes from the network.
+        mime: Option<String>,
+        bytes: Vec<u8>,
+    },
+    /// The intrinsic size only, from the header.
+    Dimensions { mime: Option<String>, bytes: Vec<u8> },
+}
+
+/// Decoder → broker.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum FromDecoder {
+    /// Dimensions first, so the receiver can size and bound the transfer before
+    /// any pixels arrive. Both are claims to be checked, not facts.
+    RasterHeader {
+        width: u32,
+        height: u32,
+        len: u64,
+    },
+    /// A piece of the RGBA buffer, in order.
+    Chunk(Vec<u8>),
+    /// All chunks sent.
+    RasterEnd,
+    /// Answer to [`ToDecoder::Dimensions`]; claims, to be bounded like a header.
+    Dimensions {
+        width: u32,
+        height: u32,
+    },
+    Failed(String),
+}

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -243,7 +243,12 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
             hover_cursor: CursorShape::Default,
             rasterizer: None,
             raster_strategy: RasterStrategy::None,
-            media_store: std::sync::Arc::new(gosub_render_pipeline::common::media::MediaStore::with_loader(loader)),
+            media_store: std::sync::Arc::new(
+                gosub_render_pipeline::common::media::MediaStore::with_loader_and_decoder(
+                    loader,
+                    image_decoder_from(&config_store),
+                ),
+            ),
             config_store,
             tile_budget: TileBudget::new(),
         }
@@ -1574,6 +1579,19 @@ fn pipeline_composite(cache: &PipelineCache, scroll_x: f64, scroll_y: f64, vp_w:
     }
 
     timing_stop!(ts7);
+}
+
+/// The image decoder this engine should use, if any.
+#[cfg(feature = "process-isolation")]
+fn image_decoder_from(config: &Config) -> Option<std::sync::Arc<dyn gosub_interface::media_decoder::ImageDecoder>> {
+    config
+        .get_bool("security.image_decoder_process")
+        .then(|| std::sync::Arc::new(crate::decoder_process::client::ProcessImageDecoder) as _)
+}
+
+#[cfg(not(feature = "process-isolation"))]
+fn image_decoder_from(_config: &Config) -> Option<std::sync::Arc<dyn gosub_interface::media_decoder::ImageDecoder>> {
+    None
 }
 
 #[cfg(test)]

--- a/crates/gosub_engine/src/engine/engine.rs
+++ b/crates/gosub_engine/src/engine/engine.rs
@@ -217,7 +217,7 @@ impl<C: RenderConfiguration> GosubEngine<C> {
     /// in CI.
     #[cfg(feature = "process-isolation")]
     fn resolve_isolation_settings(&self) {
-        const PROCESS_SETTINGS: [&str; 1] = ["security.network_process"];
+        const PROCESS_SETTINGS: [&str; 2] = ["security.network_process", "security.image_decoder_process"];
         let store = &self.context.config_store;
 
         if !crate::child_process::was_dispatched() {

--- a/crates/gosub_engine/src/engine/settings.json
+++ b/crates/gosub_engine/src/engine/settings.json
@@ -435,6 +435,12 @@
       "type": "b",
       "default": "b:true",
       "description": "Run the network stack in a sandboxed child process. Needs the embedder to dispatch child roles; turned off at start when it cannot apply."
+    },
+    {
+      "key": "image_decoder_process",
+      "type": "b",
+      "default": "b:true",
+      "description": "Decode raster images in a throwaway, sandboxed process, one per image. Needs the embedder to dispatch child roles. SVG is rasterized in that process at its intrinsic size (without system fonts), since a parsed vector tree cannot cross a process boundary; a decode the process refuses or cannot start is a failed image, never decoded in-process instead."
     }
   ],
   "telemetry": [

--- a/crates/gosub_engine/src/lib.rs
+++ b/crates/gosub_engine/src/lib.rs
@@ -145,6 +145,10 @@ mod engine;
 /// [`child_process::dispatch`] as the first statement of its `main`.
 #[cfg(feature = "process-isolation")]
 pub mod child_process;
+
+/// Image decoding in a throwaway, sandboxed process.
+#[cfg(feature = "process-isolation")]
+pub mod decoder_process;
 pub mod net;
 
 pub mod util;

--- a/crates/gosub_engine/tests/process_isolation.rs
+++ b/crates/gosub_engine/tests/process_isolation.rs
@@ -54,6 +54,29 @@ fn the_network_process_survives_hostname_resolution() {
     );
 }
 
+/// Image bytes cross into a throwaway, fully locked-down process and the exact
+/// pixels come back.
+#[test]
+fn an_image_decodes_in_a_separate_process() {
+    let out = run("decode");
+    assert!(
+        out.status.success(),
+        "decoding in a separate process failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Malformed input comes back as a refusal, not an image and not a hang.
+#[test]
+fn a_malformed_image_is_refused_rather_than_decoded() {
+    let out = run("decode-garbage");
+    assert!(
+        out.status.success(),
+        "malformed image handling failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 /// The wiring: an ordinary navigation with `security.network_process` on resolves
 /// through the child rather than an in-process fetcher.
 #[test]

--- a/crates/gosub_interface/src/lib.rs
+++ b/crates/gosub_interface/src/lib.rs
@@ -5,6 +5,7 @@ pub mod font;
 pub mod font_system;
 pub mod html5;
 pub mod input;
+pub mod media_decoder;
 pub mod node;
 pub mod render;
 pub mod resource_loader;

--- a/crates/gosub_interface/src/media_decoder.rs
+++ b/crates/gosub_interface/src/media_decoder.rs
@@ -1,0 +1,68 @@
+//! Decoding an image somewhere other than here.
+
+use std::fmt;
+
+/// A decoded raster image in the one form that survives a process boundary:
+/// dimensions plus tightly packed RGBA8.
+#[derive(Clone)]
+pub struct RasterImage {
+    pub width: u32,
+    pub height: u32,
+    /// Exactly `width * height * 4` bytes. Callers must verify this rather than
+    /// trust it - the producer may be a compromised decoder.
+    pub rgba: bytes::Bytes,
+}
+
+impl fmt::Debug for RasterImage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RasterImage")
+            .field("width", &self.width)
+            .field("height", &self.height)
+            .field("bytes", &self.rgba.len())
+            .finish()
+    }
+}
+
+/// What a decoder made of the input. Vector formats come back rasterized at
+/// their intrinsic size: a parsed tree does not cross a process boundary, and
+/// the caller must not parse untrusted bytes itself.
+#[derive(Debug, Clone)]
+pub enum BrokeredDecode {
+    Raster(RasterImage),
+}
+
+/// Why a decode produced nothing.
+#[derive(Debug, Clone)]
+pub enum DecodeError {
+    /// The bytes are not an image, or not one this decoder understands.
+    Unsupported(String),
+    /// Decoding was attempted and failed.
+    Failed(String),
+    /// The decoder did not finish in time and was abandoned. Distinct from
+    /// [`Failed`](DecodeError::Failed) because it usually means a hostile or
+    /// pathological input rather than a merely malformed one.
+    TimedOut,
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DecodeError::Unsupported(why) => write!(f, "unsupported image: {why}"),
+            DecodeError::Failed(why) => write!(f, "decode failed: {why}"),
+            DecodeError::TimedOut => write!(f, "decode timed out"),
+        }
+    }
+}
+
+impl std::error::Error for DecodeError {}
+
+/// Decodes image bytes on the caller's behalf.
+pub trait ImageDecoder: Send + Sync + fmt::Debug {
+    /// Decode `bytes`. `mime` is a hint from the response and may be absent or
+    /// wrong; a decoder is expected to sniff rather than trust it.
+    fn decode(&self, mime: Option<&str>, bytes: &[u8]) -> Result<BrokeredDecode, DecodeError>;
+
+    /// The intrinsic size of `bytes` without decoding the pixels, from the
+    /// same place `decode` would run: header parsing is decoding too.
+    fn dimensions(&self, mime: Option<&str>, bytes: &[u8]) -> Result<(u32, u32), DecodeError>;
+}

--- a/crates/gosub_render_pipeline/src/common/media.rs
+++ b/crates/gosub_render_pipeline/src/common/media.rs
@@ -20,5 +20,6 @@ pub use media::MediaType;
 pub use image::Image;
 pub use svg::Svg;
 
+pub use media_store::render_svg_tree_to_image;
 pub use media_store::MediaRequest;
 pub use media_store::MediaStore;

--- a/crates/gosub_render_pipeline/src/common/media/decoder.rs
+++ b/crates/gosub_render_pipeline/src/common/media/decoder.rs
@@ -25,6 +25,9 @@ pub struct DecodedImage {
     width: u32,
     height: u32,
     pixels: PixelBuffer,
+    /// The size the image *is* for layout, which is the pixel buffer's size
+    /// unless the decoder downscaled a huge image to bound memory.
+    intrinsic: (u32, u32),
 }
 
 impl DecodedImage {
@@ -45,15 +48,34 @@ impl DecodedImage {
             width,
             height,
             pixels: PixelBuffer::Rgba8(pixels),
+            intrinsic: (width, height),
         })
     }
 
+    /// Record that the pixels are a downscaled rendition of a `width` × `height` image.
+    pub fn with_intrinsic(mut self, width: u32, height: u32) -> Self {
+        self.intrinsic = (width, height);
+        self
+    }
+
+    /// Pixel buffer width.
     pub fn width(&self) -> u32 {
         self.width
     }
 
+    /// Pixel buffer height.
     pub fn height(&self) -> u32 {
         self.height
+    }
+
+    /// Width for layout: the image's own, even when the pixels were downscaled.
+    pub fn intrinsic_width(&self) -> u32 {
+        self.intrinsic.0
+    }
+
+    /// Height for layout: the image's own, even when the pixels were downscaled.
+    pub fn intrinsic_height(&self) -> u32 {
+        self.intrinsic.1
     }
 
     pub fn pixels(&self) -> &PixelBuffer {
@@ -77,6 +99,7 @@ impl From<image::RgbaImage> for DecodedImage {
             width,
             height,
             pixels: PixelBuffer::Rgba8(img.into_raw()),
+            intrinsic: (width, height),
         }
     }
 }
@@ -140,6 +163,12 @@ pub trait MediaDecoder: Send + Sync {
     fn supports_magic(&self, bytes: &[u8]) -> bool;
 
     fn decode(&self, bytes: &[u8]) -> Result<DecodedMedia, ImageDecodeError>;
+
+    /// The intrinsic size from the header alone, without decoding pixels. `None` when the
+    /// format has no cheap answer (vector formats, or a decoder that does not implement it).
+    fn dimensions(&self, _bytes: &[u8]) -> Option<(u32, u32)> {
+        None
+    }
 }
 
 /// Ordered set of decoders. The MIME hint (e.g. an HTTP `Content-Type`) is treated as a hint
@@ -200,6 +229,18 @@ impl MediaDecoderRegistry {
         }
 
         Err(last_err.unwrap_or(ImageDecodeError::UnsupportedFormat))
+    }
+}
+
+impl MediaDecoderRegistry {
+    /// The intrinsic size of `bytes` from its header, by the same decoder selection as
+    /// [`decode`](Self::decode); `None` when no decoder can answer without decoding.
+    pub fn dimensions(&self, mime: Option<&str>, bytes: &[u8]) -> Option<(u32, u32)> {
+        let by_mime = mime
+            .into_iter()
+            .flat_map(|mime| self.decoders.iter().filter(move |decoder| decoder.supports_mime(mime)));
+        let by_magic = self.decoders.iter().filter(|decoder| decoder.supports_magic(bytes));
+        by_mime.chain(by_magic).find_map(|decoder| decoder.dimensions(bytes))
     }
 }
 

--- a/crates/gosub_render_pipeline/src/common/media/decoder/raster.rs
+++ b/crates/gosub_render_pipeline/src/common/media/decoder/raster.rs
@@ -1,7 +1,19 @@
-use super::{DecodedMedia, ImageDecodeError, MediaDecoder};
+use super::{DecodedImage, DecodedMedia, ImageDecodeError, MediaDecoder};
+
+/// Largest edge a raster image may have before it is refused outright.
+pub const MAX_IMAGE_EDGE: u32 = 16_384;
+/// Most memory one decode may allocate before it is refused (the `image` crate's own limit).
+pub const MAX_DECODE_BYTES: u64 = 128 * 1024 * 1024;
+/// Pixels kept per image: anything larger is downscaled (keeping its intrinsic size for
+/// layout), so a page of photographs holds at most `MAX_KEPT_PIXELS * 4` bytes per image
+/// rather than whatever the camera produced. 4 Mpx is 2048² - past what a viewport shows.
+pub const MAX_KEPT_PIXELS: u64 = 4 * 1024 * 1024;
 
 /// Decodes every raster format the `image` crate is compiled with (PNG/JPEG/GIF today). `image`
 /// sniffs the real format from the bytes, so a wrong MIME hint between raster formats is harmless.
+/// Decoding is bounded ([`MAX_IMAGE_EDGE`], [`MAX_DECODE_BYTES`]) and huge images are kept
+/// downscaled ([`MAX_KEPT_PIXELS`]): a page cannot exhaust a renderer's memory with photographs,
+/// and an absurd header fails cleanly instead of allocating.
 pub struct RasterDecoder;
 
 impl RasterDecoder {
@@ -29,17 +41,56 @@ impl MediaDecoder for RasterDecoder {
     }
 
     fn decode(&self, bytes: &[u8]) -> Result<DecodedMedia, ImageDecodeError> {
-        match image::load_from_memory(bytes) {
-            Ok(img) => Ok(DecodedMedia::Raster(img.to_rgba8().into())),
+        match decode_bounded(bytes) {
+            Ok(img) => Ok(DecodedMedia::Raster(bounded(img))),
             // Browsers tolerate PNGs with bad chunk CRCs (some encoders emit them); the `image`
             // crate rejects them. Retry a PNG with checksum validation disabled so we match
             // browser behavior instead of showing a broken-image placeholder.
             Err(e) if is_png(bytes) => decode_png_lenient(bytes)
-                .map(|img| DecodedMedia::Raster(img.into()))
+                .map(|img| DecodedMedia::Raster(bounded(img)))
                 .map_err(|_| ImageDecodeError::Decode(e.to_string())),
             Err(e) => Err(ImageDecodeError::Decode(e.to_string())),
         }
     }
+
+    fn dimensions(&self, bytes: &[u8]) -> Option<(u32, u32)> {
+        let (width, height) = image::ImageReader::new(std::io::Cursor::new(bytes))
+            .with_guessed_format()
+            .ok()?
+            .into_dimensions()
+            .ok()?;
+        // The same bound `decode` enforces: an absurd header is not a size for layout.
+        (width <= MAX_IMAGE_EDGE && height <= MAX_IMAGE_EDGE).then_some((width, height))
+    }
+}
+
+/// Decode with the size and allocation limits applied by the decoder itself, so an
+/// oversized header is refused before anything is allocated for it.
+fn decode_bounded(bytes: &[u8]) -> Result<image::RgbaImage, image::ImageError> {
+    let mut reader = image::ImageReader::new(std::io::Cursor::new(bytes)).with_guessed_format()?;
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(MAX_IMAGE_EDGE);
+    limits.max_image_height = Some(MAX_IMAGE_EDGE);
+    limits.max_alloc = Some(MAX_DECODE_BYTES);
+    reader.limits(limits);
+    Ok(reader.decode()?.to_rgba8())
+}
+
+/// Keep at most [`MAX_KEPT_PIXELS`] of a decoded image, remembering its real size for layout.
+fn bounded(img: image::RgbaImage) -> DecodedImage {
+    let (w, h) = img.dimensions();
+    let pixels = u64::from(w) * u64::from(h);
+    if pixels <= MAX_KEPT_PIXELS {
+        return img.into();
+    }
+    let scale = (MAX_KEPT_PIXELS as f64 / pixels as f64).sqrt();
+    let (tw, th) = (
+        ((f64::from(w) * scale) as u32).max(1),
+        ((f64::from(h) * scale) as u32).max(1),
+    );
+    let small = image::imageops::resize(&img, tw, th, image::imageops::FilterType::Triangle);
+    drop(img);
+    DecodedImage::from(small).with_intrinsic(w, h)
 }
 
 fn is_png(bytes: &[u8]) -> bool {
@@ -56,6 +107,10 @@ fn decode_png_lenient(bytes: &[u8]) -> anyhow::Result<image::RgbaImage> {
     decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
 
     let mut reader = decoder.read_info()?;
+    let (w, h) = (reader.info().width, reader.info().height);
+    if w > MAX_IMAGE_EDGE || h > MAX_IMAGE_EDGE || u64::from(w) * u64::from(h) * 4 > MAX_DECODE_BYTES {
+        anyhow::bail!("PNG of {w}x{h} exceeds the decode limits");
+    }
     let mut buf = vec![0u8; reader.output_buffer_size().unwrap_or(0)];
     let info = reader.next_frame(&mut buf)?;
     let src = &buf[..info.buffer_size()];
@@ -84,4 +139,61 @@ fn decode_png_lenient(bytes: &[u8]) -> anyhow::Result<image::RgbaImage> {
     }
 
     image::RgbaImage::from_raw(w, h, rgba).ok_or_else(|| anyhow::anyhow!("PNG buffer size mismatch"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn png_of(width: u32, height: u32) -> Vec<u8> {
+        use image::ImageEncoder;
+        let pixels = vec![0x80u8; (width * height * 4) as usize];
+        let mut out = Vec::new();
+        image::codecs::png::PngEncoder::new(&mut out)
+            .write_image(&pixels, width, height, image::ExtendedColorType::Rgba8)
+            .expect("encode");
+        out
+    }
+
+    #[test]
+    fn huge_images_are_kept_downscaled_but_lay_out_at_their_own_size() {
+        let bytes = png_of(4000, 3000);
+        let DecodedMedia::Raster(img) = RasterDecoder.decode(&bytes).expect("decode") else {
+            panic!("expected a raster image");
+        };
+        assert_eq!((img.intrinsic_width(), img.intrinsic_height()), (4000, 3000));
+        assert!(u64::from(img.width()) * u64::from(img.height()) <= MAX_KEPT_PIXELS);
+        assert!(img.width() < 4000 && img.height() < 3000);
+        // Aspect ratio survives the downscale.
+        let ratio = f64::from(img.width()) / f64::from(img.height());
+        assert!((ratio - 4.0 / 3.0).abs() < 0.01, "ratio {ratio}");
+    }
+
+    #[test]
+    fn dimensions_come_from_the_header() {
+        assert_eq!(RasterDecoder.dimensions(&png_of(300, 20)), Some((300, 20)));
+        assert_eq!(RasterDecoder.dimensions(b"not an image"), None);
+    }
+
+    #[test]
+    fn small_images_are_untouched() {
+        let bytes = png_of(300, 200);
+        let DecodedMedia::Raster(img) = RasterDecoder.decode(&bytes).expect("decode") else {
+            panic!("expected a raster image");
+        };
+        assert_eq!((img.width(), img.height()), (300, 200));
+        assert_eq!((img.intrinsic_width(), img.intrinsic_height()), (300, 200));
+    }
+
+    #[test]
+    fn an_absurd_header_is_refused_before_allocating() {
+        // A valid PNG signature and IHDR claiming 100k x 100k: 40 GB of RGBA.
+        let mut bytes = vec![0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
+        let ihdr: [u8; 13] = [0, 1, 0x86, 0xa0, 0, 1, 0x86, 0xa0, 8, 6, 0, 0, 0];
+        bytes.extend_from_slice(&13u32.to_be_bytes());
+        bytes.extend_from_slice(b"IHDR");
+        bytes.extend_from_slice(&ihdr);
+        bytes.extend_from_slice(&[0, 0, 0, 0]); // wrong CRC; the lenient path must refuse too
+        assert!(RasterDecoder.decode(&bytes).is_err());
+    }
 }

--- a/crates/gosub_render_pipeline/src/common/media/decoder/svg.rs
+++ b/crates/gosub_render_pipeline/src/common/media/decoder/svg.rs
@@ -5,28 +5,78 @@ use std::sync::{Arc, OnceLock};
 /// Number of leading bytes scanned when sniffing for an SVG root element.
 const SVG_SNIFF_LEN: usize = 1024;
 
-/// `usvg::Options` backed by a shared fontdb, built once and reused so system font discovery
-/// happens only once per process.
-fn svg_options() -> usvg::Options<'static> {
-    static FONTDB: OnceLock<Arc<usvg::fontdb::Database>> = OnceLock::new();
-    let fontdb = Arc::clone(FONTDB.get_or_init(|| {
-        let mut db = usvg::fontdb::Database::new();
-        db.load_system_fonts();
-        Arc::new(db)
-    }));
-    usvg::Options {
-        fontdb,
-        ..Default::default()
+/// Built once per process: discovery walks every font directory.
+static FONTDB: OnceLock<Arc<usvg::fontdb::Database>> = OnceLock::new();
+
+/// The system fontdb, shared so font discovery happens only once per process.
+fn system_fontdb() -> Arc<usvg::fontdb::Database> {
+    Arc::clone(FONTDB.get_or_init(|| Arc::new(build_system_fontdb(false))))
+}
+
+/// Discovery only indexes faces; their bytes are opened lazily on use. With `pin`,
+/// every face is mapped now instead, so later use never opens a file.
+// Mapping rather than reading: the system font set runs to hundreds of MiB, and
+// a mapping costs nothing until a page is touched.
+#[allow(unsafe_code)]
+fn build_system_fontdb(pin: bool) -> usvg::fontdb::Database {
+    let mut db = usvg::fontdb::Database::new();
+    db.load_system_fonts();
+    if pin {
+        let ids: Vec<_> = db.faces().map(|face| face.id).collect();
+        for id in ids {
+            // SAFETY: the mapped files are system fonts, not written to while
+            // this process runs; the same assumption fontdb's own lazy path makes.
+            let _ = unsafe { db.make_shared_face_data(id) };
+        }
     }
+    db
+}
+
+/// Where `<text>` conversion gets its fonts.
+#[derive(Debug, Clone, Copy)]
+enum Fonts {
+    System,
+    None,
 }
 
 /// Parses SVG into a retained `usvg::Tree`. Unlike raster decoders it does not rasterize -
 /// the tree is kept so it can be re-rasterized crisply at any render size.
-pub struct SvgDecoder;
+pub struct SvgDecoder {
+    fonts: Fonts,
+}
 
 impl SvgDecoder {
     pub fn new() -> Self {
-        Self
+        Self { fonts: Fonts::System }
+    }
+
+    /// No font discovery at all, so `<text>` converts to nothing. For a process that
+    /// only *validates* SVG - the sandboxed decoder, whose parsed tree never leaves it
+    /// (the broker re-parses accepted bytes with real fonts) - and whose sandbox forbids
+    /// the filesystem walk that discovery and lazy face loading need.
+    pub fn without_system_fonts() -> Self {
+        Self { fonts: Fonts::None }
+    }
+
+    /// Map every system face into memory ahead of a sandbox that forbids opening
+    /// files, so `<text>` conversion never goes to disk afterwards. The process's
+    /// counterpart to `FontSystem::prepare_for_confinement`. Must precede the first
+    /// system-font decode in this process: the database is built once, and this
+    /// returns `false` (leaving the lazily-loading one in place) if that already
+    /// happened.
+    pub fn pin_system_fonts() -> bool {
+        FONTDB.set(Arc::new(build_system_fontdb(true))).is_ok()
+    }
+
+    fn options(&self) -> usvg::Options<'static> {
+        let fontdb = match self.fonts {
+            Fonts::System => system_fontdb(),
+            Fonts::None => Arc::new(usvg::fontdb::Database::new()),
+        };
+        usvg::Options {
+            fontdb,
+            ..Default::default()
+        }
     }
 }
 
@@ -59,7 +109,8 @@ impl MediaDecoder for SvgDecoder {
     }
 
     fn decode(&self, bytes: &[u8]) -> Result<DecodedMedia, ImageDecodeError> {
-        let tree = usvg::Tree::from_data(bytes, &svg_options()).map_err(|e| ImageDecodeError::Decode(e.to_string()))?;
+        let tree =
+            usvg::Tree::from_data(bytes, &self.options()).map_err(|e| ImageDecodeError::Decode(e.to_string()))?;
         Ok(DecodedMedia::Vector(Box::new(tree)))
     }
 }

--- a/crates/gosub_render_pipeline/src/common/media/media_store.rs
+++ b/crates/gosub_render_pipeline/src/common/media/media_store.rs
@@ -1,8 +1,9 @@
 use crate::common::hash::{hash_from_data, hash_from_string, Sha256Hash};
 use crate::common::media::{
-    DecodedMedia, Image, Media, MediaDecoderRegistry, MediaId, MediaImage, MediaSvg, MediaType, Svg,
+    DecodedImage, DecodedMedia, Image, Media, MediaDecoderRegistry, MediaId, MediaImage, MediaSvg, MediaType, Svg,
 };
 use bytes::Bytes;
+use gosub_interface::media_decoder::{BrokeredDecode, ImageDecoder};
 use gosub_interface::resource_loader::{NoResourceLoader, ResourceLoader};
 use parking_lot::RwLock;
 use std::collections::{HashMap, HashSet};
@@ -45,6 +46,9 @@ pub struct MediaStore {
     /// How remote media is fetched. The store holds a loader rather than reaching
     /// for the network itself, so layout carries no network capability.
     loader: Arc<dyn ResourceLoader>,
+    /// Where raster decoding happens. `None` decodes in this process, which is
+    /// the default; the engine installs one to move it out.
+    decoder: Option<Arc<dyn ImageDecoder>>,
 }
 
 impl Default for MediaStore {
@@ -67,6 +71,15 @@ impl MediaStore {
 
     /// A store that pulls remote media through `loader`.
     pub fn with_loader(loader: Arc<dyn ResourceLoader>) -> MediaStore {
+        Self::with_loader_and_decoder(loader, None)
+    }
+
+    /// A store that also decodes raster images through `decoder` rather than in
+    /// this process. See [`ImageDecoder`].
+    pub fn with_loader_and_decoder(
+        loader: Arc<dyn ResourceLoader>,
+        decoder: Option<Arc<dyn ImageDecoder>>,
+    ) -> MediaStore {
         let decoders = MediaDecoderRegistry::with_defaults();
 
         #[allow(clippy::expect_used)] // PANIC-SAFE: compiled-in asset, exercised by every pipeline test
@@ -102,6 +115,7 @@ impl MediaStore {
             default_image,
             decoders,
             loader,
+            decoder,
         }
     }
 
@@ -145,8 +159,24 @@ impl MediaStore {
         self.completed.swap(false, Ordering::Relaxed)
     }
 
-    /// Shared by the data, source and inline decode paths.
+    /// Shared by the data, source and inline decode paths. With a decoder
+    /// installed the bytes are never decoded here: a failure - including one
+    /// the decoder could not even start on - is the image's failure, not a
+    /// reason to decode locally after all.
     fn decode_media(&self, src: &str, mime: Option<&str>, data: &[u8]) -> anyhow::Result<Media> {
+        if let Some(decoder) = &self.decoder {
+            return match decoder.decode(mime, data) {
+                Ok(BrokeredDecode::Raster(raster)) => {
+                    // Length is checked against the dimensions rather than
+                    // trusted: the producer may be a compromised decoder.
+                    let image = DecodedImage::new_rgba8(raster.width, raster.height, raster.rgba.to_vec())
+                        .map_err(|e| anyhow::anyhow!("brokered decode of '{}' returned bad pixels: {}", src, e))?;
+                    Ok(Media::image(src, image))
+                }
+                Err(e) => Err(anyhow::anyhow!("brokered decode of '{}' failed: {}", src, e)),
+            };
+        }
+
         match self.decoders.decode(mime, data) {
             Ok(DecodedMedia::Raster(img)) => Ok(Media::image(src, img)),
             Ok(DecodedMedia::Vector(tree)) => Ok(Media::svg(src, Svg::new(*tree))),
@@ -375,7 +405,7 @@ fn percent_decode(s: &str) -> Vec<u8> {
 
 /// Rasterize a `usvg` tree to a straight-alpha RGBA [`Image`] of `w`×`h` px (scaling the tree's
 /// intrinsic size to fit). Returns `None` if the pixmap can't be allocated.
-fn render_svg_tree_to_image(tree: &resvg::usvg::Tree, w: u32, h: u32) -> Option<Image> {
+pub fn render_svg_tree_to_image(tree: &resvg::usvg::Tree, w: u32, h: u32) -> Option<Image> {
     let size = tree.size();
     let (iw, ih) = (size.width().max(1.0), size.height().max(1.0));
     let (sx, sy) = (w as f32 / iw, h as f32 / ih);

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -903,7 +903,7 @@ impl TaffyLayouter {
         match &*self.media_store.get(media_id, MediaType::Image) {
             Media::Image(mi) => Some(BackgroundMedia::Image {
                 media_id,
-                natural: (mi.image.width() as f32, mi.image.height() as f32),
+                natural: (mi.image.intrinsic_width() as f32, mi.image.intrinsic_height() as f32),
                 layout,
             }),
             Media::Svg(ms) => {


### PR DESCRIPTION

Base: `02-contract` (in the linear stack: `03-net-process`).

### What is in here

- `gosub_interface::media_decoder`: the `ImageDecoder` contract (`decode`,
  `dimensions`) and `BrokeredDecode::Raster` — the one form a decoded image
  takes across a process boundary (dimensions + tightly packed RGBA8, length
  checked against the dimensions, never trusted).
- `decoder_process`: one throwaway process per image, fed bytes, exits. Pixels
  come back chunked (4 MiB frames) and validated; a decode the process refuses
  or cannot start is a failed image, never decoded in-process instead. SVG is
  rasterized in the child at its intrinsic size without system fonts (a parsed
  tree never crosses); header parsing (`dimensions`) runs there too.
- Bounded raster decoding in the pipeline (`MAX_IMAGE_EDGE`, allocation limit,
  huge images kept downscaled with their intrinsic size preserved) and the
  `MediaStore` decoding through an installed `ImageDecoder` (`security.image_decoder_process`).
- Scenarios `decode` (exact pixels back), `decode-garbage` (malformed input is
  a refusal, not a hang), `decode-many` (cost per process).

### Testing

```
cargo test -p gosub_engine --test process_isolation      # 7
cargo test -p gosub_render_pipeline media
./target/debug/isolation-harness decode-many 20           # ~5 ms per decode
```