### PR TITLE
Font confinement tiers: each font system answers how confined a renderer may be

### DIFF
--- a/crates/gosub_engine/Cargo.toml
+++ b/crates/gosub_engine/Cargo.toml
@@ -82,6 +82,12 @@ metrics = []
 # platform without process isolation need. Compiling it in does not enable
 # anything: each process has its own `security.*` setting.
 process-isolation = ["dep:gosub_ipc", "dep:gosub_sandbox"]
+# Compile the feature-gated font systems into the isolation harness, so its
+# font scenarios can be pointed at every backend the engine supports - the
+# confinement contract has to hold per font stack, not just for the default.
+# Diagnostic only; nothing in the engine itself selects these.
+pango-fonts = ["gosub_fontmanager/pango"]
+skia-fonts = ["gosub_fontmanager/skia"]
 
 [lints]
 workspace = true

--- a/crates/gosub_engine/src/bin/isolation-harness.rs
+++ b/crates/gosub_engine/src/bin/isolation-harness.rs
@@ -1,6 +1,7 @@
 //! Drives the network process end to end, from a binary that dispatches child
 //! roles the way a real embedder does.
 
+use gosub_interface::font_system::{Confinement, FontSystem};
 use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::sync::Arc;
@@ -9,21 +10,65 @@ const BODY: &str = "<html><head><title>through the net process</title></head>\
 <body style=\"margin:0\"><a href=\"https://example.test/target\" \
 style=\"display:block;width:400px;height:200px\">a link to hover</a></body></html>";
 
-/// The harness's render configuration: null backend and compositor, nothing
-/// composites here.
-#[derive(Clone, Debug, PartialEq)]
-struct TileConfig;
+/// The harness's render configuration: null backend and compositor (nothing
+/// composites here), the scenario-selected font system.
+struct TileConfig<F>(std::marker::PhantomData<F>);
 
-impl gosub_interface::config::ModuleConfiguration for TileConfig {
+impl<F> Clone for TileConfig<F> {
+    fn clone(&self) -> Self {
+        Self(std::marker::PhantomData)
+    }
+}
+impl<F> std::fmt::Debug for TileConfig<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("TileConfig")
+    }
+}
+impl<F> PartialEq for TileConfig<F> {
+    fn eq(&self, _: &Self) -> bool {
+        true
+    }
+}
+
+impl<F: FontSystem + Default> gosub_interface::config::ModuleConfiguration for TileConfig<F> {
     type CssSystem = gosub_css3::system::Css3System;
     type Document = gosub_html5::document::document_impl::DocumentImpl<Self>;
     type HtmlParser = gosub_html5::parser::Html5Parser<'static, Self>;
 }
 
