### PR TITLE
Fork server: forked and exec'd renderers render pages confined, tiles over shm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3171,6 +3171,8 @@ dependencies = [
  "gosub_interface",
  "gosub_ipc",
  "gosub_render_pipeline",
+ "gosub_renderer_cairo",
+ "gosub_renderer_skia",
  "gosub_sandbox",
  "gosub_shared",
  "http",

--- a/crates/gosub_engine/Cargo.toml
+++ b/crates/gosub_engine/Cargo.toml
@@ -16,6 +16,8 @@ gosub_html5 = { version = "0.1.1", path = "../gosub_html5" }
 gosub_css3 = { version = "0.1.2", path = "../gosub_css3" }
 gosub_interface = { version = "0.1.2", path = "../gosub_interface" }
 gosub_fontmanager = { version = "0.1.0", path = "../gosub_fontmanager", registry = "gosub" }
+gosub_renderer_cairo = { version = "0.1.0", path = "../gosub_renderer_cairo", registry = "gosub", default-features = false, optional = true }
+gosub_renderer_skia = { version = "0.1.0", path = "../gosub_renderer_skia", registry = "gosub", default-features = false, optional = true }
 gosub_render_pipeline = { version = "0.1.0", path = "../gosub_render_pipeline" }
 uuid = { workspace = true, features = ["v4", "serde"] }
 reqwest = { workspace = true, default-features = true, features = ["json", "gzip", "brotli", "deflate", "cookies", "rustls", "stream"] }
@@ -88,6 +90,12 @@ process-isolation = ["dep:gosub_ipc", "dep:gosub_sandbox"]
 # Diagnostic only; nothing in the engine itself selects these.
 pango-fonts = ["gosub_fontmanager/pango"]
 skia-fonts = ["gosub_fontmanager/skia"]
+# Stage-6 rasterization in forked renderers: the Cairo CPU rasterizer, minus
+# its GTK/Pango default features. Diagnostic in the harness; an embedder may
+# also supply its own rasterizer through `RenderConfiguration::forked_tile_rasterizer`.
+cairo-tiles = ["dep:gosub_renderer_cairo"]
+# Same, with Skia's CPU rasterizer (`cairo-tiles` wins when both are on).
+skia-tiles = ["dep:gosub_renderer_skia"]
 
 [lints]
 workspace = true

--- a/crates/gosub_engine/src/bin/isolation-harness.rs
+++ b/crates/gosub_engine/src/bin/isolation-harness.rs
@@ -11,7 +11,8 @@ const BODY: &str = "<html><head><title>through the net process</title></head>\
 style=\"display:block;width:400px;height:200px\">a link to hover</a></body></html>";
 
 /// The harness's render configuration: null backend and compositor (nothing
-/// composites here), the scenario-selected font system.
+/// composites here), the scenario-selected font system - and, behind the
+/// `cairo-tiles` feature, the Cairo CPU rasterizer for forked renderers.
 struct TileConfig<F>(std::marker::PhantomData<F>);
 
 impl<F> Clone for TileConfig<F> {
@@ -40,6 +41,22 @@ impl<F: FontSystem + Default> gosub_engine::html::RenderConfiguration for TileCo
     type RenderBackend = gosub_render_pipeline::render::backends::null::NullBackend;
     type CompositorSink = gosub_render_pipeline::render::DefaultCompositor;
     type FontSystem = F;
+
+    fn forked_tile_rasterizer(
+        font_system: std::sync::Arc<parking_lot::Mutex<dyn FontSystem>>,
+    ) -> Option<Box<dyn gosub_render_pipeline::rasterizer::Rasterable + Send + Sync>> {
+        #[cfg(feature = "cairo-tiles")]
+        {
+            Some(Box::new(gosub_renderer_cairo::CairoRasterizer::with_font_system(
+                font_system,
+            )))
+        }
+        #[cfg(not(feature = "cairo-tiles"))]
+        {
+            let _ = font_system;
+            None
+        }
+    }
 }
 
 /// Run a font scenario against the font system named by argv[2].
@@ -101,6 +118,12 @@ fn main() {
         "webfont-under-lockdown" => with_font_backend!(webfont_under_lockdown),
         "fonts-under-font-readable-lockdown" => with_font_backend!(fonts_under_font_readable_lockdown),
         "webfont-under-font-readable-lockdown" => with_font_backend!(webfont_under_font_readable_lockdown),
+        "fork-server" => with_font_backend!(fork_server_roundtrip),
+        "render-under-lockdown" => with_font_backend!(render_under_lockdown),
+        "engine-renderer-process" => with_font_backend!(engine_renderer_process),
+        "exec-renderer" => with_font_backend!(exec_renderer_roundtrip),
+        "render-file" => with_font_backend!(render_file),
+        "render-file-locked" => with_font_backend!(render_file_locked),
         "engine" => engine(),
         "guard" => guard(),
         other => {
@@ -465,6 +488,994 @@ fn webfont_under_font_readable_lockdown<F: FontSystem + Default>() -> i32 {
     }
     println!("registered and shaped {w:.1}x{h:.1} under the font-readable renderer lockdown");
     0
+}
+
+/// The render pipeline under the renderer lockdown, in *this* process - the
+/// same stages the forked renderer runs, minus the fork machinery, so a
+/// pipeline-vs-sandbox failure can be debugged (and bisected) directly.
+fn render_under_lockdown<F: FontSystem + Default>() -> i32 {
+    #[cfg(target_os = "linux")]
+    {
+        use gosub_engine::fork_server::renderer;
+
+        let mut fonts = F::default();
+        println!("font backend: {}", std::any::type_name::<F>());
+        let _ = fonts.families();
+        match fonts.prepare_for_confinement() {
+            Confinement::Full => {}
+            other => {
+                eprintln!("this scenario needs a fully-confinable font system, got {other:?}");
+                return 2;
+            }
+        }
+
+        // SVG text goes through a system fontdb that loads face files lazily;
+        // pin them before the lockdown, exactly as the fork server does.
+        gosub_render_pipeline::common::media::SvgDecoder::pin_system_fonts();
+        let media_store = std::sync::Arc::new(gosub_render_pipeline::common::media::MediaStore::new());
+
+        gosub_sandbox::lock_down_renderer();
+
+        let shared: std::sync::Arc<parking_lot::Mutex<dyn FontSystem>> =
+            std::sync::Arc::new(parking_lot::Mutex::new(fonts));
+        let (summary, baked, _hit_regions) = renderer::render_page::<TileConfig<F>>(
+            renderer::PageRequest {
+                html: "<html><body><h1>Under lockdown</h1><p>Rendered without a fork.</p></body></html>",
+                page_url: "about:blank",
+                viewport_width: 1280.0,
+                viewport_height: 720.0,
+                known_tiles: &Default::default(),
+                hovered_node: None,
+            },
+            shared,
+            media_store,
+            std::sync::Arc::new(gosub_interface::resource_loader::NoResourceLoader),
+        );
+        if summary.page_height <= 0.0 || summary.paint_commands == 0 {
+            eprintln!("implausible page under lockdown: {summary:?}");
+            return 1;
+        }
+        // With a rasterizer compiled in, stage 6 must run under this sandbox
+        // too, and produce pixels that are actually ink rather than zeroes.
+        if cfg!(feature = "cairo-tiles") {
+            let inked: u64 = baked
+                .iter()
+                .map(|tile| match tile {
+                    renderer::RenderedTile::Fresh { tile, .. } => match &tile.pixels {
+                        gosub_render_pipeline::common::texture::TilePixels::Cpu(bytes) => {
+                            bytes.iter().filter(|&&b| b != 0).count() as u64
+                        }
+                        gosub_render_pipeline::common::texture::TilePixels::Gpu(_) => 0,
+                    },
+                    // Nothing was rasterized here (no broker memory in this
+                    // scenario, so this cannot happen).
+                    renderer::RenderedTile::Unchanged { .. } => 0,
+                })
+                .sum();
+            if baked.is_empty() || inked == 0 {
+                eprintln!("rasterization under lockdown produced no ink ({} tiles)", baked.len());
+                return 1;
+            }
+            println!(
+                "rasterized {} tiles under lockdown ({inked} non-zero bytes)",
+                baked.len()
+            );
+        }
+        println!(
+            "rendered a {:.0}x{:.0} page under the renderer lockdown ({} paint commands)",
+            summary.page_width, summary.page_height, summary.paint_commands
+        );
+        0
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the renderer lockdown exists only on Linux");
+        2
+    }
+}
+
+/// The exec-fresh renderer, driven directly: spawn one throwaway
+/// font-readable-confined renderer process, have it render the same
+/// css+font+img page the fork-server scenario uses, and verify the brokered
+/// loads and the streamed tiles - the `FontPathsReadable` tier's whole
+/// render path, without an engine around it.
+fn exec_renderer_roundtrip<F: FontSystem + Default>() -> i32 {
+    println!("font backend: {}", std::any::type_name::<F>());
+    #[cfg(target_os = "linux")]
+    {
+        let html = r#"
+            <html><head>
+            <link rel="stylesheet" href="/page.css">
+            <style> body { margin: 0; } h1 { font-size: 32px; } </style></head>
+            <body>
+                <h1>Rendered in an exec'd renderer</h1>
+                <div class="card"><p>One page, one process, gone.</p></div>
+                <img src="/tile.png" width="64" height="64">
+            </body></html>
+        "#;
+        let font_bytes = {
+            use gosub_interface::font_system::FontQuery;
+            let mut fonts = gosub_fontmanager::ParleyFontSystem::default();
+            let _ = fonts.families();
+            fonts
+                .resolve(&FontQuery::new(&["sans-serif"]))
+                .map(|resolved| resolved.blob.data.as_ref().as_ref().to_vec())
+                .unwrap_or_default()
+        };
+        let loader = HarnessResourceLoader {
+            font: font_bytes,
+            ..Default::default()
+        };
+
+        match gosub_engine::render_process::client::render_page(
+            html,
+            "http://harness.invalid/index.html",
+            "exec-harness-tab",
+            (1280.0, 720.0),
+            &loader,
+            &Default::default(),
+            None,
+        ) {
+            Ok(page) => {
+                let (summary, tiles) = (page.summary, page.tiles);
+                if summary.page_height < 300.0 || summary.paint_commands == 0 {
+                    eprintln!("implausible page from the exec'd renderer: {summary:?}");
+                    return 1;
+                }
+                if page.hit_regions.is_empty() {
+                    eprintln!("the exec'd renderer shipped no hit-test geometry");
+                    return 1;
+                }
+                let paths = loader.paths.lock().clone();
+                for expected in ["/tile.png", "/page.css", "/face.ttf"] {
+                    if !paths.iter().any(|p| p.ends_with(expected)) {
+                        eprintln!("the exec'd renderer never requested {expected} (saw: {paths:?})");
+                        return 1;
+                    }
+                }
+                if cfg!(feature = "cairo-tiles") && tiles.is_empty() {
+                    eprintln!("no tiles arrived from the exec'd renderer");
+                    return 1;
+                }
+                println!(
+                    "exec'd renderer rendered a {:.0}x{:.0} page: {} tiles, {} brokered requests",
+                    summary.page_width,
+                    summary.page_height,
+                    tiles.len(),
+                    paths.len()
+                );
+                0
+            }
+            Err(e) => {
+                eprintln!("exec'd render failed: {e}");
+                1
+            }
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the exec'd renderer exists only on Linux");
+        2
+    }
+}
+
+/// The engine-side wiring: `GosubEngine` itself spawns the fork server when
+/// `security.renderer_process` is on, announces the tier, hands out the
+/// handle, and tears it down at shutdown.
+fn engine_renderer_process<F: FontSystem + Default>() -> i32 {
+    println!("font backend: {}", std::any::type_name::<F>());
+    #[cfg(target_os = "linux")]
+    {
+        use gosub_config::settings::Setting;
+        use gosub_engine::fork_server::protocol::ConfinementTier;
+        use gosub_engine::GosubEngine;
+        use gosub_render_pipeline::render::backends::null::NullBackend;
+        use gosub_render_pipeline::render::DefaultCompositor;
+
+        let runtime = match tokio::runtime::Builder::new_multi_thread().enable_all().build() {
+            Ok(rt) => rt,
+            Err(e) => {
+                eprintln!("could not build a runtime: {e}");
+                return 1;
+            }
+        };
+
+        runtime.block_on(async move {
+            let compositor = Arc::new(DefaultCompositor::default());
+            // The engine runs the same configuration the child dispatch uses,
+            // so its (static) font-system tier decides the renderer mechanism.
+            let mut engine: GosubEngine<TileConfig<F>> =
+                GosubEngine::new(None, Arc::new(NullBackend::new()), Arc::clone(&compositor));
+
+            if let Err(e) = engine.settings().set("security.renderer_process", Setting::Bool(true)) {
+                eprintln!("could not enable the renderer process: {e}");
+                return 1;
+            }
+
+            let Ok(run) = engine.start() else {
+                eprintln!("engine failed to start");
+                return 1;
+            };
+            tokio::spawn(run);
+
+            // What the engine starts depends on the configured font system's
+            // static tier: `Full` gets a warmed fork server, `FontPathsReadable`
+            // gets exec-per-render mode (no long-lived process at all).
+            match F::confinement() {
+                Confinement::Full => {
+                    let Some(tier) = engine.renderer_process_tier() else {
+                        if !cfg!(feature = "cairo-tiles") {
+                            eprintln!(
+                                "no forked rasterizer compiled in (engine feature `cairo-tiles`); nothing to spawn"
+                            );
+                            return 2;
+                        }
+                        eprintln!("the engine did not start a renderer fork server");
+                        return 1;
+                    };
+                    println!("engine renderer process tier: {tier:?}");
+                    if !matches!(tier, ConfinementTier::Full) {
+                        eprintln!("expected the Full tier, got {tier:?}");
+                        return 1;
+                    }
+                    let Some(server) = engine.renderer_process() else {
+                        eprintln!("tier announced but no handle exposed");
+                        return 1;
+                    };
+                    let outcome = server.lock().render_page(
+                        "<html><body><p>Rendered through the engine's fork server.</p></body></html>",
+                        "http://harness.invalid/",
+                        "fork-harness-tab",
+                        (1280.0, 720.0),
+                        &gosub_interface::resource_loader::NoResourceLoader,
+                        &Default::default(),
+                        None,
+                    );
+                    match outcome {
+                        Ok(page) => {
+                            let (summary, tiles) = (page.summary, page.tiles);
+                            if summary.page_height <= 0.0 || summary.paint_commands == 0 {
+                                eprintln!("implausible page through the engine handle: {summary:?}");
+                                return 1;
+                            }
+                            println!(
+                                "engine-held fork server rendered a {:.0}x{:.0} page ({} tiles over shm)",
+                                summary.page_width,
+                                summary.page_height,
+                                tiles.len()
+                            );
+                        }
+                        Err(e) => {
+                            eprintln!("rendering through the engine handle failed: {e}");
+                            return 1;
+                        }
+                    }
+                }
+                Confinement::FontPathsReadable => {
+                    if engine.renderer_process_tier().is_some() {
+                        eprintln!("a FontPathsReadable config must not spawn a fork server");
+                        return 1;
+                    }
+                    println!("exec-per-render mode: no fork server spawned, renderers spawn per render");
+                }
+                Confinement::Unsupported(reason) => {
+                    eprintln!("unexpected Unsupported tier: {reason}");
+                    return 1;
+                }
+            }
+
+            // The tab route: a real navigation whose frame is rendered
+            // out-of-process - forked from the fork server (Full) or in a
+            // throwaway exec'd renderer (FontPathsReadable). The tab worker
+            // captures the document source, sends it out, and submits the
+            // returned tiles to the compositor - the same code path an
+            // embedder's window drives.
+            {
+                use gosub_engine::events::{NavigationEvent, TabCommand};
+                use gosub_engine::storage::{
+                    InMemoryLocalStore, InMemorySessionStore, PartitionPolicy, StorageService,
+                };
+                use gosub_engine::zone::ZoneServices;
+                use gosub_render_pipeline::render::backend::ExternalHandle;
+
+                let Ok((port, _server)) = serve_once_with(BODY) else {
+                    eprintln!("could not start the test server");
+                    return 1;
+                };
+                let mut events = engine.subscribe_events();
+                let services = ZoneServices {
+                    storage: Arc::new(StorageService::new(
+                        Arc::new(InMemoryLocalStore::new()),
+                        Arc::new(InMemorySessionStore::new()),
+                    )),
+                    cookie_store: None,
+                    cookie_jar: None,
+                    partition_policy: PartitionPolicy::None,
+                    places: None,
+                };
+                let Ok(mut zone) = engine.create_zone(None, services, None) else {
+                    eprintln!("could not create a zone");
+                    return 1;
+                };
+                let Ok(tab) = zone.create_tab(Default::default(), None).await else {
+                    eprintln!("could not create a tab");
+                    return 1;
+                };
+                let _ = tab
+                    .send(TabCommand::SetViewport {
+                        x: 0,
+                        y: 0,
+                        width: 1280,
+                        height: 720,
+                    })
+                    .await;
+                if tab.navigate(format!("http://127.0.0.1:{port}/")).await.is_err() {
+                    eprintln!("navigate failed");
+                    return 1;
+                }
+                let _ = tab.send(TabCommand::ResumeDrawing { fps: 30 }).await;
+
+                // Wait for the navigation, then for a frame to reach the
+                // compositor - both on a clock.
+                let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+                loop {
+                    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                    if remaining.is_zero() {
+                        eprintln!("timed out waiting for the navigation to finish");
+                        return 1;
+                    }
+                    match tokio::time::timeout(remaining, events.recv()).await {
+                        Ok(Ok(gosub_engine::events::EngineEvent::Navigation {
+                            event: NavigationEvent::Finished { .. },
+                            ..
+                        })) => break,
+                        Ok(Ok(gosub_engine::events::EngineEvent::Navigation {
+                            event: NavigationEvent::Failed { error, .. },
+                            ..
+                        })) => {
+                            eprintln!("navigation failed: {error}");
+                            return 1;
+                        }
+                        Ok(Ok(_)) => continue,
+                        _ => {
+                            eprintln!("event channel closed or timed out");
+                            return 1;
+                        }
+                    }
+                }
+
+                let frame = loop {
+                    if tokio::time::Instant::now() >= deadline {
+                        eprintln!("timed out waiting for a remotely rendered frame");
+                        return 1;
+                    }
+                    match compositor.frame_for(tab.tab_id) {
+                        Some(handle @ ExternalHandle::TileCache { .. }) => break handle,
+                        _ => tokio::time::sleep(std::time::Duration::from_millis(50)).await,
+                    }
+                };
+                let ExternalHandle::TileCache { tiles, page_height, .. } = frame else {
+                    eprintln!("expected a TileCache frame");
+                    return 1;
+                };
+                if page_height <= 0.0 {
+                    eprintln!("remotely rendered frame has no page height");
+                    return 1;
+                }
+                if cfg!(feature = "cairo-tiles") && tiles.is_empty() {
+                    eprintln!("remotely rendered frame carried no tiles");
+                    return 1;
+                }
+                println!(
+                    "tab frame rendered out-of-process: {} tiles, page height {page_height:.0}",
+                    tiles.len()
+                );
+
+                // Hit testing on a remotely rendered page: the layer list is
+                // process-local, so this can only work off the geometry the
+                // renderer shipped. The served page is one big link, so a
+                // move into it must raise HoverUrl with that href.
+                let _ = tab.send(TabCommand::MouseMove { x: 50.0, y: 50.0 }).await;
+                let hover_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+                let mut hovered: Option<String> = None;
+                while tokio::time::Instant::now() < hover_deadline {
+                    let remaining = hover_deadline.saturating_duration_since(tokio::time::Instant::now());
+                    match tokio::time::timeout(remaining, events.recv()).await {
+                        Ok(Ok(gosub_engine::events::EngineEvent::HoverUrl { url: Some(url), .. })) => {
+                            hovered = Some(url);
+                            break;
+                        }
+                        Ok(Ok(_)) => continue,
+                        _ => break,
+                    }
+                }
+                match hovered {
+                    Some(url) if url.contains("example.test/target") => {
+                        println!("hit test on the remotely rendered page found the link: {url}");
+                    }
+                    Some(url) => {
+                        eprintln!("hovered an unexpected url: {url}");
+                        return 1;
+                    }
+                    None => {
+                        eprintln!("no HoverUrl for a remotely rendered page: hit testing is not working");
+                        return 1;
+                    }
+                }
+
+                engine.close_zone(zone).await;
+            }
+
+            if engine.shutdown().await.is_err() {
+                eprintln!("engine shutdown failed");
+                return 1;
+            }
+            0
+        })
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the renderer process exists only on Linux");
+        2
+    }
+}
+
+/// Answers a forked renderer's brokered subresource requests from memory,
+/// recording them - the harness's stand-in for the engine's cookie-attaching
+/// brokered loader. Serves an image, an external stylesheet (which declares a
+/// layout-visible rule and an `@font-face`), and the font that face names.
+#[cfg(target_os = "linux")]
+#[derive(Debug, Default)]
+struct HarnessResourceLoader {
+    served: std::sync::atomic::AtomicU64,
+    /// Raw SFNT bytes served as `/face.ttf` (a real installed font, read
+    /// broker-side where files are still reachable).
+    font: Vec<u8>,
+    /// Every path requested, in order - what the assertions read.
+    paths: parking_lot::Mutex<Vec<String>>,
+}
+
+/// The stylesheet the renderer must fetch through the broker: one rule that
+/// visibly moves layout (asserted via page height) and one `@font-face` whose
+/// font must come back through the same channel.
+#[cfg(target_os = "linux")]
+const HARNESS_CSS: &str = r#"
+    @font-face { font-family: "HarnessFace"; src: url("/face.ttf"); }
+    .card { margin-top: 300px; font-family: "HarnessFace"; }
+    h1:hover { background: #ff0000; }
+"#;
+
+#[cfg(target_os = "linux")]
+impl gosub_interface::resource_loader::ResourceLoader for HarnessResourceLoader {
+    fn load(
+        &self,
+        url: &url::Url,
+    ) -> Result<gosub_interface::resource_loader::LoadedResource, gosub_interface::resource_loader::LoadError> {
+        use gosub_interface::resource_loader::{LoadError, LoadedResource};
+        self.served.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.paths.lock().push(url.path().to_string());
+        match url.path() {
+            path if path.ends_with("/tile.png") => Ok(LoadedResource {
+                status: 200,
+                content_type: Some("image/png".into()),
+                body: bytes::Bytes::from_static(SAMPLE_PNG),
+            }),
+            path if path.ends_with("/page.css") => Ok(LoadedResource {
+                status: 200,
+                content_type: Some("text/css".into()),
+                body: bytes::Bytes::from_static(HARNESS_CSS.as_bytes()),
+            }),
+            path if path.ends_with("/face.ttf") && !self.font.is_empty() => Ok(LoadedResource {
+                status: 200,
+                content_type: Some("font/ttf".into()),
+                body: bytes::Bytes::from(self.font.clone()),
+            }),
+            _ => Err(LoadError::Failed(format!("harness does not serve {url}"))),
+        }
+    }
+}
+
+/// The whole phase-4 chain, end to end: the fork server consumes the
+/// confinement answer and a forked renderer proves it was consumed correctly.
+fn fork_server_roundtrip<F: FontSystem + Default>() -> i32 {
+    println!("font backend: {}", std::any::type_name::<F>());
+    #[cfg(target_os = "linux")]
+    {
+        use gosub_engine::fork_server::client::ForkServer;
+        use gosub_engine::fork_server::protocol::ConfinementTier;
+
+        let mut server = match ForkServer::spawn() {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("could not spawn the fork server: {e}");
+                return 1;
+            }
+        };
+        println!("fork server ready, tier: {:?}", server.confinement());
+
+        match server.confinement() {
+            ConfinementTier::Unsupported(reason) => {
+                eprintln!("this font system cannot run isolated ({reason}); nothing to fork");
+                server.shutdown();
+                return 1;
+            }
+            // No zygote for this tier: renderers are exec'd fresh, so the
+            // correct behaviour is a refusal that says exactly that.
+            ConfinementTier::FontPathsReadable => {
+                let reply = server.prove_shaping();
+                server.shutdown();
+                return match reply {
+                    Err(e) if e.to_string().contains("no use for a fork server") => {
+                        println!("fork refused as designed: {e}");
+                        0
+                    }
+                    Err(e) => {
+                        eprintln!("expected the designed refusal, got: {e}");
+                        1
+                    }
+                    Ok(_) => {
+                        eprintln!("a FontPathsReadable fork server should refuse to fork, but forked");
+                        1
+                    }
+                };
+            }
+            ConfinementTier::Full => {}
+        }
+
+        match server.prove_shaping() {
+            Ok((w, h)) => {
+                if w <= 0.0 || h <= 0.0 {
+                    eprintln!("forked renderer shaped an empty box ({w}x{h})");
+                    return 1;
+                }
+                println!("forked renderer shaped {w:.1}x{h:.1} under its tier sandbox");
+            }
+            Err(e) => {
+                eprintln!("fork proof failed: {e}");
+                return 1;
+            }
+        }
+
+        // The renderer role proper: the whole pipeline (parse → style →
+        // layout → layering → tiling → paint) over a real page, in a fresh
+        // forked renderer, single-threaded, under the tier sandbox. The page
+        // exercises CSS (inline <style>), block flow, enough text that a
+        // dead font system could not fake the numbers - and an image, which
+        // the renderer cannot fetch: its request must come back out through
+        // the fork server and be answered by the loader below.
+        let html = r#"
+            <html><head>
+            <link rel="stylesheet" href="/page.css">
+            <style>
+                body { margin: 0; }
+                h1 { font-size: 32px; }
+                .card { padding: 16px; background: #eee; }
+            </style></head>
+            <body>
+                <h1>Rendered in a forked renderer</h1>
+                <div class="card"><p>Laid out, layered, tiled and painted under the
+                renderer sandbox, shaping through fonts inherited copy-on-write from
+                the fork server. No file was opened past this point.</p></div>
+                <img src="/tile.png" width="64" height="64">
+            </body></html>
+        "#;
+        // Real font bytes for `/face.ttf`, read broker-side (files are still
+        // reachable here) - the renderer must receive them over the channel,
+        // never from disk.
+        let font_bytes = {
+            use gosub_interface::font_system::FontQuery;
+            let mut fonts = gosub_fontmanager::ParleyFontSystem::default();
+            let _ = fonts.families();
+            fonts
+                .resolve(&FontQuery::new(&["sans-serif"]))
+                .map(|resolved| resolved.blob.data.as_ref().as_ref().to_vec())
+                .unwrap_or_default()
+        };
+        let loader = HarnessResourceLoader {
+            font: font_bytes,
+            ..Default::default()
+        };
+        let mut memory = gosub_engine::fork_server::client::TileMemory::default();
+        // Filled from the first render's hit regions; the hover pass below
+        // needs node ids, and only the renderer knows them.
+        let mut hit_region_nodes: Vec<u64>;
+        match server.render_page(
+            html,
+            "http://harness.invalid/index.html",
+            "fork-harness-tab",
+            (1280.0, 720.0),
+            &loader,
+            &memory,
+            None,
+        ) {
+            Ok(page) => {
+                let (summary, tiles, hit_regions) = (page.summary, page.tiles, page.hit_regions);
+                if summary.page_height <= 0.0 || summary.painted_tiles == 0 || summary.paint_commands == 0 {
+                    eprintln!("the forked renderer produced an implausible page: {summary:?}");
+                    return 1;
+                }
+                // Hit-test geometry must cross with the pixels: without it a
+                // remotely rendered page cannot answer what is under the
+                // pointer. The page has an <a>, so a link region must exist.
+                if hit_regions.is_empty() {
+                    eprintln!("the forked renderer shipped no hit-test geometry");
+                    return 1;
+                }
+                println!("received {} hit regions for the page", hit_regions.len());
+                memory.replace_with(tiles.iter().map(|t| {
+                    let (hash, kept) = t.keep();
+                    (hash, kept)
+                }));
+                hit_region_nodes = hit_regions.iter().map(|r| r.node_id).collect();
+                println!(
+                    "forked renderer rendered a {:.0}x{:.0} page: {} layers, {} tiles painted, {} paint commands",
+                    summary.page_width,
+                    summary.page_height,
+                    summary.layer_count,
+                    summary.painted_tiles,
+                    summary.paint_commands
+                );
+                // With a rasterizer compiled in, the pixels must arrive as
+                // mapped shared memory - and be ink, not zeroes: these are
+                // the renderer's own pages, validated and sealed.
+                if cfg!(feature = "cairo-tiles") {
+                    let inked: u64 = tiles
+                        .iter()
+                        .map(|tile| tile.pixels().iter().filter(|&&b| b != 0).count() as u64)
+                        .sum();
+                    if tiles.is_empty() || inked == 0 {
+                        eprintln!("no ink arrived over shared memory ({} tiles)", tiles.len());
+                        return 1;
+                    }
+                    println!(
+                        "received {} tiles over shared memory ({inked} non-zero bytes, zero-copy)",
+                        tiles.len()
+                    );
+
+                    // The consumer side, end to end: convert to the
+                    // compositor's `CachedTile` shape (asserting the pixels
+                    // are still the mapped pages, not a copy) and present a
+                    // frame through the production composite loop.
+                    use gosub_render_pipeline::render::tile_composite::{composite_tiles, TileTarget};
+                    let mapped_ptrs: Vec<*const u8> = tiles.iter().map(|t| t.pixels().as_ptr()).collect();
+                    let cached: Vec<_> = tiles.into_iter().map(|t| t.into_cached_tile()).collect();
+                    for (cached_tile, mapped_ptr) in cached.iter().zip(&mapped_ptrs) {
+                        if cached_tile.data.as_ptr() != *mapped_ptr {
+                            eprintln!("a tile was copied on its way into the compositor");
+                            return 1;
+                        }
+                    }
+
+                    const BACKGROUND: u32 = 0xFF00_00FF; // opaque blue: absent from the page
+                    let (vw, vh) = (1280usize, 720usize);
+                    let mut frame = vec![BACKGROUND; vw * vh];
+                    let mut target = TileTarget {
+                        buf: &mut frame,
+                        stride: vw,
+                        origin_x: 0,
+                        origin_y: 0,
+                        width: vw,
+                        height: vh,
+                    };
+                    composite_tiles(&cached, 1, (0.0, 0.0), &mut target);
+                    let presented = frame.iter().filter(|&&px| px != BACKGROUND).count();
+                    if presented == 0 {
+                        eprintln!("compositing the mapped tiles painted nothing over the background");
+                        return 1;
+                    }
+                    println!("composited a {vw}x{vh} frame from the mapped tiles ({presented} pixels changed)");
+                } else if !tiles.is_empty() {
+                    eprintln!("received tiles without a rasterizer compiled in?");
+                    return 1;
+                }
+                // The subresource inversion: the confined renderer cannot
+                // fetch, so its <img>, its <link> stylesheet, and the
+                // @font-face that stylesheet declares must all have arrived
+                // here as brokered requests.
+                let paths = loader.paths.lock().clone();
+                for expected in ["/tile.png", "/page.css", "/face.ttf"] {
+                    if !paths.iter().any(|p| p.ends_with(expected)) {
+                        eprintln!("the renderer never requested {expected} (saw: {paths:?})");
+                        return 1;
+                    }
+                }
+                // The external stylesheet must have *applied*, not merely
+                // loaded: its 300px margin puts the page height beyond what
+                // the inline styles alone produce.
+                if summary.page_height < 300.0 {
+                    eprintln!(
+                        "page height {:.0} does not reflect the brokered stylesheet's 300px margin",
+                        summary.page_height
+                    );
+                    return 1;
+                }
+                println!(
+                    "served {} brokered requests ({} paths: img, stylesheet, web font); stylesheet applied",
+                    loader.served.load(std::sync::atomic::Ordering::Relaxed),
+                    paths.len()
+                );
+            }
+            Err(e) => {
+                eprintln!("rendering in a forked renderer failed: {e}");
+                return 1;
+            }
+        }
+
+        // Incrementality: render the same page again, this time telling the
+        // renderer which tiles we kept. Nothing about the page changed, so
+        // every tile must come back as unchanged - no rasterization, no
+        // pixels, no file descriptors. Needs a rasterizer to have produced
+        // tiles in the first place.
+        if cfg!(feature = "cairo-tiles") {
+            use gosub_engine::fork_server::client::PageTile;
+            match server.render_page(
+                html,
+                "http://harness.invalid/index.html",
+                "fork-harness-tab",
+                (1280.0, 720.0),
+                &loader,
+                &memory,
+                None,
+            ) {
+                Ok(page) => {
+                    let fresh = page
+                        .tiles
+                        .iter()
+                        .filter(|t| matches!(t, PageTile::Fresh { .. }))
+                        .count();
+                    let reused = page.tiles.len() - fresh;
+                    if reused == 0 || fresh != 0 {
+                        eprintln!("re-render shipped {fresh} fresh and {reused} reused tiles; expected all reused");
+                        return 1;
+                    }
+                    println!("re-render reused all {reused} tiles: nothing rasterized, nothing shipped");
+                }
+                Err(e) => {
+                    eprintln!("re-render failed: {e}");
+                    return 1;
+                }
+            }
+        }
+
+        // Hover repaint, out of process: the renderer re-parses per render and
+        // has no hover state of its own, so the broker tells it which node is
+        // under the pointer. With the tile memory in play, only the tiles
+        // whose painted content actually changed come back - hovering the
+        // <h1> (which the brokered stylesheet gives a :hover background)
+        // must repaint some tiles while reusing the rest.
+        if cfg!(feature = "cairo-tiles") {
+            use gosub_engine::fork_server::client::PageTile;
+            let mut hovered_changed = 0usize;
+            let mut nodes: Vec<u64> = std::mem::take(&mut hit_region_nodes);
+            nodes.sort_unstable();
+            nodes.dedup();
+            for node in nodes {
+                let Ok(page) = server.render_page(
+                    html,
+                    "http://harness.invalid/index.html",
+                    "fork-harness-tab",
+                    (1280.0, 720.0),
+                    &loader,
+                    &memory,
+                    Some(node),
+                ) else {
+                    eprintln!("hover render failed for node {node}");
+                    return 1;
+                };
+                let fresh = page
+                    .tiles
+                    .iter()
+                    .filter(|t| matches!(t, PageTile::Fresh { .. }))
+                    .count();
+                if fresh > 0 {
+                    hovered_changed += 1;
+                    println!(
+                        "hovering node {node} repainted {fresh} of {} tiles out of process",
+                        page.tiles.len()
+                    );
+                }
+            }
+            if hovered_changed == 0 {
+                eprintln!("no node produced a hover repaint; :hover is not reaching the renderer");
+                return 1;
+            }
+        }
+
+        // The streaming property: a page whose tile count exceeds any
+        // process's file-descriptor limit (RLIMIT_NOFILE is 128 in the fork
+        // server and its children) must still ship every tile - possible
+        // only because each hop seals/relays/maps one fd at a time.
+        if cfg!(feature = "cairo-tiles") {
+            let tall = r#"<html><body style="margin:0">
+                <div style="height: 12000px; background: #ddd">tall</div>
+            </body></html>"#;
+            match server.render_page(
+                tall,
+                "http://harness.invalid/tall.html",
+                "fork-harness-tab",
+                (1280.0, 720.0),
+                &loader,
+                &Default::default(),
+                None,
+            ) {
+                Ok(page) => {
+                    let (summary, tiles) = (page.summary, page.tiles);
+                    if tiles.len() <= 128 {
+                        eprintln!(
+                            "expected a tall page to stream more tiles than an fd limit could buffer, got {}",
+                            tiles.len()
+                        );
+                        return 1;
+                    }
+                    println!(
+                        "streamed {} tiles for a {:.0}px-tall page (past any fd limit)",
+                        tiles.len(),
+                        summary.page_height
+                    );
+                }
+                Err(e) => {
+                    eprintln!("tall-page streaming render failed: {e}");
+                    return 1;
+                }
+            }
+        }
+        server.shutdown();
+        0
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the fork server exists only on Linux");
+        2
+    }
+}
+
+/// Debugging aid, not a test: render an arbitrary HTML file (argv[3], with an
+/// optional base url in argv[4]) through the fork server, so a real-world page
+/// that kills a forked renderer can be replayed headlessly. Subresources are
+/// refused (`NoResourceLoader`), which real pages tolerate - the interesting
+/// failures live in parse/style/layout/shaping/raster, not in the fetches.
+fn render_file<F: FontSystem + Default>() -> i32 {
+    println!("font backend: {}", std::any::type_name::<F>());
+    #[cfg(target_os = "linux")]
+    {
+        use gosub_engine::fork_server::client::ForkServer;
+        use gosub_engine::fork_server::protocol::ConfinementTier;
+
+        let Some(path) = std::env::args().nth(3) else {
+            eprintln!("usage: isolation-harness render-file <font-backend> <page.html> [base-url]");
+            return 2;
+        };
+        let html = match std::fs::read_to_string(&path) {
+            Ok(html) => html,
+            Err(e) => {
+                eprintln!("could not read {path}: {e}");
+                return 2;
+            }
+        };
+        let base_url = std::env::args()
+            .nth(4)
+            .unwrap_or_else(|| "http://harness.invalid/".into());
+
+        let mut server = match ForkServer::spawn() {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("could not spawn the fork server: {e}");
+                return 1;
+            }
+        };
+        println!("fork server ready, tier: {:?}", server.confinement());
+        if !matches!(server.confinement(), ConfinementTier::Full) {
+            eprintln!("render-file needs the Full tier");
+            server.shutdown();
+            return 2;
+        }
+
+        let outcome = server.render_page(
+            &html,
+            &base_url,
+            "render-file-tab",
+            (1280.0, 720.0),
+            &gosub_interface::resource_loader::NoResourceLoader,
+            &Default::default(),
+            None,
+        );
+        server.shutdown();
+        match outcome {
+            Ok(page) => {
+                println!(
+                    "forked renderer rendered {path}: {:.0}x{:.0}, {} tiles, {} paint commands",
+                    page.summary.page_width,
+                    page.summary.page_height,
+                    page.tiles.len(),
+                    page.summary.paint_commands
+                );
+                0
+            }
+            Err(e) => {
+                eprintln!("forked render of {path} failed: {e}");
+                1
+            }
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the fork server exists only on Linux");
+        2
+    }
+}
+
+/// `render-file` without the fork: the same pipeline over argv[3] in *this*
+/// process under the renderer lockdown, so a SIGSYS can be caught by a
+/// debugger with a full backtrace (`gdb --args isolation-harness
+/// render-file-locked parley page.html`).
+fn render_file_locked<F: FontSystem + Default>() -> i32 {
+    println!("font backend: {}", std::any::type_name::<F>());
+    #[cfg(target_os = "linux")]
+    {
+        use gosub_engine::fork_server::renderer;
+
+        let Some(path) = std::env::args().nth(3) else {
+            eprintln!("usage: isolation-harness render-file-locked <font-backend> <page.html> [base-url]");
+            return 2;
+        };
+        let html = match std::fs::read_to_string(&path) {
+            Ok(html) => html,
+            Err(e) => {
+                eprintln!("could not read {path}: {e}");
+                return 2;
+            }
+        };
+        let base_url = std::env::args()
+            .nth(4)
+            .unwrap_or_else(|| "http://harness.invalid/".into());
+
+        let mut fonts = F::default();
+        let _ = fonts.families();
+        match fonts.prepare_for_confinement() {
+            Confinement::Full => {}
+            other => {
+                eprintln!("this scenario needs a fully-confinable font system, got {other:?}");
+                return 2;
+            }
+        }
+        // As in the fork server: fonts for SVG text pinned pre-lockdown, and
+        // single-threaded fetches, since a confined renderer cannot create
+        // threads.
+        gosub_render_pipeline::common::media::SvgDecoder::pin_system_fonts();
+        let media_store = std::sync::Arc::new(gosub_render_pipeline::common::media::MediaStore::new());
+        media_store.set_synchronous_fetch(true);
+
+        gosub_sandbox::lock_down_renderer();
+
+        let shared: std::sync::Arc<parking_lot::Mutex<dyn FontSystem>> =
+            std::sync::Arc::new(parking_lot::Mutex::new(fonts));
+        let (summary, baked, _) = renderer::render_page::<TileConfig<F>>(
+            renderer::PageRequest {
+                html: &html,
+                page_url: &base_url,
+                viewport_width: 1280.0,
+                viewport_height: 720.0,
+                known_tiles: &Default::default(),
+                hovered_node: None,
+            },
+            shared,
+            media_store,
+            std::sync::Arc::new(gosub_interface::resource_loader::NoResourceLoader),
+        );
+        println!(
+            "rendered {path} under the renderer lockdown: {:.0}x{:.0}, {} tiles, {} paint commands",
+            summary.page_width,
+            summary.page_height,
+            baked.len(),
+            summary.paint_commands
+        );
+        0
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the renderer lockdown exists only on Linux");
+        2
+    }
 }
 
 /// The follow-up question to the warm-up finding: a page can introduce a font at

--- a/crates/gosub_engine/src/child_process.rs
+++ b/crates/gosub_engine/src/child_process.rs
@@ -61,8 +61,8 @@ pub fn dispatch() {
     std::process::exit(code);
 }
 
-/// Run a child role - including those that need the embedder's render
-/// configuration - if this process was started as one; otherwise return.
+/// Run a child role - including the fork server - if this process was started
+/// as one; otherwise return.
 pub fn dispatch_with<C: crate::html::RenderConfiguration>() {
     DISPATCHED.store(true, std::sync::atomic::Ordering::Release);
     let args: Vec<String> = std::env::args().collect();
@@ -75,10 +75,31 @@ pub fn dispatch_with<C: crate::html::RenderConfiguration>() {
     std::process::exit(code);
 }
 
-/// Roles that need `C` (a renderer) dispatch here; every other role behaves
-/// exactly as under [`dispatch`].
-#[allow(clippy::extra_unused_type_parameters)]
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
 fn run_role_with<C: crate::html::RenderConfiguration>(role: &str, args: &[String]) -> i32 {
+    use crate::fork_server::client::FORK_SERVER_ROLE;
+
+    if role == FORK_SERVER_ROLE {
+        gosub_sandbox::deny_debugger_attach();
+        return match adopt_link(role, args) {
+            Ok(endpoint) => crate::fork_server::child::serve::<C>(endpoint),
+            Err(code) => code,
+        };
+    }
+    if role == crate::render_process::client::RENDERER_ROLE {
+        gosub_sandbox::deny_debugger_attach();
+        return match adopt_link(role, args) {
+            Ok(endpoint) => crate::render_process::child::serve::<C>(endpoint),
+            Err(code) => code,
+        };
+    }
+    run_role(role, args)
+}
+
+#[cfg(not(all(feature = "process-isolation", target_os = "linux")))]
+fn run_role_with<C: crate::html::RenderConfiguration>(role: &str, args: &[String]) -> i32 {
+    // No fork server here (feature off, or a platform with nothing to fork);
+    // every other role behaves exactly as under `dispatch`.
     run_role(role, args)
 }
 

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -8,7 +8,7 @@
 
 use crate::engine::events::{CursorShape, HitTestResponse};
 use crate::engine::storage::{StorageArea, StorageHandles};
-use crate::html::EngineDocument;
+use crate::html::{is_text_input, EngineDocument};
 use gosub_config::{Config, HasConfig};
 use gosub_render_pipeline::rasterizer::{
     collect_placed_gpu_tiles, cpu_cached_tiles, rasterize_parallel, rasterize_sequential, BakedTile, RasterStrategy,
@@ -73,23 +73,6 @@ fn hover_matches<C: RenderConfiguration>(fp: &HoverFingerprints, doc: &EngineDoc
     }
     false
 }
-/// True for elements whose content is edited as text (they show the I-beam cursor).
-fn is_text_input<C: RenderConfiguration>(doc: &EngineDocument<C>, node_id: NodeId) -> bool {
-    match doc.tag_name(node_id) {
-        Some("textarea") => true,
-        Some("input") => !doc.attribute(node_id, "type").is_some_and(|t| {
-            [
-                "button", "submit", "reset", "checkbox", "radio", "range", "color", "file", "image", "hidden",
-            ]
-            .iter()
-            .any(|k| t.eq_ignore_ascii_case(k))
-        }),
-        _ => doc
-            .attribute(node_id, "contenteditable")
-            .is_some_and(|v| v.is_empty() || v.eq_ignore_ascii_case("true")),
-    }
-}
-
 /// True for elements that participate in keyboard focus: links, form controls,
 /// editable regions, and anything with a non-negative `tabindex`.
 fn is_focusable<C: RenderConfiguration>(doc: &EngineDocument<C>, node_id: NodeId) -> bool {
@@ -118,7 +101,14 @@ struct PipelineCache {
     /// Pre-built CachedTile list (Arc-shared pixel data) for zero-copy scroll handles.
     cached_tiles: Arc<Vec<CachedTile>>,
     /// Layer list retained for hit-testing (hover).
-    layer_list: Arc<LayerList>,
+    /// `None` for a page rendered out-of-process: the layer list is a
+    /// process-local structure. Such a page carries `hit_regions` instead,
+    /// which answers hit testing; only hover *repaint* still needs the layer
+    /// list (it re-paints tiles), so that stays local-only.
+    layer_list: Option<Arc<LayerList>>,
+    /// Hit-test geometry for a remotely rendered page, in hit-test order.
+    /// Empty for local renders, which hit-test through `layer_list`.
+    hit_regions: Vec<crate::fork_server::protocol::HitRegion>,
     /// Rasterized tile data keyed by (page_x, page_y, layer_id, content_hash).
     /// Passed to the next render so unchanged tiles skip rasterization.
     /// Value is (physical_width, physical_height, pixel_data).
@@ -207,6 +197,50 @@ pub struct BrowsingContext<C: RenderConfiguration = crate::html::DefaultRenderCo
     /// LRU bookkeeping + eviction for the tile caches, bounded by the
     /// `renderer.tile.cache_budget_mb` setting.
     tile_budget: TileBudget,
+    /// The loader subresources go through - kept beside the media store (which
+    /// also holds it) because an out-of-process render needs it directly: the
+    /// broker answers the remote renderer's resource requests with it.
+    #[cfg_attr(not(all(feature = "process-isolation", target_os = "linux")), allow(dead_code))]
+    loader: std::sync::Arc<dyn gosub_interface::resource_loader::ResourceLoader>,
+    /// The source text of the current document, kept when a renderer process
+    /// will re-parse it there. `None` when rendering in-process.
+    document_source: Option<std::sync::Arc<str>>,
+    /// The current document's URL.
+    document_url: Option<Url>,
+    /// Tiles from the last remote render, keyed by content hash; offered to the
+    /// next render so unchanged tiles are neither rasterized nor shipped again.
+    /// Remote counterpart of `tile_pixel_cache`.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    remote_tile_memory: crate::fork_server::client::TileMemory,
+    /// How this tab renders out-of-process, installed by the tab worker when
+    /// `security.renderer_process` is on: through the engine's fork server
+    /// (`Full`-tier font systems) or via a fresh exec'd renderer per render
+    /// (`FontPathsReadable`).
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    remote_renderer: Option<RemoteRenderer>,
+    /// The tab this context renders for, as a display string - sent with each
+    /// remote render for telemetry and logs. Empty until a remote renderer is
+    /// installed.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    remote_tab: String,
+    /// Why the last out-of-process render could not happen at all - page
+    /// content is never rendered in-process instead; the tab worker takes
+    /// this and tells the embedder.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    remote_failure: Option<String>,
+}
+
+/// The two ways a tab's renders leave this process - which one applies is the
+/// configured font system's confinement tier, decided statically.
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+pub enum RemoteRenderer {
+    /// Fork a throwaway renderer per render from the engine's warmed fork
+    /// server (tier `Full`).
+    ForkServer(std::sync::Arc<parking_lot::Mutex<crate::fork_server::client::ForkServer>>),
+    /// Spawn a throwaway exec'd renderer per render (tier `FontPathsReadable`:
+    /// warming buys nothing when font files stay reachable, and the stack may
+    /// not even be constructible in a fork server).
+    ExecPerRender,
 }
 
 impl<C: RenderConfiguration> BrowsingContext<C> {
@@ -245,12 +279,45 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
             raster_strategy: RasterStrategy::None,
             media_store: std::sync::Arc::new(
                 gosub_render_pipeline::common::media::MediaStore::with_loader_and_decoder(
-                    loader,
+                    loader.clone(),
                     image_decoder_from(&config_store),
                 ),
             ),
             config_store,
             tile_budget: TileBudget::new(),
+            loader,
+            document_source: None,
+            document_url: None,
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            remote_tile_memory: Default::default(),
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            remote_renderer: None,
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            remote_tab: String::new(),
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            remote_failure: None,
+        }
+    }
+
+    /// Route this tab's full renders out-of-process. Installed once by the
+    /// tab worker; see [`Self::remote_render_active`] for when it engages.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    pub fn set_remote_renderer(&mut self, renderer: RemoteRenderer, tab: String) {
+        self.remote_renderer = Some(renderer);
+        self.remote_tab = tab;
+    }
+
+    /// Whether full renders go out-of-process: a remote renderer is installed
+    /// *and* the current document's source is available to send it.
+    #[allow(clippy::needless_return)] // the cfg arms need explicit returns
+    pub fn remote_render_active(&self) -> bool {
+        #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+        {
+            return self.remote_renderer.is_some() && self.document_source.is_some();
+        }
+        #[cfg(not(all(feature = "process-isolation", target_os = "linux")))]
+        {
+            return false;
         }
     }
 
@@ -277,9 +344,29 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
         self.storage.as_ref().map(|s| s.session.clone())
     }
 
-    /// Sets the parsed DOM document for the given tab.
-    pub fn set_document(&mut self, doc: Arc<EngineDocument<C>>) {
+    /// Say on the firehose why a full render is about to happen.
+    fn note_invalidate(&self, reason: &str) {
+        if !crate::telemetry::enabled() {
+            return;
+        }
+        #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+        let tab = self.remote_tab.as_str();
+        #[cfg(not(all(feature = "process-isolation", target_os = "linux")))]
+        let tab = "";
+        crate::telemetry::emit("tab.invalidate", serde_json::json!({ "tab": tab, "reason": reason }));
+    }
+
+    /// Sets the parsed DOM document for the given tab. `source` is the text it
+    /// was parsed from, kept when an out-of-process renderer will re-parse it.
+    pub fn set_document(&mut self, doc: Arc<EngineDocument<C>>, source: Option<std::sync::Arc<str>>) {
+        let url = {
+            use gosub_interface::document::Document as _;
+            doc.url()
+        };
+        self.note_invalidate("document");
         self.document = Some(doc);
+        self.document_url = url;
+        self.document_source = source;
         self.dom_dirty = true;
         self.style_dirty = true;
         self.layout_dirty = true;
@@ -307,6 +394,7 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
         self.viewport.width = vp.width;
         self.viewport.height = vp.height;
         self.layout_dirty = true;
+        self.note_invalidate("viewport");
         self.invalidate_render();
         self.pipeline_cache = None;
         self.scene_cache = None;
@@ -366,6 +454,7 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
     /// is consumed (cleared) by this call.
     pub fn poll_media_completed(&mut self) -> bool {
         if self.media_store.take_completed() {
+            self.note_invalidate("media");
             self.render_dirty = true;
             true
         } else {
@@ -378,6 +467,43 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
     /// Shared by [`Self::rebuild_pipeline_cache_if_needed`] and
     /// [`Self::rebuild_render_list_if_needed`].
     fn rebuild_full_pipeline(&mut self) {
+        #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+        if self.remote_render_active() {
+            match self.try_remote_pipeline() {
+                Ok(()) => {
+                    // Every tile is live again; an earlier in-process render may have evicted some.
+                    // Remote pages are otherwise unbudgeted: their pixels are shared with the
+                    // tile memory that makes re-renders incremental, so evicting here frees nothing.
+                    self.tile_budget.note_full_raster();
+                    self.note_rastered_window();
+                    self.render_dirty = false;
+                    self.hover_dirty = false;
+                    self.dom_dirty = false;
+                    self.style_dirty = false;
+                    self.layout_dirty = false;
+                    return;
+                }
+                // Isolation is on: page content does not get to run in this
+                // process just because the process meant for it is gone. The
+                // tab shows nothing until a render succeeds again; the worker
+                // reports the failure. Internal pages are the engine's own and
+                // may still render here.
+                Err(error) if !self.is_internal_page() => {
+                    log::error!("out-of-process render failed ({error}); not rendering this page in-process");
+                    self.pipeline_cache = None;
+                    self.remote_failure = Some(error);
+                    self.render_dirty = false;
+                    self.hover_dirty = false;
+                    self.dom_dirty = false;
+                    self.style_dirty = false;
+                    self.layout_dirty = false;
+                    return;
+                }
+                Err(error) => {
+                    log::warn!("out-of-process render of an internal page failed ({error}); rendering it in-process");
+                }
+            }
+        }
         if let Some(doc) = &self.document {
             let prev_tile_cache = self
                 .pipeline_cache
@@ -417,8 +543,24 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
             page_height,
             tile_pixel_cache,
             tiles,
-            ..
+            cached_tiles,
+            hit_regions,
         } = old_cache;
+
+        // A remotely rendered page has no local layer list to re-tile from, and
+        // the remote render already covers the whole page: nothing to extend.
+        let Some(layer_list) = layer_list else {
+            self.pipeline_cache = Some(PipelineCache {
+                tiles,
+                page_height,
+                cached_tiles,
+                layer_list: None,
+                hit_regions,
+                tile_pixel_cache,
+            });
+            self.raster_dirty = false;
+            return;
+        };
 
         self.pipeline_cache = Some(pipeline_extend_raster(
             layer_list,
@@ -438,6 +580,105 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
         self.tile_budget.note_full_raster();
         self.enforce_tile_budget(false);
         self.raster_dirty = false;
+    }
+
+    /// Whether the current document is one of the engine's own pages.
+    pub(crate) fn is_internal_page(&self) -> bool {
+        self.document_url
+            .as_ref()
+            .is_some_and(|url| matches!(url.scheme(), "gosub" | "about"))
+    }
+
+    /// The reason the last out-of-process render could not happen, once.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    pub fn take_remote_failure(&mut self) -> Option<String> {
+        self.remote_failure.take()
+    }
+
+    /// Render the current document in a renderer process and adopt the result
+    /// as this tab's pipeline cache.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    fn try_remote_pipeline(&mut self) -> Result<(), String> {
+        let (Some(remote), Some(source)) = (&self.remote_renderer, &self.document_source) else {
+            return Err("no remote renderer or no document source".into());
+        };
+
+        // The document's own URL is the renderer's base for relative
+        // subresource URLs; about:blank when it has none.
+        let page_url = self
+            .document_url
+            .as_ref()
+            .map(|url| url.to_string())
+            .unwrap_or_else(|| "about:blank".to_string());
+        let viewport = (self.viewport.width as f64, self.viewport.height as f64);
+        let started = std::time::Instant::now();
+        let resources = crate::fork_server::client::LoaderResources(&self.loader);
+        let loader: &dyn crate::fork_server::client::RenderResources = &resources;
+        // The whole exchange blocks on the renderer's socket (and, relaying its
+        // subresource requests, on the I/O runtime). Blocking a runtime worker
+        // while holding its scheduler core can trap tasks woken into this
+        // worker's unstealable LIFO slot - the brokered loader's reply path
+        // among them - so hand the core to another thread for the duration.
+        let run = || match remote {
+            RemoteRenderer::ForkServer(server) => server.lock().render_page(
+                source,
+                &page_url,
+                &self.remote_tab,
+                viewport,
+                loader,
+                &self.remote_tile_memory,
+                self.hover_leaf.map(|id| id.into()),
+            ),
+            RemoteRenderer::ExecPerRender => crate::render_process::client::render_page(
+                source,
+                &page_url,
+                &self.remote_tab,
+                viewport,
+                loader,
+                &self.remote_tile_memory,
+                self.hover_leaf.map(|id| id.into()),
+            ),
+        };
+        let result = match tokio::runtime::Handle::try_current() {
+            Ok(h) if h.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+                tokio::task::block_in_place(run)
+            }
+            _ => run(),
+        };
+        match result {
+            Ok(page) => {
+                report_remote_pass(
+                    "remote.navigate",
+                    &self.remote_tab,
+                    &page_url,
+                    self.scroll_y,
+                    &page,
+                    started.elapsed(),
+                );
+                self.adopt_remote_page(page);
+                Ok(())
+            }
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    /// A whole page from a renderer replaces what this tab holds.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    fn adopt_remote_page(&mut self, page: crate::fork_server::client::RenderedPage) {
+        // This page's tiles are exactly what came back: what an
+        // earlier page of this tab kept cannot help it.
+        self.remote_tile_memory
+            .replace_with(page.tiles.into_iter().map(kept_tile));
+        let baked = self.remote_tile_memory.baked_tiles(&page.summary.layer_order);
+        let cached_tiles = Arc::new(gosub_render_pipeline::rasterizer::cpu_cached_tiles(&baked));
+        self.pipeline_cache = Some(PipelineCache {
+            tiles: baked,
+            page_height: page.summary.page_height,
+            cached_tiles,
+            layer_list: None,
+            hit_regions: page.hit_regions,
+            tile_pixel_cache: Default::default(),
+        });
     }
 
     /// Record the window now rastered, so scrolling can tell when it reaches unbaked content.
@@ -492,14 +733,30 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
             self.extend_raster_window();
         } else if self.hover_dirty {
             // Paint-only repaint: reuse the cached layout tree, skip stages 1–2.
+            // A remotely rendered page has no layer list to repaint from; hover
+            // there re-renders instead (see `update_hover`).
+            let has_layer_list = self
+                .pipeline_cache
+                .as_ref()
+                .is_some_and(|cache| cache.layer_list.is_some());
+            if !has_layer_list && self.pipeline_cache.is_some() {
+                self.hover_dirty = false;
+                self.scroll_dirty = false;
+                return;
+            }
             if let Some(old_cache) = self.pipeline_cache.take() {
                 let PipelineCache {
-                    layer_list,
+                    layer_list: Some(layer_list),
                     page_height,
                     tile_pixel_cache: prev_tile_cache,
                     tiles: prev_baked_tiles,
                     ..
-                } = old_cache;
+                } = old_cache
+                else {
+                    // Checked above: the cache has a layer list; this arm
+                    // cannot run, and diverging satisfies let-else.
+                    return;
+                };
                 self.pipeline_cache = Some(pipeline_hover_repaint(
                     layer_list,
                     page_height,
@@ -621,7 +878,7 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
         self.scene_cache
             .as_ref()
             .map(|c| &c.layer_list)
-            .or_else(|| self.pipeline_cache.as_ref().map(|c| &c.layer_list))
+            .or_else(|| self.pipeline_cache.as_ref().and_then(|c| c.layer_list.as_ref()))
     }
 
     /// Page-space top of the element a URL fragment points at, per the HTML "indicated part
@@ -858,6 +1115,15 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
     /// content. URLs are resolved against `base`. Read-only: does not touch hover state.
     pub fn hit_test(&self, vp_x: f64, vp_y: f64, base: Option<&Url>) -> HitTestResponse {
         let mut out = HitTestResponse::default();
+        #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+        if let Some(regions) = self.remote_hit_regions() {
+            if let Some(region) = hit_region_at(regions, vp_x, vp_y, self.scroll_x, self.scroll_y) {
+                out.link_url = region.link.clone();
+                out.image_url = region.image.clone();
+                out.is_editable = region.editable;
+            }
+            return out;
+        }
         let (Some(layer_list), Some(doc)) = (self.active_layer_list(), self.document.as_ref()) else {
             return out;
         };
@@ -919,6 +1185,15 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
 
         let (scroll_x, scroll_y) = (self.scroll_x, self.scroll_y);
 
+        // A remotely rendered page carries hit-test geometry instead of a layer
+        // list; the layout element id is unavailable there, which costs hover
+        // repaint, not hit testing (see `PipelineCache::hit_regions`).
+        #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+        if let Some(regions) = self.remote_hit_regions() {
+            let hit = hit_region_at(regions, vp_x, vp_y, scroll_x, scroll_y).cloned();
+            return self.apply_remote_hover(hit.as_ref());
+        }
+
         let (new_leaf, new_lei) = self.active_layer_list().map_or((None, None), |layer_list| {
             let _t = gosub_shared::timing_guard!("hover.hit_test");
             // find_element_at handles scroll per-layer (fixed layers ignore it).
@@ -929,6 +1204,54 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
             (dom_node_id, Some(lei))
         });
 
+        self.apply_hover(new_leaf, new_lei)
+    }
+
+    /// Hit-test geometry for a remotely rendered page, when that is how the
+    /// current page was produced.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    fn remote_hit_regions(&self) -> Option<&[crate::fork_server::protocol::HitRegion]> {
+        let cache = self.pipeline_cache.as_ref()?;
+        (cache.layer_list.is_none() && !cache.hit_regions.is_empty()).then_some(cache.hit_regions.as_slice())
+    }
+
+    /// Hover over a remotely rendered page: the region carries what the
+    /// renderer resolved (link, cursor); the next render applies `:hover`
+    /// there, so any change of element is visually dirty.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    fn apply_remote_hover(
+        &mut self,
+        hit: Option<&crate::fork_server::protocol::HitRegion>,
+    ) -> (bool, bool, Option<String>) {
+        use crate::fork_server::protocol::HitCursor;
+        let new_leaf = hit.map(|r| NodeId::from(r.node_id));
+        if new_leaf == self.hover_leaf {
+            return (false, false, self.hover_link_url.clone());
+        }
+        self.hover_leaf = new_leaf;
+        self.hover_layout_element = None;
+        let link = hit.and_then(|r| r.link.clone());
+        self.hover_cursor = match hit.map(|r| r.cursor) {
+            Some(HitCursor::Pointer) => CursorShape::Pointer,
+            Some(HitCursor::Text) => CursorShape::Text,
+            _ => CursorShape::Default,
+        };
+        let url_changed = link != self.hover_link_url;
+        self.hover_link_url = link.clone();
+        // The renderer re-parses per render and skips tiles whose painted
+        // content did not change, so a hover re-render stays cheap.
+        self.render_dirty = true;
+        (true, url_changed, link)
+    }
+
+    /// Fold a hit-test result into hover state: ancestor walk for the link and
+    /// `:hover` sensitivity, CSS invalidation for the nodes whose hover state
+    /// changed, and the repaint decision.
+    fn apply_hover(
+        &mut self,
+        new_leaf: Option<NodeId>,
+        new_lei: Option<LayoutElementId>,
+    ) -> (bool, bool, Option<String>) {
         // Common case: same element - skip the ancestor walk entirely.
         if new_leaf == self.hover_leaf {
             return (false, false, self.hover_link_url.clone());
@@ -1021,7 +1344,14 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
             }
             // Hover-only changes are paint-only (color, background, box-shadow).
             // Use the cheap hover-dirty path which skips render-tree + layout.
-            self.hover_dirty = true;
+            // A remotely rendered page has no local layout tree to repaint from,
+            // so hover falls back to a re-render; the renderer skips tiles with
+            // unchanged content, so this stays cheap.
+            if self.remote_render_active() {
+                self.render_dirty = true;
+            } else {
+                self.hover_dirty = true;
+            }
         }
 
         (visual_dirty, url_changed, link_url)
@@ -1243,7 +1573,8 @@ fn pipeline_build_cache<C: RenderConfiguration>(
         tiles: baked_tiles,
         page_height,
         cached_tiles,
-        layer_list: saved_layer_list,
+        layer_list: Some(saved_layer_list),
+        hit_regions: Vec::new(),
         tile_pixel_cache: new_tile_cache,
     }
 }