-impl gosub_engine::html::RenderConfiguration for TileConfig {
+impl<F: FontSystem + Default> gosub_engine::html::RenderConfiguration for TileConfig<F> {
     type RenderBackend = gosub_render_pipeline::render::backends::null::NullBackend;
     type CompositorSink = gosub_render_pipeline::render::DefaultCompositor;
-    type FontSystem = gosub_fontmanager::ParleyFontSystem;
+    type FontSystem = F;
+}
+
+/// Run a font scenario against the font system named by argv[2].
+macro_rules! with_font_backend {
+    ($scenario:ident) => {{
+        let backend = std::env::args().nth(2).unwrap_or_else(|| "parley".into());
+        // Spawned children (the fork server) inherit this, which is how a
+        // re-exec - where type parameters cannot travel - ends up dispatching
+        // with the same font system the scenario is testing. A production
+        // embedder has no such indirection: it names its one font system in
+        // `dispatch_with` directly.
+        std::env::set_var("GOSUB_HARNESS_FONT_BACKEND", &backend);
+        match backend.as_str() {
+            "parley" => $scenario::<gosub_fontmanager::ParleyFontSystem>(),
+            "cosmic" => $scenario::<gosub_fontmanager::CosmicFontSystem>(),
+            #[cfg(feature = "pango-fonts")]
+            "pango" => $scenario::<gosub_fontmanager::PangoFontSystem>(),
+            #[cfg(feature = "skia-fonts")]
+            "skia" => $scenario::<gosub_fontmanager::SkiaFontSystem>(),
+            other => {
+                eprintln!(
+                    "font backend {other:?} is not compiled into this harness; \
+                     'parley' and 'cosmic' are always available, 'pango' and 'skia' \
+                     need the engine features 'pango-fonts' / 'skia-fonts'"
+                );
+                2
+            }
+        }
+    }};
 }
 
 fn main() {
@@ -31,7 +76,18 @@ fn main() {
     // this runs the role and exits, so nothing below executes there. Skipping it
     // is the mistake the `guard` scenario reproduces.
     if std::env::var_os("GOSUB_HARNESS_SKIP_DISPATCH").is_none() {
-        gosub_engine::child_process::dispatch_with::<TileConfig>();
+        match std::env::var("GOSUB_HARNESS_FONT_BACKEND").as_deref() {
+            Ok("cosmic") => {
+                gosub_engine::child_process::dispatch_with::<TileConfig<gosub_fontmanager::CosmicFontSystem>>()
+            }
+            #[cfg(feature = "pango-fonts")]
+            Ok("pango") => {
+                gosub_engine::child_process::dispatch_with::<TileConfig<gosub_fontmanager::PangoFontSystem>>()
+            }
+            #[cfg(feature = "skia-fonts")]
+            Ok("skia") => gosub_engine::child_process::dispatch_with::<TileConfig<gosub_fontmanager::SkiaFontSystem>>(),
+            _ => gosub_engine::child_process::dispatch_with::<TileConfig<gosub_fontmanager::ParleyFontSystem>>(),
+        }
     }
 
     let scenario = std::env::args().nth(1).unwrap_or_default();
@@ -41,10 +97,14 @@ fn main() {
         "decode" => decode(),
         "decode-garbage" => decode_garbage(),
         "decode-many" => decode_many(),
+        "fonts-under-lockdown" => with_font_backend!(fonts_under_lockdown),
+        "webfont-under-lockdown" => with_font_backend!(webfont_under_lockdown),
+        "fonts-under-font-readable-lockdown" => with_font_backend!(fonts_under_font_readable_lockdown),
+        "webfont-under-font-readable-lockdown" => with_font_backend!(webfont_under_font_readable_lockdown),
         "engine" => engine(),
         "guard" => guard(),
         other => {
-            eprintln!("unknown scenario {other:?}; expected 'direct', 'resolve', 'engine', 'guard' or 'decode[-garbage|-many]'");
+            eprintln!("unknown scenario {other:?}; see the match above for the scenario names");
             2
         }
     };
@@ -224,6 +284,258 @@ fn decode() -> i32 {
 
 /// A small SVG with a `<text>` element, so decoding it consults the fontdb.
 const SAMPLE_SVG: &[u8] = br##"<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18"><rect width="18" height="18" fill="#f60"/><text x="4" y="13" font-family="serif" font-size="10">Y</text></svg>"##;
+
+/// The open question for a renderer process: can text be laid out by a process
+/// confined the way a renderer must be?
+fn fonts_under_lockdown<F: FontSystem + Default>() -> i32 {
+    use gosub_interface::font_system::TextStyle;
+
+    let mut fonts = F::default();
+    println!("font backend: {}", std::any::type_name::<F>());
+
+    // Warm-up. `families()` is documented to populate lazily-built databases, and
+    // resolving plus shaping forces the actual file reads that follow.
+    let families = fonts.families();
+    println!("warm-up: {} families visible before lockdown", families.len());
+    if families.is_empty() {
+        eprintln!("no font families found; this host cannot answer the question");
+        return 2;
+    }
+    // Exercise the trait hook rather than hand-rolled warm-up: this is what a
+    // renderer will call, and it is the configured font system's own answer to
+    // "get ready to be confined". Timed and measured, because the cost of that
+    // answer is part of whether the strategy is usable. This scenario tests the
+    // *full* lockdown, so any answer below `Full` ends it here - the tiered
+    // scenarios cover the rest.
+    let rss_before_mib = rss_mib();
+    let start = std::time::Instant::now();
+    match fonts.prepare_for_confinement() {
+        Confinement::Full => {}
+        other => {
+            eprintln!("this font system does not support full confinement: {other:?}");
+            return 3;
+        }
+    }
+    println!(
+        "prepare_for_confinement over {} families: {:?}, RSS {} -> {} MiB",
+        families.len(),
+        start.elapsed(),
+        rss_before_mib,
+        rss_mib()
+    );
+
+    gosub_sandbox::lock_down_renderer();
+
+    // Text and a size never used above, so any per-face lazy load still pending
+    // has to happen now - after the sandbox is in place.
+    let cold_style = TextStyle::new("serif", 31.0);
+    let (cold_w, cold_h) = fonts.measure("Text shaped only after the sandbox applied", &cold_style);
+    if cold_w <= 0.0 || cold_h <= 0.0 {
+        eprintln!("shaping under lockdown produced an empty box ({cold_w}x{cold_h})");
+        return 1;
+    }
+    println!("shaped {cold_w:.1}x{cold_h:.1} under the renderer lockdown");
+
+    // A real page runs hundreds of layouts before it first needs some face.
+    // Parley prunes its source cache every layout (entries idle for 128
+    // layouts go), so a warm-up that merely *loaded* every face is undone by
+    // the time a long page reaches a face it has not used yet - and the
+    // reload is a file read. Churn past that window, then ask for a face
+    // nothing above has touched.
+    let churn_style = TextStyle::new("sans-serif", 13.0);
+    for i in 0..300 {
+        let _ = fonts.measure(&format!("layout {i}"), &churn_style);
+    }
+    let mut late_style = TextStyle::new("serif", 27.0);
+    late_style.weight = gosub_interface::font_system::FontWeight(700);
+    late_style.style = gosub_interface::font::FontStyle::Italic;
+    let (late_w, late_h) = fonts.measure("Bold italic serif, first used after 300 layouts", &late_style);
+    if late_w <= 0.0 || late_h <= 0.0 {
+        eprintln!("shaping a late face under lockdown produced an empty box ({late_w}x{late_h})");
+        return 1;
+    }
+    println!("shaped a never-before-used face after 300 layouts under lockdown ({late_w:.1}x{late_h:.1})");
+    0
+}
+
+/// The middle tier: can a font system that *cannot* be confined outright
+/// (fontconfig consults the filesystem while shaping) run in a renderer that is
+/// allowed to read font paths and nothing else?
+fn fonts_under_font_readable_lockdown<F: FontSystem + Default>() -> i32 {
+    use gosub_interface::font_system::TextStyle;
+
+    let mut fonts = F::default();
+    println!("font backend: {}", std::any::type_name::<F>());
+
+    let families = fonts.families();
+    println!("{} families visible before lockdown", families.len());
+    if families.is_empty() {
+        eprintln!("no font families found; this host cannot answer the question");
+        return 2;
+    }
+
+    // A runtime guard rather than a cfg'd block, so the code below it is not
+    // flagged unreachable on the platforms this returns on.
+    if cfg!(not(target_os = "linux")) {
+        eprintln!("the font-readable renderer tier exists only on Linux");
+        return 2;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let paths = gosub_sandbox::font_filesystem_paths();
+        if paths.is_empty() {
+            eprintln!("no font paths exist on this host; the profile would test nothing");
+            return 2;
+        }
+        println!(
+            "font paths granted read-only: {}",
+            paths
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        let refs: Vec<(&std::path::Path, bool)> = paths.iter().map(|p| (p.as_path(), false)).collect();
+        gosub_sandbox::lock_down_renderer_with_font_access(&refs);
+    }
+
+    // Never shaped, never warmed: the match runs cold, under the profile.
+    let cold_style = TextStyle::new("serif", 31.0);
+    let (cold_w, cold_h) = fonts.measure("Text shaped only after the sandbox applied", &cold_style);
+    if cold_w <= 0.0 || cold_h <= 0.0 {
+        eprintln!("shaping under the font-readable lockdown produced an empty box ({cold_w}x{cold_h})");
+        return 1;
+    }
+    println!("shaped {cold_w:.1}x{cold_h:.1} under the font-readable renderer lockdown");
+    0
+}
+
+/// Web fonts under the middle tier - the follow-up that decides whether the
+/// tier is actually usable, because `@font-face` is everywhere.
+fn webfont_under_font_readable_lockdown<F: FontSystem + Default>() -> i32 {
+    use gosub_interface::font_system::{FontQuery, TextStyle};
+
+    let mut fonts = F::default();
+    println!("font backend: {}", std::any::type_name::<F>());
+    let _ = fonts.families();
+
+    let Ok(resolved) = fonts.resolve(&FontQuery::new(&["sans-serif"])) else {
+        eprintln!("no resolvable font on this host to use as sample bytes");
+        return 2;
+    };
+    let downloaded: Vec<u8> = resolved.blob.data.as_ref().as_ref().to_vec();
+    if downloaded.is_empty() {
+        eprintln!("resolved font carried no bytes; the control is broken");
+        return 2;
+    }
+    println!("holding {} bytes of font data before lockdown", downloaded.len());
+
+    if cfg!(not(target_os = "linux")) {
+        eprintln!("the font-readable renderer tier exists only on Linux");
+        return 2;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let scratch = std::env::temp_dir().join(format!("gosub-webfont-scratch-{}", std::process::id()));
+        if std::fs::create_dir_all(&scratch).is_err() {
+            eprintln!("could not create the scratch directory; cannot set the tier up");
+            return 2;
+        }
+        // Backends that stage fonts as files use the standard temp dir; point
+        // it inside the ruleset so the write is scoped, not just allowed.
+        std::env::set_var("TMPDIR", &scratch);
+
+        let paths = gosub_sandbox::font_filesystem_paths();
+        let mut refs: Vec<(&std::path::Path, bool)> = paths.iter().map(|p| (p.as_path(), false)).collect();
+        refs.push((scratch.as_path(), true));
+        gosub_sandbox::lock_down_renderer_with_font_access(&refs);
+    }
+
+    if let Err(e) = fonts.register_font(downloaded, Some("gosub-webfont-test")) {
+        eprintln!("registering a web font under the font-readable lockdown failed: {e:?}");
+        return 1;
+    }
+    let (w, h) = fonts.measure(
+        "Web font registered after the sandbox applied",
+        &TextStyle::new(resolved.family.clone(), 24.0),
+    );
+    if w <= 0.0 || h <= 0.0 {
+        eprintln!("shaping with the registered font produced an empty box ({w}x{h})");
+        return 1;
+    }
+    println!("registered and shaped {w:.1}x{h:.1} under the font-readable renderer lockdown");
+    0
+}
+
+/// The follow-up question to the warm-up finding: a page can introduce a font at
+/// any moment with `@font-face`, long after the sandbox is in place. Does that
+/// need a file, and therefore a process that can open one?
+fn webfont_under_lockdown<F: FontSystem + Default>() -> i32 {
+    use gosub_interface::font_system::{FontQuery, TextStyle};
+
+    let mut fonts = F::default();
+    println!("font backend: {}", std::any::type_name::<F>());
+    let _ = fonts.families();
+
+    // Stand in for a downloaded font: bytes in hand, nothing else.
+    let Ok(resolved) = fonts.resolve(&FontQuery::new(&["sans-serif"])) else {
+        eprintln!("no resolvable font on this host to use as sample bytes");
+        return 2;
+    };
+    let downloaded: Vec<u8> = resolved.blob.data.as_ref().as_ref().to_vec();
+    if downloaded.is_empty() {
+        eprintln!("resolved font carried no bytes; the control is broken");
+        return 2;
+    }
+    println!("holding {} bytes of font data before lockdown", downloaded.len());
+
+    // The renderer's documented sequence: prepare, confine, and only then let
+    // content introduce fonts. Skipping the preparation here would test a
+    // sequence no renderer runs - and shaping a web font still consults
+    // fallback faces, which some backends (cosmic-text) load lazily per face.
+    // Full lockdown only: backends answering a weaker tier are covered by the
+    // font-readable scenarios.
+    match fonts.prepare_for_confinement() {
+        Confinement::Full => {}
+        other => {
+            eprintln!("this font system does not support full confinement: {other:?}");
+            return 3;
+        }
+    }
+
+    gosub_sandbox::lock_down_renderer();
+
+    // Everything from here is what a renderer would do on encountering
+    // `@font-face` mid-page.
+    if let Err(e) = fonts.register_font(downloaded, Some("gosub-webfont-test")) {
+        eprintln!("registering a web font under lockdown failed: {e:?}");
+        return 1;
+    }
+    let (w, h) = fonts.measure(
+        "Web font registered after the sandbox applied",
+        &TextStyle::new(resolved.family.clone(), 24.0),
+    );
+    if w <= 0.0 || h <= 0.0 {
+        eprintln!("shaping with the registered font produced an empty box ({w}x{h})");
+        return 1;
+    }
+    println!("registered and shaped {w:.1}x{h:.1} under the renderer lockdown");
+    0
+}
+
+/// Resident set size in MiB, from `/proc/self/statm` (pages), so the cost of a
+/// strategy is a number rather than an impression. 0 where unavailable.
+fn rss_mib() -> u64 {
+    let Ok(statm) = std::fs::read_to_string("/proc/self/statm") else {
+        return 0;
+    };
+    let pages: u64 = statm
+        .split_whitespace()
+        .nth(1)
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(0);
+    pages * 4096 / (1024 * 1024)
+}
 
 /// Decode the sample image repeatedly and report the wall-clock cost per image,
 /// so the price of a process per decode is a measured number rather than a

--- a/crates/gosub_engine/tests/process_isolation.rs
+++ b/crates/gosub_engine/tests/process_isolation.rs
@@ -20,6 +20,13 @@ fn run(scenario: &str) -> std::process::Output {
         .expect("spawn isolation-harness")
 }
 
+fn run_with_backend(scenario: &str, backend: &str) -> std::process::Output {
+    Command::new(harness())
+        .args([scenario, backend])
+        .output()
+        .expect("spawn isolation-harness")
+}
+
 /// The boundary itself: a request crosses into a separate, sandboxed process and
 /// the response comes back byte-for-byte.
 ///
@@ -73,6 +80,128 @@ fn a_malformed_image_is_refused_rather_than_decoded() {
     assert!(
         out.status.success(),
         "malformed image handling failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A renderer process must be able to lay out text, and this pins the one
+/// arrangement under which it can.
+///
+/// A renderer denies `openat` - that is most of what makes it a renderer - but
+/// font stacks read font files lazily, on first use of a family. Measurement
+/// showed the laziness is per family, not per shape: a family resolved and
+/// shaped before the sandbox is applied goes on shaping new text at new sizes
+/// afterwards, while one first touched under the sandbox dies on `SIGSYS`.
+#[test]
+fn a_warmed_font_system_can_shape_under_the_renderer_lockdown() {
+    let out = run("fonts-under-lockdown");
+
+    // Exit 2 means the host has no fonts to test with, which is a skip rather
+    // than a failure: the property is about the sandbox, not the machine.
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: {}", String::from_utf8_lossy(&out.stderr).trim());
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "a warmed font system should still shape once confined:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A font that arrives *after* the sandbox is applied still works, as long as it
+/// arrives as bytes.
+#[test]
+fn a_web_font_can_be_registered_under_the_renderer_lockdown() {
+    let out = run("webfont-under-lockdown");
+
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: {}", String::from_utf8_lossy(&out.stderr).trim());
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "registering a web font once confined should work:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The same confinement property, for the *other* always-compiled font system -
+/// because the engine is generic over font systems, the property is per
+/// implementation, not per engine.
+///
+/// cosmic-text loads face data lazily per (face, weight), and shaping consults
+/// fallback faces a family-by-family warm-up never touches; the trait's default
+/// `prepare_for_confinement` measurably left it dying on `openat` under the
+/// sandbox. This pins its override, which loads every face in the database.
+#[test]
+fn cosmic_text_can_shape_under_the_renderer_lockdown() {
+    let out = run_with_backend("fonts-under-lockdown", "cosmic");
+
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: {}", String::from_utf8_lossy(&out.stderr).trim());
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "a prepared cosmic-text font system should still shape once confined:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Web fonts after lockdown, for cosmic-text - the sequence a renderer actually
+/// runs is prepare, confine, then let content register fonts, and for
+/// cosmic-text the preparation is load-bearing even for a font that arrives as
+/// bytes, because shaping it still consults fallback faces.
+#[test]
+fn a_web_font_can_be_registered_with_cosmic_text_under_the_renderer_lockdown() {
+    let out = run_with_backend("webfont-under-lockdown", "cosmic");
+
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: {}", String::from_utf8_lossy(&out.stderr).trim());
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "registering a web font once confined should work with cosmic-text:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The middle sandbox tier: a renderer allowed to *read font paths and nothing
+/// else* (plus one private writable scratch), for font systems that consult
+/// the filesystem while shaping and so can never satisfy full confinement.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_font_system_can_shape_under_the_font_readable_lockdown() {
+    let out = run("fonts-under-font-readable-lockdown");
+
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: {}", String::from_utf8_lossy(&out.stderr).trim());
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "shaping under the font-readable renderer profile failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Web fonts under the middle tier, including the writable-scratch arrangement
+/// some backends need (Pango stages a web font as a file; fontconfig's
+/// app-font API takes a path, not memory).
+#[cfg(target_os = "linux")]
+#[test]
+fn a_web_font_can_be_registered_under_the_font_readable_lockdown() {
+    let out = run("webfont-under-font-readable-lockdown");
+
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: {}", String::from_utf8_lossy(&out.stderr).trim());
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "registering a web font under the font-readable renderer profile failed:\n{}",
         String::from_utf8_lossy(&out.stderr)
     );
 }

--- a/crates/gosub_fontmanager/src/cosmic_system.rs
+++ b/crates/gosub_fontmanager/src/cosmic_system.rs
@@ -1,10 +1,4 @@
-//! A second [`FontSystem`] implementation, backed by **cosmic-text** (fontdb discovery +
-//! rustybuzz shaping + swash). It implements exactly the same trait as [`crate::ParleyFontSystem`],
-//! demonstrating that the font abstraction is engine-agnostic - the layouter can measure with it,
-//! and a backend that paints [`ShapedText`] glyph runs can render with it.
-//!
-//! Note: cosmic-text doesn't expose the underlying shared font bytes, so `blob_for` copies them
-//! when filling a [`FontBlob`] (cached upstream by whoever holds the `ResolvedFont`).
+//! [`FontSystem`] backed by cosmic-text (fontdb discovery + rustybuzz shaping + swash).
 
 use cosmic_text::{
     fontdb, Align, Attrs, Buffer, Family, FontSystem as CosmicTextFontSystem, Metrics, Shaping, Stretch, Style, Weight,
@@ -12,8 +6,8 @@ use cosmic_text::{
 use cow_utils::CowUtils;
 use gosub_interface::font::{FontBlob, FontError, FontStyle};
 use gosub_interface::font_system::{
-    FontQuery, FontStretch, FontSystem, ResolvedFont, RunMetrics, ShapedGlyph, ShapedRun, ShapedText, TextAlign,
-    TextStyle,
+    Confinement, FontQuery, FontStretch, FontSystem, ResolvedFont, RunMetrics, ShapedGlyph, ShapedRun, ShapedText,
+    TextAlign, TextStyle,
 };
 use std::sync::Arc;
 
@@ -34,9 +28,8 @@ impl Default for CosmicFontSystem {
     }
 }
 
-/// A run of shaped glyphs that all share one font. Collected while the cosmic-text `buffer`
-/// is borrowed, so the per-run font-blob lookup (which borrows `self.inner`) can run afterward
-/// without overlapping borrows.
+/// A run of shaped glyphs sharing one font. Collected while the cosmic-text `buffer` is
+/// borrowed, so the font-blob lookup (which borrows `self.inner`) can run afterward.
 struct RawRun {
     id: fontdb::ID,
     weight: Weight,
@@ -46,11 +39,7 @@ struct RawRun {
     glyphs: Vec<ShapedGlyph>,
 }
 
-/// Decoration metrics estimated from the font size.
-///
-/// cosmic-text doesn't surface the font's own underline/strikeout tables, so use the common
-/// conventions (underline ~1/10 em below the baseline, strikeout ~1/4 em above, both ~1/14 em
-/// thick) until a swash-based lookup replaces this.
+/// cosmic-text doesn't surface the font's underline/strikeout tables; estimate from em size.
 fn heuristic_metrics(size: f32) -> RunMetrics {
     RunMetrics {
         underline_offset: size * 0.1,
@@ -64,8 +53,7 @@ impl CosmicFontSystem {
     /// Create a font system with system fonts loaded and Roboto registered as a bundled fallback.
     pub fn new() -> Self {
         let mut inner = CosmicTextFontSystem::new();
-        // Load the bundled Roboto without copying: the static bytes already implement
-        // `AsRef<[u8]>`, so hand fontdb a shared reference instead of an owned `Vec`.
+        // Source::Binary avoids copying the static Roboto bytes.
         inner
             .db_mut()
             .load_font_source(fontdb::Source::Binary(Arc::new(gosub_shared::ROBOTO_FONT)));
@@ -98,12 +86,8 @@ impl CosmicFontSystem {
         buffer
     }
 
-    /// Raw font bytes for a resolved face, as a [`FontBlob`].
-    ///
-    /// cosmic-text doesn't expose the underlying shared `Arc<[u8]>`, so this copies the file
-    /// bytes and assumes face index 0 (correct for single-face files; `.ttc` collections would
-    /// need the real index). Only used to fill `FontBlob`, which a cosmic draw path doesn't yet
-    /// consume - so the copy is harmless for now.
+    /// cosmic-text doesn't expose the shared `Arc<[u8]>`, so this copies the bytes and
+    /// assumes face index 0 (wrong for `.ttc` collections).
     fn blob_for(&mut self, id: fontdb::ID, weight: Weight) -> Option<FontBlob> {
         let font = self.inner.get_font(id, weight)?;
         Some(FontBlob::new(Arc::new(font.data().to_vec()), 0))
@@ -134,8 +118,7 @@ impl FontSystem for CosmicFontSystem {
     /// Resolve a CSS font query to a concrete font via fontdb.
     fn resolve(&mut self, query: &FontQuery<'_>) -> Result<ResolvedFont, FontError> {
         let mut families: Vec<Family> = query.families.iter().map(|f| css_family(f)).collect();
-        // Bundled last-resort fallback so resolution always succeeds even with no system fonts
-        // (e.g. headless/CI) - Roboto is registered in `new()`.
+        // Roboto (registered in `new()`) as last resort so resolution succeeds with no system fonts.
         families.push(Family::Name("Roboto"));
         let weight = Weight(query.weight.0);
         let fq = fontdb::Query {
@@ -161,6 +144,15 @@ impl FontSystem for CosmicFontSystem {
             stretch: query.stretch,
             blob,
         })
+    }
+
+    /// Force every face in the database into cosmic-text's font cache.
+    fn prepare_for_confinement(&mut self) -> Confinement {
+        let faces: Vec<(fontdb::ID, Weight)> = self.inner.db().faces().map(|f| (f.id, f.weight)).collect();
+        for (id, weight) in faces {
+            let _ = self.inner.get_font(id, weight);
+        }
+        Confinement::Full
     }
 
     fn families(&mut self) -> Vec<String> {
@@ -266,7 +258,7 @@ impl FontSystem for CosmicFontSystem {
     }
 }
 
-// ── conversions: our neutral font-query types → cosmic-text/fontdb types ──
+// Conversions to cosmic-text/fontdb types
 
 fn css_family(name: &str) -> Family<'_> {
     match name.cow_to_lowercase().as_ref() {

--- a/crates/gosub_fontmanager/src/pango_system.rs
+++ b/crates/gosub_fontmanager/src/pango_system.rs
@@ -1,13 +1,10 @@
 //! `PangoFontSystem` - fontconfig lookup + Pango/HarfBuzz shaping (the Linux desktop stack).
-//!
-//! Lives here (rather than in the Cairo renderer crate) because a font system is
-//! renderer-independent: it resolves, shapes, and measures; any glyph-painting backend can
-//! consume its output.
 
 use cow_utils::CowUtils;
 use gosub_interface::font::{FontBlob, FontError, FontStyle};
 use gosub_interface::font_system::{
-    FontQuery, FontSystem, ResolvedFont, RunMetrics, ShapedGlyph, ShapedRun, ShapedText, TextAlign, TextStyle,
+    Confinement, FontQuery, FontSystem, ResolvedFont, RunMetrics, ShapedGlyph, ShapedRun, ShapedText, TextAlign,
+    TextStyle,
 };
 use gtk4::pango;
 use gtk4::pango::Weight;
@@ -19,24 +16,16 @@ use std::sync::{Arc, OnceLock};
 
 const DEFAULT_FONT_FAMILY: &str = "sans";
 
-/// Serialises every direct fontconfig call in this module. Mutating the process-global config
-/// (`FcConfigAppFontAddFile`/`FcConfigBuildFonts`) while another thread matches against it
-/// (`FcFontMatch`) segfaults - fontconfig's documented thread safety does not cover concurrent
-/// mutation of the current config.
+/// Serialises direct fontconfig calls: mutating the process-global config while another
+/// thread runs `FcFontMatch` against it segfaults (fontconfig's documented thread safety
+/// excludes concurrent mutation of the current config).
 static FONTCONFIG_LOCK: Mutex<()> = Mutex::new(());
 
 /// Register an in-memory `@font-face` font so Pango (via fontconfig) can discover it.
 ///
-/// The bytes are written to a uniquely-named file in the temp dir - intentionally left on
-/// disk for the process lifetime, since fontconfig references it by path - and added to the
-/// process-global fontconfig config with `FcConfigAppFontAddFile`. fontconfig reads the
-/// font's own family name from its `name` table (so the family CSS asked for, e.g.
-/// "Source Serif 4", is what becomes available); `family_override` is informational.
-///
-/// Because the font is added to the *process-global* config (not a per-thread Pango font
-/// map), any Pango `FcFontMap` built afterwards on any thread sees it - provided it is
-/// registered before that font map is first built (the engine registers web fonts right
-/// after the document is set, before the first layout).
+/// The temp file is intentionally left on disk for the process lifetime: fontconfig
+/// references it by path. The family name comes from the font's own `name` table;
+/// `family_override` is informational. Must run before Pango's font map is first built.
 fn register_font_via_fontconfig(data: &[u8], family_override: Option<&str>) -> Result<(), FontError> {
     use fontconfig_sys::{FcConfigAppFontAddFile, FcConfigBuildFonts, FcConfigGetCurrent};
     use std::io::Write as _;
@@ -137,10 +126,9 @@ fn to_fc_width(ratio: f32) -> c_int {
     (ratio * 100.0).round() as c_int
 }
 
-/// Match `families` (already mapped to fontconfig names, in priority order) against the
-/// process-global fontconfig config - the same database Pango itself resolves from - and return
-/// the winning face. fontconfig always matches *something* after `FcDefaultSubstitute`, so this
-/// only errors when fontconfig is unavailable or the matched pattern lacks a file path.
+/// Match `families` against the process-global fontconfig config (the database Pango itself
+/// resolves from). `FcDefaultSubstitute` always matches something, so this only errors when
+/// fontconfig is unavailable or the matched pattern lacks a file path.
 fn fontconfig_match(
     families: &[&str],
     weight: c_int,
@@ -232,25 +220,13 @@ fn pango_generic_family(name: &str) -> Option<&'static str> {
     }
 }
 
-// PangoFontSystem
-
-/// Font-system state for the Cairo/Pango backend.
-///
-/// Holds the cached `system-ui` family name, which must be resolved from the
-/// GTK main thread before any background rendering.  After [`init_from_gtk_thread`]
-/// is called the struct is read-only and can be shared freely behind an [`Arc`].
-///
-/// Obtain a shared instance via [`get`] (which returns the process-wide singleton
-/// initialised by [`init`]) or construct an independent instance with [`new`] and
-/// call [`PangoFontSystem::init_from_gtk_thread`] yourself.
 /// Font file bytes keyed by `(path, ttc index)`.
 type BlobCache = HashMap<(String, u32), Arc<Vec<u8>>>;
 
 pub struct PangoFontSystem {
     system_ui_font: Option<String>,
-    /// Cached font file bytes. Shaping resolves a font per glyph run, and re-reading e.g.
-    /// DejaVu Sans from disk for every text run would hurt; interior mutability keeps the
-    /// read-only-after-init sharing contract of the struct intact.
+    /// Shaping resolves a font per glyph run; cache the file bytes so each run doesn't
+    /// re-read from disk. Interior mutability keeps the struct shareable after init.
     blob_cache: Mutex<BlobCache>,
 }
 
@@ -272,8 +248,8 @@ impl PangoFontSystem {
 
     /// Resolve and cache the system-ui font via GSettings.
     ///
-    /// **Must** be called from the GTK main thread before any background rendering
-    /// begins.  Calling it a second time is a no-op.
+    /// Must be called from the GTK main thread before any background rendering begins.
+    /// Calling it a second time is a no-op.
     pub fn init_from_gtk_thread(&mut self) {
         if self.system_ui_font.is_none() {
             self.system_ui_font = get_system_ui_font_from_gsettings();
@@ -299,11 +275,8 @@ impl PangoFontSystem {
                 continue;
             }
 
-            // Generic CSS families resolve through Pango/fontconfig aliases ("serif",
-            // "sans", "monospace") and never appear in `list_families()`, so map them
-            // explicitly. Without this the generic at the end of a list (e.g. the `serif`
-            // in `"Source Serif 4", Georgia, serif`) is skipped and the heading wrongly
-            // falls back to the default sans family.
+            // CSS generics resolve through fontconfig aliases and never appear in
+            // `list_families()`; without this a trailing `serif` would fall back to sans.
             if let Some(generic) = pango_generic_family(&font_name) {
                 return generic.to_string();
             }
@@ -360,9 +333,8 @@ impl PangoFontSystem {
         Ok(FontBlob::new(data, index))
     }
 
-    /// Build a laid-out Pango layout for `text` in `style` on a throwaway 1×1 surface (no pixels
-    /// are drawn). The shared front half of `measure` and `shape`, and the same font-description
-    /// path as the rasterizer - so measuring, shaping, and painting all see identical fonts and
+    /// Lay out `text` on a throwaway 1×1 surface. Shared by `measure` and `shape`, and the
+    /// same font-description path as the rasterizer, so all three see identical fonts and
     /// line breaking.
     fn build_layout(&self, text: &str, style: &TextStyle) -> Option<pango::Layout> {
         use pangocairo::functions::{context_set_resolution, create_layout};
@@ -394,11 +366,8 @@ impl PangoFontSystem {
         }
         match style.max_width {
             Some(w) => {
-                // Pango width is in Pango units (CSS px × display_scale × SCALE). Compute in
-                // f64 and guard against i32 overflow: a very large / unbounded max_width is
-                // treated as "no wrap limit" (-1), which is what an effectively-infinite
-                // width means anyway. Without this, large widths panic in debug (overflow)
-                // and silently wrap in release.
+                // Pango units = CSS px × display_scale × SCALE. An effectively-infinite
+                // max_width overflows i32 (panics in debug), so treat it as no wrap limit (-1).
                 let units = w as f64 * style.display_scale as f64 * pango::SCALE as f64;
                 layout.set_width(if units >= i32::MAX as f64 { -1 } else { units as i32 });
             }
@@ -415,12 +384,9 @@ impl PangoFontSystem {
         Some((w as f32, h as f32))
     }
 
-    /// Walk a laid-out Pango layout and export its glyph runs in the neutral [`ShapedText`] form.
-    ///
-    /// Glyph IDs are FreeType glyph indices into the run's font file; positions are pixels with
-    /// `y` on the baseline, per the [`ShapedGlyph`] contract. Each run's font is the one Pango
-    /// actually chose (mid-string fallback included), routed back through fontconfig to obtain
-    /// its bytes - same database, so the description round-trip lands on the same file.
+    /// Export a laid-out Pango layout's glyph runs as [`ShapedText`]. Glyph ids are FreeType
+    /// indices into the run's font file; each run's font is the one Pango actually chose
+    /// (fallback included), resolved back through fontconfig to obtain its bytes.
     fn runs_from_layout(&mut self, layout: &pango::Layout, style: &TextStyle) -> ShapedText {
         let scale = pango::SCALE as f32;
         let (px_w, px_h) = layout.pixel_size();
@@ -502,15 +468,21 @@ impl PangoFontSystem {
 
 /// Pango as a swappable [`FontSystem`].
 ///
-/// Pango bundles the three jobs the trait names: fontconfig does the lookup (`resolve` queries it
-/// directly - the same database Pango picks fonts from), Pango/HarfBuzz do the shaping (`shape`
-/// exports the `PangoLayout` glyph runs in neutral form), and `measure` reads the same layout's
-/// pixel size. The Cairo rasterizer still draws through Pango natively; the glyph runs exist so
-/// any [`ShapedText`]-painting backend can consume this font system too.
-///
-/// Note: Pango uses its own natural line height (matching how the Cairo rasterizer draws), so
+/// Pango uses its own natural line height (matching how the Cairo rasterizer draws), so
 /// `TextStyle::line_height` is intentionally not applied during measurement or shaping.
 impl FontSystem for PangoFontSystem {
+    /// Statically [`Confinement::FontPathsReadable`]. The static form matters: this stack
+    /// cannot be constructed in the fork server (GLib spawns a worker thread; a
+    /// PID-namespace-unshared process cannot create threads, so GLib aborts).
+    fn confinement() -> Confinement {
+        Confinement::FontPathsReadable
+    }
+
+    /// Pango needs the font paths readable, and no preparation helps or hurts.
+    fn prepare_for_confinement(&mut self) -> Confinement {
+        Confinement::FontPathsReadable
+    }
+
     fn register_font(&mut self, data: Vec<u8>, family_override: Option<&str>) -> Result<(), FontError> {
         register_font_via_fontconfig(&data, family_override)
     }
@@ -534,9 +506,8 @@ impl FontSystem for PangoFontSystem {
     }
 
     fn families(&mut self) -> Vec<String> {
-        // A throwaway pangocairo context (same construction as `build_layout`) reads the
-        // default font map - the fontconfig database, including web fonts registered before
-        // the font map was first built.
+        // A throwaway pangocairo context reads the default font map, including web fonts
+        // registered before the font map was first built.
         use pangocairo::functions::create_layout;
         let Ok(surface) = cairo::ImageSurface::create(cairo::Format::ARgb32, 1, 1) else {
             return Vec::new();
@@ -577,17 +548,11 @@ impl FontSystem for PangoFontSystem {
 
 // Process-wide singleton (required because GTK init must happen on main thread)
 
-/// Process-wide `PangoFontSystem` singleton.
-///
-/// Set by [`init`]; read by [`get`].  The `OnceLock` is intentional - GTK's
-/// font resolution is tied to the main thread and the result is immutable once
-/// resolved, so a static `Arc` is the correct primitive here.
+/// Process-wide singleton: GTK font resolution is tied to the main thread and immutable
+/// once resolved.
 static PANGO_FONT_SYSTEM: OnceLock<Arc<PangoFontSystem>> = OnceLock::new();
 
-/// Initialise the singleton from the GTK main thread.
-///
-/// Called once at startup (e.g. from `crate::init_gtk_resources()`).
-/// Subsequent calls are silently ignored.
+/// Initialise the singleton from the GTK main thread. Subsequent calls are ignored.
 pub fn init() {
     PANGO_FONT_SYSTEM.get_or_init(|| {
         let mut fs = PangoFontSystem::new();
@@ -601,8 +566,6 @@ pub fn init() {
 pub fn get() -> Arc<PangoFontSystem> {
     Arc::clone(PANGO_FONT_SYSTEM.get_or_init(|| Arc::new(PangoFontSystem::new())))
 }
-
-// Weight mapping
 
 pub fn to_pango_weight(weight: usize) -> Weight {
     match weight {
@@ -627,8 +590,6 @@ pub fn to_pango_weight(weight: usize) -> Weight {
 pub fn init_system_ui_font() {
     init();
 }
-
-// Internal helpers
 
 fn get_system_ui_font_from_gsettings() -> Option<String> {
     use gtk4::gio::{Settings, SettingsSchemaSource};
@@ -656,10 +617,7 @@ fn get_system_ui_font_from_gsettings() -> Option<String> {
 mod tests {
     use super::*;
 
-    /// Exercises the full registration path end-to-end: temp-file write plus the fontconfig
-    /// FFI (`FcConfigGetCurrent` / `FcConfigAppFontAddFile` / `FcConfigBuildFonts`). Uses the
-    /// always-available bundled Roboto bytes. A misdeclared FFI signature would crash here;
-    /// a clean `Ok(())` confirms the unsafe boundary is sound at runtime.
+    /// Exercises the fontconfig FFI end-to-end; a misdeclared signature would crash here.
     #[test]
     fn registers_font_via_fontconfig() {
         let res = register_font_via_fontconfig(gosub_shared::ROBOTO_FONT, Some("Gosub Roboto Test"));
@@ -676,9 +634,6 @@ mod tests {
         assert!(families.windows(2).all(|w| w[0] < w[1]), "must be sorted and deduped");
     }
 
-    /// End-to-end resolve + shape through fontconfig and Pango: the resolved font must carry its
-    /// file bytes, shaping must produce glyph runs, and the shape bounding box must agree with
-    /// `measure` (both read the same `PangoLayout`).
     #[test]
     fn resolves_and_shapes_via_fontconfig() {
         let mut fs = PangoFontSystem::new();

--- a/crates/gosub_fontmanager/src/parley_system.rs
+++ b/crates/gosub_fontmanager/src/parley_system.rs
@@ -1,25 +1,28 @@
 use cow_utils::CowUtils;
 use gosub_interface::font::{FontBlob, FontError, FontStyle};
 use gosub_interface::font_system::{
-    FontQuery, FontStretch, FontSystem, FontWeight, ResolvedFont, RunMetrics, ShapedGlyph, ShapedRun, ShapedText,
-    TextAlign, TextStyle,
+    Confinement, FontQuery, FontStretch, FontSystem, FontWeight, ResolvedFont, RunMetrics, ShapedGlyph, ShapedRun,
+    ShapedText, TextAlign, TextStyle,
 };
-use parley::fontique::{Attributes, FontWidth, GenericFamily, QueryFamily, QueryStatus, SourceCache};
+use parley::fontique::{Attributes, Blob, FontWidth, GenericFamily, QueryFamily, QueryStatus, SourceCache};
 use parley::style::{FontStyle as ParleyStyle, FontWeight as ParleyWeight};
 use parley::{Alignment, AlignmentOptions, FontContext, LayoutContext, PositionedLayoutItem};
 
-/// A [`FontSystem`] implementation backed by Parley + Fontique.
+/// A [`FontSystem`] backed by Parley + Fontique.
 ///
-/// Holds a single `FontContext` (fontique collection) and `LayoutContext` so that
-/// all callers - the layout engine and every renderer - share the same font data and
-/// produce consistent glyph metrics.
-///
-/// Construct once at application start, wrap in `Arc<Mutex<ParleyFontSystem>>`, and
-/// pass the same `Arc` into both the Taffy layouter and the rendering backend.
+/// One shared `FontContext`/`LayoutContext` so layout and rendering produce consistent
+/// glyph metrics. Wrap in `Arc<Mutex<..>>` and hand the same `Arc` to layouter and backend.
 pub struct ParleyFontSystem {
     font_cx: FontContext,
     layout_cx: LayoutContext<()>,
+    /// Shares one backing store with `font_cx.source_cache`: Parley prunes that
+    /// one every layout (entries idle for 128 layouts are dropped), and a miss
+    /// there falls through to the shared store's weak handle rather than to disk
+    /// - as long as something still holds the blob strongly (`pinned`).
     source_cache: SourceCache,
+    /// Strong handles to every face [`FontSystem::prepare_for_confinement`]
+    /// loaded, so pruning can never turn a warmed face back into a file read.
+    pinned: Vec<Blob<u8>>,
 }
 
 impl std::fmt::Debug for ParleyFontSystem {
@@ -40,25 +43,26 @@ impl ParleyFontSystem {
     pub fn new() -> Self {
         let mut font_cx = FontContext::new();
 
-        // Register Roboto as a bundled fallback so there is always something to
-        // render with even on systems that have no fonts installed.
+        // Bundled Roboto fallback so rendering works with no system fonts installed.
         font_cx
             .collection
             .register_fonts(gosub_shared::ROBOTO_FONT.to_vec().into(), None);
 
+        // Clones of a shared cache share its backing store; see the field docs.
+        let source_cache = SourceCache::new_shared();
+        font_cx.source_cache = source_cache.clone();
+
         Self {
             font_cx,
             layout_cx: LayoutContext::new(),
-            source_cache: SourceCache::new_shared(),
+            source_cache,
+            pinned: Vec::new(),
         }
     }
 }
 
 impl ParleyFontSystem {
-    /// Grants direct access to the underlying Parley font collection.
-    ///
-    /// Used by `TaffyLayouter` so that the same font collection is shared between
-    /// the layout engine and rendering, ensuring consistent shaping.
+    /// Used by `TaffyLayouter` so layout and rendering share one font collection.
     pub fn font_cx_mut(&mut self) -> &mut FontContext {
         &mut self.font_cx
     }
@@ -120,6 +124,22 @@ impl FontSystem for ParleyFontSystem {
         out
     }
 
+    /// Load every face of every family into the shared source store and pin it.
+    fn prepare_for_confinement(&mut self) -> Confinement {
+        let names: Vec<String> = self.font_cx.collection.family_names().map(str::to_string).collect();
+        for name in names {
+            let Some(family) = self.font_cx.collection.family_by_name(&name) else {
+                continue;
+            };
+            for font in family.fonts() {
+                if let Some(blob) = font.load(Some(&mut self.source_cache)) {
+                    self.pinned.push(blob);
+                }
+            }
+        }
+        Confinement::Full
+    }
+
     /// Shape `text` into positioned glyph runs, resolving `style.family` first so shaping starts
     /// from the same concrete font that [`FontSystem::measure`] used.
     fn shape(&mut self, text: &str, style: &TextStyle) -> ShapedText {
@@ -140,9 +160,6 @@ impl FontSystem for ParleyFontSystem {
     }
 
     /// Measure the bounding box of `text` laid out in `style`, in CSS pixels.
-    ///
-    /// Resolves the family (mapping generics, appending a `sans-serif` fallback) then lays it out
-    /// with Parley and reads the line extents.
     fn measure(&mut self, text: &str, style: &TextStyle) -> (f32, f32) {
         if text.is_empty() {
             return (0.0, 0.0);
@@ -196,9 +213,8 @@ impl FontSystem for ParleyFontSystem {
 }
 
 impl ParleyFontSystem {
-    /// Shape `text` with an already-resolved font. Layout parameters (size, line height, wrap
-    /// width, letter spacing, display scale) come from `style`; the font identity comes from
-    /// `font` - which is why measurement and drawing agree when both go through this path.
+    /// Shape `text` with an already-resolved font, so measurement and drawing agree on the
+    /// concrete font.
     fn shape_resolved(&mut self, text: &str, font: &ResolvedFont, style: &TextStyle) -> ShapedText {
         if text.is_empty() {
             return ShapedText::empty();
@@ -218,8 +234,7 @@ impl ParleyFontSystem {
         if let Some(lh) = style.line_height {
             builder.push_default(parley::StyleProperty::LineHeight(parley::LineHeight::Absolute(lh)));
         }
-        // Applied during measurement too - shaping without it would draw narrower than the
-        // layout box that measurement reserved.
+        // Must match measurement, or drawing comes out narrower than the reserved layout box.
         if style.letter_spacing != 0.0 {
             builder.push_default(parley::StyleProperty::LetterSpacing(style.letter_spacing));
         }
@@ -263,10 +278,8 @@ impl ParleyFontSystem {
                         .collect();
 
                     if !glyphs.is_empty() {
-                        // Use the run's *actual* font: parley may substitute a fallback for
-                        // glyphs the requested family lacks (emoji, CJK, …), and the glyph ids
-                        // index into that fallback font - so drawing must use it, not the
-                        // originally requested `font`.
+                        // Parley may substitute a fallback font (emoji, CJK); the glyph ids
+                        // index into that font, so draw with the run's actual font.
                         let prun = run.run();
                         let run_font = prun.font();
                         let (data_arc, _) = run_font.data.clone().into_raw_parts();
@@ -311,14 +324,8 @@ impl ParleyFontSystem {
     }
 }
 
-/// Split a CSS `font-family` value (e.g. `Verdana, Geneva, sans-serif`) into individual family
-/// names, trimming whitespace and matching quotes. A trailing `sans-serif` generic is appended as
-/// an ultimate fallback if the list doesn't already end in a generic, so resolution always has a
-/// last resort.
-///
-/// Passing the whole comma-joined string as a single family name (the old behaviour) never matches
-/// an installed family like `Verdana`, so resolution silently fell through to the `sans-serif`
-/// generic - picking a different (often thinner) font than the page author intended.
+/// Split a CSS `font-family` value into trimmed, unquoted family names, appending a
+/// `sans-serif` generic as last resort if none is present.
 pub fn split_css_families(families: &str) -> Vec<&str> {
     let mut out: Vec<&str> = families
         .split(',')

--- a/crates/gosub_fontmanager/src/skia_system.rs
+++ b/crates/gosub_fontmanager/src/skia_system.rs
@@ -1,13 +1,9 @@
 //! `SkiaFontSystem` - measurement and shaping through Skia's `textlayout` engine.
-//!
-//! Lives here (rather than in the Skia renderer crate) because a font system is
-//! renderer-independent: it resolves, shapes, and measures; any glyph-painting backend can
-//! consume its output.
 
 use gosub_interface::font::{FontBlob, FontError, FontStyle as CssFontStyle};
 use gosub_interface::font_system::{
-    FontQuery, FontSystem, ResolvedFont, RunMetrics, ShapedGlyph, ShapedRun, ShapedText, TextAlign as GosubTextAlign,
-    TextStyle as GosubTextStyle,
+    Confinement, FontQuery, FontSystem, ResolvedFont, RunMetrics, ShapedGlyph, ShapedRun, ShapedText,
+    TextAlign as GosubTextAlign, TextStyle as GosubTextStyle,
 };
 use parking_lot::Mutex;
 use skia_safe::textlayout::{
@@ -18,13 +14,9 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 
-// ── Registered web fonts ──────────────────────────────────────────────────────
-//
-// `@font-face` fonts are registered as raw bytes in a process-global registry (bytes are
-// `Send + Sync`; Skia's `Typeface`/`FontMgr` are not). Each thread lazily materialises the
-// bytes into a `TypefaceFontProvider` when the registry's generation changes, so both the
-// measure path (this module's `FontCollection`) and the draw path (`rasterizer::text`) see
-// newly-registered fonts without sharing non-`Send` Skia objects across threads.
+// `@font-face` fonts live as raw bytes in a process-global registry (bytes are
+// `Send + Sync`; Skia's `Typeface`/`FontMgr` are not). Each thread rebuilds its
+// `TypefaceFontProvider` when the registry generation changes.
 
 struct FontRegistry {
     generation: u64,
@@ -46,15 +38,11 @@ pub(crate) fn web_font_generation() -> u64 {
     registry().lock().generation
 }
 
-/// Build a `FontMgr` (backed by a `TypefaceFontProvider`) containing every registered web
-/// font, or `None` if none are registered or none could be decoded.
+/// Build a `FontMgr` containing every registered web font, or `None` if none decode.
 ///
-/// A variable font is registered as one instance per standard CSS weight stop (100–900)
-/// within its `wght` axis range, not just its default instance. Google Fonts serves a single
-/// variable file for a multi-weight `@font-face` set (e.g. `wght@600;700` → one file whose
-/// default instance is 400); registering only the default made every bold-ish weight request
-/// fall back to faux-bold of the 400 instance. With per-weight instances,
-/// `FontCollection::matchStyle` selects the genuinely-instanced weight.
+/// Variable fonts are registered as one instance per CSS weight stop (100–900): Google
+/// Fonts serves one variable file whose default instance is 400, and registering only
+/// that made bold weights fall back to faux-bold.
 fn build_web_font_mgr() -> Option<FontMgr> {
     let reg = registry().lock();
     if reg.fonts.is_empty() {
@@ -155,10 +143,7 @@ pub(crate) fn with_font_collection<R>(f: impl FnOnce(&FontCollection) -> R) -> R
     })
 }
 
-/// Split a CSS `font-family` value (`"Source Serif 4", Georgia, serif`) into its individual
-/// family names, trimmed and unquoted, in priority order. The font system tries each in turn
-/// so the CSS fallback chain (including the generic `serif`/`sans-serif`/`monospace`) is
-/// honoured instead of only the first name being attempted.
+/// Split a CSS `font-family` value into trimmed, unquoted family names in priority order.
 pub(crate) fn split_font_families(families: &str) -> Vec<String> {
     families
         .split(',')
@@ -174,9 +159,8 @@ fn is_real_generic(name: &str) -> bool {
         .any(|generic| name.eq_ignore_ascii_case(generic))
 }
 
-/// Newer CSS generic keywords that fontconfig usually does *not* map. We drop them so resolution
-/// falls through to the real generic (`monospace`, `sans-serif`, …) that CSS font stacks
-/// conventionally end with, instead of letting the platform default masquerade as this family.
+/// Newer CSS generic keywords fontconfig usually does not map; dropped so resolution falls
+/// through to the real generic the stack ends with.
 fn is_pseudo_generic(name: &str) -> bool {
     [
         "system-ui",
@@ -201,18 +185,12 @@ thread_local! {
 
 /// Prune a CSS `font-family` list to the entries Skia should actually try, in order.
 ///
-/// Skia's `FontCollection` walks the list and, on Linux, fontconfig returns *some* face for *every*
-/// name - even an unknown one like `ui-monospace` - so an unavailable leading family silently
-/// captures the platform default and the real generic (`monospace`) at the end of the chain is never
-/// reached.
-///
-/// We keep an entry when it's a real generic, or when it resolves to a *genuine* face: either an
-/// exact name match, or a fontconfig **alias** to a family other than the bare default fallback
-/// (e.g. `Arial` → Liberation Sans, which is what Firefox uses). We drop the newer pseudo-generics
-/// (`ui-*`, `system-ui`) and any name that only yields the default fallback, so the stack's trailing
-/// real generic decides instead of the platform default impersonating an unavailable family. If
-/// nothing survives, fall back to the original list so text still draws. Applied to both measure and
-/// draw so they stay on the same faces.
+/// On Linux fontconfig returns some face for every name, so an unavailable leading family
+/// silently captures the platform default and the trailing real generic is never reached.
+/// Keep real generics and names resolving to a genuine face or alias (e.g. `Arial` →
+/// Liberation Sans); drop pseudo-generics and names that only yield the default fallback.
+/// If nothing survives, keep the original list so text still draws. Applied to both
+/// measure and draw so they stay on the same faces.
 pub(crate) fn resolve_family_list(families: &str) -> Vec<String> {
     RESOLVED_FAMILIES.with(|cell| {
         let mut cell = cell.borrow_mut();
@@ -229,9 +207,8 @@ pub(crate) fn resolve_family_list(families: &str) -> Vec<String> {
         let web = web_font_mgr();
         let normal = FontStyle::normal();
 
-        // The face fontconfig hands back for a name it doesn't actually have. A name that resolves
-        // to anything *else* is a real family or a real alias; a name that only yields this is an
-        // unavailable family we should drop.
+        // The face fontconfig hands back for a name it doesn't actually have; a name that
+        // only yields this is an unavailable family to drop.
         let default_fallback = fm
             .match_family_style("__gosub_nonexistent_family__", normal)
             .map(|tf| tf.family_name());
@@ -257,12 +234,10 @@ pub(crate) fn resolve_family_list(families: &str) -> Vec<String> {
                 continue;
             }
             if is_real_generic(&name) {
-                // Replace the generic with the concrete family fontconfig picks for it
-                // (what `fc-match` and Firefox use). Skia's textlayout resolves families via
-                // `matchFamily()`, whose fontconfig style-set is ordered differently from
-                // `matchFamilyStyle()` - it hands back e.g. FreeMono for `monospace` and
-                // FreeSerif for `serif` instead of DejaVu Sans Mono / Noto Serif. Concrete
-                // names round-trip through textlayout unchanged, so resolve the generic here.
+                // Replace the generic with the concrete family fontconfig picks: textlayout's
+                // `matchFamily()` orders fontconfig style-sets differently from
+                // `matchFamilyStyle()` (FreeMono for `monospace` instead of DejaVu Sans Mono);
+                // concrete names round-trip unchanged.
                 match fm.match_family_style(&name, normal) {
                     Some(tf) => out.push(tf.family_name()),
                     None => out.push(name),
@@ -315,11 +290,8 @@ fn to_skia_slant(style: CssFontStyle) -> skia_safe::font_style::Slant {
     }
 }
 
-/// Build and lay out the measurement/shaping paragraph for `text` in `style`.
-///
-/// This is the single source of truth for how a [`GosubTextStyle`] maps onto Skia's textlayout -
-/// `measure` reads this paragraph's extents and `shape` exports its glyph runs, so the two can't
-/// disagree.
+/// Build and lay out the paragraph for `text` in `style`. `measure` reads its extents and
+/// `shape` exports its glyph runs, so the two can't disagree.
 fn build_style_paragraph(fc: &FontCollection, text: &str, style: &GosubTextStyle) -> Paragraph {
     let mut paragraph_style = ParagraphStyle::new();
     paragraph_style.set_text_align(match style.align {
@@ -332,10 +304,8 @@ fn build_style_paragraph(fc: &FontCollection, text: &str, style: &GosubTextStyle
 
     let mut ts = TextStyle::new();
     ts.set_font_size(style.size);
-    // Apply the CSS line-height (absolute px → multiple of font size) exactly as the draw
-    // path (`build_paragraph`) does, so the measured box height matches what is painted.
-    // Skipping this measured the font's natural ~1.2× box while draw rendered the CSS 1.7×,
-    // overflowing the reserved box into the next element.
+    // CSS line-height (absolute px → multiple of font size), same as the draw path, so the
+    // measured box height matches what is painted.
     if let Some(line_height) = style.line_height {
         if line_height > 0.0 && style.size > 0.0 {
             ts.set_height(line_height / style.size);
@@ -364,16 +334,21 @@ fn build_style_paragraph(fc: &FontCollection, text: &str, style: &GosubTextStyle
 }
 
 /// A [`FontSystem`] backed by Skia's `skia_safe` text layout.
-///
-/// Measurement, shaping, and the Skia rasterizer's own drawing all go through the same
-/// thread-local [`FontCollection`], so they can't disagree. `resolve`/`shape` export concrete
-/// fonts (via `Typeface::to_font_data`) and positioned glyph runs in the neutral trait types, so
-/// a [`ShapedText`]-painting backend can consume this font system like any other; the Skia
-/// rasterizer itself still draws through textlayout natively.
 #[derive(Debug, Default)]
 pub struct SkiaFontSystem;
 
 impl FontSystem for SkiaFontSystem {
+    /// Statically [`Confinement::FontPathsReadable`], so the fork server knows
+    /// not to construct (or warm) this stack at all.
+    fn confinement() -> Confinement {
+        Confinement::FontPathsReadable
+    }
+
+    /// Skia needs the font paths readable, and no preparation helps or hurts.
+    fn prepare_for_confinement(&mut self) -> Confinement {
+        Confinement::FontPathsReadable
+    }
+
     fn register_font(&mut self, data: Vec<u8>, family_override: Option<&str>) -> Result<(), FontError> {
         // Validate the bytes and derive the family name if none was supplied.
         let family = match family_override {
@@ -524,9 +499,7 @@ impl FontSystem for SkiaFontSystem {
 }
 
 /// Map a CSS `font-stretch` percentage (normal = 100) onto Skia's 1–9 width classes
-/// (normal = 5), using the CSS-defined keyword percentages as bucket centres. The previous
-/// `width / 100` mapping sent the default 100% to width class 1 (ultra-condensed), which
-/// disagreed with the measure path's `Width::NORMAL` and could select a condensed face.
+/// (normal = 5). A naive `pct / 100` sends the default 100% to class 1 (ultra-condensed).
 fn width_from_css_percent(pct: i32) -> skia_safe::font_style::Width {
     let class = match pct {
         ..=56 => 1,     // ultra-condensed (50%)
@@ -562,9 +535,6 @@ mod tests {
         assert!(families.windows(2).all(|w| w[0] < w[1]), "must be sorted and deduped");
     }
 
-    /// End-to-end resolve + shape through Skia: the resolved font must carry its file bytes,
-    /// shaping must produce glyph runs, and the shape bounding box must agree with `measure`
-    /// (both read the same textlayout paragraph).
     #[test]
     fn resolves_and_shapes_via_skia() {
         let mut fs = SkiaFontSystem;

--- a/crates/gosub_interface/src/font_system.rs
+++ b/crates/gosub_interface/src/font_system.rs
@@ -99,10 +99,9 @@ pub struct ShapedGlyph {
 
 /// Decoration metrics for a shaped run, in pixels.
 ///
-/// Offsets are measured from the run's baseline to the **top** of the stroke, positive
-/// **downward** (so `underline_offset` is typically positive, `strikethrough_offset` typically
-/// negative). A painter draws a decoration as a filled rect at
-/// `(run.x, run.baseline + offset, run.width, size)`.
+/// Offsets are from the run's baseline to the top of the stroke, positive downward
+/// (underline typically positive, strikethrough typically negative). Draw as a filled
+/// rect at `(run.x, run.baseline + offset, run.width, size)`.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct RunMetrics {
     pub underline_offset: f32,
@@ -173,10 +172,6 @@ pub enum TextAlign {
 }
 
 /// CSS-resolved text style passed to [`FontSystem::measure`].
-///
-/// Carries everything an engine needs to lay out a run of text: the family (the implementation
-/// appends its own generic/bundled fallback), size, the font selectors, an optional absolute line
-/// height, an optional wrap width, and the device-pixel scale.
 #[derive(Debug, Clone)]
 pub struct TextStyle {
     /// Primary CSS family name (implementations append a generic/bundled fallback).
@@ -219,19 +214,29 @@ impl TextStyle {
 
 // Core trait
 
-/// A swappable font system - the entire surface the engine and layouter need.
+/// Sandbox tier a renderer process may run under with this font system,
+/// as reported by [`FontSystem::prepare_for_confinement`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use = "the answer decides which sandbox tier the renderer gets; ignoring it defeats the preparation"]
+pub enum Confinement {
+    /// All filesystem data is in memory; a no-file-access sandbox works.
+    /// Fonts arriving later as bytes (`@font-face`) keep working.
+    Full,
+    /// Reads font files at match time (e.g. fontconfig cache revalidation), so the
+    /// sandbox must grant read-only platform font paths plus one private writable
+    /// scratch dir (some stacks can only ingest a web font as a file).
+    FontPathsReadable,
+    /// Cannot operate in an isolated renderer; the string says why. The engine
+    /// must fall back to single-process rendering.
+    Unsupported(String),
+}
+
+/// A swappable font system: registers fonts, resolves CSS font queries, shapes and measures text.
 ///
-/// It registers fonts, **resolves** CSS font queries to concrete fonts (with their raw bytes),
-/// **shapes** text into positioned glyph runs, and **measures** it. All of it goes through
-/// whichever font system the engine was configured with, so layout boxes are sized by the very
-/// engine whose glyphs will be drawn (Parley, Pango, Skia, cosmic-text, …) - measurement,
-/// shaping, and drawing can't disagree.
+/// Layout and rendering must share one implementation so measurement, shaping, and drawing agree.
+/// Drawing is not on this trait: glyph IDs plus a [`crate::font::FontBlob`] are all a rasterizer
+/// needs, so any font system serves any backend.
 ///
-/// Drawing itself is *not* on this trait: painting the [`ShapedText`] returned by
-/// [`FontSystem::shape`] is the render backend's job - glyph IDs + a [`crate::font::FontBlob`]
-/// are everything a rasterizer needs, so any font system serves any backend.
-///
-/// # Threading
 /// `Send + Sync` so it can live behind `Arc<Mutex<dyn FontSystem>>`, shared between the layouter
 /// and the renderer.
 pub trait FontSystem: Send + Sync + 'static {
@@ -255,6 +260,27 @@ pub trait FontSystem: Send + Sync + 'static {
     /// [`FontSystem::resolve`], not families, so they don't appear here. Takes `&mut self`
     /// because some engines populate their font database lazily on first enumeration.
     fn families(&mut self) -> Vec<String>;
+
+    /// The confinement tier this font system supports; static, no instance needed.
+    fn confinement() -> Confinement
+    where
+        Self: Sized,
+    {
+        Confinement::Full
+    }
+
+    /// Front-load all filesystem work, then report the sandbox tier the renderer
+    /// may apply. Overstating the tier means content-dependent `SIGSYS` deaths
+    /// when a page later uses an unloaded typeface.
+    fn prepare_for_confinement(&mut self) -> Confinement {
+        for family in self.families() {
+            // Measuring forces lazy work resolve leaves until first use.
+            // Failures are skipped: one bad family shouldn't block the rest.
+            let _ = self.resolve(&FontQuery::new(&[family.as_str()]));
+            let _ = self.measure("Ag", &TextStyle::new(family, 16.0));
+        }
+        Confinement::Full
+    }
 
     /// Shape `text` laid out in `style` into positioned glyph runs.
     ///

--- a/docs/fonts.md
+++ b/docs/fonts.md
@@ -24,6 +24,13 @@ pub trait FontSystem: Send + Sync + 'static {
     /// Measure the bounding box of `text` laid out in `style`, in CSS pixels.
     /// Provided: shapes and reads the bounding box; implementations may override.
     fn measure(&mut self, text: &str, style: &TextStyle) -> (f32, f32) { … }
+    /// The confinement tier, knowable without an instance (see below).
+    /// Provided: answers `Confinement::Full`.
+    fn confinement() -> Confinement where Self: Sized { … }
+    /// Load everything that needs the filesystem now, then answer how confined
+    /// a renderer process using this font system may be (see below).
+    /// Provided: warms every family and answers `Confinement::Full`.
+    fn prepare_for_confinement(&mut self) -> Confinement { … }
 }
 ```
 
@@ -41,6 +48,25 @@ The trait file also defines the shared value types: `TextStyle` (family, size, w
 | `SkiaFontSystem`   | [`gosub_fontmanager/src/skia_system.rs`](../crates/gosub_fontmanager/src/skia_system.rs) (feature `skia`)     | Skia, `skia_safe`, paragraph layout        | Measures and shapes through a thread-local `FontCollection`; `resolve`/`shape` export font bytes via `Typeface::to_font_data`. |
 
 The heavyweight engines are feature-gated (`pango` pulls in the GTK/fontconfig stack, `skia` pulls in `skia-safe`). The Cairo and Skia renderer crates enable their feature and re-export the type for convenience (`gosub_renderer_cairo::PangoFontSystem`, `gosub_renderer_skia::SkiaFontSystem`).
+
+### Font systems under process isolation
+
+A future renderer process runs behind a default-deny seccomp sandbox that wants to forbid file access outright — but font stacks read font files, and *when* they read them differs per stack. Because the font system is a configuration choice, "can a renderer be sandboxed" is not a fact about the engine; it is a fact about each font system, and only the implementation knows what it defers to the filesystem. That is what `FontSystem::prepare_for_confinement()` expresses: the implementation loads whatever it can front-load, then answers with a `Confinement` value naming the strongest sandbox tier it supports. All of the below was measured on Linux via the `isolation-harness` font scenarios (`fonts-under-lockdown`, `webfont-under-lockdown`, and the `…-font-readable-…` variants, each taking the backend name as an argument).
+
+| Answer | Sandbox the renderer gets | Who |
+|---|---|---|
+| `Confinement::Full` | `lock_down_renderer()`: **no file access at all** | Parley, cosmic-text |
+| `Confinement::FontPathsReadable` | `lock_down_renderer_with_font_access()`: read-only font paths + one private writable scratch, nothing else | Pango, Skia |
+| `Confinement::Unsupported(reason)` | none — the engine must fall back to single-process rendering | no bundled system |
+
+Per implementation:
+
+- **Parley (fontique)** — defers file reads lazily **per face**: a family-level warm-up loads only the face the default attributes select (regular), and the first *bold* heading laid out under the sandbox died opening `…-Bold.ttf`. Its override loads every face of every family — into **both** of the system's source caches, which are separate (`resolve` reads its own; parley's shaping reads the one inside `FontContext`) — at ~110 ms and near-zero RSS, since fontique memory-maps the files. Fully confinable.
+- **cosmic-text** — defers lazily **per face** (through its `get_font` cache), and shaping consults fallback faces that a family-by-family warm-up never touches, so the trait default is *not* enough (measured as a `SIGSYS` on `openat` mid-shape). Its override loads every face in the fontdb instead: ~20 ms / +46 MiB, and fully confinable. Note that even a web font delivered as bytes only shapes safely because preparation ran — shaping it still consults fallback faces.
+- **Pango** — cannot be fully confined, and no warm-up changes that: fontconfig re-validates its caches against the filesystem (`access(2)`, then re-opening files) *while matching*, in steady state. It answers `FontPathsReadable` and does no preparation work at all — under that tier it shapes cold, with nothing pre-loaded. Two Pango-specific limitations to know about: web fonts must be **staged as temp files** (fontconfig's app-font API takes a path; there is no from-memory variant), which is why the tier includes a writable scratch directory with `TMPDIR` pointed at it; and the fontconfig config is **process-global**, so registered web fonts are visible engine-wide rather than per-instance.
+- **Skia** — same fontconfig story on Linux (its default `FontMgr` is fontconfig-backed), so the same `FontPathsReadable` answer. Its font machinery additionally wants `getcwd`, `fstatfs`/`statfs`, and `fadvise64`, all included in the tier's allowlist. Its `FontCollection` is **thread-local**, which under full confinement would be an independent problem (a worker thread rebuilds its collection from scratch, re-reading files); under the font-readable tier it is harmless, since the paths stay reachable.
+
+The font-readable tier is the WebKitGTK arrangement (their fontconfig-based renderers get font directories bind-mounted read-only) and lives in `gosub_sandbox`: the renderer seccomp baseline plus the file-reading syscalls, with a **Landlock** ruleset confining those syscalls to `font_filesystem_paths()` — the font directories, fontconfig configuration, and caches, read-only. What an exploited renderer gains under it, compared to full confinement, is the ability to read world-readable font data and enumerate installed fonts; network, exec, devices, and all other filesystem access stay denied. On kernels without Landlock the path scoping degrades (the syscalls stay allowed unscoped), which is one more reason the engine applies the strongest tier the configured font system answers rather than defaulting to the relaxed one.
 
 ### How a font system reaches layout and rendering
 


### PR DESCRIPTION

Base: `04-decoder-process`. The contract a renderer process needs from the
font system, measured per implementation.

### What is in here

- `FontSystem::confinement()` (static) and `prepare_for_confinement()`
  answering `Confinement::Full` / `FontPathsReadable` / `Unsupported(reason)`.
- Parley and cosmic-text front-load every face of every family so a renderer
  can be fully confined (no file access at all): Parley into both of its
  source caches (its per-layout prune had been undoing a naive warm-up),
  cosmic-text every face in the fontdb (shaping consults fallback faces a
  per-family warm-up never touches). Pango and Skia answer
  `FontPathsReadable`: fontconfig re-validates its caches against the
  filesystem while matching, so they get a read-only font-path tier plus a
  private writable scratch (Pango stages web fonts as files).
- Harness scenarios per backend (`fonts-under-lockdown`,
  `webfont-under-lockdown`, and the `-font-readable-` variants), including
  the "300 layouts then a never-used bold italic face" check that found the
  Parley prune. `docs/fonts.md` gains the tier table and the measurements.
- Engine features `pango-fonts` / `skia-fonts` compile the tier-2 backends
  into the harness.

### Testing

```
cargo test -p gosub_engine --test process_isolation      # 13
./target/debug/isolation-harness fonts-under-lockdown {parley,cosmic}
./target/debug/isolation-harness webfont-under-lockdown {parley,cosmic}
```