@@ -1328,9 +1659,115 @@ fn pipeline_extend_raster(
         tiles: all_baked_tiles,
         page_height,
         cached_tiles,
-        layer_list,
+        layer_list: Some(layer_list),
+        hit_regions: Vec::new(),
         tile_pixel_cache: merged_tile_cache,
     }
+}
+
+/// One remote render, onto the telemetry firehose: the exchange as the
+/// broker saw it, plus the stage costs the renderer reported.
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+fn report_remote_pass(
+    kind: &str,
+    tab: &str,
+    url: &str,
+    scroll_y: f64,
+    page: &crate::fork_server::client::RenderedPage,
+    exchange: std::time::Duration,
+) {
+    use crate::fork_server::client::PageTile;
+    if !crate::telemetry::enabled() {
+        return;
+    }
+    let fresh = page
+        .tiles
+        .iter()
+        .filter(|t| matches!(t, PageTile::Fresh { .. }))
+        .count();
+    let bytes: usize = page
+        .tiles
+        .iter()
+        .map(|t| match t {
+            PageTile::Fresh { mapping, .. } => mapping.as_slice().len(),
+            PageTile::Reused { .. } => 0,
+        })
+        .sum();
+    let renderer: serde_json::Map<String, serde_json::Value> = page
+        .summary
+        .timings_us
+        .iter()
+        .map(|(name, us)| (name.clone(), serde_json::json!(us)))
+        .collect();
+    crate::telemetry::emit(
+        kind,
+        serde_json::json!({
+            "tab": tab,
+            "url": url,
+            "scroll_y": scroll_y,
+            "exchange_us": exchange.as_micros() as u64,
+            "tiles_fresh": fresh,
+            "tiles_reused": page.tiles.len() - fresh,
+            "bytes_shipped": bytes,
+            "page_height": page.summary.page_height,
+            "painted_tiles": page.summary.painted_tiles,
+            "renderer_us": renderer,
+        }),
+    );
+}
+
+/// A received tile as this tab keeps it: fresh pixels are the renderer's
+/// mapped pages (zero-copy), reused ones are what was kept before.
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+fn kept_tile(tile: crate::fork_server::client::PageTile) -> (u64, crate::fork_server::client::KeptTile) {
+    use crate::fork_server::client::{KeptTile, PageTile};
+    match tile {
+        PageTile::Fresh { header, mapping } => (
+            header.content_hash,
+            KeptTile::from_header(&header, bytes::Bytes::from_owner(mapping)),
+        ),
+        PageTile::Reused { header, kept } => (header.content_hash, kept),
+    }
+}
+
+/// Which node a point lands on, per a remotely rendered page's geometry.
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+fn hit_region_at(
+    regions: &[crate::fork_server::protocol::HitRegion],
+    vp_x: f64,
+    vp_y: f64,
+    scroll_x: f64,
+    scroll_y: f64,
+) -> Option<&crate::fork_server::protocol::HitRegion> {
+    use crate::fork_server::protocol::TileWireAnchor;
+    use gosub_render_pipeline::render::backend::StickyConstraint;
+
+    for region in regions {
+        let (x, y) = match region.anchor {
+            TileWireAnchor::Fixed => (vp_x, vp_y),
+            TileWireAnchor::Scroll => (vp_x + scroll_x, vp_y + scroll_y),
+            TileWireAnchor::Sticky(s) => {
+                let (dx, dy) = StickyConstraint {
+                    inset_top: s.inset_top,
+                    inset_left: s.inset_left,
+                    natural_x: s.natural_x,
+                    natural_y: s.natural_y,
+                    natural_w: s.natural_w,
+                    natural_h: s.natural_h,
+                    cage_x: s.cage_x,
+                    cage_y: s.cage_y,
+                    cage_w: s.cage_w,
+                    cage_h: s.cage_h,
+                }
+                .offset(scroll_x, scroll_y);
+                (vp_x + scroll_x - dx, vp_y + scroll_y - dy)
+            }
+        };
+        if x >= region.x && x < region.x + region.width && y >= region.y && y < region.y + region.height {
+            return Some(region);
+        }
+    }
+    None
 }
 
 /// Hover-only repaint: skip stages 1–2 (render-tree + layout), reuse the cached
@@ -1434,7 +1871,8 @@ fn pipeline_hover_repaint(
             tiles: all_tiles,
             page_height,
             cached_tiles,
-            layer_list,
+            layer_list: Some(layer_list),
+            hit_regions: Vec::new(),
             tile_pixel_cache: prev_tile_cache,
         };
     }
@@ -1479,7 +1917,8 @@ fn pipeline_hover_repaint(
         tiles: all_baked_tiles,
         page_height,
         cached_tiles,
-        layer_list,
+        layer_list: Some(layer_list),
+        hit_regions: Vec::new(),
         tile_pixel_cache: new_tile_cache,
     }
 }
@@ -1626,7 +2065,7 @@ mod tests {
             </body></html>"#;
             let mut doc = gosub_html5::html_compile::<DefaultRenderConfig>(html);
             doc.add_stylesheet(Css3System::load_default_useragent_stylesheet());
-            ctx.set_document(Arc::new(doc));
+            ctx.set_document(Arc::new(doc), None);
             ctx.rebuild_pipeline_cache_if_needed();
             ctx
         }
@@ -1667,7 +2106,7 @@ mod tests {
             </body></html>"#;
             let mut doc = gosub_html5::html_compile::<DefaultRenderConfig>(html);
             doc.add_stylesheet(Css3System::load_default_useragent_stylesheet());
-            ctx.set_document(Arc::new(doc));
+            ctx.set_document(Arc::new(doc), None);
             ctx.rebuild_pipeline_cache_if_needed();
 
             // Empty div: arrow.
@@ -1706,7 +2145,7 @@ mod tests {
             </body></html>"#;
             let mut doc = gosub_html5::html_compile::<DefaultRenderConfig>(html);
             doc.add_stylesheet(Css3System::load_default_useragent_stylesheet());
-            ctx.set_document(Arc::new(doc));
+            ctx.set_document(Arc::new(doc), None);
             ctx.rebuild_pipeline_cache_if_needed();
             let base = Url::parse("https://example.com/dir/page.html").unwrap();
 
@@ -1753,7 +2192,7 @@ mod tests {
             </body></html>"#;
             let mut doc = gosub_html5::html_compile::<DefaultRenderConfig>(html);
             doc.add_stylesheet(Css3System::load_default_useragent_stylesheet());
-            ctx.set_document(Arc::new(doc));
+            ctx.set_document(Arc::new(doc), None);
             ctx.rebuild_pipeline_cache_if_needed();
 
             // Tab cycles a → input → button → wraps to a. The tabindex=-1 link is skipped.
@@ -1802,7 +2241,7 @@ mod tests {
             </body></html>"#;
             let mut doc = gosub_html5::html_compile::<DefaultRenderConfig>(html);
             doc.add_stylesheet(Css3System::load_default_useragent_stylesheet());
-            ctx.set_document(Arc::new(doc));
+            ctx.set_document(Arc::new(doc), None);
             ctx.rebuild_pipeline_cache_if_needed();
             assert!(ctx.page_height() > 0.0, "page laid out");
         }
@@ -1899,7 +2338,7 @@ mod tests {
                 r#"<html><body style="margin:0"><div style="height:10000px;background:#ddd"></div></body></html>"#;
             let mut doc = gosub_html5::html_compile::<DefaultRenderConfig>(html);
             doc.add_stylesheet(Css3System::load_default_useragent_stylesheet());
-            ctx.set_document(Arc::new(doc));
+            ctx.set_document(Arc::new(doc), None);
 
             (ctx, calls)
         }

--- a/crates/gosub_engine/src/engine/engine.rs
+++ b/crates/gosub_engine/src/engine/engine.rs
@@ -75,6 +75,14 @@ pub struct EngineContext {
     /// this to attach cookies itself, so no cookie value is ever handled by tab
     /// code — see [`TabIdentityRegistry`].
     pub tab_identities: Arc<TabIdentityRegistry>,
+    /// The fork server renderers are forked from, if `security.renderer_process`
+    /// is on and it started (set once at [`GosubEngine::start`], like `io_tx`).
+    /// One per engine: what it holds (a warmed font system, a confinement tier)
+    /// is engine-wide state. On the shared context so tab workers can route
+    /// their renders through it; behind a `Mutex` because its request/reply
+    /// protocol is strictly serial.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    pub renderer_process: OnceLock<Arc<Mutex<crate::fork_server::client::ForkServer>>>,
 }
 
 impl Default for EngineContext {
@@ -87,6 +95,8 @@ impl Default for EngineContext {
             request_reference_map: Arc::new(RwLock::new(RequestReferenceMap::new())),
             internal_pages: InternalPages::with_builtins(),
             tab_identities: Arc::new(TabIdentityRegistry::new()),
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            renderer_process: OnceLock::new(),
         }
     }
 }
@@ -127,6 +137,8 @@ impl<C: RenderConfiguration> GosubEngine<C> {
                 request_reference_map: Arc::new(RwLock::new(RequestReferenceMap::new())),
                 internal_pages: InternalPages::with_builtins(),
                 tab_identities: Arc::new(TabIdentityRegistry::new()),
+                #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+                renderer_process: OnceLock::new(),
             }),
             render_backend: backend,
             compositor,
@@ -168,10 +180,140 @@ impl<C: RenderConfiguration> GosubEngine<C> {
         #[cfg(feature = "metrics")]
         crate::metrics::start(9090);
 
+        // Spawn the renderer fork server if asked to. Blocks briefly (spawn
+        // plus font warm-up, ~200 ms typical) - acceptable at startup, and
+        // the answer decides engine-wide behaviour, so it belongs here.
+        #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+        self.start_renderer_process();
+
         // Hand the run-loop future to the caller to drive (spawn / await / select!) rather than
         // spawning it ourselves. `run()` yields `None` only if the loop was already taken, which
         // cannot happen here since `self.running` was false above.
         self.run().ok_or(EngineError::AlreadyRunning)
+    }
+
+    /// Spawn the fork server when `security.renderer_process` asks for it.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    fn start_renderer_process(&mut self) {
+        use crate::fork_server::client::ForkServer;
+        use crate::fork_server::protocol::ConfinementTier;
+
+        if !self.context.config_store.get_bool("security.renderer_process") {
+            return;
+        }
+
+        let by_default = self.setting_at_default("security.renderer_process");
+
+        // The configured font system's (static) tier decides the mechanism:
+        // only `Full` systems benefit from a warmed fork server.
+        // `FontPathsReadable` renders in throwaway exec'd processes spawned
+        // per render (see `render_process`) - nothing to start here, and not
+        // by default either: an embedder opts into that mode knowingly.
+        {
+            use gosub_interface::font_system::{Confinement, FontSystem as _};
+            match C::FontSystem::confinement() {
+                Confinement::Full => {}
+                Confinement::FontPathsReadable if by_default => {
+                    log::info!(
+                        "renderer isolation is off by default for this font system (it reads font \
+                         files while operating, so renderers would be exec'd per render); set \
+                         security.renderer_process explicitly to opt in"
+                    );
+                    self.turn_off("security.renderer_process");
+                    return;
+                }
+                Confinement::FontPathsReadable => {
+                    log::info!(
+                        "renderer isolation active in exec-per-render mode \
+                         (the configured font system reads font files while operating)"
+                    );
+                    return;
+                }
+                Confinement::Unsupported(reason) => {
+                    if by_default {
+                        log::info!(
+                            "renderer isolation is off: the configured font system cannot run isolated ({reason})"
+                        );
+                    } else {
+                        log::warn!(
+                            "security.renderer_process is on, but the configured font system cannot run \
+                             isolated ({reason}); rendering stays in-process"
+                        );
+                    }
+                    self.turn_off("security.renderer_process");
+                    return;
+                }
+            }
+        }
+
+        // A renderer that cannot rasterize would ship geometry and no pixels:
+        // blank tabs with no way back. Better to say so and stay in-process.
+        {
+            let fonts: Arc<Mutex<dyn gosub_interface::font_system::FontSystem>> =
+                Arc::new(Mutex::new(C::FontSystem::default()));
+            if C::forked_tile_rasterizer(fonts).is_none() {
+                if by_default {
+                    log::info!(
+                        "renderer isolation is off: this RenderConfiguration provides no \
+                         forked_tile_rasterizer (enable the engine's `cairo-tiles`/`skia-tiles` feature)"
+                    );
+                } else {
+                    log::warn!(
+                        "security.renderer_process is on, but this RenderConfiguration provides no \
+                         forked_tile_rasterizer (enable the engine's `cairo-tiles`/`skia-tiles` feature, \
+                         or implement it); rendering stays in-process"
+                    );
+                }
+                self.turn_off("security.renderer_process");
+                return;
+            }
+        }
+
+        match ForkServer::spawn() {
+            Ok(mut server) => {
+                let tier = server.confinement().clone();
+                match tier {
+                    ConfinementTier::Unsupported(reason) => {
+                        log::warn!(
+                            "security.renderer_process is on, but the configured font system cannot run \
+                             isolated ({reason}); rendering stays in-process"
+                        );
+                        self.turn_off("security.renderer_process");
+                        server.shutdown();
+                    }
+                    tier => {
+                        log::info!("renderer fork server ready (confinement tier: {tier:?})");
+                        // Set once, like `io_tx`; `start()` refuses to run twice.
+                        let _ = self.context.renderer_process.set(Arc::new(Mutex::new(server)));
+                    }
+                }
+            }
+            Err(e) => {
+                log::warn!(
+                    "security.renderer_process is on, but the fork server could not be started ({e}); \
+                     rendering stays in-process. The most likely cause is an embedder that has not \
+                     called gosub_engine::child_process::dispatch_with() first thing in main()."
+                );
+            }
+        }
+    }
+
+    /// The running renderer fork server, when `security.renderer_process` is on
+    /// and it started - the handle render routing goes through. `None` means
+    /// this engine renders in-process.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    pub fn renderer_process(&self) -> Option<&Arc<Mutex<crate::fork_server::client::ForkServer>>> {
+        self.context.renderer_process.get()
+    }
+
+    /// The confinement tier the renderer fork server announced, when one is
+    /// running: how confined this engine's forked renderers are.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    pub fn renderer_process_tier(&self) -> Option<crate::fork_server::protocol::ConfinementTier> {
+        self.context
+            .renderer_process
+            .get()
+            .map(|server| server.lock().confinement().clone())
     }
 
     /// Return a receiver for engine events.
@@ -217,7 +359,11 @@ impl<C: RenderConfiguration> GosubEngine<C> {
     /// in CI.
     #[cfg(feature = "process-isolation")]
     fn resolve_isolation_settings(&self) {
-        const PROCESS_SETTINGS: [&str; 2] = ["security.network_process", "security.image_decoder_process"];
+        const PROCESS_SETTINGS: [&str; 3] = [
+            "security.network_process",
+            "security.image_decoder_process",
+            "security.renderer_process",
+        ];
         let store = &self.context.config_store;
 
         if !crate::child_process::was_dispatched() {
@@ -307,6 +453,14 @@ impl<C: RenderConfiguration> GosubEngine<C> {
 
         // Persist cookie stores before tearing anything down.
         self.flush_persistence();
+
+        // Ask the fork server for a clean exit (it kills-and-reaps on drop
+        // regardless, but a Shutdown lets it leave without a SIGKILL).
+        #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+        if let Some(server) = self.context.renderer_process.get() {
+            log::trace!("signal: shutting down the renderer fork server");
+            server.lock().shutdown();
+        }
 
         // Shutdown I/O thread
         log::trace!("signal: shutting down I/O thread");
@@ -451,6 +605,47 @@ mod tests {
             partition_policy: PartitionPolicy::None,
             places: None,
         }
+    }
+
+    /// Without `child_process::dispatch()` the process settings must not survive
+    /// `start()`: a child would re-exec into this test binary's own startup.
+    #[cfg(feature = "process-isolation")]
+    #[tokio::test]
+    async fn process_settings_are_dropped_without_dispatch() {
+        use gosub_config::settings::Setting;
+        let mut engine = engine_with_max_zones(1);
+        for key in [
+            "security.network_process",
+            "security.image_decoder_process",
+            "security.renderer_process",
+        ] {
+            engine.settings().set(key, Setting::Bool(true)).expect("set");
+            assert!(engine.settings().get_bool(key));
+        }
+        assert!(!crate::child_process::was_dispatched());
+        let _join = tokio::spawn(engine.start().expect("start"));
+        for key in [
+            "security.network_process",
+            "security.image_decoder_process",
+            "security.renderer_process",
+        ] {
+            assert!(!engine.settings().get_bool(key), "{key} should have been turned off");
+        }
+    }
+
+    /// The defaults are on, but they too need `dispatch()`: an engine in a
+    /// process that never dispatched ends up with all three off, quietly.
+    #[cfg(feature = "process-isolation")]
+    #[tokio::test]
+    async fn process_settings_default_on_but_need_dispatch() {
+        let mut engine = engine_with_max_zones(1);
+        assert!(engine.settings().get_bool("security.network_process"));
+        assert!(engine.settings().get_bool("security.image_decoder_process"));
+        assert!(engine.settings().get_bool("security.renderer_process"));
+        let _join = tokio::spawn(engine.start().expect("start"));
+        assert!(!engine.settings().get_bool("security.network_process"));
+        assert!(!engine.settings().get_bool("security.image_decoder_process"));
+        assert!(!engine.settings().get_bool("security.renderer_process"));
     }
 
     fn engine_with_max_zones(max_zones: usize) -> GosubEngine {

--- a/crates/gosub_engine/src/engine/events.rs
+++ b/crates/gosub_engine/src/engine/events.rs
@@ -674,6 +674,15 @@ pub enum EngineEvent {
         zone_id: ZoneId,
         error: String,
     },
+    /// A renderer process could not render a tab's page. Page content is
+    /// never rendered in-process once isolation is on, so the tab stays
+    /// blank until a render succeeds again; an embedder may want to show
+    /// something meanwhile.
+    RendererCrashed {
+        zone_id: ZoneId,
+        tabs: Vec<TabId>,
+        error: String,
+    },
     // Uncategorized / generic
 }
 

--- a/crates/gosub_engine/src/engine/resource_pipeline.rs
+++ b/crates/gosub_engine/src/engine/resource_pipeline.rs
@@ -44,6 +44,7 @@ impl<C: RenderConfiguration> ResourcePipelines<C> {
         io_tx: IoChannel,
         accept_language: Option<String>,
         max_document_bytes: usize,
+        capture_source: bool,
     ) -> Self {
         Self {
             html: Box::new(HtmlPipelineImpl::new(
@@ -52,6 +53,7 @@ impl<C: RenderConfiguration> ResourcePipelines<C> {
                 io_tx,
                 accept_language,
                 max_document_bytes,
+                capture_source,
             )),
             css: Box::new(CssPipelineImpl {}),
             js: Box::new(JsPipelineImpl {}),

--- a/crates/gosub_engine/src/engine/resource_pipeline/html.rs
+++ b/crates/gosub_engine/src/engine/resource_pipeline/html.rs
@@ -19,6 +19,19 @@ use tokio::io::AsyncRead;
 use tokio::task::JoinHandle;
 use tokio_util::io::StreamReader;
 
+/// What the pipeline made of a document body: the parsed document, with its
+/// source when a renderer process may re-parse it.
+pub struct ParsedDocument<C: RenderConfiguration> {
+    pub doc: Box<EngineDocument<C>>,
+    pub source: Option<Arc<str>>,
+}
+
+impl<C: RenderConfiguration> ParsedDocument<C> {
+    pub fn into_parts(self) -> (EngineDocument<C>, Option<Arc<str>>) {
+        (*self.doc, self.source)
+    }
+}
+
 #[async_trait]
 pub trait HtmlPipeline<C: RenderConfiguration> {
     async fn parse_stream(
@@ -28,7 +41,7 @@ pub trait HtmlPipeline<C: RenderConfiguration> {
         meta: FetchResultMeta,
         peek_buf: PeekBuf,
         body: Arc<SharedBody>,
-    ) -> anyhow::Result<EngineDocument<C>>;
+    ) -> anyhow::Result<ParsedDocument<C>>;
 
     async fn parse_bytes(
         &mut self,
@@ -36,7 +49,7 @@ pub trait HtmlPipeline<C: RenderConfiguration> {
         handle: FetchHandle,
         meta: FetchResultMeta,
         body: &[u8],
-    ) -> anyhow::Result<EngineDocument<C>>;
+    ) -> anyhow::Result<ParsedDocument<C>>;
 }
 
 pub struct HtmlPipelineImpl {
@@ -49,6 +62,10 @@ pub struct HtmlPipelineImpl {
     accept_language: Option<String>,
     /// Max document size in bytes (`net.document.max_bytes`); larger documents are truncated.
     max_document_bytes: usize,
+    /// Also return the parsed document's source text (see
+    /// `HtmlParseConfig::capture_source`) - on when the engine renders
+    /// out-of-process and its renderer will need to re-parse.
+    capture_source: bool,
 }
 
 impl HtmlPipelineImpl {
@@ -58,6 +75,7 @@ impl HtmlPipelineImpl {
         io_tx: IoChannel,
         accept_language: Option<String>,
         max_document_bytes: usize,
+        capture_source: bool,
     ) -> Self {
         Self {
             io_tx,
@@ -65,6 +83,7 @@ impl HtmlPipelineImpl {
             tab_id,
             accept_language,
             max_document_bytes,
+            capture_source,
         }
     }
 
@@ -74,7 +93,7 @@ impl HtmlPipelineImpl {
         handle: FetchHandle,
         meta: FetchResultMeta,
         reader: R,
-    ) -> anyhow::Result<EngineDocument<C>>
+    ) -> anyhow::Result<ParsedDocument<C>>
     where
         C: RenderConfiguration,
         R: AsyncRead + Unpin + Send + 'static,
@@ -87,6 +106,7 @@ impl HtmlPipelineImpl {
 
         let cfg = crate::html::HtmlParseConfig {
             max_bytes: self.max_document_bytes,
+            capture_source: self.capture_source,
             // The parse happens on this tab's behalf, so its stylesheet loads carry
             // the tab's identity and cookies like any other request — and are
             // cancelled with the parse that wanted them.
@@ -199,7 +219,11 @@ impl HtmlPipelineImpl {
             }
         }
 
-        res.map_err(|e| anyhow!("Failed to parse HTML document: {:?}", e))
+        res.map(|(doc, source)| ParsedDocument {
+            doc: Box::new(doc),
+            source,
+        })
+        .map_err(|e| anyhow!("Failed to parse HTML document: {:?}", e))
     }
 }
 
@@ -212,7 +236,7 @@ impl<C: RenderConfiguration> HtmlPipeline<C> for HtmlPipelineImpl {
         meta: FetchResultMeta,
         peek_buf: PeekBuf,
         shared: Arc<SharedBody>,
-    ) -> anyhow::Result<EngineDocument<C>> {
+    ) -> anyhow::Result<ParsedDocument<C>> {
         let reader = SharedBody::combined_reader(peek_buf, shared);
         self.parse_with_reader::<C, _>(request, handle, meta, reader).await
     }
@@ -223,7 +247,7 @@ impl<C: RenderConfiguration> HtmlPipeline<C> for HtmlPipelineImpl {
         handle: FetchHandle,
         meta: FetchResultMeta,
         body: &[u8],
-    ) -> anyhow::Result<EngineDocument<C>> {
+    ) -> anyhow::Result<ParsedDocument<C>> {
         // parsing bytes is just creating a stream of those bytes and passing it to the stream reader
         let stream = stream::iter(vec![Ok::<Bytes, std::io::Error>(Bytes::copy_from_slice(body))]);
         let reader = StreamReader::new(stream);
@@ -331,16 +355,17 @@ mod tests {
         // Arrange
         let (io_tx, seen_children) = start_dummy_io();
         let zone_id = ZoneId::new();
-        let mut pipeline = HtmlPipelineImpl::new(zone_id, TabId::new(), io_tx, None, 10 * 1024 * 1024);
+        let mut pipeline = HtmlPipelineImpl::new(zone_id, TabId::new(), io_tx, None, 10 * 1024 * 1024, false);
 
         let (req, handle) = test_request("https://example.com/path/index.html");
         let meta = test_meta("https://example.com/path/index.html");
         let body = HTML_WITH_RESOURCES.as_bytes();
 
         // Act
-        let doc = HtmlPipeline::<DefaultRenderConfig>::parse_bytes(&mut pipeline, req, handle, meta, body)
+        let (doc, _source) = HtmlPipeline::<DefaultRenderConfig>::parse_bytes(&mut pipeline, req, handle, meta, body)
             .await
-            .expect("parse_bytes should succeed");
+            .expect("parse_bytes should succeed")
+            .into_parts();
 
         // Allow spawned tasks to submit to IO and be recorded
         sleep(Duration::from_millis(10)).await;
@@ -360,7 +385,7 @@ mod tests {
         // Arrange
         let (io_tx, seen_children) = start_dummy_io();
         let zone_id = ZoneId::new();
-        let mut pipeline = HtmlPipelineImpl::new(zone_id, TabId::new(), io_tx, None, 10 * 1024 * 1024);
+        let mut pipeline = HtmlPipelineImpl::new(zone_id, TabId::new(), io_tx, None, 10 * 1024 * 1024, false);
 
         let (req, handle) = test_request("https://example.com/");
         let meta = test_meta("https://example.com/");

--- a/crates/gosub_engine/src/engine/settings.json
+++ b/crates/gosub_engine/src/engine/settings.json
@@ -441,6 +441,12 @@
       "type": "b",
       "default": "b:true",
       "description": "Decode raster images in a throwaway, sandboxed process, one per image. Needs the embedder to dispatch child roles. SVG is rasterized in that process at its intrinsic size (without system fonts), since a parsed vector tree cannot cross a process boundary; a decode the process refuses or cannot start is a failed image, never decoded in-process instead."
+    },
+    {
+      "key": "renderer_process",
+      "type": "b",
+      "default": "b:true",
+      "description": "Spawn the renderer fork server at engine start: a warmed, sandboxed process that renderers are forked from, one throwaway renderer per render, confined to the tier the configured font system answers. On by default on Linux when the embedder calls gosub_engine::child_process::dispatch_with::<AppConfig>() first thing in main() (plain dispatch() cannot run this role), the configured font system can run fully confined (Parley, cosmic-text) and the configuration has a forked rasterizer (the engine's cairo-tiles/skia-tiles feature, or a custom RenderConfiguration); a font system that reads font files while operating (Skia, Pango) renders in a throwaway exec'd process per render instead and must be opted into explicitly. If the fork server cannot start, pages render in-process (with a warning at startup); once it runs, page content is never rendered in-process - a failed render leaves the tab blank and emits EngineEvent::RendererCrashed. Linux only."
     }
   ],
   "telemetry": [

--- a/crates/gosub_engine/src/engine/tab/worker.rs
+++ b/crates/gosub_engine/src/engine/tab/worker.rs
@@ -148,6 +148,9 @@ pub enum NavigationResult<C: RenderConfiguration> {
         final_url: Url,
         title: Option<String>,
         doc: Arc<crate::html::EngineDocument<C>>,
+        /// The document's source text, captured when this engine renders
+        /// out-of-process (the renderer re-parses it there).
+        source: Option<Arc<str>>,
     },
     Err {
         nav_id: NavigationId,
@@ -256,6 +259,10 @@ pub struct TabWorker<C: RenderConfiguration> {
     /// height are only known then, and `set_scroll` clamps against the latter). Set by
     /// `on_nav_result`, consumed by `tick_draw`.
     pending_scroll: Option<PendingScroll>,
+    /// Set by the background web-font task each time a face registers, consumed
+    /// by `tick_draw` to re-run layout with the newly available font (the same
+    /// shape as `poll_media_completed` for images).
+    web_fonts_fresh: Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// Deferred scroll for a freshly committed document.
@@ -265,160 +272,6 @@ enum PendingScroll {
     Offset(i32, i32),
     /// Scroll to the element the URL fragment indicates (fresh load of `…#anchor`).
     Fragment(String),
-}
-
-/// Whether a CSS `unicode-range` descriptor (e.g. `"U+0000-00FF, U+0131"`) includes the
-/// Basic-Latin letter `U+0041` ('A') - our proxy for "covers Latin-script text".
-fn unicode_range_covers_basic_latin(range: &str) -> bool {
-    const TARGET: u32 = 0x41; // 'A'
-    for token in range.split([',', ' ', '\t', '\n', '\r']).filter(|t| !t.is_empty()) {
-        let Some(hex) = token
-            .trim()
-            .strip_prefix("U+")
-            .or_else(|| token.trim().strip_prefix("u+"))
-        else {
-            continue;
-        };
-        let (lo, hi) = match hex.split_once('-') {
-            Some((a, b)) => (parse_hex_bound(a, false), parse_hex_bound(b, true)),
-            None => (parse_hex_bound(hex, false), parse_hex_bound(hex, true)),
-        };
-        if let (Some(lo), Some(hi)) = (lo, hi) {
-            if lo <= TARGET && TARGET <= hi {
-                return true;
-            }
-        }
-    }
-    false
-}
-
-/// Unwrap a downloaded web-font payload into raw SFNT bytes the font backends can decode.
-///
-/// WOFF2 (magic `wOF2`) is a Brotli-compressed wrapper around an OpenType/TrueType font,
-/// with the `glyf`/`loca` tables stored in a transformed form. Skia and fontconfig don't
-/// decode it (e.g. Google Fonts serves WOFF2 to modern UAs like ours), so we decompress it
-/// to a flat SFNT here. Bare SFNT (`OTTO`/`true`/`ttcf`/`0x00010000`) and anything we don't
-/// recognise are returned unchanged - including WOFF1, which the backends already handle.
-/// On a decode error we log and return the original bytes so the subsequent `register_font`
-/// surfaces a single, consistent failure path.
-fn decode_web_font(bytes: Vec<u8>, font_url: &Url) -> Vec<u8> {
-    const WOFF2_MAGIC: &[u8; 4] = b"wOF2";
-    if bytes.len() < 4 || &bytes[0..4] != WOFF2_MAGIC {
-        return bytes;
-    }
-    match woff2_to_sfnt(&bytes) {
-        Ok(sfnt) => {
-            log::debug!(
-                "Decoded WOFF2 web font from {font_url} ({} → {} bytes)",
-                bytes.len(),
-                sfnt.len()
-            );
-            sfnt
-        }
-        Err(e) => {
-            log::warn!("Failed to decode WOFF2 web font from {font_url}: {e}");
-            bytes
-        }
-    }
-}
-
-/// Decompress a WOFF2 font to a flat SFNT (TTF/OTF) byte buffer. allsorts handles the Brotli
-/// decompression and the `glyf`/`loca` transform reconstruction; we then re-assemble the
-/// reconstructed tables into the on-disk SFNT layout (offset table + table directory + 4-byte
-/// aligned table data) that font backends expect.
-fn woff2_to_sfnt(bytes: &[u8]) -> Result<Vec<u8>, String> {
-    use allsorts::binary::read::ReadScope;
-    use allsorts::woff2::Woff2Font;
-
-    let font = ReadScope::new(bytes)
-        .read::<Woff2Font<'_>>()
-        .map_err(|e| format!("parse: {e:?}"))?;
-    let sfnt_version = font.flavor();
-    let tables = font
-        .table_provider(0)
-        .map_err(|e| format!("reconstruct: {e:?}"))?
-        .into_tables();
-
-    Ok(assemble_sfnt(sfnt_version, tables))
-}
-
-/// Pack a set of font tables into an SFNT byte buffer per the OpenType spec: a 12-byte offset
-/// table, a 16-byte directory entry per table (sorted by tag), then each table's data padded to
-/// a 4-byte boundary. Per-table checksums are computed; the `head` table's `checkSumAdjustment`
-/// is left as-is (font backends parse without validating it).
-fn assemble_sfnt(sfnt_version: u32, tables: std::collections::HashMap<u32, Box<[u8]>>) -> Vec<u8> {
-    let mut entries: Vec<(u32, Box<[u8]>)> = tables.into_iter().collect();
-    entries.sort_by_key(|(tag, _)| *tag);
-    let num_tables = entries.len() as u16;
-
-    // Binary-search hint fields: largest power of two <= num_tables.
-    let mut entry_selector = 0u16;
-    while (1u16 << (entry_selector + 1)) <= num_tables {
-        entry_selector += 1;
-    }
-    let search_range = (1u16 << entry_selector) * 16;
-    let range_shift = num_tables.wrapping_mul(16).wrapping_sub(search_range);
-
-    let mut directory = Vec::with_capacity(16 * entries.len());
-    let mut data = Vec::new();
-    let mut offset = 12 + 16 * entries.len();
-    for (tag, table) in &entries {
-        directory.extend_from_slice(&tag.to_be_bytes());
-        directory.extend_from_slice(&sfnt_table_checksum(table).to_be_bytes());
-        directory.extend_from_slice(&(offset as u32).to_be_bytes());
-        directory.extend_from_slice(&(table.len() as u32).to_be_bytes());
-        data.extend_from_slice(table);
-        while data.len() % 4 != 0 {
-            data.push(0);
-        }
-        offset += (table.len() + 3) & !3;
-    }
-
-    let mut out = Vec::with_capacity(12 + directory.len() + data.len());
-    out.extend_from_slice(&sfnt_version.to_be_bytes());
-    out.extend_from_slice(&num_tables.to_be_bytes());
-    out.extend_from_slice(&search_range.to_be_bytes());
-    out.extend_from_slice(&entry_selector.to_be_bytes());
-    out.extend_from_slice(&range_shift.to_be_bytes());
-    out.extend_from_slice(&directory);
-    out.extend_from_slice(&data);
-    out
-}
-
-/// SFNT table checksum: the sum of the table's contents read as big-endian `u32`s, with the
-/// final partial word zero-padded, in wrapping (mod 2^32) arithmetic.
-fn sfnt_table_checksum(data: &[u8]) -> u32 {
-    let mut sum = 0u32;
-    for chunk in data.chunks(4) {
-        let mut word = [0u8; 4];
-        word[..chunk.len()].copy_from_slice(chunk);
-        sum = sum.wrapping_add(u32::from_be_bytes(word));
-    }
-    sum
-}
-
-/// Parse a `unicode-range` hex bound, expanding `?` wildcards to `0` (low bound) or `F`
-/// (high bound), e.g. `U+00??` → `0x0000..=0x00FF`.
-fn parse_hex_bound(s: &str, high: bool) -> Option<u32> {
-    let s = s.trim();
-    if s.is_empty() {
-        return None;
-    }
-    let filled: String = s
-        .chars()
-        .map(|c| {
-            if c == '?' {
-                if high {
-                    'F'
-                } else {
-                    '0'
-                }
-            } else {
-                c
-            }
-        })
-        .collect();
-    u32::from_str_radix(&filled, 16).ok()
 }
 
 impl<C: RenderConfiguration> TabWorker<C> {
@@ -432,10 +285,34 @@ impl<C: RenderConfiguration> TabWorker<C> {
         cmd_rx: mpsc::Receiver<TabCommand>,
     ) -> Self {
         let config_store = zone_context.config_store.clone();
-        let context = BrowsingContext::new(
+        #[allow(unused_mut)] // mut only used on the isolation-capable platform below
+        let mut context = BrowsingContext::new(
             config_store.clone(),
             BrokeredLoader::new(zone_id, Some(tab_id), zone_context.io_tx.clone()).shared(),
         );
+
+        // Install this tab's remote-render mode per the configured font
+        // system's (static) confinement tier: `Full` renders through the
+        // engine's warmed fork server, `FontPathsReadable` spawns a throwaway
+        // exec'd renderer per render, `Unsupported` stays in-process.
+        #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+        {
+            use crate::engine::context::RemoteRenderer;
+            use gosub_interface::font_system::{Confinement, FontSystem as _};
+            match C::FontSystem::confinement() {
+                Confinement::Full => {
+                    if let Some(server) = zone_context.engine_context.renderer_process.get() {
+                        context.set_remote_renderer(RemoteRenderer::ForkServer(Arc::clone(server)), tab_id.to_string());
+                    }
+                }
+                Confinement::FontPathsReadable => {
+                    if config_store.get_bool("security.renderer_process") {
+                        context.set_remote_renderer(RemoteRenderer::ExecPerRender, tab_id.to_string());
+                    }
+                }
+                Confinement::Unsupported(_) => {}
+            }
+        }
         let runtime = TabRuntime::with_fps(config_store.get_uint("renderer.tab.default_fps") as u32);
 
         Self {
@@ -467,6 +344,7 @@ impl<C: RenderConfiguration> TabWorker<C> {
             history: History::default(),
             reported_cursor: CursorShape::Default,
             pending_scroll: None,
+            web_fonts_fresh: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 
@@ -501,6 +379,23 @@ impl<C: RenderConfiguration> TabWorker<C> {
         });
 
         Ok(join_handle)
+    }
+
+    /// One frame onto the telemetry firehose: how it was produced and what it
+    /// cost, so a viewer can see stalls as they happen.
+    fn report_frame(&self, path: &str, started: std::time::Instant) {
+        if !crate::telemetry::enabled() {
+            return;
+        }
+        crate::telemetry::emit(
+            "tab.frame",
+            serde_json::json!({
+                "tab": self.tab_id.to_string(),
+                "path": path,
+                "frame_us": started.elapsed().as_micros() as u64,
+                "scroll_y": self.context.scroll_xy().1,
+            }),
+        );
     }
 
     // Main loop of the tab worker
@@ -592,52 +487,11 @@ impl<C: RenderConfiguration> TabWorker<C> {
         self.services.storage.drop_tab(self.zone_id, self.tab_id);
     }
 
-    /// Resolve the document's icon URL: the first `<link>` whose `rel` contains `icon`
-    /// (covers `icon`, `shortcut icon`, `apple-touch-icon`) with an `href`, resolved against
-    /// the document URL; else the well-known `/favicon.ico` for http(s) documents.
-    fn favicon_url(doc: &C::Document, base_url: &Url) -> Option<Url> {
-        use gosub_interface::document::Document as _;
-
-        fn walk<C: RenderConfiguration>(
-            doc: &C::Document,
-            node: gosub_shared::node::NodeId,
-            base: &Url,
-        ) -> Option<Url> {
-            for &child in doc.children(node) {
-                if doc.tag_name(child).is_some_and(|t| t.eq_ignore_ascii_case("link")) {
-                    // `icon`, `shortcut icon` (space-separated tokens) and the hyphenated
-                    // `apple-touch-icon` / `apple-touch-icon-precomposed`.
-                    let is_icon = doc.attribute(child, "rel").is_some_and(|rel| {
-                        rel.split_ascii_whitespace().any(|t| {
-                            t.eq_ignore_ascii_case("icon")
-                                || t.len() >= 16 && t[..16].eq_ignore_ascii_case("apple-touch-icon")
-                        })
-                    });
-                    if is_icon {
-                        if let Some(url) = doc.attribute(child, "href").and_then(|h| base.join(h).ok()) {
-                            return Some(url);
-                        }
-                    }
-                }
-                if let Some(found) = walk::<C>(doc, child, base) {
-                    return Some(found);
-                }
-            }
-            None
-        }
-
-        walk::<C>(doc, doc.root(), base_url).or_else(|| {
-            matches!(base_url.scheme(), "http" | "https")
-                .then(|| base_url.join("/favicon.ico").ok())
-                .flatten()
-        })
-    }
-
     /// Fetch the document's icon through the zone fetcher (so it carries the UA, cookies and
     /// shows up in resource events) and emit `FavIconChanged` with its bytes on success.
     /// Fire-and-forget: runs on its own task, cancelled with the navigation.
     fn fetch_favicon(&self, doc: &C::Document, base_url: &Url, nav_cancel: &CancellationToken) {
-        let Some(icon_url) = Self::favicon_url(doc, base_url) else {
+        let Some(icon_url) = crate::html::favicon_url::<C>(doc, base_url) else {
             return;
         };
         let req_id = RequestId::new();
@@ -702,69 +556,73 @@ impl<C: RenderConfiguration> TabWorker<C> {
         }
     }
 
-    /// Fetch and register any `@font-face` web fonts declared in the document's stylesheets
-    /// so the first layout/paint can use them. Runs once per navigation, before the first
-    /// render, and deduplicates by resolved font URL. Fetches are synchronous (blocking this
-    /// worker briefly during initial load); each face is registered under its CSS family so
-    /// the font system selects the right weight/style from the font's own metadata.
-    fn load_web_fonts(&self, doc: &C::Document, base_url: &Url) {
-        use gosub_interface::css3::CssStylesheet as _;
-        use gosub_interface::document::Document as _;
+    /// Fetch and register the document's `@font-face` web fonts into the
+    /// engine's font system, via the shared walk in [`crate::html::web_fonts`]
+    /// (the forked renderer runs the same walk with its own loader and fonts).
+    ///
+    /// Runs in the background: the loader blocks on the broker for each face,
+    /// and that wait belongs on a blocking thread, not in the worker loop (on a
+    /// current-thread runtime it would starve the very I/O task that produces
+    /// the reply). First paint may therefore use fallback fonts; each face that
+    /// lands flips `web_fonts_fresh`, and `tick_draw` re-renders with it.
+    fn load_web_fonts(&self, doc: &Arc<C::Document>, base_url: &Url) {
         use gosub_interface::font_system::FontSystem as _;
 
-        // Brokered rather than fetched here: this code becomes renderer-side, which
-        // must hold no network capability of its own (see `net::brokered_loader`).
-        let loader = self.resource_loader();
+        // A remotely rendered page registers its fonts in the renderer, which
+        // lays out with them; nothing here is painted with a fallback.
+        if self.context.remote_render_active() && !self.context.is_internal_page() {
+            return;
+        }
 
-        let mut fetched: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for sheet in doc.stylesheets() {
-            let sheet_url = Url::parse(sheet.url()).ok();
-            for (family, sources, unicode_range) in sheet.font_faces() {
-                // Google-style web fonts split a family into many `unicode-range` subsets
-                // (latin, cyrillic, greek, …). We don't do per-glyph subset fallback, so
-                // register only subsets covering Basic Latin (and ranges with no descriptor),
-                // which covers Latin-script content without piling unusable subsets onto the
-                // same family.
-                if let Some(range) = &unicode_range {
-                    if !unicode_range_covers_basic_latin(range) {
-                        continue;
+        // Brokered rather than fetched here: this code is renderer-side in
+        // spirit, and must hold no network capability of its own. The loader is
+        // tied to the navigation's cancel token, so an abandoned page stops
+        // downloading its fonts.
+        let loader = self.resource_loader();
+        let doc = Arc::clone(doc);
+        let base_url = base_url.clone();
+        let font_system = Arc::clone(&self.zone_context.font_system);
+        let fresh = Arc::clone(&self.web_fonts_fresh);
+        spawn_named("tab-web-fonts", async move {
+            let walk = tokio::task::spawn_blocking(move || {
+                crate::html::web_fonts::load_web_fonts::<C>(&doc, &base_url, loader.as_ref(), &mut |bytes, family| {
+                    let registered = font_system.lock().register_font(bytes, Some(family));
+                    if registered.is_ok() {
+                        fresh.store(true, std::sync::atomic::Ordering::Release);
                     }
-                }
-                for src in &sources {
-                    let resolved = sheet_url
-                        .as_ref()
-                        .unwrap_or(base_url)
-                        .join(src)
-                        .or_else(|_| base_url.join(src));
-                    let Ok(font_url) = resolved else { continue };
-                    if !fetched.insert(font_url.to_string()) {
-                        break; // this exact font file is already registered
-                    }
-                    match loader.load(&font_url) {
-                        Ok(resp) if resp.is_ok() && !resp.body.is_empty() => {
-                            // Web fonts are commonly served as WOFF2 (e.g. Google Fonts content-
-                            // negotiates WOFF2 for modern UAs like ours). The font backends
-                            // (Skia/fontconfig) only decode raw SFNT (TTF/OTF), so unwrap WOFF2
-                            // to TTF first. Other formats pass through unchanged.
-                            let font_bytes = decode_web_font(resp.body.to_vec(), &font_url);
-                            match self
-                                .zone_context
-                                .font_system
-                                .lock()
-                                .register_font(font_bytes, Some(&family))
-                            {
-                                Ok(()) => {
-                                    log::debug!("Registered web font '{family}' from {font_url}");
-                                    break; // family face loaded; skip remaining sources
-                                }
-                                Err(e) => log::warn!("Failed to register web font '{family}': {e:?}"),
-                            }
-                        }
-                        Ok(resp) => log::warn!("Web font fetch {font_url} returned status {}", resp.status),
-                        Err(e) => log::warn!("Web font fetch {font_url} failed: {e}"),
-                    }
-                }
+                    registered
+                });
+            });
+            if let Err(e) = walk.await {
+                log::warn!("web font loading failed: {e}");
             }
+        });
+    }
+
+    /// Whether this tab's full renders go out-of-process (fork server or
+    /// exec-per-render). Decides both the routing and whether navigation
+    /// captures the document source (the renderer re-parses it there).
+    #[allow(clippy::needless_return)] // the cfg arms need explicit returns
+    fn remote_render_available(&self) -> bool {
+        #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+        {
+            return self.context.remote_render_active() || {
+                // Before a document exists `remote_render_active` is false;
+                // what navigation needs to know is whether a mode is
+                // *installed*, which set_remote_renderer decided in `new`.
+                use gosub_interface::font_system::{Confinement, FontSystem as _};
+                match C::FontSystem::confinement() {
+                    Confinement::Full => self.zone_context.engine_context.renderer_process.get().is_some(),
+                    Confinement::FontPathsReadable => {
+                        self.zone_context.config_store.get_bool("security.renderer_process")
+                    }
+                    Confinement::Unsupported(_) => false,
+                }
+            };
+        }
+        #[cfg(not(all(feature = "process-isolation", target_os = "linux")))]
+        {
+            return false;
         }
     }
 
@@ -775,8 +633,9 @@ impl<C: RenderConfiguration> TabWorker<C> {
                 final_url,
                 title,
                 doc,
+                source,
             } => {
-                self.context.set_document(Arc::clone(&doc));
+                self.context.set_document(Arc::clone(&doc), source);
                 self.load_web_fonts(&doc, &final_url);
                 if let Some(cancel) = self
                     .active_nav
@@ -1529,6 +1388,9 @@ impl<C: RenderConfiguration> TabWorker<C> {
         let event_tx = self.zone_context.event_tx.clone();
         let accept_language = self.services.accept_language.clone();
         let max_document_bytes = self.zone_context.config_store.get_uint("net.document.max_bytes");
+        // Capture the document source only when a renderer process may need it
+        // (it re-parses there); otherwise skip the copy.
+        let capture_source = self.remote_render_available();
 
         let span = tracing::info_span!(
             "tab_nav",
@@ -1599,6 +1461,7 @@ impl<C: RenderConfiguration> TabWorker<C> {
                 io_tx.clone(),
                 accept_language.clone(),
                 max_document_bytes,
+                capture_source,
             );
 
             let outcome = route_response_for(
@@ -1612,7 +1475,7 @@ impl<C: RenderConfiguration> TabWorker<C> {
             .await;
 
             match outcome {
-                Ok(RoutedOutcome::MainDocument(doc)) => {
+                Ok(RoutedOutcome::MainDocument { doc, source }) => {
                     use gosub_interface::document::Document as _;
                     let final_url = doc.url().unwrap_or_else(about_blank);
                     let title = crate::html::document_title(&doc);
@@ -1621,6 +1484,7 @@ impl<C: RenderConfiguration> TabWorker<C> {
                         final_url,
                         title,
                         doc,
+                        source,
                     });
                 }
                 Ok(RoutedOutcome::DownloadOffer(meta)) => {
@@ -1768,6 +1632,8 @@ impl<C: RenderConfiguration> TabWorker<C> {
         let io_tx = self.zone_context.io_tx.clone();
         let accept_language = self.services.accept_language.clone();
         let max_document_bytes = self.zone_context.config_store.get_uint("net.document.max_bytes");
+        // Same rule as navigate(): keep the source only when a renderer process may re-parse it.
+        let capture_source = self.remote_render_available();
 
         let span = tracing::info_span!(
             "tab_load_html",
@@ -1804,11 +1670,13 @@ impl<C: RenderConfiguration> TabWorker<C> {
                 io_tx.clone(),
                 accept_language.clone(),
                 max_document_bytes,
+                capture_source,
             );
 
             match hooks.html.parse_bytes(req, handle, meta, html.as_bytes()).await {
-                Ok(doc) => {
+                Ok(parsed) => {
                     use gosub_interface::document::Document as _;
+                    let (doc, source) = parsed.into_parts();
                     let doc = Arc::new(doc);
                     let final_url = doc.url().unwrap_or(url);
                     let title = crate::html::document_title(&doc);
@@ -1817,6 +1685,7 @@ impl<C: RenderConfiguration> TabWorker<C> {
                         final_url,
                         title,
                         doc,
+                        source,
                     });
                 }
                 Err(e) => {
@@ -1883,6 +1752,20 @@ impl<C: RenderConfiguration> TabWorker<C> {
             self.runtime.dirty = true;
         }
 
+        // Likewise a web font registered by the background font task: text was
+        // measured and painted with a fallback, so layout must run again. Not
+        // for a remotely rendered page: its renderer registered the fonts
+        // itself before laying out, so nothing here was painted with a fallback.
+        if self.web_fonts_fresh.swap(false, std::sync::atomic::Ordering::AcqRel) && !self.context.remote_render_active()
+        {
+            crate::telemetry::emit(
+                "tab.invalidate",
+                serde_json::json!({ "tab": self.tab_id.to_string(), "reason": "web-fonts" }),
+            );
+            self.context.invalidate_render();
+            self.runtime.dirty = true;
+        }
+
         // Skip rendering when nothing has changed to avoid burning CPU at the tick rate.
         if !self.runtime.dirty {
             return Ok(());
@@ -1916,25 +1799,39 @@ impl<C: RenderConfiguration> TabWorker<C> {
         //
         // DPR comes from the backend: Cairo rasterizes at physical pixels (DPR > 1 on HiDPI);
         // Skia and Vello rasterize at CSS pixels (DPR = 1).
-        if render_backend.raster_strategy() != RasterStrategy::None && !render_backend.renders_to_gpu_texture() {
+        let remote_render = self.context.remote_render_active();
+        if remote_render
+            || (render_backend.raster_strategy() != RasterStrategy::None && !render_backend.renders_to_gpu_texture())
+        {
             let dpr = render_backend.device_pixel_ratio();
+            let frame_started = std::time::Instant::now();
 
             // Scroll-only fast path: tiles are still valid, only the offset changed.
             if let Some(handle) = self.context.take_scroll_handle(dpr) {
                 self.runtime.committed_scene_epoch = self.context.scene_epoch();
                 self.zone_context.compositor.submit_frame(self.tab_id, handle);
+                self.report_frame("scroll", frame_started);
                 return Ok(());
             }
 
             // Full render: rebuild stages 1-6 only (no display list), then submit TileCache.
             self.context.set_viewport(self.desired_viewport);
             self.context.rebuild_pipeline_cache_if_needed();
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            if let Some(error) = self.context.take_remote_failure() {
+                self.send_event(EngineEvent::RendererCrashed {
+                    zone_id: self.zone_id,
+                    tabs: vec![self.tab_id],
+                    error,
+                });
+            }
             let scene_epoch = self.context.scene_epoch();
             if let Some(handle) = self.context.tile_cache_handle(dpr) {
                 self.runtime.committed_scene_epoch = scene_epoch;
                 self.zone_context.compositor.submit_frame(self.tab_id, handle);
             }
             self.sink.inc_frame();
+            self.report_frame("rebuild", frame_started);
             return Ok(());
         }
 
@@ -2231,13 +2128,12 @@ mod tests {
 
     mod favicon_url {
         use crate::html::DefaultRenderConfig;
-        use crate::tab::worker::TabWorker;
         use url::Url;
 
         fn resolve(html: &str, base: &str) -> Option<String> {
             let doc = gosub_html5::html_compile::<DefaultRenderConfig>(html);
             let base = Url::parse(base).unwrap();
-            TabWorker::<DefaultRenderConfig>::favicon_url(&doc, &base).map(|u| u.to_string())
+            crate::html::favicon_url::<DefaultRenderConfig>(&doc, &base).map(|u| u.to_string())
         }
 
         #[test]
@@ -2275,36 +2171,6 @@ mod tests {
         #[test]
         fn no_fallback_for_non_http_documents() {
             assert_eq!(resolve("<html></html>", "gosub://home"), None);
-        }
-    }
-
-    /// Verify `decode_web_font` turns a real WOFF2 payload into an SFNT the font stack can
-    /// parse. Reads the fixture path from `GOSUB_WOFF2_FIXTURE` so we neither hit the network
-    /// nor commit a binary font; skips when unset.
-    #[test]
-    fn decode_web_font_woff2_roundtrips_to_sfnt() {
-        let Ok(path) = std::env::var("GOSUB_WOFF2_FIXTURE") else {
-            eprintln!("skipping: set GOSUB_WOFF2_FIXTURE to a .woff2 file to run");
-            return;
-        };
-        let woff2 = std::fs::read(&path).expect("read fixture");
-        assert_eq!(&woff2[0..4], b"wOF2", "fixture must be WOFF2");
-
-        let url = url::Url::parse("https://example.test/font.woff2").unwrap();
-        let sfnt = super::decode_web_font(woff2, &url);
-
-        // Output must be a different, valid SFNT (TrueType `0x00010000` or OpenType `OTTO`).
-        let magic = u32::from_be_bytes([sfnt[0], sfnt[1], sfnt[2], sfnt[3]]);
-        assert!(magic == 0x0001_0000 || magic == 0x4F54_544F, "not SFNT: {magic:#010x}");
-
-        // It must re-parse and expose the core tables a backend reads.
-        use allsorts::binary::read::ReadScope;
-        use allsorts::font_data::FontData;
-        use allsorts::tables::FontTableProvider;
-        let font = ReadScope::new(&sfnt).read::<FontData<'_>>().expect("parse SFNT");
-        let provider = font.table_provider(0).expect("table provider");
-        for tag in [allsorts::tag::HEAD, allsorts::tag::CMAP, allsorts::tag::GLYF] {
-            assert!(provider.has_table(tag), "missing table {tag:#010x}");
         }
     }
 

--- a/crates/gosub_engine/src/engine/zone/zone.rs
+++ b/crates/gosub_engine/src/engine/zone/zone.rs
@@ -118,6 +118,10 @@ pub struct ZoneContext<C: RenderConfiguration = crate::html::DefaultRenderConfig
     pub(crate) config_store: Config,
     /// `gosub://` page registry, shared from the engine context.
     pub(crate) internal_pages: crate::engine::internal_pages::InternalPages,
+    /// The engine-wide shared context, so tabs can reach engine-scoped state
+    /// installed after zone creation (e.g. the renderer fork server).
+    #[cfg_attr(not(all(feature = "process-isolation", target_os = "linux")), allow(dead_code))]
+    pub(crate) engine_context: Arc<EngineContext>,
 }
 
 // Things that are shared upwards to the engine
@@ -221,6 +225,7 @@ impl<C: RenderConfiguration> Zone<C> {
         let tab_identities = engine_context.tab_identities.clone();
         let config_store = engine_context.config_store.clone();
         let internal_pages = engine_context.internal_pages.clone();
+        let engine_context_for_tabs = Arc::clone(&engine_context);
 
         let zone = Self {
             engine_context,
@@ -245,6 +250,7 @@ impl<C: RenderConfiguration> Zone<C> {
                 font_system,
                 config_store,
                 internal_pages,
+                engine_context: engine_context_for_tabs,
             }),
             id: zone_id,
             tabs: HashMap::new(),

--- a/crates/gosub_engine/src/fork_server.rs
+++ b/crates/gosub_engine/src/fork_server.rs
@@ -1,0 +1,16 @@
+//! The fork server: a warmed, sandboxed process renderers are forked from.
+//!
+//! Spawn is cheap (~3.7 ms measured); font warm-up is not, so it is paid once
+//! here and forked renderers inherit the warmed font system copy-on-write.
+//! The font system's [`Confinement`](gosub_interface::font_system::Confinement)
+//! answer picks both this process's sandbox and its children's.
+
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+pub mod child;
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+pub mod client;
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+pub mod loader;
+pub mod protocol;
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+pub mod renderer;

--- a/crates/gosub_engine/src/fork_server/child.rs
+++ b/crates/gosub_engine/src/fork_server/child.rs
@@ -1,0 +1,511 @@
+//! The fork server: the process that already has the fonts.
+//!
+//! Exists for font warm-up, not fork speed (spawn measured ~3.7 ms): the
+//! warmed font system is built once and every forked renderer inherits it
+//! copy-on-write, whichever confinement tier applies.
+
+use crate::fork_server::loader::ForkedResourceLoader;
+use crate::fork_server::protocol::{
+    ConfinementTier, FromForkServer, FromRenderer, HitRegion, PageSummary, ProofReply, TileHeader, ToForkServer,
+};
+use crate::fork_server::renderer::{self, RenderedTile};
+use crate::html::RenderConfiguration;
+use gosub_interface::font_system::{Confinement, FontSystem, TextStyle};
+use gosub_ipc::Endpoint;
+use parking_lot::Mutex;
+use std::os::fd::AsRawFd;
+use std::sync::Arc;
+
+/// Run the fork server for the embedder's configuration `C`.
+pub fn serve<C: RenderConfiguration>(link: Endpoint) -> i32 {
+    // Before any lockdown (the capture reads /proc): the anchor and every
+    // forked renderer inherit the capture and can then rename themselves in
+    // `ps`; this process itself reads as the fork server on both paths below.
+    gosub_sandbox::capture_process_title_region();
+    gosub_sandbox::set_process_title("gosub-forksrv", "gosub: renderer fork server");
+
+    match C::FontSystem::confinement() {
+        Confinement::Full => serve_warmed::<C>(link),
+        other => decline(link, &other),
+    }
+}
+
+/// The warmed zygote: build, prepare, confine per the instance answer, fork on
+/// request.
+fn serve_warmed<C: RenderConfiguration>(mut link: Endpoint) -> i32 {
+    // Before the font system, which may start a thread: `TMPDIR` is set here.
+    // Shared by every forked renderer, so it is granted read-only to them
+    // below; only the fork server's own warm-up may stage files in it.
+    let scratch = match gosub_sandbox::claim_scratch_dir("fork-server") {
+        Ok(dir) => dir,
+        Err(e) => {
+            eprintln!("[fork-server] could not create a private scratch directory: {e}");
+            return 1;
+        }
+    };
+    let mut fonts = C::FontSystem::default();
+    // Populate lazily-built databases before asking anything of them.
+    let _ = fonts.families();
+
+    // The instance answer outranks the static one: a system whose readiness
+    // depends on what preparation actually found reports it here, and the
+    // sandbox tier follows the report.
+    let answer = fonts.prepare_for_confinement();
+    let tier = ConfinementTier::from(&answer);
+
+    // The media store is the pipeline's other piece of lazily-file-loading
+    // state: SVG `<text>` goes through a system fontdb that discovers fonts
+    // on first use and opens each face's file on first *use of that face*.
+    // Pinned here, pre-lockdown, and inherited copy-on-write by every forked
+    // renderer - the same move as the font warm-up, for the same reason.
+    if !gosub_render_pipeline::common::media::SvgDecoder::pin_system_fonts() {
+        eprintln!("[fork-server] system fontdb was built before it could be pinned; SVG text may fail confined");
+    }
+    let forked_loader = ForkedResourceLoader::disconnected();
+    let media_store = Arc::new(gosub_render_pipeline::common::media::MediaStore::with_loader(
+        Arc::clone(&forked_loader) as Arc<dyn gosub_interface::resource_loader::ResourceLoader>,
+    ));
+    media_store.set_synchronous_fetch(true);
+
+    // First fork, deliberately: this process sits in a lazily-unshared PID
+    // namespace, whose PID 1 is whatever forks first - and must then outlive
+    // every renderer, or `fork` starts failing with `ENOMEM`. Held for the
+    // whole serve loop.
+    let anchor = match gosub_sandbox::hold_pid_namespace_anchor() {
+        Ok(anchor) => anchor,
+        Err(e) => {
+            eprintln!("[fork-server] could not anchor the PID namespace: {e}");
+            return 1;
+        }
+    };
+    // What a forked renderer inherits but may not keep: this process's link
+    // to the broker (it could forge messages and read brokered replies) and
+    // the anchor pipe (one byte kills every sibling renderer).
+    let mut parent_only = link.raw_fds();
+    parent_only.push(anchor.raw_fd());
+
+    let font_access = confine_self(&answer, &scratch);
+
+    // Announced only now, so `Ready` also means "still alive under the filter
+    // the answer selected" - a wrong tier mapping dies here, at startup,
+    // rather than in the first forked renderer.
+    gosub_sandbox::verify_fork_server_filter();
+    if link.send(&FromForkServer::Ready { tier: tier.clone() }).is_err() {
+        return 1;
+    }
+
+    // In an `Option` so a forked child can take ownership of its
+    // copy-on-write copy (the pipeline wants the font system behind an
+    // `Arc<Mutex<dyn FontSystem>>`). The parent's slot is never taken.
+    let mut fonts = Some(fonts);
+
+    loop {
+        let request = match link.recv::<ToForkServer>() {
+            Ok(msg) => msg,
+            // The broker went away; nothing left to serve.
+            Err(_) => return 0,
+        };
+        let reply = match request {
+            ToForkServer::Ping => FromForkServer::Pong,
+            ToForkServer::Shutdown => return 0,
+            // Resource replies only make sense inside a RenderPage exchange,
+            // where the relay loop consumes them; one arriving here is a
+            // confused broker.
+            ToForkServer::Resource(_) => FromForkServer::Refused("resource reply with no render in flight".into()),
+            ToForkServer::ForkProof => match &tier {
+                ConfinementTier::Unsupported(reason) => {
+                    FromForkServer::Refused(format!("this font system cannot run isolated: {reason}"))
+                }
+                _ => fork_and_prove(&mut fonts, font_access, &parent_only),
+            },
+            ToForkServer::RenderPage {
+                html,
+                url,
+                tab,
+                viewport_width,
+                viewport_height,
+                known_tiles,
+                hovered_node,
+            } => match &tier {
+                ConfinementTier::Unsupported(reason) => {
+                    FromForkServer::Refused(format!("this font system cannot run isolated: {reason}"))
+                }
+                // Streamed reply (tiles relayed as they arrive, then the
+                // summary), so this arm sends for itself - a `Refused` after
+                // partial tiles tells the broker to discard them.
+                _ => {
+                    let outcome = fork_and_render::<C>(
+                        &mut link,
+                        &mut fonts,
+                        &media_store,
+                        &forked_loader,
+                        font_access,
+                        &parent_only,
+                        &html,
+                        &url,
+                        &tab,
+                        viewport_width,
+                        viewport_height,
+                        &known_tiles.iter().copied().collect(),
+                        hovered_node,
+                    );
+                    match outcome {
+                        Ok(()) => continue, // PageRendered already sent
+                        Err(e) => FromForkServer::Refused(e),
+                    }
+                }
+            },
+        };
+        if link.send(&reply).is_err() {
+            return 1;
+        }
+    }
+}
+
+/// A tier with no use for a zygote: report the answer so the broker can act on
+/// it, refuse to fork, and idle confined.
+fn decline(mut link: Endpoint, answer: &Confinement) -> i32 {
+    // Idle or not, this process gets no more privilege than it needs; the
+    // plain fork-server filter is a superset of "answer pings".
+    gosub_sandbox::lock_down_fork_server();
+    if link
+        .send(&FromForkServer::Ready {
+            tier: ConfinementTier::from(answer),
+        })
+        .is_err()
+    {
+        return 1;
+    }
+
+    let refusal = match answer {
+        Confinement::FontPathsReadable => "this tier has no use for a fork server: renderers are spawned \
+             fresh and confine themselves with the font-readable profile"
+            .to_string(),
+        Confinement::Unsupported(reason) => format!("this font system cannot run isolated: {reason}"),
+        Confinement::Full => unreachable!("Full is served by the warmed zygote"),
+    };
+
+    loop {
+        let request = match link.recv::<ToForkServer>() {
+            Ok(msg) => msg,
+            Err(_) => return 0,
+        };
+        let reply = match request {
+            ToForkServer::Ping => FromForkServer::Pong,
+            ToForkServer::Shutdown => return 0,
+            ToForkServer::ForkProof | ToForkServer::RenderPage { .. } | ToForkServer::Resource(_) => {
+                FromForkServer::Refused(refusal.clone())
+            }
+        };
+        if link.send(&reply).is_err() {
+            return 1;
+        }
+    }
+}
+
+/// Apply the fork-server lockdown the answer calls for; returns whether forked
+/// renderers get the file-reading tier.
+fn confine_self(answer: &Confinement, scratch: &std::path::Path) -> bool {
+    match answer {
+        Confinement::FontPathsReadable => {
+            // The ruleset is inherited by every forked renderer: the scratch
+            // is readable there, never a channel one site's renderer can
+            // write into for another's.
+            let paths = gosub_sandbox::font_filesystem_paths();
+            let mut refs: Vec<(&std::path::Path, bool)> = paths.iter().map(|p| (p.as_path(), false)).collect();
+            refs.push((scratch, false));
+            gosub_sandbox::lock_down_fork_server_with_font_access(&refs);
+            true
+        }
+        // `Unsupported` still confines: an idle process holds page-shaping
+        // machinery and deserves no more privilege for being useless.
+        Confinement::Full | Confinement::Unsupported(_) => {
+            gosub_sandbox::lock_down_fork_server();
+            false
+        }
+    }
+}
+
+/// Fork a renderer, confine it to its tier, run `task` in it, and return what
+/// the child sent back over their private pair.
+fn fork_confined_task<R, T>(font_access: bool, parent_only: &[i32], task: T) -> Result<R, String>
+where
+    R: serde::Serialize + serde::de::DeserializeOwned,
+    T: FnOnce() -> Option<R>,
+{
+    let (ours, theirs) = match gosub_ipc::channel::Channel::pair() {
+        Ok(pair) => pair,
+        Err(e) => return Err(format!("could not create the renderer link: {e}")),
+    };
+
+    match gosub_sandbox::fork_process() {
+        Err(e) => Err(format!("fork failed: {e}")),
+        Ok(gosub_sandbox::Forked::Child) => {
+            drop(ours);
+            gosub_sandbox::close_inherited(parent_only);
+            let Ok(mut link) = Endpoint::from_channel(theirs) else {
+                gosub_sandbox::exit_now(1);
+            };
+            // From here on this is a renderer: confine, then use only what
+            // was inherited copy-on-write.
+            gosub_sandbox::lock_down_forked_renderer(font_access);
+            let code = match task() {
+                Some(reply) if link.send(&reply).is_ok() => 0,
+                _ => 1,
+            };
+            gosub_sandbox::exit_now(code);
+        }
+        Ok(gosub_sandbox::Forked::Parent { pid }) => {
+            // Close our copy of the child's half so a dead child reads as EOF.
+            drop(theirs);
+            let reply = match Endpoint::from_channel(ours) {
+                Ok(mut link) => link.recv::<R>(),
+                Err(e) => Err(e),
+            };
+            let status = gosub_sandbox::reap_child(pid);
+            match (reply, status) {
+                (Ok(reply), Ok(_)) => Ok(reply),
+                (Err(e), _) => Err(format!("forked renderer sent no reply: {e}")),
+                (_, Err(e)) => Err(format!("forked renderer could not be reaped: {e}")),
+            }
+        }
+    }
+}
+
+/// The smallest fork: shape one line with the inherited fonts and report the
+/// measured box.
+fn fork_and_prove<F: FontSystem>(fonts: &mut Option<F>, font_access: bool, parent_only: &[i32]) -> FromForkServer {
+    let result = fork_confined_task(font_access, parent_only, || {
+        let fonts = fonts.as_mut()?;
+        let (width, height) = fonts.measure(
+            "Shaped in a forked renderer with inherited fonts",
+            &TextStyle::new("serif", 21.0),
+        );
+        (width > 0.0 && height > 0.0).then_some(ProofReply { width, height })
+    });
+    match result {
+        Ok(proof) => FromForkServer::Proof {
+            width: proof.width,
+            height: proof.height,
+        },
+        Err(e) => FromForkServer::Refused(e),
+    }
+}
+
+/// The renderer role: run the pipeline over a page in a forked, confined
+/// child, seal each rasterized tile into a memfd there, and collect the lot -
+/// relaying the renderer's subresource requests to the broker along the way.
+#[allow(clippy::too_many_arguments)] // the serve loop's context, spelled out
+fn fork_and_render<C: RenderConfiguration>(
+    broker: &mut Endpoint,
+    fonts: &mut Option<C::FontSystem>,
+    media_store: &Arc<gosub_render_pipeline::common::media::MediaStore>,
+    forked_loader: &Arc<ForkedResourceLoader>,
+    font_access: bool,
+    parent_only: &[i32],
+    html: &str,
+    page_url: &str,
+    tab: &str,
+    viewport_width: f64,
+    viewport_height: f64,
+    known_tiles: &std::collections::HashSet<u64>,
+    hovered_node: Option<u64>,
+) -> Result<(), String> {
+    let (ours, theirs) = match gosub_ipc::channel::Channel::pair() {
+        Ok(pair) => pair,
+        Err(e) => return Err(format!("could not create the renderer link: {e}")),
+    };
+
+    match gosub_sandbox::fork_process() {
+        Err(e) => Err(format!("fork failed: {e}")),
+        Ok(gosub_sandbox::Forked::Child) => {
+            drop(ours);
+            gosub_sandbox::close_inherited(parent_only);
+            // Fork keeps the parent's name; say who this really is.
+            let _ = (&tab, &page_url);
+            gosub_sandbox::set_process_title(&comm(), &title());
+            let Ok(link) = Endpoint::from_channel(theirs) else {
+                gosub_sandbox::exit_now(1);
+            };
+            gosub_sandbox::lock_down_forked_renderer(font_access);
+
+            // The link is shared between the loader (mid-render round trips)
+            // and the final result send - safe because this process is
+            // single-threaded and strictly alternates.
+            let link = Arc::new(Mutex::new(link));
+            forked_loader.connect(Arc::clone(&link));
+
+            let Some(owned) = fonts.take() else {
+                gosub_sandbox::exit_now(1);
+            };
+            let shared: Arc<Mutex<dyn FontSystem>> = Arc::new(Mutex::new(owned));
+            let (summary, tiles, hit_regions) = renderer::render_page::<C>(
+                renderer::PageRequest {
+                    html,
+                    page_url,
+                    viewport_width,
+                    viewport_height,
+                    known_tiles,
+                    hovered_node,
+                },
+                shared,
+                Arc::clone(media_store),
+                Arc::clone(forked_loader) as Arc<dyn gosub_interface::resource_loader::ResourceLoader>,
+            );
+
+            let ok = stream_rendered(&mut link.lock(), &tiles, summary, hit_regions);
+            gosub_sandbox::exit_now(if ok { 0 } else { 1 });
+        }
+        Ok(gosub_sandbox::Forked::Parent { pid }) => {
+            drop(theirs);
+            // Same EOF-or-broker-clock error model as `fork_confined_task`,
+            // now a pure relay: resource requests go broker-ward and back,
+            // tiles go broker-ward one fd at a time (received, forwarded,
+            // dropped), and the final summary closes the exchange. Strict
+            // alternation on both links; O(1) fds held here.
+            let relayed = (|| -> std::io::Result<()> {
+                let mut link = Endpoint::from_channel(ours)?;
+                loop {
+                    match link.recv::<FromRenderer>()? {
+                        FromRenderer::NeedResource { url } => {
+                            broker
+                                .send(&FromForkServer::NeedResource { url })
+                                .map_err(|e| std::io::Error::other(format!("broker unreachable: {e}")))?;
+                            match broker
+                                .recv::<ToForkServer>()
+                                .map_err(|e| std::io::Error::other(format!("broker sent no resource: {e}")))?
+                            {
+                                ToForkServer::Resource(reply) => link.send(&reply)?,
+                                other => {
+                                    return Err(std::io::Error::other(format!(
+                                        "expected a resource from the broker, got {other:?}"
+                                    )))
+                                }
+                            }
+                        }
+                        FromRenderer::TileUnchanged(header) => {
+                            broker
+                                .send(&FromForkServer::TileUnchanged(header))
+                                .map_err(|e| std::io::Error::other(format!("broker unreachable: {e}")))?;
+                        }
+                        FromRenderer::Tile(header) => {
+                            let fd = link.rx.recv_fd()?;
+                            broker
+                                .send(&FromForkServer::Tile(header))
+                                .map_err(|e| std::io::Error::other(format!("broker unreachable: {e}")))?;
+                            broker
+                                .tx
+                                .send_fd(fd.as_raw_fd())
+                                .map_err(|e| std::io::Error::other(format!("could not relay a tile fd: {e}")))?;
+                            // `fd` drops here; the broker holds the only copy.
+                        }
+                        FromRenderer::Rendered { summary, hit_regions } => {
+                            broker
+                                .send(&FromForkServer::PageRendered { summary, hit_regions })
+                                .map_err(|e| std::io::Error::other(format!("broker unreachable: {e}")))?;
+                            return Ok(());
+                        }
+                    }
+                }
+            })();
+            let status = gosub_sandbox::reap_child(pid);
+            match (relayed, status) {
+                (Ok(()), Ok(_)) => Ok(()),
+                (Err(e), _) => Err(format!("forked renderer died mid-render: {e}")),
+                (_, Err(e)) => Err(format!("forked renderer could not be reaped: {e}")),
+            }
+        }
+    }
+}
+
+/// This renderer's `ps` name: `renderer-<6 hex>`, drawn once per process.
+/// Deliberately not the site or tab: the process list is visible to every
+/// user on the machine, and what a renderer renders is not their business.
+fn comm() -> String {
+    static ID: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    ID.get_or_init(|| {
+        let id = uuid::Uuid::new_v4().simple().to_string();
+        format!("renderer-{}", &id[..6])
+    })
+    .clone()
+}
+
+/// The cmdline to go with [`comm`].
+fn title() -> String {
+    format!("gosub: {}", comm())
+}
+
+/// Stream a render out over `link`: every CPU tile sealed into an immutable
+/// memfd and sent as header + fd, one at a time (so this process never holds
+/// more than one tile fd regardless of page height), then the summary. All
+/// of it - memfd_create, ftruncate, mmap, the seals - is in the renderer
+/// baseline precisely so a confined renderer can hand off pixels. `false`
+/// means the link is gone and the caller should exit.
+fn stream_rendered(
+    link: &mut Endpoint,
+    tiles: &[RenderedTile],
+    summary: PageSummary,
+    hit_regions: Vec<HitRegion>,
+) -> bool {
+    for tile in tiles {
+        let sent = match tile {
+            RenderedTile::Unchanged {
+                page_x,
+                page_y,
+                layer_id,
+                hash,
+            } => link
+                .send(&FromRenderer::TileUnchanged(unchanged_header(
+                    *page_x, *page_y, *layer_id, *hash,
+                )))
+                .is_ok(),
+            RenderedTile::Fresh { tile, hash } => {
+                let gosub_render_pipeline::common::texture::TilePixels::Cpu(bytes) = &tile.pixels else {
+                    // GPU handles are process-local and cannot cross; a
+                    // forked rasterizer should never produce one.
+                    continue;
+                };
+                let Ok(fd) = gosub_ipc::shm::create_sealed_tile(tile.width, tile.height, |buf| {
+                    let n = buf.len().min(bytes.len());
+                    buf[..n].copy_from_slice(&bytes[..n]);
+                }) else {
+                    return false;
+                };
+                let header = TileHeader {
+                    page_x: tile.page_x,
+                    page_y: tile.page_y,
+                    layer_id: tile.layer_id,
+                    width: tile.width,
+                    height: tile.height,
+                    format: tile.format.into(),
+                    content_hash: *hash,
+                    opacity: tile.opacity,
+                    anchor: tile.anchor.into(),
+                };
+                link.send(&FromRenderer::Tile(header)).is_ok() && link.tx.send_fd(fd.as_raw_fd()).is_ok()
+                // `fd` drops here: SCM_RIGHTS duplicated it onward.
+            }
+        };
+        if !sent {
+            return false;
+        }
+    }
+    link.send(&FromRenderer::Rendered { summary, hit_regions }).is_ok()
+}
+
+/// The header for a tile the broker already holds. Its physical dimensions
+/// are left at zero deliberately: nothing rasterized them here, and the
+/// broker fills them from the pixels it kept.
+fn unchanged_header(page_x: f64, page_y: f64, layer_id: u64, hash: u64) -> TileHeader {
+    TileHeader {
+        page_x,
+        page_y,
+        layer_id,
+        width: 0,
+        height: 0,
+        format: crate::fork_server::protocol::TileWireFormat::PreMulArgb32,
+        content_hash: hash,
+        opacity: 1.0,
+        anchor: crate::fork_server::protocol::TileWireAnchor::Scroll,
+    }
+}

--- a/crates/gosub_engine/src/fork_server/client.rs
+++ b/crates/gosub_engine/src/fork_server/client.rs
@@ -1,0 +1,560 @@
+//! The broker's side of the fork server: spawn it, learn its confinement
+//! tier, ask it to fork.
+
+use crate::fork_server::protocol::{
+    ConfinementTier, FromForkServer, FromRenderer, HitRegion, PageSummary, ResourceReply, TileHeader, ToForkServer,
+};
+use gosub_interface::resource_loader::{LoadError, LoadedResource};
+use gosub_ipc::Endpoint;
+use std::time::Duration;
+
+/// The argv role name the broker re-execs itself with.
+pub const FORK_SERVER_ROLE: &str = "fork-server";
+
+/// Committed memory a renderer process may hold (`RLIMIT_DATA`).
+pub const RENDERER_DATA_LIMIT: u64 = 1024 * 1024 * 1024;
+
+/// How long to wait for `Ready`. Spawn plus font warm-up: the slowest measured
+/// preparation (full warm-up on a font-heavy host) is well under a second, so
+/// tens of seconds means a process that is not a fork server.
+const READY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How long any later request may take. A fork plus one shape is milliseconds.
+const REPLY_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Bounds on one render exchange, so a renderer cannot hold the tab thread
+/// or fill the broker's memory by talking forever. Generous: a heavy page
+/// stays far below every one of them.
+const MAX_EXCHANGE_MESSAGES: usize = 50_000;
+const MAX_EXCHANGE_RESOURCES: usize = 2_000;
+const MAX_EXCHANGE_TILE_BYTES: usize = 512 * 1024 * 1024;
+const EXCHANGE_DEADLINE: Duration = Duration::from_secs(600);
+/// Longest `link`/`image` string kept from a hit region, and longest title.
+const MAX_HIT_TEXT: usize = 2048;
+const MAX_TITLE: usize = 1024;
+const MAX_LAYER_ORDER: usize = 100_000;
+const MAX_TIMINGS: usize = 64;
+
+/// What answers a renderer's subresource requests during an exchange: the
+/// broker's loader, where identity and cookies live.
+pub trait RenderResources {
+    fn load(&self, url: &url::Url) -> Result<LoadedResource, LoadError>;
+}
+
+impl<T: gosub_interface::resource_loader::ResourceLoader + ?Sized> RenderResources for T {
+    fn load(&self, url: &url::Url) -> Result<LoadedResource, LoadError> {
+        gosub_interface::resource_loader::ResourceLoader::load(self, url)
+    }
+}
+
+/// A shared loader as a render's resources (a `dyn` loader cannot be
+/// re-erased into `dyn RenderResources` directly).
+pub struct LoaderResources<'a>(pub &'a std::sync::Arc<dyn gosub_interface::resource_loader::ResourceLoader>);
+
+impl RenderResources for LoaderResources<'_> {
+    fn load(&self, url: &url::Url) -> Result<LoadedResource, LoadError> {
+        self.0.load(url)
+    }
+}
+
+/// One step of a render exchange, whichever peer is speaking.
+pub(crate) enum RenderEvent {
+    NeedResource {
+        url: String,
+    },
+    Tile(TileHeader),
+    TileUnchanged(TileHeader),
+    Rendered {
+        summary: PageSummary,
+        hit_regions: Vec<HitRegion>,
+    },
+    Refused(String),
+}
+
+/// A peer's render-exchange dialect: the fork server relays its forked
+/// child's stream wrapped in [`FromForkServer`] and wants resources wrapped
+/// back; a forked renderer speaks [`FromRenderer`] directly and its loader
+/// reads a bare [`ResourceReply`].
+pub(crate) trait RenderStream: serde::de::DeserializeOwned + std::fmt::Debug {
+    fn into_event(self) -> anyhow::Result<RenderEvent>;
+    fn send_resource(link: &mut Endpoint, reply: ResourceReply) -> std::io::Result<()>;
+}
+
+impl RenderStream for FromForkServer {
+    fn into_event(self) -> anyhow::Result<RenderEvent> {
+        Ok(match self {
+            FromForkServer::NeedResource { url } => RenderEvent::NeedResource { url },
+            FromForkServer::Tile(header) => RenderEvent::Tile(header),
+            FromForkServer::TileUnchanged(header) => RenderEvent::TileUnchanged(header),
+            FromForkServer::PageRendered { summary, hit_regions } => RenderEvent::Rendered { summary, hit_regions },
+            FromForkServer::Refused(reason) => RenderEvent::Refused(reason),
+            other => anyhow::bail!("unexpected render-exchange message: {other:?}"),
+        })
+    }
+
+    fn send_resource(link: &mut Endpoint, reply: ResourceReply) -> std::io::Result<()> {
+        link.send(&ToForkServer::Resource(reply))
+    }
+}
+
+impl RenderStream for FromRenderer {
+    fn into_event(self) -> anyhow::Result<RenderEvent> {
+        Ok(match self {
+            FromRenderer::NeedResource { url } => RenderEvent::NeedResource { url },
+            FromRenderer::Tile(header) => RenderEvent::Tile(header),
+            FromRenderer::TileUnchanged(header) => RenderEvent::TileUnchanged(header),
+            FromRenderer::Rendered { summary, hit_regions } => RenderEvent::Rendered { summary, hit_regions },
+        })
+    }
+
+    fn send_resource(link: &mut Endpoint, reply: ResourceReply) -> std::io::Result<()> {
+        link.send(&reply)
+    }
+}
+
+/// Drive the broker's half of a render exchange, whoever the renderer is.
+/// Tiles stream in one at a time (each fd mapped and released before the
+/// next message), the summary closes the exchange, and a `Refused`
+/// mid-stream discards everything collected - atomicity lives here, not in
+/// transport buffering. `loader` answers the renderer's subresource requests
+/// inline, where identity and cookies live.
+pub(crate) fn drive_render_exchange<M: RenderStream>(
+    link: &mut Endpoint,
+    loader: &dyn RenderResources,
+    known_tiles: &TileMemory,
+) -> anyhow::Result<RenderedPage> {
+    let mut received = Vec::new();
+    let started = std::time::Instant::now();
+    let (mut messages, mut resources, mut tile_bytes) = (0usize, 0usize, 0usize);
+    loop {
+        messages += 1;
+        if messages > MAX_EXCHANGE_MESSAGES {
+            anyhow::bail!("renderer sent more than {MAX_EXCHANGE_MESSAGES} messages in one render");
+        }
+        if started.elapsed() > EXCHANGE_DEADLINE {
+            anyhow::bail!("render did not finish within {EXCHANGE_DEADLINE:?}");
+        }
+        match link.recv::<M>()?.into_event()? {
+            RenderEvent::NeedResource { url } => {
+                resources += 1;
+                if resources > MAX_EXCHANGE_RESOURCES {
+                    anyhow::bail!("renderer asked for more than {MAX_EXCHANGE_RESOURCES} resources in one render");
+                }
+                let asked = std::time::Instant::now();
+                let reply = match url::Url::parse(&url) {
+                    Ok(parsed) => {
+                        let loaded = loader.load(&parsed);
+                        if crate::telemetry::enabled() {
+                            let (outcome, bytes) = match &loaded {
+                                Ok(resource) => ("served", resource.body.len()),
+                                Err(_) => ("failed", 0),
+                            };
+                            crate::telemetry::emit(
+                                "remote.resource",
+                                serde_json::json!({
+                                    "url": url,
+                                    "outcome": outcome,
+                                    "bytes": bytes,
+                                    "renderer_waited_us": asked.elapsed().as_micros() as u64,
+                                }),
+                            );
+                        }
+                        match loaded {
+                            Ok(resource) => ResourceReply::Ok {
+                                status: resource.status,
+                                content_type: resource.content_type,
+                                body: resource.body.to_vec(),
+                            },
+                            Err(e) => ResourceReply::Failed(e.to_string()),
+                        }
+                    }
+                    Err(e) => ResourceReply::Failed(format!("renderer asked for an unparseable url: {e}")),
+                };
+                M::send_resource(link, reply)?;
+            }
+            RenderEvent::Tile(header) => {
+                let fd = link.rx.recv_fd()?;
+                let mapping = gosub_ipc::shm::map_sealed_tile(fd, header.width, header.height)?;
+                tile_bytes += mapping.as_slice().len();
+                if tile_bytes > MAX_EXCHANGE_TILE_BYTES {
+                    anyhow::bail!("renderer sent more than {MAX_EXCHANGE_TILE_BYTES} bytes of tiles in one render");
+                }
+                received.push(PageTile::Fresh { header, mapping });
+            }
+            // The renderer skipped this one because we said we had it. If we
+            // do not, our memory and its `known_tiles` disagree - a bug, not
+            // a page problem, so fail the render rather than paper over a
+            // hole in the page.
+            RenderEvent::TileUnchanged(header) => {
+                let Some(kept) = known_tiles.get(header.content_hash) else {
+                    anyhow::bail!("renderer skipped a tile we do not have (hash {})", header.content_hash);
+                };
+                received.push(PageTile::Reused { header, kept });
+            }
+            RenderEvent::Rendered {
+                mut summary,
+                mut hit_regions,
+            } => {
+                bound_summary(&mut summary);
+                bound_hit_regions(&mut hit_regions);
+                return Ok(RenderedPage {
+                    summary,
+                    tiles: received,
+                    hit_regions,
+                });
+            }
+            RenderEvent::Refused(reason) => anyhow::bail!("{reason}"),
+        }
+    }
+}
+
+/// Cut a renderer-supplied string to `max` characters.
+fn bound_text(text: &mut String, max: usize) {
+    if text.len() > max {
+        *text = text.chars().take(max).collect();
+    }
+}
+
+/// The renderer's summary, sized as this side is willing to keep and forward it.
+fn bound_summary(summary: &mut crate::fork_server::protocol::PageSummary) {
+    if let Some(title) = summary.title.as_mut() {
+        bound_text(title, MAX_TITLE);
+    }
+    if let Some(favicon) = summary.favicon.as_mut() {
+        bound_text(favicon, MAX_HIT_TEXT);
+    }
+    summary.layer_order.truncate(MAX_LAYER_ORDER);
+    summary.timings_us.truncate(MAX_TIMINGS);
+    for (name, _) in summary.timings_us.iter_mut() {
+        bound_text(name, MAX_TIMINGS);
+    }
+}
+
+/// [`MAX_HIT_REGIONS`](crate::fork_server::protocol::MAX_HIT_REGIONS) is the
+/// producer's promise; this is the consumer's.
+fn bound_hit_regions(regions: &mut Vec<crate::fork_server::protocol::HitRegion>) {
+    regions.truncate(crate::fork_server::protocol::MAX_HIT_REGIONS);
+    for region in regions.iter_mut() {
+        if let Some(link) = region.link.as_mut() {
+            bound_text(link, MAX_HIT_TEXT);
+        }
+        if let Some(image) = region.image.as_mut() {
+            bound_text(image, MAX_HIT_TEXT);
+        }
+    }
+}
+
+/// One page as the broker receives it: what the renderer measured, its tiles
+/// (freshly mapped or reused from the previous render), and the geometry hit
+/// testing needs.
+#[derive(Debug)]
+pub struct RenderedPage {
+    pub summary: crate::fork_server::protocol::PageSummary,
+    pub tiles: Vec<PageTile>,
+    pub hit_regions: Vec<crate::fork_server::protocol::HitRegion>,
+}
+
+/// A tile of a rendered page: either pixels that just crossed, or pixels the
+/// broker already had and the renderer therefore never produced.
+#[derive(Debug)]
+pub enum PageTile {
+    Fresh {
+        header: crate::fork_server::protocol::TileHeader,
+        mapping: gosub_ipc::shm::TileMapping,
+    },
+    Reused {
+        header: crate::fork_server::protocol::TileHeader,
+        kept: KeptTile,
+    },
+}
+
+impl PageTile {
+    /// This tile's identity and pixels, for a broker keeping it until the
+    /// next render (see [`TileMemory::replace_with`]).
+    pub fn keep(&self) -> (u64, KeptTile) {
+        let (header, kept) = match self {
+            PageTile::Fresh { header, mapping } => (
+                header,
+                KeptTile::from_header(header, bytes::Bytes::copy_from_slice(mapping.as_slice())),
+            ),
+            PageTile::Reused { header, kept } => (header, kept.clone()),
+        };
+        (header.content_hash, kept)
+    }
+
+    /// This tile's pixels, whichever render produced them. Always the
+    /// renderer's own mapped pages - a reused tile is the *same* mapping an
+    /// earlier render handed over, not a copy of it.
+    pub fn pixels(&self) -> &[u8] {
+        match self {
+            PageTile::Fresh { mapping, .. } => mapping.as_slice(),
+            PageTile::Reused { kept, .. } => kept.pixels.as_ref(),
+        }
+    }
+
+    /// Hand this tile to the compositor as the [`CachedTile`] the host-side
+    /// compositing loop consumes. Zero-copy: a fresh tile's mapping becomes
+    /// the `Bytes` owner (`Bytes::from_owner`), so the compositor blends
+    /// straight out of the renderer's sealed pages.
+    pub fn into_cached_tile(self) -> gosub_interface::render::backend::CachedTile {
+        let (header, width, height, format, pixels) = match self {
+            PageTile::Fresh { header, mapping } => {
+                let (w, h, f) = (header.width, header.height, header.format);
+                (header, w, h, f, bytes::Bytes::from_owner(mapping))
+            }
+            PageTile::Reused { header, kept } => (header, kept.width, kept.height, kept.format, kept.pixels),
+        };
+        // Alpha is the 4th byte in both supported formats ([B,G,R,A] / [R,G,B,A]).
+        let opaque = pixels.as_chunks::<4>().0.iter().all(|px| px[3] == 0xFF);
+        gosub_interface::render::backend::CachedTile {
+            page_x: header.page_x as f32,
+            page_y: header.page_y as f32,
+            width,
+            height,
+            data: pixels,
+            format: format.into(),
+            opacity: header.opacity,
+            anchor: header.anchor.into(),
+            opaque,
+        }
+    }
+}
+
+/// Pixels the broker keeps between renders of a tab, so an unchanged tile
+/// need not be rasterized or shipped again. The bytes are the renderer's
+/// mapped pages from an earlier render - still zero-copy, still sealed.
+#[derive(Debug, Clone)]
+pub struct KeptTile {
+    pub page_x: f64,
+    pub page_y: f64,
+    pub layer_id: u64,
+    pub width: u32,
+    pub height: u32,
+    pub format: crate::fork_server::protocol::TileWireFormat,
+    pub opacity: f32,
+    pub anchor: crate::fork_server::protocol::TileWireAnchor,
+    pub pixels: bytes::Bytes,
+}
+
+impl KeptTile {
+    /// A fresh tile's header plus its (mapped or copied) pixels.
+    pub fn from_header(header: &crate::fork_server::protocol::TileHeader, pixels: bytes::Bytes) -> Self {
+        Self {
+            page_x: header.page_x,
+            page_y: header.page_y,
+            layer_id: header.layer_id,
+            width: header.width,
+            height: header.height,
+            format: header.format,
+            opacity: header.opacity,
+            anchor: header.anchor,
+            pixels,
+        }
+    }
+
+    /// This tile as the compositor's input.
+    pub fn to_baked(&self) -> gosub_render_pipeline::rasterizer::BakedTile {
+        gosub_render_pipeline::rasterizer::BakedTile {
+            page_x: self.page_x,
+            page_y: self.page_y,
+            layer_id: self.layer_id,
+            width: self.width,
+            height: self.height,
+            format: self.format.into(),
+            opacity: self.opacity,
+            anchor: self.anchor.into(),
+            pixels: gosub_render_pipeline::common::texture::TilePixels::Cpu(self.pixels.clone()),
+        }
+    }
+}
+
+/// What the broker remembers of a tab's last remote render, keyed by content
+/// hash - the input to the next render's `known_tiles`.
+#[derive(Debug, Default)]
+pub struct TileMemory {
+    tiles: std::collections::HashMap<u64, KeptTile>,
+}
+
+impl TileMemory {
+    /// The hashes to offer a renderer.
+    pub fn hashes(&self) -> Vec<u64> {
+        self.tiles.keys().copied().collect()
+    }
+
+    pub fn get(&self, hash: u64) -> Option<KeptTile> {
+        self.tiles.get(&hash).cloned()
+    }
+
+    /// Replace the memory with exactly this page's tiles: what is not on the
+    /// page cannot help the next render of it, and keeping it would grow
+    /// without bound.
+    pub fn replace_with(&mut self, tiles: impl IntoIterator<Item = (u64, KeptTile)>) {
+        self.tiles = tiles.into_iter().collect();
+    }
+
+    /// Every kept tile as compositor input, back to front: `layer_order` is
+    /// the renderer's (a layer it does not name sorts last), then top-down
+    /// within a layer - tiles of one layer never overlap, so that order is
+    /// only for determinism.
+    pub fn baked_tiles(&self, layer_order: &[u64]) -> Vec<gosub_render_pipeline::rasterizer::BakedTile> {
+        let ranks: std::collections::HashMap<u64, usize> =
+            layer_order.iter().enumerate().map(|(i, &l)| (l, i)).collect();
+        let rank = |layer: u64| ranks.get(&layer).copied().unwrap_or(usize::MAX);
+        let mut tiles: Vec<&KeptTile> = self.tiles.values().collect();
+        tiles.sort_by(|a, b| {
+            rank(a.layer_id)
+                .cmp(&rank(b.layer_id))
+                .then(a.page_y.total_cmp(&b.page_y))
+                .then(a.page_x.total_cmp(&b.page_x))
+        });
+        tiles.into_iter().map(KeptTile::to_baked).collect()
+    }
+}
+
+/// A running fork server, its announced confinement tier, and the link to it.
+pub struct ForkServer {
+    link: Endpoint,
+    tier: ConfinementTier,
+    child: Option<gosub_sandbox::spawn::Child>,
+}
+
+impl std::fmt::Debug for ForkServer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ForkServer")
+            .field("tier", &self.tier)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ForkServer {
+    /// Re-exec this binary as the fork server and wait for its confinement
+    /// answer.
+    pub fn spawn() -> anyhow::Result<Self> {
+        // Same guard as every spawner: an undispatched child must not recurse.
+        if crate::child_process::is_child_process() {
+            anyhow::bail!(
+                "this process was started as an engine child role but is running embedder startup, \
+                 which means gosub_engine::child_process::dispatch_with() was not called at the top \
+                 of main(); refusing to spawn further processes"
+            );
+        }
+
+        let exe = std::env::current_exe()?;
+        let (ours, theirs) = gosub_ipc::channel::Channel::pair()?;
+
+        let child = gosub_sandbox::spawn::spawn(
+            &exe,
+            &[crate::child_process::ROLE_FLAG, FORK_SERVER_ROLE],
+            theirs,
+            // Renderers must not reach the network, and namespace isolation is
+            // inherited by everything this process forks.
+            gosub_sandbox::NamespaceIsolation::Full,
+            gosub_sandbox::spawn::ContainerProfile {
+                name: "gosub-fork-server",
+                internet: false,
+                fs_grant: None,
+                // Inherited by every renderer forked from it. A renderer holds
+                // a laid-out page, its tiles, and a bounded decoded-image cache,
+                // and still needs room for one large image decode on top.
+                data_limit: Some(RENDERER_DATA_LIMIT),
+                extra_fds: &[],
+                // Every forked renderer lives under this one.
+                max_tasks: 4096,
+                file_size_limit: None,
+            },
+        )?;
+        if let Err(e) = gosub_sandbox::confine_spawned_child(&child) {
+            log::warn!("could not apply parent-side confinement to the fork server: {e}");
+        }
+
+        let mut link = Endpoint::from_channel(ours)?;
+        let _ = link.tx.set_write_timeout(Some(REPLY_TIMEOUT));
+        let _ = link.rx.set_read_timeout(Some(READY_TIMEOUT));
+
+        let tier = match link.recv::<FromForkServer>() {
+            Ok(FromForkServer::Ready { tier }) => tier,
+            Ok(other) => anyhow::bail!("the fork server sent {other:?} before Ready"),
+            Err(e) => anyhow::bail!("the fork server never became ready: {e}"),
+        };
+        let _ = link.rx.set_read_timeout(Some(REPLY_TIMEOUT));
+
+        Ok(Self {
+            link,
+            tier,
+            child: Some(child),
+        })
+    }
+
+    /// The confinement tier the configured font system answered - what decides
+    /// whether renderer isolation is offered at all, and under which sandbox.
+    pub fn confinement(&self) -> &ConfinementTier {
+        &self.tier
+    }
+
+    /// The fork server's pid, as this process sees it; `None` once shut down.
+    pub fn pid(&self) -> Option<u32> {
+        self.child.as_ref().map(|c| c.id())
+    }
+
+    /// Fork a renderer, have it shape under its tier sandbox with the
+    /// inherited fonts, and return the measured box.
+    pub fn prove_shaping(&mut self) -> anyhow::Result<(f32, f32)> {
+        self.link.send(&ToForkServer::ForkProof)?;
+        match self.link.recv::<FromForkServer>()? {
+            FromForkServer::Proof { width, height } => Ok((width, height)),
+            FromForkServer::Refused(reason) => anyhow::bail!("{reason}"),
+            other => anyhow::bail!("unexpected reply to ForkProof: {other:?}"),
+        }
+    }
+
+    /// Fork a renderer and run the pipeline over `html` in it - parse, style,
+    /// layout, layering, tiling, paint, and (when the configuration has a
+    /// forked rasterizer) rasterize - under its tier sandbox, with the
+    /// inherited fonts. Returns the measured summary plus the rasterized
+    /// tiles, whose pixels arrive as sealed memfds and are mapped - never
+    /// copied - into this process.
+    #[allow(clippy::too_many_arguments)] // one wire message, spelled out
+    pub fn render_page(
+        &mut self,
+        html: &str,
+        url: &str,
+        tab: &str,
+        viewport: (f64, f64),
+        loader: &dyn RenderResources,
+        known_tiles: &TileMemory,
+        hovered_node: Option<u64>,
+    ) -> anyhow::Result<RenderedPage> {
+        self.link.send(&ToForkServer::RenderPage {
+            html: html.to_string(),
+            url: url.to_string(),
+            tab: tab.to_string(),
+            viewport_width: viewport.0,
+            viewport_height: viewport.1,
+            known_tiles: known_tiles.hashes(),
+            hovered_node,
+        })?;
+        drive_render_exchange::<FromForkServer>(&mut self.link, loader, known_tiles)
+    }
+
+    /// Ask for a clean exit, then make sure of it. `&mut self` rather than
+    /// consuming, so a handle shared behind a lock (the engine's) can be shut
+    /// down in place; afterwards the handle is inert and Drop has nothing to
+    /// kill.
+    pub fn shutdown(&mut self) {
+        let _ = self.link.send(&ToForkServer::Shutdown);
+        if let Some(mut child) = self.child.take() {
+            let _ = child.wait();
+        }
+    }
+}
+
+impl Drop for ForkServer {
+    fn drop(&mut self) {
+        // A fork server left running holds warmed page-shaping state for no
+        // one; kill-then-reap, the same discipline as the other children.
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}

--- a/crates/gosub_engine/src/fork_server/loader.rs
+++ b/crates/gosub_engine/src/fork_server/loader.rs
@@ -1,0 +1,76 @@
+//! The renderer's [`ResourceLoader`]: every load is a blocking round trip to
+//! the broker.
+
+use crate::fork_server::protocol::{FromRenderer, ResourceReply};
+use gosub_interface::resource_loader::{LoadError, LoadedResource, ResourceLoader};
+use gosub_ipc::Endpoint;
+use parking_lot::Mutex;
+use std::sync::Arc;
+use url::Url;
+
+/// Shared as `Arc<dyn ResourceLoader>` inside the `MediaStore` and as
+/// `Arc<ForkedResourceLoader>` by the fork server, so a forked child can
+/// reach `connect` on the very object the store already holds.
+pub struct ForkedResourceLoader {
+    link: Mutex<Option<Arc<Mutex<Endpoint>>>>,
+}
+
+impl std::fmt::Debug for ForkedResourceLoader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ForkedResourceLoader")
+            .field("connected", &self.link.lock().is_some())
+            .finish()
+    }
+}
+
+impl ForkedResourceLoader {
+    /// A loader with no link yet - safe to embed in shared state pre-fork.
+    pub fn disconnected() -> Arc<Self> {
+        Arc::new(Self { link: Mutex::new(None) })
+    }
+
+    /// Point this (copy-on-write) copy of the loader at the renderer's own
+    /// endpoint. Called once, by a forked child, before it renders; the same
+    /// endpoint later carries its `Rendered` result, which is safe because
+    /// the renderer is single-threaded and strictly alternates.
+    pub fn connect(&self, link: Arc<Mutex<Endpoint>>) {
+        *self.link.lock() = Some(link);
+    }
+
+    fn load_with(&self, url: &Url) -> Result<LoadedResource, LoadError> {
+        let slot = self.link.lock();
+        let Some(link) = slot.as_ref() else {
+            return Err(LoadError::Failed(
+                "renderer loader is not connected (loads only exist inside a forked renderer)".into(),
+            ));
+        };
+        let mut link = link.lock();
+
+        link.send(&FromRenderer::NeedResource { url: url.to_string() })
+            .map_err(|e| LoadError::Failed(format!("could not reach the broker: {e}")))?;
+        // No timeout on this recv: the renderer filter has no `setsockopt`.
+        // A dead parent is an EOF; a wedged one is bounded by the broker's
+        // clocks, which tear this whole process family down.
+        match link
+            .recv::<ResourceReply>()
+            .map_err(|e| LoadError::Failed(format!("the broker never answered: {e}")))?
+        {
+            ResourceReply::Ok {
+                status,
+                content_type,
+                body,
+            } => Ok(LoadedResource {
+                status,
+                content_type,
+                body: bytes::Bytes::from(body),
+            }),
+            ResourceReply::Failed(reason) => Err(LoadError::Failed(reason)),
+        }
+    }
+}
+
+impl ResourceLoader for ForkedResourceLoader {
+    fn load(&self, url: &Url) -> Result<LoadedResource, LoadError> {
+        self.load_with(url)
+    }
+}

--- a/crates/gosub_engine/src/fork_server/protocol.rs
+++ b/crates/gosub_engine/src/fork_server/protocol.rs
@@ -1,0 +1,343 @@
+//! The broker↔fork-server wire vocabulary.
+
+use serde::{Deserialize, Serialize};
+
+/// The confinement answer, as it crosses the process boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ConfinementTier {
+    /// The font system front-loaded everything; renderers get the strictest
+    /// sandbox (no file access at all).
+    Full,
+    /// The font system reads font files while operating; renderers get
+    /// read-only font paths plus a private writable scratch.
+    FontPathsReadable,
+    /// The font system cannot run isolated; the fork server refuses to fork
+    /// and the engine must render single-process.
+    Unsupported(String),
+}
+
+impl From<&gosub_interface::font_system::Confinement> for ConfinementTier {
+    fn from(answer: &gosub_interface::font_system::Confinement) -> Self {
+        use gosub_interface::font_system::Confinement;
+        match answer {
+            Confinement::Full => ConfinementTier::Full,
+            Confinement::FontPathsReadable => ConfinementTier::FontPathsReadable,
+            Confinement::Unsupported(reason) => ConfinementTier::Unsupported(reason.clone()),
+        }
+    }
+}
+
+/// Broker → fork server.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ToForkServer {
+    /// Liveness check.
+    Ping,
+    /// Fork a renderer, confine it to the announced tier, shape text with the
+    /// inherited (copy-on-write) font system, and report the measured box.
+    ForkProof,
+    /// Fork a renderer and run the render pipeline in it: parse `html`, style,
+    /// lay out against the viewport, layer, tile, and paint - single-threaded,
+    /// under the announced tier's sandbox, measuring and shaping through the
+    /// inherited font system. Replies with [`FromForkServer::PageRendered`].
+    RenderPage {
+        html: String,
+        /// The page's URL - the base against which the renderer resolves
+        /// relative subresource URLs (stylesheets, images, fonts).
+        url: String,
+        /// The tab this render is for. Display only (telemetry, logs); the
+        /// process name never carries it. Empty when the caller has no tab.
+        tab: String,
+        viewport_width: f64,
+        viewport_height: f64,
+        /// Content hashes of tiles the broker still holds from a previous
+        /// render of this tab. A tile whose hash is in here is neither
+        /// rasterized nor shipped - the renderer answers
+        /// [`TileUnchanged`](FromForkServer::TileUnchanged) and the broker
+        /// reuses the pixels it already has. Empty on a first render.
+        known_tiles: Vec<u64>,
+        /// The DOM node under the pointer, so the renderer can apply
+        /// `:hover` styles. The broker hit-tests (it holds the geometry and
+        /// its own document) and tells the renderer the answer; the renderer
+        /// re-parses per render and would otherwise have no hover state at
+        /// all. With `known_tiles`, a hover re-render costs only the tiles
+        /// whose painted content actually changed.
+        hovered_node: Option<u64>,
+    },
+    /// Exit cleanly.
+    Shutdown,
+    /// The broker's answer to [`FromForkServer::NeedResource`], relayed on to
+    /// the renderer that is blocked waiting for it. Only ever sent while a
+    /// [`RenderPage`](ToForkServer::RenderPage) exchange is in flight.
+    Resource(ResourceReply),
+}
+
+/// Fork server → broker.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum FromForkServer {
+    /// Sent once, after the font system answered and the fork server confined
+    /// itself accordingly: it is warmed, sandboxed, and ready to fork.
+    Ready { tier: ConfinementTier },
+    /// Liveness reply.
+    Pong,
+    /// A forked renderer shaped text under its tier sandbox and measured this.
+    Proof { width: f32, height: f32 },
+    /// One rasterized tile of the page being rendered; its sealed-memfd file
+    /// descriptor follows immediately on the link. Streamed: tiles arrive
+    /// one at a time, each fd relayed and released before the next - no side
+    /// of the transport ever holds more than one tile fd, so page size is
+    /// bounded by memory, not by file-descriptor limits.
+    Tile(TileHeader),
+    /// A tile the broker already holds (its hash was in `known_tiles`): no
+    /// fd follows and nothing was rasterized for it. Arrives in composite
+    /// order alongside `Tile`, so the broker rebuilds the page's tile list
+    /// by walking the two in the order they came.
+    TileUnchanged(TileHeader),
+    /// The render finished; every [`Tile`](FromForkServer::Tile) of the page
+    /// has already streamed past. A render that dies mid-stream ends in
+    /// [`Refused`](FromForkServer::Refused) instead, and the broker discards
+    /// the partial tile set - atomicity lives at the consumer now, not in
+    /// transport buffering.
+    PageRendered {
+        summary: PageSummary,
+        hit_regions: Vec<HitRegion>,
+    },
+    /// The request could not be served; the string says why (e.g. forking is
+    /// refused under `Unsupported`, or the forked child died).
+    Refused(String),
+    /// A renderer needs a subresource it has no capability to fetch - the
+    /// brokered-load inversion, mirroring cookies: the renderer names what it
+    /// wants, the broker performs the fetch where identity and cookies live,
+    /// and only bytes come back. Sent mid-[`RenderPage`](ToForkServer::RenderPage);
+    /// the broker answers with [`ToForkServer::Resource`] before anything else.
+    NeedResource { url: String },
+}
+
+/// What a forked renderer sends its parent over their private pair before
+/// exiting. Internal to the fork-server process family, but it crosses a
+/// process boundary (fork), so it is wire vocabulary all the same.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProofReply {
+    pub width: f32,
+    pub height: f32,
+}
+
+/// What a page came to, measured by the forked renderer that laid it out and
+/// painted it. Numbers rather than pixels - the pixels travel separately, as
+/// sealed memfds - but enough on their own for the broker to assert the
+/// pipeline really ran (a dead font system collapses heights to zero; a dead
+/// painter produces no commands).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PageSummary {
+    /// The document's `<title>` and icon URL, from the renderer's parse: the
+    /// broker does not parse page content itself.
+    pub title: Option<String>,
+    pub favicon: Option<String>,
+    pub page_width: f64,
+    pub page_height: f64,
+    pub layer_count: u64,
+    pub painted_tiles: u64,
+    pub paint_commands: u64,
+    /// Layer ids back to front: the order the broker composites the tiles
+    /// in; the renderer's tile list is the only thing that knows it.
+    pub layer_order: Vec<u64>,
+    /// What the renderer spent on this pass, per stage, in microseconds. It
+    /// has no way to report anywhere itself; the broker relays these to the
+    /// telemetry firehose on its behalf.
+    pub timings_us: Vec<(String, u64)>,
+}
+
+/// One hit-testable box of the page, in page space, in hit-test order:
+/// the first region containing a point is the one under the pointer (the
+/// renderer emits them exactly as its layer list would have walked them,
+/// topmost first).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HitRegion {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    /// The node in the renderer's DOM; only meaningful back in that renderer
+    /// (`RenderPage { hovered_node }`).
+    pub node_id: u64,
+    /// How the region's layer responds to scroll; the broker inverts the same
+    /// composite mapping the tiles use.
+    pub anchor: TileWireAnchor,
+    /// What the broker would otherwise read off a DOM it no longer holds:
+    /// the nearest enclosing `<a href>` (absolute), the `<img src>` at or
+    /// around the box, the cursor for the box, and whether it is editable.
+    pub link: Option<String>,
+    pub image: Option<String>,
+    pub cursor: HitCursor,
+    pub editable: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum HitCursor {
+    #[default]
+    Default,
+    Pointer,
+    Text,
+}
+
+/// Upper bound on regions shipped for one page. A pathological page (tens of
+/// thousands of boxes) would otherwise spend more on hit geometry than on
+/// pixels; past this the tail is dropped and the renderer says so, rather
+/// than silently pretending the page ends there.
+pub const MAX_HIT_REGIONS: usize = 20_000;
+
+/// Everything about one rasterized tile except its pixels, which follow as a
+/// sealed memfd (see `gosub_ipc::shm` - the consumer derives the byte count
+/// from these dimensions and validates the fd against them, never trusting a
+/// length from the wire). Carries what the compositor's `CachedTile` needs,
+/// so a mapped tile converts without consulting the renderer again.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TileHeader {
+    /// Position of this tile on the page, in CSS pixels.
+    pub page_x: f64,
+    pub page_y: f64,
+    /// Owning layer: `(0,0)` can exist in both a base layer and a sticky one.
+    pub layer_id: u64,
+    pub width: u32,
+    pub height: u32,
+    pub format: TileWireFormat,
+    /// This tile's content hash (see
+    /// `gosub_render_pipeline::rasterizer::tile_content_hash`): what the
+    /// broker keys its kept pixels by, and what a later render compares
+    /// against to decide the tile is unchanged.
+    pub content_hash: u64,
+    /// Group opacity of the tile's layer, applied by the compositor.
+    pub opacity: f32,
+    /// How the tile's layer responds to scroll.
+    pub anchor: TileWireAnchor,
+}
+
+/// The in-memory byte order of a shipped tile - the wire mirror of the
+/// interface crate's `PixelFormat` (which carries no serde).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TileWireFormat {
+    /// Little-endian premultiplied ARGB32 (`[B, G, R, A]`): Cairo, Skia.
+    PreMulArgb32,
+    /// Premultiplied RGBA8: Vello.
+    Rgba8,
+}
+
+impl From<gosub_interface::render::backend::PixelFormat> for TileWireFormat {
+    fn from(format: gosub_interface::render::backend::PixelFormat) -> Self {
+        use gosub_interface::render::backend::PixelFormat;
+        match format {
+            PixelFormat::PreMulArgb32 => TileWireFormat::PreMulArgb32,
+            PixelFormat::Rgba8 => TileWireFormat::Rgba8,
+        }
+    }
+}
+
+impl From<TileWireFormat> for gosub_interface::render::backend::PixelFormat {
+    fn from(format: TileWireFormat) -> Self {
+        use gosub_interface::render::backend::PixelFormat;
+        match format {
+            TileWireFormat::PreMulArgb32 => PixelFormat::PreMulArgb32,
+            TileWireFormat::Rgba8 => PixelFormat::Rgba8,
+        }
+    }
+}
+
+/// Wire mirror of the interface crate's `TileAnchor` (no serde there).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum TileWireAnchor {
+    Scroll,
+    Fixed,
+    Sticky(StickyWire),
+}
+
+/// Wire mirror of `StickyConstraint`: plain page-space geometry.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct StickyWire {
+    pub inset_top: Option<f64>,
+    pub inset_left: Option<f64>,
+    pub natural_x: f64,
+    pub natural_y: f64,
+    pub natural_w: f64,
+    pub natural_h: f64,
+    pub cage_x: f64,
+    pub cage_y: f64,
+    pub cage_w: f64,
+    pub cage_h: f64,
+}
+
+impl From<gosub_interface::render::backend::TileAnchor> for TileWireAnchor {
+    fn from(anchor: gosub_interface::render::backend::TileAnchor) -> Self {
+        use gosub_interface::render::backend::TileAnchor;
+        match anchor {
+            TileAnchor::Scroll => TileWireAnchor::Scroll,
+            TileAnchor::Fixed => TileWireAnchor::Fixed,
+            TileAnchor::Sticky(s) => TileWireAnchor::Sticky(StickyWire {
+                inset_top: s.inset_top,
+                inset_left: s.inset_left,
+                natural_x: s.natural_x,
+                natural_y: s.natural_y,
+                natural_w: s.natural_w,
+                natural_h: s.natural_h,
+                cage_x: s.cage_x,
+                cage_y: s.cage_y,
+                cage_w: s.cage_w,
+                cage_h: s.cage_h,
+            }),
+        }
+    }
+}
+
+impl From<TileWireAnchor> for gosub_interface::render::backend::TileAnchor {
+    fn from(anchor: TileWireAnchor) -> Self {
+        use gosub_interface::render::backend::{StickyConstraint, TileAnchor};
+        match anchor {
+            TileWireAnchor::Scroll => TileAnchor::Scroll,
+            TileWireAnchor::Fixed => TileAnchor::Fixed,
+            TileWireAnchor::Sticky(s) => TileAnchor::Sticky(StickyConstraint {
+                inset_top: s.inset_top,
+                inset_left: s.inset_left,
+                natural_x: s.natural_x,
+                natural_y: s.natural_y,
+                natural_w: s.natural_w,
+                natural_h: s.natural_h,
+                cage_x: s.cage_x,
+                cage_y: s.cage_y,
+                cage_w: s.cage_w,
+                cage_h: s.cage_h,
+            }),
+        }
+    }
+}
+
+/// Everything a forked renderer can say over its private link to the fork
+/// server, which relays it to the broker.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum FromRenderer {
+    /// Mid-render: fetch this for me. The parent relays it to the broker and
+    /// sends the [`ResourceReply`] back; the renderer is blocked until then.
+    NeedResource { url: String },
+    /// One rasterized tile; its sealed memfd follows immediately. The
+    /// renderer seals, sends, and drops each before baking the next into a
+    /// memfd, so it never holds more than one tile fd itself.
+    Tile(TileHeader),
+    /// A tile the broker already holds - no fd, no rasterization.
+    TileUnchanged(TileHeader),
+    /// The final message: the render is complete, with the page's hit-test
+    /// geometry.
+    Rendered {
+        summary: PageSummary,
+        hit_regions: Vec<HitRegion>,
+    },
+}
+
+/// A fetched subresource (or its failure), as it travels broker → fork server
+/// → renderer. Mirrors `gosub_interface::resource_loader::LoadedResource`,
+/// which carries no serde.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ResourceReply {
+    Ok {
+        status: u16,
+        content_type: Option<String>,
+        body: Vec<u8>,
+    },
+    Failed(String),
+}

--- a/crates/gosub_engine/src/fork_server/renderer.rs
+++ b/crates/gosub_engine/src/fork_server/renderer.rs
@@ -1,0 +1,646 @@
+//! The renderer role: the render pipeline, run inside a forked, confined
+//! child.
+//!
+//! [`RetainedPage`] is a parsed, styled, laid-out page kept between renders:
+//! a one-shot renderer builds one and renders the whole page, a resident
+//! renderer keeps it and renders only the raster window around the viewport,
+//! rasterizing more as the viewport moves, repainting the few tiles a hover
+//! touches, and letting go of tiles that drift too far.
+
+use crate::fork_server::protocol::{HitRegion, PageSummary, MAX_HIT_REGIONS};
+use crate::html::{EngineDocument, RenderConfiguration};
+use gosub_html5::document::builder::DocumentBuilderImpl;
+use gosub_html5::parser::{Html5Parser, Html5ParserOptions};
+use gosub_interface::css3::CssSystem as _;
+use gosub_interface::document::Document as _;
+use gosub_interface::font_system::FontSystem;
+use gosub_interface::resource_loader::ResourceLoader;
+use gosub_render_pipeline::common::document::pipeline_doc::GosubDocumentAdapter;
+use gosub_render_pipeline::common::geo::{Dimension, Rect};
+use gosub_render_pipeline::layering::layer::{LayerId, LayerList};
+use gosub_render_pipeline::rasterizer::{BakedTile, Rasterable};
+use gosub_render_pipeline::render::backend::TileAnchor;
+use gosub_render_pipeline::tile_budget::{defer_tiles_outside_window, raster_window, TilePosKey};
+use gosub_render_pipeline::tiler::{TileList, TileState};
+use gosub_shared::byte_stream::{ByteStream, Encoding};
+use gosub_shared::node::NodeId;
+use parking_lot::Mutex;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use url::Url;
+
+/// Tile edge in CSS pixels, matching the engine's default.
+const TILE_SIZE: f64 = 256.0;
+
+/// How far (in viewport heights) from the raster window a shipped tile may
+/// drift before a retained page lets go of it. Wider than the window's own
+/// margin so ordinary back-and-forth scrolling reuses tiles rather than
+/// re-shipping them.
+pub const EVICT_MARGIN_VIEWPORTS: f64 = 3.0;
+
+/// Parse, style, lay out, layer, tile, paint - and, when the configuration
+/// provides a forked rasterizer, rasterize - the whole of `html`, measuring
+/// and shaping through `fonts`. Pure compute plus allocation: safe under the
+/// strictest renderer filter. Returns the summary and the baked tiles (empty
+/// without a rasterizer); sealing them into memfds is the caller's business,
+/// since that is transport, not rendering.
+pub fn render_page<C: RenderConfiguration>(
+    page: PageRequest<'_>,
+    fonts: Arc<Mutex<dyn FontSystem>>,
+    media_store: Arc<gosub_render_pipeline::common::media::MediaStore>,
+    loader: Arc<dyn ResourceLoader>,
+) -> (PageSummary, Vec<RenderedTile>, Vec<HitRegion>) {
+    let known_tiles = page.known_tiles;
+    let mut retained = RetainedPage::build::<C>(page, fonts, media_store, loader);
+    let pass = retained.render(None, known_tiles);
+    (pass.summary, pass.tiles, retained.hit_regions)
+}
+
+/// What to render: the page, the viewport it is laid out against, and the
+/// tiles the broker already holds.
+pub struct PageRequest<'a> {
+    pub html: &'a str,
+    /// Base URL for the page's relative subresource URLs.
+    pub page_url: &'a str,
+    pub viewport_width: f64,
+    pub viewport_height: f64,
+    /// Content hashes the broker kept from a previous render; a tile whose
+    /// hash is here is neither rasterized nor shipped.
+    pub known_tiles: &'a HashSet<u64>,
+    /// The DOM node under the pointer, for `:hover` styling.
+    pub hovered_node: Option<u64>,
+}
+
+/// One tile as the renderer decided to handle it, in composite order.
+pub enum RenderedTile {
+    /// Rasterized here; its pixels must be shipped.
+    Fresh { tile: BakedTile, hash: u64 },
+    /// The broker already holds this tile's pixels: nothing was rasterized
+    /// and nothing travels but the identity. The broker fills the physical
+    /// dimensions from what it kept - the renderer never produced them.
+    Unchanged {
+        page_x: f64,
+        page_y: f64,
+        layer_id: u64,
+        hash: u64,
+    },
+}
+
+/// What one render pass produced.
+pub struct RenderPass {
+    pub summary: PageSummary,
+    pub tiles: Vec<RenderedTile>,
+    /// Content hashes of tiles the broker held that this page no longer
+    /// accounts for.
+    pub evicted: Vec<u64>,
+}
+
+/// A tile the broker holds from this page.
+struct Shipped {
+    hash: u64,
+    rect: Rect,
+    /// Viewport-pinned tiles are never far from the viewport.
+    scrolls: bool,
+}
+
+/// A page after stages 1-3: everything up to the layer list, retained so
+/// later passes can tile, paint and rasterize any window of it without
+/// parsing again.
+pub struct RetainedPage {
+    title: Option<String>,
+    favicon: Option<String>,
+    layer_list: Arc<LayerList>,
+    layer_ids: Vec<LayerId>,
+    fonts: Arc<Mutex<dyn FontSystem>>,
+    media_store: Arc<gosub_render_pipeline::common::media::MediaStore>,
+    rasterizer: Option<Box<dyn Rasterable + Send + Sync>>,
+    viewport_width: f64,
+    viewport_height: f64,
+    page_width: f64,
+    page_height: f64,
+    /// The page's hit-test geometry, fixed at layout time.
+    pub hit_regions: Vec<HitRegion>,
+    /// What the broker holds of this page, by tile position: the tiles a
+    /// pass need not produce, and the pool eviction draws from.
+    shipped: HashMap<TilePosKey, Shipped>,
+    /// Where the viewport was last: a hover repaint stays within that window.
+    scroll_y: f64,
+    /// The DOM node under the pointer, as the broker last told us.
+    hovered: Option<NodeId>,
+    /// Moves the document's `:hover` state; the document itself sits behind
+    /// the pipeline's document adapter, which does not expose that.
+    set_hovered: Box<dyn Fn(Option<NodeId>) + Send + Sync>,
+    /// Stage costs of `build`, reported with the first pass only.
+    build_timings: Vec<(String, u64)>,
+}
+
+impl RetainedPage {
+    /// Stages 1-3 over `page`: parse (subresources through `loader`), apply
+    /// hover, register web fonts, build the render tree, lay out, layer.
+    pub fn build<C: RenderConfiguration>(
+        page: PageRequest<'_>,
+        fonts: Arc<Mutex<dyn FontSystem>>,
+        media_store: Arc<gosub_render_pipeline::common::media::MediaStore>,
+        loader: Arc<dyn ResourceLoader>,
+    ) -> Self {
+        use gosub_render_pipeline::layouter::taffy::TaffyLayouter;
+        use gosub_render_pipeline::layouter::CanLayout;
+        use gosub_render_pipeline::rendertree_builder::RenderTree;
+
+        let PageRequest {
+            html,
+            page_url,
+            viewport_width,
+            viewport_height,
+            hovered_node,
+            ..
+        } = page;
+
+        // Viewport-relative CSS units resolve against the real viewport; must
+        // precede parse(), which computes styles for display:none filtering.
+        gosub_css3::stylesheet::set_layout_viewport(viewport_width as f32, viewport_height as f32);
+
+        // Parse with the page's base URL (relative subresource URLs resolve
+        // against it) and with the loader, so `<link rel="stylesheet">` is
+        // fetched through the broker mid-parse - the same arrangement as the
+        // engine's own parse, with the renderer's brokered loader in the seat.
+        let started = std::time::Instant::now();
+        let base_url = Url::parse(page_url).ok();
+        let mut stream = ByteStream::from_str(html, Encoding::UTF8);
+        let mut doc = DocumentBuilderImpl::new_document::<C>(base_url.clone());
+        let parser_options = Html5ParserOptions {
+            resource_loader: Some(Arc::clone(&loader)),
+            ..Default::default()
+        };
+        let _ = Html5Parser::<C>::parse_document(&mut stream, &mut doc, Some(parser_options));
+        doc.add_stylesheet(C::CssSystem::load_default_useragent_stylesheet());
+
+        // Hover state, as the broker hit-tested it. Applied before the render
+        // tree is built, which is when styles (including `:hover`) are computed.
+        let hovered = hovered_node.map(NodeId::from);
+        if hovered.is_some() {
+            doc.set_hovered_nodes(hovered);
+        }
+
+        // `@font-face` web fonts: the same walk the tab worker runs, fetching
+        // through this renderer's loader and registering into the inherited font
+        // system - so text set in a web font lays out here exactly as in-process.
+        if let Some(base) = &base_url {
+            crate::html::web_fonts::load_web_fonts::<C>(&doc, base, loader.as_ref(), &mut |bytes, family| {
+                fonts.lock().register_font(bytes, Some(family))
+            });
+        }
+        let parse_us = started.elapsed().as_micros() as u64;
+        let title = crate::html::document_title::<C>(&doc);
+        let favicon = base_url
+            .as_ref()
+            .and_then(|base| crate::html::favicon_url::<C>(&doc, base))
+            .map(|url| url.to_string());
+
+        // Stage 1: render tree.
+        let doc = Arc::new(doc);
+        let doc_for_regions = Arc::clone(&doc);
+        let set_hovered: Box<dyn Fn(Option<NodeId>) + Send + Sync> = {
+            let doc = Arc::clone(&doc);
+            Box::new(move |leaf| doc.set_hovered_nodes(leaf))
+        };
+        let adapter = GosubDocumentAdapter::<C>::new(doc);
+        let mut render_tree = RenderTree::new(Arc::new(adapter));
+        if let Err(e) = render_tree.parse() {
+            // Same degradation as the engine: the layouter tolerates a rootless
+            // tree and the page renders empty.
+            log::error!("failed to build render tree in the forked renderer: {e}");
+        }
+        let render_tree_us = started.elapsed().as_micros() as u64 - parse_us;
+
+        // Stage 2: layout, measured through the inherited font system. The
+        // media store must be passed at construction: `with_font_system` builds
+        // a private default store first, which is exactly the filesystem-touching
+        // construction this process can no longer do.
+        let mut layouter =
+            TaffyLayouter::with_font_system_and_media_store(Arc::clone(&fonts), Arc::clone(&media_store));
+        let vp_dim =
+            (viewport_width > 0.0 && viewport_height > 0.0).then(|| Dimension::new(viewport_width, viewport_height));
+        let layout_tree = layouter.layout(render_tree, vp_dim, 1.0);
+        let page_width = layout_tree.root_dimension.width;
+        let page_height = layout_tree.root_dimension.height;
+        let layout_us = started.elapsed().as_micros() as u64 - parse_us - render_tree_us;
+
+        // Stage 3: layering.
+        let layer_list = Arc::new(LayerList::new(layout_tree));
+        let layer_ids = layer_list.layer_ids.read().clone();
+        let hit_regions = collect_hit_regions::<C>(&layer_list, &doc_for_regions, base_url.as_ref());
+        let build_timings = vec![
+            ("build.parse".to_string(), parse_us),
+            ("build.render_tree".to_string(), render_tree_us),
+            ("build.layout".to_string(), layout_us),
+        ];
+
+        Self {
+            title,
+            favicon,
+            layer_list,
+            layer_ids,
+            rasterizer: C::forked_tile_rasterizer(Arc::clone(&fonts)),
+            fonts,
+            media_store,
+            viewport_width,
+            viewport_height,
+            page_width,
+            page_height,
+            hit_regions,
+            shipped: HashMap::new(),
+            scroll_y: 0.0,
+            hovered,
+            set_hovered,
+            build_timings,
+        }
+    }
+
+    /// Stages 4-6 over one window of the page: the raster window around
+    /// `scroll_y`, or the whole page for `None`. Tiles the broker already
+    /// holds - from an earlier pass of this page, or (by content hash) from
+    /// `known_tiles` - are neither rasterized nor shipped. With a window,
+    /// shipped tiles that now lie further than [`EVICT_MARGIN_VIEWPORTS`]
+    /// from it are given up and reported as evicted.
+    pub fn render(&mut self, scroll_y: Option<f64>, known_tiles: &HashSet<u64>) -> RenderPass {
+        if let Some(scroll_y) = scroll_y {
+            self.scroll_y = scroll_y;
+        }
+        self.pass(scroll_y, known_tiles, None)
+    }
+
+    /// The pointer moved to `node` (a DOM node id, or nothing): restyle the
+    /// old and new hover chains and repaint only the tiles those elements
+    /// cover, within the current raster window. No re-layout - the same
+    /// simplification as the in-process hover repaint. Tiles whose painted
+    /// content comes out identical are not shipped again.
+    pub fn hover(&mut self, node: Option<u64>) -> RenderPass {
+        let new_leaf = node.map(NodeId::from);
+        let old_leaf = self.hovered;
+        if new_leaf == old_leaf {
+            return self.empty_pass();
+        }
+        self.hovered = new_leaf;
+
+        let doc = &self.layer_list.layout_tree.render_tree.doc;
+        // Only the two ancestor chains can gain or lose `:hover`.
+        let mut dirty_nodes: Vec<NodeId> = Vec::new();
+        let mut seen = HashSet::new();
+        for start in [old_leaf, new_leaf].into_iter().flatten() {
+            let mut id = start;
+            loop {
+                if seen.insert(id) {
+                    dirty_nodes.push(id);
+                }
+                match doc.parent(id) {
+                    Some(parent) => id = parent,
+                    None => break,
+                }
+            }
+        }
+        (self.set_hovered)(new_leaf);
+        doc.invalidate_style_for_nodes(&dirty_nodes);
+
+        // Everything either element covers, as laid out.
+        let mut repaint: Option<Rect> = None;
+        for element in self.layer_list.layout_tree.arena.values() {
+            let matches = [old_leaf, new_leaf]
+                .into_iter()
+                .flatten()
+                .any(|leaf| element.dom_node_id == leaf);
+            if !matches {
+                continue;
+            }
+            let m = &element.box_model.margin_box;
+            let r = Rect::new(m.x, m.y, m.width, m.height);
+            repaint = Some(match repaint {
+                None => r,
+                Some(u) => {
+                    let x0 = u.x.min(r.x);
+                    let y0 = u.y.min(r.y);
+                    let x1 = (u.x + u.width).max(r.x + r.width);
+                    let y1 = (u.y + u.height).max(r.y + r.height);
+                    Rect::new(x0, y0, x1 - x0, y1 - y0)
+                }
+            });
+        }
+        let Some(repaint) = repaint else {
+            return self.empty_pass();
+        };
+        self.pass(Some(self.scroll_y), &HashSet::new(), Some(repaint))
+    }
+
+    fn empty_pass(&self) -> RenderPass {
+        RenderPass {
+            summary: self.summary(0, 0, Vec::new()),
+            tiles: Vec::new(),
+            evicted: Vec::new(),
+        }
+    }
+
+    fn summary(&self, painted_tiles: u64, paint_commands: u64, timings_us: Vec<(String, u64)>) -> PageSummary {
+        PageSummary {
+            title: self.title.clone(),
+            favicon: self.favicon.clone(),
+            page_width: self.page_width,
+            page_height: self.page_height,
+            layer_count: self.layer_ids.len() as u64,
+            painted_tiles,
+            paint_commands,
+            layer_order: self.layer_ids.iter().map(|id| id.as_u64()).collect(),
+            timings_us,
+        }
+    }
+
+    /// One pass: tile, decide which tiles need paint, paint, hash, rasterize,
+    /// evict. `repaint` narrows the work to tiles overlapping it (a hover),
+    /// forcing those even if the broker holds them; otherwise a tile the
+    /// broker already holds by position needs nothing.
+    fn pass(&mut self, scroll_y: Option<f64>, known_tiles: &HashSet<u64>, repaint: Option<Rect>) -> RenderPass {
+        use gosub_render_pipeline::common::browser_state::{BrowserState, WireframeState};
+        use gosub_render_pipeline::painter::Painter;
+
+        let started = std::time::Instant::now();
+        let mut timings = std::mem::take(&mut self.build_timings);
+        let lap = |name: &str, timings: &mut Vec<(String, u64)>, since: &mut u64| {
+            let now = started.elapsed().as_micros() as u64;
+            timings.push((name.to_string(), now - *since));
+            *since = now;
+        };
+        let mut since = 0u64;
+
+        // Stage 4: tiling, from the retained layer list.
+        let mut tile_list = TileList::from_arc(Arc::clone(&self.layer_list), Dimension::new(TILE_SIZE, TILE_SIZE));
+        tile_list.generate();
+        if let Some(scroll_y) = scroll_y {
+            defer_tiles_outside_window(&mut tile_list, scroll_y, self.viewport_height);
+        }
+
+        for tile in tile_list.arena.values_mut() {
+            if tile.state != TileState::Dirty {
+                continue;
+            }
+            let key = (tile.rect.x.to_bits(), tile.rect.y.to_bits(), tile.layer_id.as_u64());
+            let needs_paint = match repaint {
+                Some(area) => {
+                    tile.rect.x < area.x + area.width
+                        && tile.rect.x + tile.rect.width > area.x
+                        && tile.rect.y < area.y + area.height
+                        && tile.rect.y + tile.rect.height > area.y
+                }
+                None => !self.shipped.contains_key(&key),
+            };
+            if !needs_paint {
+                tile.state = TileState::Ready;
+            }
+        }
+        lap("render.tiling", &mut timings, &mut since);
+
+        // Stage 5: paint what is still dirty.
+        let full_page_rect = Rect::new(0.0, 0.0, self.viewport_width, self.page_height.max(1.0));
+        let paint_state = BrowserState {
+            visible_layer_list: vec![true; self.layer_ids.len()],
+            wireframed: WireframeState::None,
+            debug_hover: false,
+            current_hovered_element: None,
+            show_tilegrid: false,
+            debug_table_cells: false,
+            viewport: full_page_rect,
+            tile_list: None,
+            dpi_scale_factor: 1.0,
+        };
+        let painter = Painter::new(Arc::clone(&tile_list.layer_list), Some(Arc::clone(&self.fonts)));
+        let mut painted_tiles: u64 = 0;
+        let mut paint_commands: u64 = 0;
+        for &layer_id in &self.layer_ids {
+            for tile_id in tile_list.get_intersecting_tiles(layer_id, full_page_rect) {
+                let Some(tile) = tile_list.get_tile_mut(tile_id) else {
+                    continue;
+                };
+                if tile.state != TileState::Dirty {
+                    continue;
+                }
+                painted_tiles += 1;
+                for tiled_element in &mut tile.elements {
+                    tiled_element.paint_commands = painter.paint(tiled_element, &paint_state);
+                    paint_commands += tiled_element.paint_commands.len() as u64;
+                }
+            }
+        }
+        lap("render.paint", &mut timings, &mut since);
+
+        // Between painting and rasterizing: a tile's hash covers its position,
+        // layer and painted content, so a hit in `known_tiles` - or the same
+        // hash the broker already holds for this position - means the pixels
+        // would come out byte-identical: no reason to rasterize it, let alone
+        // ship it. Marking such a tile non-dirty is what makes stage 6 skip it.
+        let mut plan: Vec<TilePlan> = Vec::new();
+        for &layer_id in &self.layer_ids {
+            let scrolls = self.layer_list.layer_anchor(layer_id) == TileAnchor::Scroll;
+            for tile_id in tile_list.get_intersecting_tiles(layer_id, full_page_rect) {
+                let Some(tile) = tile_list.get_tile_mut(tile_id) else {
+                    continue;
+                };
+                if tile.state != TileState::Dirty {
+                    continue;
+                }
+                let key = (tile.rect.x.to_bits(), tile.rect.y.to_bits(), layer_id.as_u64());
+                let hash = gosub_render_pipeline::rasterizer::tile_content_hash(tile);
+                if self.shipped.get(&key).is_some_and(|s| s.hash == hash) {
+                    tile.state = TileState::Ready;
+                    continue;
+                }
+                let unchanged = known_tiles.contains(&hash);
+                if unchanged {
+                    tile.state = TileState::Ready;
+                }
+                plan.push(TilePlan {
+                    key,
+                    rect: tile.rect,
+                    scrolls,
+                    hash,
+                    unchanged,
+                });
+            }
+        }
+
+        // Stage 6, when this configuration can rasterize in a forked child.
+        // Sequential on purpose: the renderer filter has no `clone`, so the
+        // parallel strategy is not merely unwanted here, it is impossible.
+        let baked = match &self.rasterizer {
+            Some(rasterizer) => {
+                let (baked, _tile_cache) = gosub_render_pipeline::rasterizer::rasterize_sequential(
+                    rasterizer.as_ref(),
+                    &self.layer_ids,
+                    &mut tile_list,
+                    full_page_rect,
+                    &self.media_store,
+                );
+                baked
+            }
+            None => Vec::new(),
+        };
+        lap("render.raster", &mut timings, &mut since);
+
+        // Re-join the freshly baked tiles with the plan, so what leaves this
+        // process is in composite order regardless of which tiles were skipped.
+        let mut fresh: HashMap<TilePosKey, BakedTile> = baked
+            .into_iter()
+            .map(|tile| ((tile.page_x.to_bits(), tile.page_y.to_bits(), tile.layer_id), tile))
+            .collect();
+        let mut tiles: Vec<RenderedTile> = Vec::with_capacity(plan.len());
+        let mut evicted = Vec::new();
+        for entry in plan {
+            let rendered = if entry.unchanged {
+                Some(RenderedTile::Unchanged {
+                    page_x: entry.rect.x,
+                    page_y: entry.rect.y,
+                    layer_id: entry.key.2,
+                    hash: entry.hash,
+                })
+            } else {
+                fresh
+                    .remove(&entry.key)
+                    .map(|tile| RenderedTile::Fresh { tile, hash: entry.hash })
+            };
+            let Some(rendered) = rendered else {
+                continue;
+            };
+            // A repainted position replaces what the broker held there.
+            if let Some(previous) = self.shipped.insert(
+                entry.key,
+                Shipped {
+                    hash: entry.hash,
+                    rect: entry.rect,
+                    scrolls: entry.scrolls,
+                },
+            ) {
+                evicted.push(previous.hash);
+            }
+            tiles.push(rendered);
+        }
+
+        // Let go of what drifted out of reach. Whole-page passes keep
+        // everything: there is no viewport to measure distance from.
+        if let Some(scroll_y) = scroll_y {
+            let (lo, hi) = raster_window(scroll_y, self.viewport_height);
+            let margin = EVICT_MARGIN_VIEWPORTS * self.viewport_height;
+            let (keep_lo, keep_hi) = (lo - margin, hi + margin);
+            self.shipped.retain(|_, shipped| {
+                let far =
+                    shipped.scrolls && (shipped.rect.y + shipped.rect.height <= keep_lo || shipped.rect.y >= keep_hi);
+                if far {
+                    evicted.push(shipped.hash);
+                }
+                !far
+            });
+        }
+
+        RenderPass {
+            summary: self.summary(painted_tiles, paint_commands, timings),
+            tiles,
+            evicted,
+        }
+    }
+}
+
+/// Bookkeeping between the paint and rasterize stages: what each tile is and
+/// whether the broker already has it.
+struct TilePlan {
+    key: TilePosKey,
+    rect: Rect,
+    scrolls: bool,
+    hash: u64,
+    unchanged: bool,
+}
+
+/// Flatten the layer list into hit-test geometry for the broker.
+/// Everything the broker needs to answer hit tests and hovers without a DOM
+/// of its own, resolved here per box.
+fn describe_hit<C: RenderConfiguration>(
+    doc: &EngineDocument<C>,
+    node: NodeId,
+    base_url: Option<&Url>,
+) -> (
+    Option<String>,
+    Option<String>,
+    crate::fork_server::protocol::HitCursor,
+    bool,
+) {
+    use crate::fork_server::protocol::HitCursor;
+    use gosub_interface::node::NodeType;
+    let resolve = |raw: &str| base_url.and_then(|b| b.join(raw).ok()).map(|u| u.to_string());
+    let mut link = None;
+    let mut image = None;
+    let mut editable = false;
+    let mut cursor = if doc.node_type(node) == NodeType::TextNode {
+        HitCursor::Text
+    } else {
+        HitCursor::Default
+    };
+    let mut id = Some(node);
+    while let Some(current) = id {
+        if link.is_none() && doc.tag_name(current) == Some("a") {
+            if let Some(href) = doc.attribute(current, "href") {
+                link = Some(resolve(href).unwrap_or_else(|| href.to_string()));
+                cursor = HitCursor::Pointer;
+            }
+        }
+        if image.is_none() && doc.tag_name(current) == Some("img") {
+            image = doc
+                .attribute(current, "src")
+                .map(|src| resolve(src).unwrap_or_else(|| src.to_string()));
+        }
+        if crate::html::is_text_input::<C>(doc, current) {
+            editable = true;
+            if cursor != HitCursor::Pointer {
+                cursor = HitCursor::Text;
+            }
+        }
+        id = doc.parent(current);
+    }
+    (link, image, cursor, editable)
+}
+
+fn collect_hit_regions<C: RenderConfiguration>(
+    layer_list: &LayerList,
+    doc: &EngineDocument<C>,
+    base_url: Option<&Url>,
+) -> Vec<HitRegion> {
+    let mut regions = Vec::new();
+    let layer_ids = layer_list.layer_ids.read();
+    let layers = layer_list.layers.read();
+
+    'outer: for layer_id in layer_ids.iter().rev() {
+        let Some(layer) = layers.get(layer_id) else {
+            continue;
+        };
+        for element_id in layer.elements.iter().rev() {
+            let Some(element) = layer_list.layout_tree.get_node_by_id(*element_id) else {
+                continue;
+            };
+            if regions.len() >= MAX_HIT_REGIONS {
+                log::warn!(
+                    "page has more than {MAX_HIT_REGIONS} hit-testable boxes;                      hit testing covers the topmost {MAX_HIT_REGIONS}"
+                );
+                break 'outer;
+            }
+            let margin = &element.box_model.margin_box;
+            let (link, image, cursor, editable) = describe_hit::<C>(doc, element.dom_node_id, base_url);
+            regions.push(HitRegion {
+                x: margin.x,
+                y: margin.y,
+                width: margin.width,
+                height: margin.height,
+                node_id: element.dom_node_id.into(),
+                anchor: layer.anchor.into(),
+                link,
+                image,
+                cursor,
+                editable,
+            });
+        }
+    }
+    regions
+}

--- a/crates/gosub_engine/src/html.rs
+++ b/crates/gosub_engine/src/html.rs
@@ -1,5 +1,6 @@
 //! HTML parsing entry points and the render-side configuration traits.
 mod parser;
+pub(crate) mod web_fonts;
 
 pub use parser::parse_main_document_stream;
 pub use parser::{DocumentError, HtmlParseConfig, ResourceHint};
@@ -76,6 +77,15 @@ pub trait RenderConfiguration: ModuleConfiguration<Document = DocumentImpl<Self>
     /// Font system used for text measurement (layout) and shared with the renderer for drawing.
     /// The engine owns one instance, created via `Default`, and hands it to both.
     type FontSystem: FontSystem + Default;
+
+    /// A stage-6 tile rasterizer for a forked renderer process, or `None`
+    /// if forked renderers should stop after painting.
+    fn forked_tile_rasterizer(
+        font_system: std::sync::Arc<parking_lot::Mutex<dyn gosub_interface::font_system::FontSystem>>,
+    ) -> Option<Box<dyn gosub_render_pipeline::rasterizer::Rasterable + Send + Sync>> {
+        let _ = font_system;
+        None
+    }
 }
 
 impl<B, F, S> RenderConfiguration for DefaultRenderConfig<B, F, S>
@@ -87,6 +97,32 @@ where
     type RenderBackend = B;
     type CompositorSink = S;
     type FontSystem = F;
+
+    /// A CPU tile rasterizer for forked renderers, when one is compiled in
+    /// (`cairo-tiles`, else `skia-tiles`). Independent of `B`: a GPU backend in
+    /// the broker still receives isolated tiles as CPU pixels.
+    fn forked_tile_rasterizer(
+        font_system: std::sync::Arc<parking_lot::Mutex<dyn gosub_interface::font_system::FontSystem>>,
+    ) -> Option<Box<dyn gosub_render_pipeline::rasterizer::Rasterable + Send + Sync>> {
+        #[cfg(feature = "cairo-tiles")]
+        {
+            Some(Box::new(gosub_renderer_cairo::CairoRasterizer::with_font_system(
+                font_system,
+            )))
+        }
+        #[cfg(all(feature = "skia-tiles", not(feature = "cairo-tiles")))]
+        {
+            Some(Box::new(gosub_renderer_skia::SkiaRasterizer::with_font_system(
+                1.0,
+                font_system,
+            )))
+        }
+        #[cfg(not(any(feature = "cairo-tiles", feature = "skia-tiles")))]
+        {
+            let _ = font_system;
+            None
+        }
+    }
 }
 
 /// The parsed document type used by the engine for a given config (defaults to [`DefaultRenderConfig`]).
@@ -95,6 +131,57 @@ pub type EngineDocument<C = DefaultRenderConfig> = DocumentImpl<C>;
 /// Extract the text content of the first `<title>` element in the document.
 pub fn document_title<C: RenderConfiguration>(doc: &EngineDocument<C>) -> Option<String> {
     find_title(doc, doc.root())
+}
+
+/// Whether `node_id` is a text-editable control: `<textarea>`, a text-like
+/// `<input>`, or `contenteditable`.
+pub fn is_text_input<C: RenderConfiguration>(doc: &EngineDocument<C>, node_id: NodeId) -> bool {
+    match doc.tag_name(node_id) {
+        Some("textarea") => true,
+        Some("input") => !doc.attribute(node_id, "type").is_some_and(|t| {
+            [
+                "button", "submit", "reset", "checkbox", "radio", "range", "color", "file", "image", "hidden",
+            ]
+            .iter()
+            .any(|k| t.eq_ignore_ascii_case(k))
+        }),
+        _ => doc
+            .attribute(node_id, "contenteditable")
+            .is_some_and(|v| v.is_empty() || v.eq_ignore_ascii_case("true")),
+    }
+}
+
+/// The document's icon: the first `<link rel="icon">` (or `shortcut icon`,
+/// `apple-touch-icon*`) resolved against `base_url`, else `/favicon.ico` for
+/// http(s) documents.
+pub fn favicon_url<C: RenderConfiguration>(doc: &EngineDocument<C>, base_url: &url::Url) -> Option<url::Url> {
+    fn walk<C: RenderConfiguration>(doc: &EngineDocument<C>, node: NodeId, base: &url::Url) -> Option<url::Url> {
+        for &child in doc.children(node) {
+            if doc.tag_name(child).is_some_and(|t| t.eq_ignore_ascii_case("link")) {
+                let is_icon = doc.attribute(child, "rel").is_some_and(|rel| {
+                    rel.split_ascii_whitespace().any(|t| {
+                        t.eq_ignore_ascii_case("icon")
+                            || t.len() >= 16 && t[..16].eq_ignore_ascii_case("apple-touch-icon")
+                    })
+                });
+                if is_icon {
+                    if let Some(url) = doc.attribute(child, "href").and_then(|h| base.join(h).ok()) {
+                        return Some(url);
+                    }
+                }
+            }
+            if let Some(found) = walk::<C>(doc, child, base) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    walk::<C>(doc, doc.root(), base_url).or_else(|| {
+        matches!(base_url.scheme(), "http" | "https")
+            .then(|| base_url.join("/favicon.ico").ok())
+            .flatten()
+    })
 }
 
 fn find_title<C: RenderConfiguration>(doc: &EngineDocument<C>, node_id: NodeId) -> Option<String> {

--- a/crates/gosub_engine/src/html/parser.rs
+++ b/crates/gosub_engine/src/html/parser.rs
@@ -64,6 +64,11 @@ pub struct HtmlParseConfig {
     /// the parser has no network capability of its own (see
     /// `gosub_html5::parser::Html5ParserOptions::resource_loader`).
     pub resource_loader: Option<std::sync::Arc<dyn gosub_interface::resource_loader::ResourceLoader>>,
+    /// Also return the document's source text, for an engine that will hand it
+    /// to a renderer process (which re-parses; a DOM cannot cross a fork by
+    /// value). Off by default - retaining a copy of every document would tax
+    /// engines that render in-process.
+    pub capture_source: bool,
 }
 
 impl Default for HtmlParseConfig {
@@ -72,6 +77,7 @@ impl Default for HtmlParseConfig {
         Self {
             max_bytes: 10 * 1024 * 1024,
             resource_loader: None,
+            capture_source: false,
         }
     }
 }
@@ -90,7 +96,7 @@ pub async fn parse_main_document_stream<C, R, F>(
     cancel: CancellationToken,
     cfg: HtmlParseConfig,
     mut on_discover: F,
-) -> Result<EngineDocument<C>, DocumentError>
+) -> Result<(EngineDocument<C>, Option<std::sync::Arc<str>>), DocumentError>
 where
     C: RenderConfiguration,
     R: AsyncRead + Unpin + Send + 'static,
@@ -133,8 +139,12 @@ where
         }
     }
 
-    // Use lossy UTF-8 only for the fast resource-discovery regex scan.
+    // Lossy UTF-8 for the fast resource-discovery regex scan and the captured
+    // source; the parse below decodes properly.
     let html_lossy = String::from_utf8_lossy(&buf);
+    let source = cfg
+        .capture_source
+        .then(|| std::sync::Arc::<str>::from(html_lossy.as_ref()));
 
     // Fire sub-resource callbacks using the fast regex-based scanner so that
     // image/CSS/script fetches are submitted before the full parse completes.
@@ -164,7 +174,7 @@ where
     let ua = <C::CssSystem as CssSystem>::load_default_useragent_stylesheet();
     doc.add_stylesheet(ua);
 
-    Ok(doc)
+    Ok((doc, source))
 }
 
 // ======== Forgiving resource discovery (regex-based) ========
@@ -315,7 +325,7 @@ mod tests {
         let cancel = CancellationToken::new();
         let mut hints = Vec::new();
 
-        parse_main_document_stream::<DefaultRenderConfig, _, _>(
+        let (_doc, _) = parse_main_document_stream::<DefaultRenderConfig, _, _>(
             base.clone(),
             reader_from_str(html),
             cancel,

--- a/crates/gosub_engine/src/html/web_fonts.rs
+++ b/crates/gosub_engine/src/html/web_fonts.rs
@@ -1,0 +1,253 @@
+//! `@font-face` web fonts: extraction, fetching, decoding, registration.
+
+use crate::html::RenderConfiguration;
+use gosub_interface::font::FontError;
+use gosub_interface::resource_loader::ResourceLoader;
+use url::Url;
+
+/// How a fetched face reaches a font system: `(bytes, css_family)`. A closure
+/// rather than `&mut dyn FontSystem`, because the two callers hold their font
+/// systems behind different locks.
+pub(crate) type RegisterFont<'a> = &'a mut dyn FnMut(Vec<u8>, &str) -> Result<(), FontError>;
+
+/// Fetch and register any `@font-face` web fonts declared in the document's
+/// stylesheets. Deduplicates by resolved font URL; fetches are synchronous
+/// through `loader`, so the caller decides where the blocking happens (the tab
+/// worker runs this walk on a blocking thread; in a forked renderer, blocking
+/// on the broker is the intended shape). Each face is handed to `register`
+/// under its CSS family so the font system selects the right weight/style from
+/// the font's own metadata.
+pub(crate) fn load_web_fonts<C: RenderConfiguration>(
+    doc: &C::Document,
+    base_url: &Url,
+    loader: &dyn ResourceLoader,
+    register: RegisterFont<'_>,
+) {
+    use gosub_interface::css3::CssStylesheet as _;
+    use gosub_interface::document::Document as _;
+
+    let mut fetched: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for sheet in doc.stylesheets() {
+        let sheet_url = Url::parse(sheet.url()).ok();
+        for (family, sources, unicode_range) in sheet.font_faces() {
+            // Google-style web fonts split a family into many `unicode-range` subsets
+            // (latin, cyrillic, greek, …). We don't do per-glyph subset fallback, so
+            // register only subsets covering Basic Latin (and ranges with no descriptor),
+            // which covers Latin-script content without piling unusable subsets onto the
+            // same family.
+            if let Some(range) = &unicode_range {
+                if !unicode_range_covers_basic_latin(range) {
+                    continue;
+                }
+            }
+            for src in &sources {
+                let resolved = sheet_url
+                    .as_ref()
+                    .unwrap_or(base_url)
+                    .join(src)
+                    .or_else(|_| base_url.join(src));
+                let Ok(font_url) = resolved else { continue };
+                if !fetched.insert(font_url.to_string()) {
+                    break; // this exact font file is already registered
+                }
+                match loader.load(&font_url) {
+                    Ok(resp) if resp.is_ok() && !resp.body.is_empty() => {
+                        // Web fonts are commonly served as WOFF2 (e.g. Google Fonts content-
+                        // negotiates WOFF2 for modern UAs like ours). The font backends
+                        // (Skia/fontconfig) only decode raw SFNT (TTF/OTF), so unwrap WOFF2
+                        // to TTF first. Other formats pass through unchanged.
+                        let font_bytes = decode_web_font(resp.body.to_vec(), &font_url);
+                        match register(font_bytes, &family) {
+                            Ok(()) => {
+                                log::debug!("Registered web font '{family}' from {font_url}");
+                                break; // family face loaded; skip remaining sources
+                            }
+                            Err(e) => log::warn!("Failed to register web font '{family}': {e:?}"),
+                        }
+                    }
+                    Ok(resp) => log::warn!("Web font fetch {font_url} returned status {}", resp.status),
+                    Err(e) => log::warn!("Web font fetch {font_url} failed: {e}"),
+                }
+            }
+        }
+    }
+}
+
+/// Whether a CSS `unicode-range` descriptor (e.g. `"U+0000-00FF, U+0131"`) includes the
+/// Basic-Latin letter `U+0041` ('A') - our proxy for "covers Latin-script text".
+fn unicode_range_covers_basic_latin(range: &str) -> bool {
+    const TARGET: u32 = 0x41; // 'A'
+    for token in range.split([',', ' ', '\t', '\n', '\r']).filter(|t| !t.is_empty()) {
+        let Some(hex) = token
+            .trim()
+            .strip_prefix("U+")
+            .or_else(|| token.trim().strip_prefix("u+"))
+        else {
+            continue;
+        };
+        let (lo, hi) = match hex.split_once('-') {
+            Some((a, b)) => (parse_hex_bound(a, false), parse_hex_bound(b, true)),
+            None => (parse_hex_bound(hex, false), parse_hex_bound(hex, true)),
+        };
+        if let (Some(lo), Some(hi)) = (lo, hi) {
+            if lo <= TARGET && TARGET <= hi {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Unwrap a downloaded web-font payload into raw SFNT bytes the font backends can decode.
+fn decode_web_font(bytes: Vec<u8>, font_url: &Url) -> Vec<u8> {
+    const WOFF2_MAGIC: &[u8; 4] = b"wOF2";
+    if bytes.len() < 4 || &bytes[0..4] != WOFF2_MAGIC {
+        return bytes;
+    }
+    match woff2_to_sfnt(&bytes) {
+        Ok(sfnt) => {
+            log::debug!(
+                "Decoded WOFF2 web font from {font_url} ({} → {} bytes)",
+                bytes.len(),
+                sfnt.len()
+            );
+            sfnt
+        }
+        Err(e) => {
+            log::warn!("Failed to decode WOFF2 web font from {font_url}: {e}");
+            bytes
+        }
+    }
+}
+
+/// Decompress a WOFF2 font to a flat SFNT (TTF/OTF) byte buffer. allsorts handles the Brotli
+/// decompression and the `glyf`/`loca` transform reconstruction; we then re-assemble the
+/// reconstructed tables into the on-disk SFNT layout (offset table + table directory + 4-byte
+/// aligned table data) that font backends expect.
+fn woff2_to_sfnt(bytes: &[u8]) -> Result<Vec<u8>, String> {
+    use allsorts::binary::read::ReadScope;
+    use allsorts::woff2::Woff2Font;
+
+    let font = ReadScope::new(bytes)
+        .read::<Woff2Font<'_>>()
+        .map_err(|e| format!("parse: {e:?}"))?;
+    let sfnt_version = font.flavor();
+    let tables = font
+        .table_provider(0)
+        .map_err(|e| format!("reconstruct: {e:?}"))?
+        .into_tables();
+
+    Ok(assemble_sfnt(sfnt_version, tables))
+}
+
+/// Pack a set of font tables into an SFNT byte buffer per the OpenType spec: a 12-byte offset
+/// table, a 16-byte directory entry per table (sorted by tag), then each table's data padded to
+/// a 4-byte boundary. Per-table checksums are computed; the `head` table's `checkSumAdjustment`
+/// is left as-is (font backends parse without validating it).
+fn assemble_sfnt(sfnt_version: u32, tables: std::collections::HashMap<u32, Box<[u8]>>) -> Vec<u8> {
+    let mut entries: Vec<(u32, Box<[u8]>)> = tables.into_iter().collect();
+    entries.sort_by_key(|(tag, _)| *tag);
+    let num_tables = entries.len() as u16;
+
+    // Binary-search hint fields: largest power of two <= num_tables.
+    let mut entry_selector = 0u16;
+    while (1u16 << (entry_selector + 1)) <= num_tables {
+        entry_selector += 1;
+    }
+    let search_range = (1u16 << entry_selector) * 16;
+    let range_shift = num_tables.wrapping_mul(16).wrapping_sub(search_range);
+
+    let mut directory = Vec::with_capacity(16 * entries.len());
+    let mut data = Vec::new();
+    let mut offset = 12 + 16 * entries.len();
+    for (tag, table) in &entries {
+        directory.extend_from_slice(&tag.to_be_bytes());
+        directory.extend_from_slice(&sfnt_table_checksum(table).to_be_bytes());
+        directory.extend_from_slice(&(offset as u32).to_be_bytes());
+        directory.extend_from_slice(&(table.len() as u32).to_be_bytes());
+        data.extend_from_slice(table);
+        while data.len() % 4 != 0 {
+            data.push(0);
+        }
+        offset += (table.len() + 3) & !3;
+    }
+
+    let mut out = Vec::with_capacity(12 + directory.len() + data.len());
+    out.extend_from_slice(&sfnt_version.to_be_bytes());
+    out.extend_from_slice(&num_tables.to_be_bytes());
+    out.extend_from_slice(&search_range.to_be_bytes());
+    out.extend_from_slice(&entry_selector.to_be_bytes());
+    out.extend_from_slice(&range_shift.to_be_bytes());
+    out.extend_from_slice(&directory);
+    out.extend_from_slice(&data);
+    out
+}
+
+/// SFNT table checksum: the sum of the table's contents read as big-endian `u32`s, with the
+/// final partial word zero-padded, in wrapping (mod 2^32) arithmetic.
+fn sfnt_table_checksum(data: &[u8]) -> u32 {
+    let mut sum = 0u32;
+    for chunk in data.chunks(4) {
+        let mut word = [0u8; 4];
+        word[..chunk.len()].copy_from_slice(chunk);
+        sum = sum.wrapping_add(u32::from_be_bytes(word));
+    }
+    sum
+}
+
+/// Parse a `unicode-range` hex bound, expanding `?` wildcards to `0` (low bound) or `F`
+/// (high bound), e.g. `U+00??` → `0x0000..=0x00FF`.
+fn parse_hex_bound(s: &str, high: bool) -> Option<u32> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    let filled: String = s
+        .chars()
+        .map(|c| {
+            if c == '?' {
+                if high {
+                    'F'
+                } else {
+                    '0'
+                }
+            } else {
+                c
+            }
+        })
+        .collect();
+    u32::from_str_radix(&filled, 16).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    /// Verify `decode_web_font` turns a real WOFF2 payload into an SFNT the font stack can
+    /// parse. Reads the fixture path from `GOSUB_WOFF2_FIXTURE` so we neither hit the network
+    /// nor commit a binary font; skips when unset.
+    #[test]
+    fn decode_web_font_woff2_roundtrips_to_sfnt() {
+        let Ok(path) = std::env::var("GOSUB_WOFF2_FIXTURE") else {
+            eprintln!("skipping: set GOSUB_WOFF2_FIXTURE to a .woff2 file to run");
+            return;
+        };
+        let woff2 = std::fs::read(&path).expect("read fixture");
+        assert_eq!(&woff2[0..4], b"wOF2", "fixture must be WOFF2");
+
+        let url = url::Url::parse("https://example.test/font.woff2").unwrap();
+        let sfnt = super::decode_web_font(woff2, &url);
+
+        // Output must be a different, valid SFNT (TrueType `0x00010000` or OpenType `OTTO`).
+        let magic = u32::from_be_bytes([sfnt[0], sfnt[1], sfnt[2], sfnt[3]]);
+        assert!(magic == 0x0001_0000 || magic == 0x4F54_544F, "not SFNT: {magic:#010x}");
+
+        // It must re-parse and expose the core tables a backend reads.
+        use allsorts::binary::read::ReadScope;
+        use allsorts::font_data::FontData;
+        use allsorts::tables::FontTableProvider;
+        let font = ReadScope::new(&sfnt).read::<FontData<'_>>().expect("parse SFNT");
+        let provider = font.table_provider(0).expect("table provider");
+        for tag in [allsorts::tag::HEAD, allsorts::tag::CMAP, allsorts::tag::GLYF] {
+            assert!(provider.has_table(tag), "missing table {tag:#010x}");
+        }
+    }
+}

--- a/crates/gosub_engine/src/lib.rs
+++ b/crates/gosub_engine/src/lib.rs
@@ -149,7 +149,18 @@ pub mod child_process;
 /// Image decoding in a throwaway, sandboxed process.
 #[cfg(feature = "process-isolation")]
 pub mod decoder_process;
+
+/// The fork server renderers are forked from: warmed fonts, tier-chosen
+/// sandbox. The processes are Linux only - no other platform has a fork to
+/// serve - but the wire protocol is plain data and stays available everywhere,
+/// so the tab's remotely-rendered page state need not be gated.
+pub mod fork_server;
+
 pub mod net;
+/// Exec-fresh, throwaway renderer processes - how `FontPathsReadable`
+/// configurations render out-of-process. Linux only.
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+pub mod render_process;
 
 pub mod util;
 

--- a/crates/gosub_engine/src/net/router.rs
+++ b/crates/gosub_engine/src/net/router.rs
@@ -16,8 +16,12 @@ use std::sync::Arc;
 /// The outcome of routing a fetch result.
 #[derive(Debug)]
 pub enum RoutedOutcome<C: RenderConfiguration> {
-    /// The main document has been parsed and is ready.
-    MainDocument(Arc<EngineDocument<C>>),
+    /// The main document has been parsed and is ready, with its source when
+    /// a renderer process will re-parse it.
+    MainDocument {
+        doc: Arc<EngineDocument<C>>,
+        source: Option<Arc<str>>,
+    },
     /// The resource has been rendered in a viewer (text, image, pdf, etc.).
     ViewerRendered(Bytes),
 
@@ -181,7 +185,7 @@ pub async fn route_response_for<C: RenderConfiguration>(
     match (dest, outcome.decision, body_content) {
         (RequestDestination::Document, HandlingDecision::Render(target), body_content) => match target {
             RenderTarget::HtmlParser => {
-                let doc = match body_content {
+                let parsed = match body_content {
                     BodyContent::Stream { shared } => {
                         hooks.html.parse_stream(request, handle, meta, peek_buf, shared).await?
                     }
@@ -189,7 +193,11 @@ pub async fn route_response_for<C: RenderConfiguration>(
                         hooks.html.parse_bytes(request, handle, meta, body.as_ref()).await?
                     }
                 };
-                Ok(RoutedOutcome::MainDocument(Arc::new(doc)))
+                let (doc, source) = parsed.into_parts();
+                Ok(RoutedOutcome::MainDocument {
+                    doc: Arc::new(doc),
+                    source,
+                })
             }
             RenderTarget::CssParser => Ok(RoutedOutcome::ViewerRendered(body_content.to_bytes(peek_buf).await?)),
             RenderTarget::JsEngine => Ok(RoutedOutcome::ViewerRendered(body_content.to_bytes(peek_buf).await?)),
@@ -216,8 +224,15 @@ pub async fn route_response_for<C: RenderConfiguration>(
                 };
                 let mut meta = meta;
                 meta.content_type = Some("text/html; charset=utf-8".into());
-                let doc = hooks.html.parse_bytes(request, handle, meta, html.as_bytes()).await?;
-                return Ok(RoutedOutcome::MainDocument(Arc::new(doc)));
+                let (doc, source) = hooks
+                    .html
+                    .parse_bytes(request, handle, meta, html.as_bytes())
+                    .await?
+                    .into_parts();
+                return Ok(RoutedOutcome::MainDocument {
+                    doc: Arc::new(doc),
+                    source,
+                });
             }
             // Binary content or an explicit attachment: offer it to the embedder as a
             // download instead of failing the navigation.

--- a/crates/gosub_engine/src/render_process.rs
+++ b/crates/gosub_engine/src/render_process.rs
@@ -1,0 +1,12 @@
+//! The exec-fresh renderer: one page render in its own throwaway process.
+//!
+//! How `FontPathsReadable` configurations get renderer isolation. Their font
+//! stacks read font files while operating, so fork-server font warm-up buys
+//! nothing, and such a stack may not even be constructible inside the fork
+//! server (GLib insists on a worker thread; the fork server's PID-namespace
+//! unshare forbids thread creation). These renderers are instead exec'd fresh
+//! per render (~3.7 ms measured), confined with the font-readable profile,
+//! and exit after one page.
+
+pub mod child;
+pub mod client;

--- a/crates/gosub_engine/src/render_process/child.rs
+++ b/crates/gosub_engine/src/render_process/child.rs
@@ -1,0 +1,211 @@
+//! The exec'd renderer role: set up, confine, render one page, exit.
+
+use crate::fork_server::protocol::{FromForkServer, ResourceReply, TileHeader, ToForkServer};
+use crate::fork_server::renderer;
+use crate::html::RenderConfiguration;
+use gosub_interface::font_system::{Confinement, FontSystem};
+use gosub_interface::resource_loader::{LoadError, LoadedResource, ResourceLoader};
+use gosub_ipc::Endpoint;
+use parking_lot::Mutex;
+use std::os::fd::AsRawFd;
+use std::sync::Arc;
+use url::Url;
+
+/// The renderer's loader when it talks to the broker *directly* (no fork
+/// server in between): `NeedResource` out, `Resource` back, on the same link
+/// the render request arrived on. Blocking, one exchange in flight - the
+/// renderer is single-threaded where it loads.
+struct DirectBrokeredLoader {
+    link: Arc<Mutex<Endpoint>>,
+}
+
+impl std::fmt::Debug for DirectBrokeredLoader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("DirectBrokeredLoader")
+    }
+}
+
+impl ResourceLoader for DirectBrokeredLoader {
+    fn load(&self, url: &Url) -> Result<LoadedResource, LoadError> {
+        let mut link = self.link.lock();
+        link.send(&FromForkServer::NeedResource { url: url.to_string() })
+            .map_err(|e| LoadError::Failed(format!("could not reach the broker: {e}")))?;
+        match link
+            .recv::<ToForkServer>()
+            .map_err(|e| LoadError::Failed(format!("the broker never answered: {e}")))?
+        {
+            ToForkServer::Resource(ResourceReply::Ok {
+                status,
+                content_type,
+                body,
+            }) => Ok(LoadedResource {
+                status,
+                content_type,
+                body: bytes::Bytes::from(body),
+            }),
+            ToForkServer::Resource(ResourceReply::Failed(reason)) => Err(LoadError::Failed(reason)),
+            other => Err(LoadError::Failed(format!("expected a resource, got {other:?}"))),
+        }
+    }
+}
+
+/// Render one page for the broker, then return the process exit code.
+///
+/// Everything that touches the filesystem beyond font paths - building the
+/// font system (which may spawn a library worker thread; permitted, this
+/// process kept its PID namespace and the filter is applied with TSYNC), the
+/// media store's placeholder decode - happens before the lockdown; the parse
+/// and render happen confined, reading only font paths and the private
+/// scratch, fetching everything else through the broker.
+pub fn serve<C: RenderConfiguration>(link: Endpoint) -> i32 {
+    // Before the lockdown (it reads /proc), so the rename on the incoming
+    // request can rewrite the cmdline too.
+    gosub_sandbox::capture_process_title_region();
+
+    // Before the font system, which may start a thread: `TMPDIR` is set here.
+    let scratch = match gosub_sandbox::claim_scratch_dir("renderer") {
+        Ok(dir) => dir,
+        Err(e) => {
+            eprintln!("[renderer] could not create a private scratch directory: {e}");
+            return 1;
+        }
+    };
+
+    let mut fonts = C::FontSystem::default();
+    let _ = fonts.families();
+    let answer = fonts.prepare_for_confinement();
+    if let Confinement::Unsupported(reason) = &answer {
+        let mut link = link;
+        let _ = link.send(&FromForkServer::Refused(format!(
+            "this font system cannot run isolated: {reason}"
+        )));
+        return 1;
+    }
+
+    let link = Arc::new(Mutex::new(link));
+    let loader: Arc<dyn ResourceLoader> = Arc::new(DirectBrokeredLoader {
+        link: Arc::clone(&link),
+    });
+    let media_store = Arc::new(gosub_render_pipeline::common::media::MediaStore::with_loader(
+        Arc::clone(&loader),
+    ));
+    media_store.set_synchronous_fetch(true);
+
+    // The font-readable tier, whatever the instance answered: a `Full` system
+    // routed here still works under the weaker profile, and this role exists
+    // for the systems that need it.
+    let paths = gosub_sandbox::font_filesystem_paths();
+    let mut refs: Vec<(&std::path::Path, bool)> = paths.iter().map(|p| (p.as_path(), false)).collect();
+    refs.push((scratch.as_path(), true));
+    gosub_sandbox::lock_down_renderer_with_font_access(&refs);
+
+    // One request, one render, gone.
+    let request = {
+        let mut link = link.lock();
+        match link.recv::<ToForkServer>() {
+            Ok(msg) => msg,
+            // The broker went away before asking; nothing to do.
+            Err(_) => return 0,
+        }
+    };
+    let ToForkServer::RenderPage {
+        html,
+        url,
+        tab,
+        viewport_width,
+        viewport_height,
+        known_tiles,
+        hovered_node,
+    } = request
+    else {
+        let _ = link.lock().send(&FromForkServer::Refused(
+            "an exec'd renderer serves exactly one RenderPage".into(),
+        ));
+        return 1;
+    };
+
+    // Display only, like the forked path: name the process after its tab.
+    // PR_SET_NAME is on this filter's allowlist; the cmdline rewrite is
+    // plain memory writes into the region captured above.
+    // Not the tab or the URL: the process list is visible to every user on the machine.
+    let _ = (&tab, &url);
+    let id = uuid::Uuid::new_v4().simple().to_string();
+    let comm = format!("renderer-{}", &id[..6]);
+    gosub_sandbox::set_process_title(&comm, &format!("gosub: {comm}"));
+
+    let shared: Arc<Mutex<dyn FontSystem>> = Arc::new(Mutex::new(fonts));
+    let (summary, tiles, hit_regions) = renderer::render_page::<C>(
+        renderer::PageRequest {
+            html: &html,
+            page_url: &url,
+            viewport_width,
+            viewport_height,
+            known_tiles: &known_tiles.into_iter().collect(),
+            hovered_node,
+        },
+        shared,
+        media_store,
+        loader,
+    );
+
+    // Stream the tiles out exactly as a forked renderer does: seal, send,
+    // drop, one at a time.
+    let mut link = link.lock();
+    for tile in &tiles {
+        let sent = match tile {
+            renderer::RenderedTile::Unchanged {
+                page_x,
+                page_y,
+                layer_id,
+                hash,
+            } => link
+                .send(&FromForkServer::TileUnchanged(TileHeader {
+                    page_x: *page_x,
+                    page_y: *page_y,
+                    layer_id: *layer_id,
+                    // Zero dimensions: nothing rasterized here, so the broker
+                    // fills them from the pixels it kept.
+                    width: 0,
+                    height: 0,
+                    format: crate::fork_server::protocol::TileWireFormat::PreMulArgb32,
+                    content_hash: *hash,
+                    opacity: 1.0,
+                    anchor: crate::fork_server::protocol::TileWireAnchor::Scroll,
+                }))
+                .is_ok(),
+            renderer::RenderedTile::Fresh { tile, hash } => {
+                let gosub_render_pipeline::common::texture::TilePixels::Cpu(bytes) = &tile.pixels else {
+                    continue;
+                };
+                let Ok(fd) = gosub_ipc::shm::create_sealed_tile(tile.width, tile.height, |buf| {
+                    let n = buf.len().min(bytes.len());
+                    buf[..n].copy_from_slice(&bytes[..n]);
+                }) else {
+                    return 1;
+                };
+                let header = TileHeader {
+                    page_x: tile.page_x,
+                    page_y: tile.page_y,
+                    layer_id: tile.layer_id,
+                    width: tile.width,
+                    height: tile.height,
+                    format: tile.format.into(),
+                    content_hash: *hash,
+                    opacity: tile.opacity,
+                    anchor: tile.anchor.into(),
+                };
+                link.send(&FromForkServer::Tile(header)).is_ok() && link.tx.send_fd(fd.as_raw_fd()).is_ok()
+            }
+        };
+        if !sent {
+            return 1;
+        }
+    }
+    if link
+        .send(&FromForkServer::PageRendered { summary, hit_regions })
+        .is_err()
+    {
+        return 1;
+    }
+    0
+}

--- a/crates/gosub_engine/src/render_process/client.rs
+++ b/crates/gosub_engine/src/render_process/client.rs
@@ -1,0 +1,86 @@
+//! The broker's side of an exec'd renderer: spawn, render one page, reap.
+
+use crate::fork_server::client::{drive_render_exchange, RenderedPage, TileMemory};
+use crate::fork_server::protocol::ToForkServer;
+use gosub_ipc::Endpoint;
+use std::time::Duration;
+
+/// The argv role name the broker re-execs itself with.
+pub const RENDERER_ROLE: &str = "renderer";
+
+/// How long any message in the exchange may take. Spawn plus font-system
+/// setup is a few hundred ms at worst; page rendering produces a message per
+/// tile, so this bounds *gaps*, not the whole render.
+const REPLY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Render `html` in a fresh, throwaway, font-readable-confined renderer
+/// process: spawn, send the one `RenderPage` it serves, drive the exchange
+/// (subresources answered by `loader`, tiles streamed in as sealed memfds),
+/// reap. The process is gone when this returns - the strongest isolation a
+/// `FontPathsReadable` configuration can get, at ~4 ms of spawn cost.
+pub fn render_page(
+    html: &str,
+    url: &str,
+    tab: &str,
+    viewport: (f64, f64),
+    loader: &dyn crate::fork_server::client::RenderResources,
+    known_tiles: &TileMemory,
+    hovered_node: Option<u64>,
+) -> anyhow::Result<RenderedPage> {
+    // Same guard as every spawner: an undispatched child must not recurse.
+    if crate::child_process::is_child_process() {
+        anyhow::bail!(
+            "this process was started as an engine child role but is running embedder startup, \
+             which means gosub_engine::child_process::dispatch_with() was not called at the top \
+             of main(); refusing to spawn further processes"
+        );
+    }
+
+    let exe = std::env::current_exe()?;
+    let (ours, theirs) = gosub_ipc::channel::Channel::pair()?;
+
+    let mut child = gosub_sandbox::spawn::spawn(
+        &exe,
+        &[crate::child_process::ROLE_FLAG, RENDERER_ROLE],
+        theirs,
+        // No network, no IPC/UTS - but the PID namespace is kept: this role's
+        // font stack must be able to create threads (a PID-unshared process
+        // cannot), and it never forks, so nothing is lost.
+        gosub_sandbox::NamespaceIsolation::NoPidNamespace,
+        gosub_sandbox::spawn::ContainerProfile {
+            name: "gosub-renderer",
+            internet: false,
+            fs_grant: None,
+            data_limit: None,
+            extra_fds: &[],
+            max_tasks: 256,
+            file_size_limit: None,
+        },
+    )?;
+    if let Err(e) = gosub_sandbox::confine_spawned_child(&child) {
+        log::warn!("could not apply parent-side confinement to the renderer: {e}");
+    }
+
+    let result = (|| {
+        let mut link = Endpoint::from_channel(ours)?;
+        let _ = link.tx.set_write_timeout(Some(REPLY_TIMEOUT));
+        let _ = link.rx.set_read_timeout(Some(REPLY_TIMEOUT));
+        link.send(&ToForkServer::RenderPage {
+            html: html.to_string(),
+            url: url.to_string(),
+            tab: tab.to_string(),
+            viewport_width: viewport.0,
+            viewport_height: viewport.1,
+            known_tiles: known_tiles.hashes(),
+            hovered_node,
+        })?;
+        drive_render_exchange::<crate::fork_server::protocol::FromForkServer>(&mut link, loader, known_tiles)
+    })();
+
+    // Kill before reaping, on every path: a renderer that will not exit -
+    // wedged or hostile - must not be able to hold this thread open.
+    let _ = child.kill();
+    let _ = child.wait();
+
+    result
+}

--- a/crates/gosub_engine/tests/process_isolation.rs
+++ b/crates/gosub_engine/tests/process_isolation.rs
@@ -206,6 +206,114 @@ fn a_web_font_can_be_registered_under_the_font_readable_lockdown() {
     );
 }
 
+/// The fork server consumes the confinement answer end to end: for a
+/// `Full`-tier font system it warms once, confines itself, and forks a
+/// renderer that shapes under the strictest sandbox using only inherited,
+/// copy-on-write font state.
+#[cfg(target_os = "linux")]
+#[test]
+fn the_fork_server_forks_a_confined_renderer_for_a_full_tier_font_system() {
+    let out = run("fork-server");
+
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: {}", String::from_utf8_lossy(&out.stderr).trim());
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "the fork-server roundtrip failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("tier: Full"),
+        "expected the default font system to announce the Full tier:\n{stdout}"
+    );
+}
+
+/// The same roundtrip for the other always-compiled font system, whose warmed
+/// state is the per-face override - a forked renderer shaping proves the
+/// override's work really crosses the fork.
+#[cfg(target_os = "linux")]
+#[test]
+fn the_fork_server_forks_a_confined_renderer_with_cosmic_text() {
+    let out = run_with_backend("fork-server", "cosmic");
+
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: {}", String::from_utf8_lossy(&out.stderr).trim());
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "the cosmic fork-server roundtrip failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The render pipeline - parse, style, layout, layering, tiling, paint -
+/// under the strictest renderer sandbox, in-process (no fork machinery), so a
+/// pipeline-vs-sandbox regression is directly attributable.
+#[cfg(target_os = "linux")]
+#[test]
+fn the_render_pipeline_runs_under_the_renderer_lockdown() {
+    let out = run("render-under-lockdown");
+
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: {}", String::from_utf8_lossy(&out.stderr).trim());
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "the pipeline under the renderer lockdown failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The engine-side wiring: with `security.renderer_process` on, `start()`
+/// spawns the fork server, announces its tier, renders through the
+/// engine-held handle, and `shutdown()` tears it down cleanly.
+#[cfg(target_os = "linux")]
+#[test]
+fn the_engine_spawns_the_renderer_fork_server_behind_its_setting() {
+    let out = run("engine-renderer-process");
+
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: {}", String::from_utf8_lossy(&out.stderr).trim());
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "the engine's renderer-process wiring failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("tier: Full"),
+        "expected the default font system to announce the Full tier through the engine:\n{stdout}"
+    );
+}
+
+/// The exec-fresh renderer: one throwaway, font-readable-confined process
+/// renders one page - the `FontPathsReadable` tier's whole render path,
+/// driven directly. Runs with the default (Full-tier) font system here,
+/// which the weaker profile also serves; the tier-2 backends exercise the
+/// same path behind their features.
+#[cfg(target_os = "linux")]
+#[test]
+fn an_exec_fresh_renderer_renders_one_page_confined() {
+    let out = run("exec-renderer");
+
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: {}", String::from_utf8_lossy(&out.stderr).trim());
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "the exec'd renderer roundtrip failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 /// The wiring: an ordinary navigation with `security.network_process` on resolves
 /// through the child rather than an in-process fetcher.
 #[test]

--- a/crates/gosub_render_pipeline/src/common/media/media_store.rs
+++ b/crates/gosub_render_pipeline/src/common/media/media_store.rs
@@ -36,6 +36,10 @@ pub struct MediaStore {
     pending: RwLock<HashSet<Sha256Hash>>,
     /// Set whenever a background fetch lands, so the engine knows a reflow is needed
     completed: AtomicBool,
+    /// Fetch inline on the calling thread instead of spawning `media-fetch` threads.
+    /// A sandboxed renderer cannot spawn (its seccomp filter has no `clone`; a spawn is
+    /// SIGSYS, not `Err`), and an inline fetch means one layout pass instead of fetch-then-reflow.
+    synchronous_fetch: AtomicBool,
     /// Next media ID (atomic to prevent allocation races)
     next_id: AtomicU64,
     /// Compiled-in placeholder returned when an SVG is missing or failed to load
@@ -110,6 +114,7 @@ impl MediaStore {
             cache: RwLock::new(HashMap::new()),
             pending: RwLock::new(HashSet::new()),
             completed: AtomicBool::new(false),
+            synchronous_fetch: AtomicBool::new(false),
             next_id: AtomicU64::new(FIRST_FREE_IMAGE_ID),
             default_svg,
             default_image,
@@ -117,6 +122,13 @@ impl MediaStore {
             loader,
             decoder,
         }
+    }
+
+    /// Fetch inline instead of spawning `media-fetch` threads (see the field). Set once,
+    /// before the store is shared with a context that cannot thread (the fork server sets
+    /// it before renderers are forked from it).
+    pub fn set_synchronous_fetch(&self, on: bool) {
+        self.synchronous_fetch.store(on, Ordering::Relaxed);
     }
 
     /// Non-blocking media load: cached hits return `Ready`, otherwise a background fetch (deduped
@@ -133,6 +145,20 @@ impl MediaStore {
         // Register as in-flight; if another request already owns this hash, just report Pending.
         if !self.pending.write().insert(h) {
             return MediaRequest::Pending;
+        }
+
+        // Synchronous mode: fetch on the calling thread. `load_media` caches even
+        // failures (as the placeholder), so the lookup below normally succeeds.
+        if self.synchronous_fetch.load(Ordering::Relaxed) {
+            let loaded = self.load_media(src);
+            self.pending.write().remove(&h);
+            if loaded.is_ok() {
+                self.completed.store(true, Ordering::Relaxed);
+            }
+            return match self.cache.read().get(&h) {
+                Some(media_id) => MediaRequest::Ready(*media_id),
+                None => MediaRequest::Pending,
+            };
         }
 
         let store = Arc::clone(self);

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -192,12 +192,21 @@ impl TaffyLayouter {
 
     /// Create a layouter that shares an existing font system.
     pub fn with_font_system(font_system: Arc<Mutex<dyn FontSystem>>) -> Self {
+        Self::with_font_system_and_media_store(font_system, Arc::new(MediaStore::new()))
+    }
+
+    /// Create a layouter that shares an existing font system *and* media
+    /// store, constructing neither.
+    pub fn with_font_system_and_media_store(
+        font_system: Arc<Mutex<dyn FontSystem>>,
+        media_store: Arc<MediaStore>,
+    ) -> Self {
         Self {
             tree: TaffyTree::new(),
             root_id: TaffyNodeId::new(0),
             layout_taffy_mapping: HashMap::new(),
             anon_container_map: HashMap::new(),
-            media_store: Arc::new(MediaStore::new()),
+            media_store,
             font_system,
             measure_cache: HashMap::new(),
             dom_to_layout_mapping: HashMap::new(),

--- a/crates/gosub_render_pipeline/src/rasterizer.rs
+++ b/crates/gosub_render_pipeline/src/rasterizer.rs
@@ -80,13 +80,30 @@ pub struct BakedTile {
 /// Format: (page_x bits, page_y bits, layer_id, paint-command hash).
 pub type TileCacheKey = (u64, u64, u64, u64);
 
+/// A tile's identity folded to one number: position, layer, and painted
+/// content. What a process that *keeps* tiles (the broker) sends to a process
+/// that *produces* them (a renderer), so the renderer can skip both
+/// rasterizing and shipping a tile the other side already holds.
+pub fn tile_content_hash(tile: &crate::tiler::Tile) -> u64 {
+    let (x, y, layer, content) = tile_cache_key(tile);
+    // FNV-1a over the four components, matching the key's own hasher.
+    let mut h: u64 = 14695981039346656037;
+    for part in [x, y, layer, content] {
+        for b in part.to_le_bytes() {
+            h ^= b as u64;
+            h = h.wrapping_mul(1099511628211);
+        }
+    }
+    h
+}
+
 /// Rasterized tile cache: maps a [`TileCacheKey`] to `(physical_width, physical_height, pixels)`.
 /// Carried between renders so unchanged tiles skip rasterization.
 pub type TilePixelCache = std::collections::HashMap<TileCacheKey, (u32, u32, TilePixels)>;
 
 /// Compute a stable cache key for a tile: (page_x bits, page_y bits, layer_id, content hash).
 /// The content hash covers all paint commands so any visual change produces a different key.
-fn tile_cache_key(tile: &crate::tiler::Tile) -> TileCacheKey {
+pub fn tile_cache_key(tile: &crate::tiler::Tile) -> TileCacheKey {
     use crate::painter::commands::{
         border::{BorderRadius, BorderStyle},
         brush::Brush,


### PR DESCRIPTION

Base: `06-telemetry`. The renderer boundary as a *per-render* process. This is
an intermediate design — the next PR makes renderers resident — but it is the
half of the machinery that is about confinement and transport, and it is
reviewable on its own.

### What is in here

- **`fork_server`**: a warmed zygote. The child builds the font system, calls
  `prepare_for_confinement`, pins the SVG fontdb, builds the media store, then
  confines itself per the answered tier (`lock_down_fork_server[_with_font_access]`),
  anchors its PID namespace, and forks a renderer per request; a forked
  renderer closes the broker link and anchor pipe it inherited, confines
  itself (`lock_down_forked_renderer`), and runs `renderer::render_page`:
  parse (stylesheets brokered mid-parse), hover state, web fonts, render tree,
  layout, layering, tiling, paint, and stage-6 rasterization when the
  configuration provides `RenderConfiguration::forked_tile_rasterizer` (the
  `cairo-tiles` / `skia-tiles` engine features give `DefaultRenderConfig` one).
- **Tiles over shared memory**: each rasterized tile is sealed into a memfd and
  sent header + fd, one at a time (seal/relay/map/drop per hop, so page height
  is bounded by memory, not fd limits); the broker maps them zero-copy into the
  compositor's `CachedTile`s. `known_tiles` by content hash: unchanged tiles
  are neither rasterized nor shipped again; hover re-renders repaint only the
  tiles whose paint changed.
- **Brokered subresources**: a renderer has no fetch capability; every load is
  a round trip (`NeedResource` → `Resource`) answered by the broker's loader
  where identity and cookies live. The `MediaStore` runs in synchronous-fetch
  mode there (no threads under the renderer filter).
- **Hit testing without a DOM**: the renderer ships hit-test geometry
  (`HitRegion`: box, anchor, link, image, cursor, editability); the broker
  answers hover and hit tests from it.
- **Exec-fresh renderers** (`render_process`) for the `FontPathsReadable`
  tier: spawn, render one page, exit (~4 ms of spawn).
- Engine wiring: `security.renderer_process`; `start()` spawns the fork server
  only for `Full`-tier font systems with a forked rasterizer (otherwise info /
  warning and in-process); tab workers route full renders through it and keep
  the document source for the renderer to re-parse; page content is never
  rendered in-process once isolation is on (`EngineEvent::RendererCrashed`).
  `dispatch_with::<AppConfig>()` is required for this role.
- Web fonts move to `html::web_fonts`, one walk shared by the tab worker
  (background) and the renderer.

### Testing

```
cargo test -p gosub_engine --test process_isolation --features cairo-tiles   # 18
./target/debug/isolation-harness fork-server {parley,cosmic}      # real ink over shm, brokered css/font/img, reuse, hover
./target/debug/isolation-harness engine-renderer-process parley   # a tab frame rendered out-of-process, remote hit test
./target/debug/isolation-harness exec-renderer parley
./target/debug/isolation-harness render-file parley page.html     # debugging aid; -locked for gdb
```

### Deliberate limits

Renderers are forked per render and exit; scroll and hover are full renders.
The next PR makes them resident.