### PR TITLE
Resident renderers: one process per (zone, site), retained pages, async passes, crash recovery, deferred images

### DIFF
--- a/crates/gosub_engine/src/bin/isolation-harness.rs
+++ b/crates/gosub_engine/src/bin/isolation-harness.rs
@@ -6,6 +6,12 @@ use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::sync::Arc;
 
+/// [`BODY`] with a long tail, for scrolling a remotely rendered page.
+const TALL_BODY: &str = "<html><head><title>through the net process</title></head>\
+<body style=\"margin:0\"><a href=\"https://example.test/target\" \
+style=\"display:block;width:400px;height:200px\">a link to hover</a>\
+<div style=\"height:12000px;background:#ddd\">tall</div></body></html>";
+
 const BODY: &str = "<html><head><title>through the net process</title></head>\
 <body style=\"margin:0\"><a href=\"https://example.test/target\" \
 style=\"display:block;width:400px;height:200px\">a link to hover</a></body></html>";
@@ -124,6 +130,14 @@ fn main() {
         "exec-renderer" => with_font_backend!(exec_renderer_roundtrip),
         "render-file" => with_font_backend!(render_file),
         "render-file-locked" => with_font_backend!(render_file_locked),
+        "renderer-lifecycle" => with_font_backend!(renderer_lifecycle),
+        "renderer-scroll-window" => with_font_backend!(renderer_scroll_window),
+        "renderer-hover" => with_font_backend!(renderer_hover),
+        "renderer-crash" => with_font_backend!(renderer_crash),
+        "engine-renderer-crash" => with_font_backend!(engine_renderer_crash),
+        "engine-renderer-slow-image" => with_font_backend!(engine_renderer_slow_image),
+        "renderer-soak" => with_font_backend!(renderer_soak),
+        "engine-soak" => with_font_backend!(engine_soak),
         "engine" => engine(),
         "guard" => guard(),
         other => {
@@ -778,7 +792,7 @@ fn engine_renderer_process<F: FontSystem + Default>() -> i32 {
                 use gosub_engine::zone::ZoneServices;
                 use gosub_render_pipeline::render::backend::ExternalHandle;
 
-                let Ok((port, _server)) = serve_once_with(BODY) else {
+                let Ok((port, _server)) = serve_once_with(TALL_BODY) else {
                     eprintln!("could not start the test server");
                     return 1;
                 };
@@ -901,6 +915,45 @@ fn engine_renderer_process<F: FontSystem + Default>() -> i32 {
                         eprintln!("no HoverUrl for a remotely rendered page: hit testing is not working");
                         return 1;
                     }
+                }
+
+                // Scrolling a remotely rendered page: the first frame carried
+                // only a window of the tall page; scrolling far past it must
+                // bring more tiles, delivered by a pass that ran while frames
+                // kept flowing - so a later frame has to hold more tiles.
+                let _ = tab
+                    .send(TabCommand::MouseScroll {
+                        delta_x: 0.0,
+                        delta_y: 6000.0,
+                    })
+                    .await;
+                let scroll_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(15);
+                let grown = loop {
+                    if tokio::time::Instant::now() >= scroll_deadline {
+                        break None;
+                    }
+                    match compositor.frame_for(tab.tab_id) {
+                        Some(ExternalHandle::TileCache {
+                            tiles: now, scroll_y, ..
+                        }) if now.len() > tiles.len() => {
+                            break Some((now.len(), scroll_y));
+                        }
+                        _ => tokio::time::sleep(std::time::Duration::from_millis(50)).await,
+                    }
+                };
+                match grown {
+                    Some((count, scroll_y)) if cfg!(feature = "cairo-tiles") => {
+                        println!(
+                            "scrolled to {scroll_y:.0}: frame grew from {} to {count} tiles via an async pass",
+                            tiles.len()
+                        );
+                    }
+                    Some(_) => {}
+                    None if cfg!(feature = "cairo-tiles") => {
+                        eprintln!("no frame with more tiles arrived after scrolling a tall remote page");
+                        return 1;
+                    }
+                    None => {}
                 }
 
                 engine.close_zone(zone).await;
@@ -1477,6 +1530,1503 @@ fn render_file_locked<F: FontSystem + Default>() -> i32 {
         2
     }
 }
+
+/// Resident renderers, driven through the pool the engine uses: one process
+/// per (zone, site) shared by that site's tabs, a cross-site navigation
+/// moving a tab to another process, and the last tab leaving shutting the
+/// process down.
+fn renderer_lifecycle<F: FontSystem + Default>() -> i32 {
+    println!("font backend: {}", std::any::type_name::<F>());
+    #[cfg(target_os = "linux")]
+    {
+        use gosub_engine::fork_server::client::ForkServer;
+        use gosub_engine::fork_server::pool::RendererPool;
+        use gosub_engine::fork_server::protocol::ConfinementTier;
+        use gosub_engine::tab::TabId;
+        use gosub_engine::zone::ZoneId;
+
+        let server = match ForkServer::spawn() {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("could not spawn the fork server: {e}");
+                return 1;
+            }
+        };
+        if !matches!(server.confinement(), ConfinementTier::Full) {
+            eprintln!("renderer-lifecycle needs the Full tier, got {:?}", server.confinement());
+            return 2;
+        }
+        let pool = RendererPool::new(Arc::new(parking_lot::Mutex::new(server)), None);
+        let zone = ZoneId::new();
+        let (tab_a, tab_b) = (TabId::new(), TabId::new());
+        let loader = gosub_interface::resource_loader::NoResourceLoader;
+        let memory = Default::default();
+
+        let render = |site: &str, tab: TabId, html: &str| -> Result<i32, String> {
+            let renderer = pool.renderer_for(zone, site, tab).map_err(|e| e.to_string())?;
+            let mut renderer = renderer.lock();
+            let page = renderer
+                .navigate(
+                    html,
+                    &format!("{site}/"),
+                    &tab.to_string(),
+                    (1280.0, 720.0),
+                    0.0,
+                    &loader,
+                    &memory,
+                    None,
+                )
+                .map_err(|e| e.to_string())?;
+            if page.summary.page_height <= 0.0 || page.summary.paint_commands == 0 {
+                return Err(format!("implausible page: {:?}", page.summary));
+            }
+            Ok(renderer.pid())
+        };
+
+        // Two tabs, one site: one process, and it survives both renders.
+        let pid_a = match render("https://one.test", tab_a, "<p>tab a, render 1</p>") {
+            Ok(pid) => pid,
+            Err(e) => {
+                eprintln!("first render failed: {e}");
+                return 1;
+            }
+        };
+        let pid_b = match render("https://one.test", tab_b, "<p>tab b</p>") {
+            Ok(pid) => pid,
+            Err(e) => {
+                eprintln!("second tab's render failed: {e}");
+                return 1;
+            }
+        };
+        let pid_a2 = match render("https://one.test", tab_a, "<p>tab a, render 2</p>") {
+            Ok(pid) => pid,
+            Err(e) => {
+                eprintln!("re-render in the resident renderer failed: {e}");
+                return 1;
+            }
+        };
+        if pid_a != pid_b || pid_a != pid_a2 {
+            eprintln!("same-site tabs should share one renderer: {pid_a} / {pid_b} / {pid_a2}");
+            return 1;
+        }
+        let running = pool.snapshot();
+        if running.len() != 1 || running[0].tabs != 2 {
+            eprintln!("expected one renderer hosting two tabs, got {running:?}");
+            return 1;
+        }
+        println!("two tabs on https://one.test share renderer pid {pid_a} (survived 3 renders)");
+
+        // Tab A goes cross-site: a second process, while B keeps the first.
+        let pid_other = match render("https://two.test", tab_a, "<p>tab a, elsewhere</p>") {
+            Ok(pid) => pid,
+            Err(e) => {
+                eprintln!("cross-site render failed: {e}");
+                return 1;
+            }
+        };
+        if pid_other == pid_a {
+            eprintln!("a cross-site navigation must land in a different renderer");
+            return 1;
+        }
+        let running = pool.snapshot();
+        if running.len() != 2 || running.iter().any(|r| r.tabs != 1) {
+            eprintln!("expected two renderers with one tab each, got {running:?}");
+            return 1;
+        }
+        println!("tab a moved to https://two.test: renderer pid {pid_other}; b still on {pid_b}");
+
+        // The last tab leaving a site shuts its renderer down.
+        pool.release(tab_b);
+        let running = pool.snapshot();
+        if running.len() != 1 || running[0].key.site != "https://two.test" {
+            eprintln!("releasing the last tab should have shut https://one.test down, got {running:?}");
+            return 1;
+        }
+        pool.release(tab_a);
+        if !pool.snapshot().is_empty() {
+            eprintln!(
+                "releasing every tab should leave no renderer, got {:?}",
+                pool.snapshot()
+            );
+            return 1;
+        }
+        println!("last tabs released: every renderer shut down");
+
+        // A tab that returns after its renderer went away gets a new one.
+        match render("https://one.test", tab_b, "<p>tab b is back</p>") {
+            Ok(pid) if pid != pid_a => println!("returning tab got a fresh renderer, pid {pid}"),
+            Ok(pid) => {
+                eprintln!("a shut-down renderer's pid came back: {pid}");
+                return 1;
+            }
+            Err(e) => {
+                eprintln!("render after shutdown failed: {e}");
+                return 1;
+            }
+        }
+
+        pool.shutdown_all();
+        pool.fork_server().lock().shutdown();
+        0
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the fork server exists only on Linux");
+        2
+    }
+}
+
+/// A resident renderer retains the page and rasterizes only around the
+/// viewport: a tall page's first render ships a window of tiles rather than
+/// the whole page, scrolling ships what came into the window, tiles left far
+/// behind are evicted, and scrolling back ships them afresh.
+fn renderer_scroll_window<F: FontSystem + Default>() -> i32 {
+    println!("font backend: {}", std::any::type_name::<F>());
+    #[cfg(target_os = "linux")]
+    {
+        use gosub_engine::fork_server::client::{ForkServer, PageTile};
+        use gosub_engine::fork_server::pool::RendererPool;
+        use gosub_engine::fork_server::protocol::ConfinementTier;
+        use gosub_engine::tab::TabId;
+        use gosub_engine::zone::ZoneId;
+
+        if !cfg!(feature = "cairo-tiles") {
+            eprintln!("renderer-scroll-window needs a rasterizer (feature cairo-tiles)");
+            return 2;
+        }
+        let server = match ForkServer::spawn() {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("could not spawn the fork server: {e}");
+                return 1;
+            }
+        };
+        if !matches!(server.confinement(), ConfinementTier::Full) {
+            eprintln!(
+                "renderer-scroll-window needs the Full tier, got {:?}",
+                server.confinement()
+            );
+            return 2;
+        }
+        let pool = RendererPool::new(Arc::new(parking_lot::Mutex::new(server)), None);
+        let (zone, tab) = (ZoneId::new(), TabId::new());
+        let loader = gosub_interface::resource_loader::NoResourceLoader;
+        let mut memory = gosub_engine::fork_server::client::TileMemory::default();
+        const PAGE: f64 = 12_000.0;
+        const VP: (f64, f64) = (1280.0, 720.0);
+        let tall =
+            r#"<html><body style="margin:0"><div style="height: 12000px; background: #ddd">tall</div></body></html>"#;
+
+        let renderer = match pool.renderer_for(zone, "https://tall.test", tab) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("could not get a renderer: {e}");
+                return 1;
+            }
+        };
+        let mut renderer = renderer.lock();
+        let tab_name = tab.to_string();
+
+        // First render, at the top: a window's worth of tiles, not the page's.
+        let page = match renderer.navigate(tall, "https://tall.test/", &tab_name, VP, 0.0, &loader, &memory, None) {
+            Ok(page) => page,
+            Err(e) => {
+                eprintln!("navigate failed: {e}");
+                return 1;
+            }
+        };
+        if page.summary.page_height < PAGE {
+            eprintln!("expected a {PAGE}px page, got {:?}", page.summary);
+            return 1;
+        }
+        let first = page.tiles.len();
+        let rows_on_page = (PAGE / 256.0).ceil() as usize;
+        if first == 0 || first >= rows_on_page * 3 {
+            eprintln!("first render should ship a viewport window, not the page: {first} tiles");
+            return 1;
+        }
+        let max_y = page
+            .tiles
+            .iter()
+            .map(|t| match t {
+                PageTile::Fresh { header, .. } | PageTile::Reused { header, .. } => header.page_y,
+            })
+            .fold(0.0, f64::max);
+        if max_y > 3.0 * VP.1 {
+            eprintln!("first render shipped a tile at y={max_y}, far outside the window");
+            return 1;
+        }
+        memory.replace_with(page.tiles.iter().map(PageTile::keep));
+        println!("first render shipped {first} tiles for a {PAGE}px page (lowest at y={max_y})");
+
+        // Scroll to the middle: new tiles arrive, the top ones are evicted.
+        let page = match renderer.scroll(&tab_name, 6000.0, &loader, &memory) {
+            Ok(page) => page,
+            Err(e) => {
+                eprintln!("scroll failed: {e}");
+                return 1;
+            }
+        };
+        let fresh = page
+            .tiles
+            .iter()
+            .filter(|t| matches!(t, PageTile::Fresh { .. }))
+            .count();
+        if fresh == 0 {
+            eprintln!("scrolling into unrendered page must ship tiles");
+            return 1;
+        }
+        if page.evicted.is_empty() {
+            eprintln!("tiles three viewports behind must be evicted");
+            return 1;
+        }
+        memory.apply_pass(&page.evicted, page.tiles.iter().map(PageTile::keep));
+        println!("scroll to 6000: {fresh} tiles shipped, {} evicted", page.evicted.len());
+
+        // Staying put ships nothing.
+        let page = match renderer.scroll(&tab_name, 6000.0, &loader, &memory) {
+            Ok(page) => page,
+            Err(e) => {
+                eprintln!("repeat scroll failed: {e}");
+                return 1;
+            }
+        };
+        if !page.tiles.is_empty() || !page.evicted.is_empty() {
+            eprintln!(
+                "a scroll that moved nowhere shipped {} tiles and evicted {}",
+                page.tiles.len(),
+                page.evicted.len()
+            );
+            return 1;
+        }
+
+        // Back to the top: the evicted tiles come back as fresh pixels.
+        let page = match renderer.scroll(&tab_name, 0.0, &loader, &memory) {
+            Ok(page) => page,
+            Err(e) => {
+                eprintln!("scroll back failed: {e}");
+                return 1;
+            }
+        };
+        let fresh = page
+            .tiles
+            .iter()
+            .filter(|t| matches!(t, PageTile::Fresh { .. }))
+            .count();
+        if fresh == 0 {
+            eprintln!("scrolling back over evicted tiles must ship them again");
+            return 1;
+        }
+        println!(
+            "scroll back to 0: {fresh} tiles re-shipped, {} evicted",
+            page.evicted.len()
+        );
+
+        drop(renderer);
+        pool.shutdown_all();
+        pool.fork_server().lock().shutdown();
+        0
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the fork server exists only on Linux");
+        2
+    }
+}
+
+/// Hover on a retained page is a repaint, not a re-render: the renderer
+/// restyles the hover chains and ships only the tiles the hovered element
+/// covers - no parse, no layout - and nothing at all when the pointer stays.
+fn renderer_hover<F: FontSystem + Default>() -> i32 {
+    println!("font backend: {}", std::any::type_name::<F>());
+    #[cfg(target_os = "linux")]
+    {
+        use gosub_engine::fork_server::client::{ForkServer, PageTile};
+        use gosub_engine::fork_server::pool::RendererPool;
+        use gosub_engine::fork_server::protocol::ConfinementTier;
+        use gosub_engine::tab::TabId;
+        use gosub_engine::zone::ZoneId;
+
+        if !cfg!(feature = "cairo-tiles") {
+            eprintln!("renderer-hover needs a rasterizer (feature cairo-tiles)");
+            return 2;
+        }
+        let server = match ForkServer::spawn() {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("could not spawn the fork server: {e}");
+                return 1;
+            }
+        };
+        if !matches!(server.confinement(), ConfinementTier::Full) {
+            eprintln!("renderer-hover needs the Full tier, got {:?}", server.confinement());
+            return 2;
+        }
+        let pool = RendererPool::new(Arc::new(parking_lot::Mutex::new(server)), None);
+        let (zone, tab) = (ZoneId::new(), TabId::new());
+        let loader = gosub_interface::resource_loader::NoResourceLoader;
+        let mut memory = gosub_engine::fork_server::client::TileMemory::default();
+        let html = r#"<html><head><style>
+            body { margin: 0; } p { height: 300px; }
+            a { display: block; width: 200px; height: 40px; background: #ddd; }
+            a:hover { background: #f00; }
+        </style></head><body>
+            <p>above</p><a href="/x">hover me</a><p>below</p><p>more</p><p>and more</p>
+        </body></html>"#;
+
+        let renderer = match pool.renderer_for(zone, "https://hover.test", tab) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("could not get a renderer: {e}");
+                return 1;
+            }
+        };
+        let mut renderer = renderer.lock();
+        let tab_name = tab.to_string();
+        let page = match renderer.navigate(
+            html,
+            "https://hover.test/",
+            &tab_name,
+            (1280.0, 720.0),
+            0.0,
+            &loader,
+            &memory,
+            None,
+        ) {
+            Ok(page) => page,
+            Err(e) => {
+                eprintln!("navigate failed: {e}");
+                return 1;
+            }
+        };
+        let first = page.tiles.len();
+        // The link is the only 40px-tall box on the page.
+        let Some(link) = page.hit_regions.iter().find(|r| (r.height - 40.0).abs() < 1.0) else {
+            eprintln!("no hit region for the 40px link among {:?}", page.hit_regions);
+            return 1;
+        };
+        let link_node = link.node_id;
+        memory.replace_with(page.tiles.iter().map(PageTile::keep));
+        println!("page rendered: {first} tiles, link is node {link_node}");
+
+        let hover = |renderer: &mut gosub_engine::fork_server::client::ResidentRenderer,
+                     memory: &mut gosub_engine::fork_server::client::TileMemory,
+                     node: Option<u64>|
+         -> Result<(usize, Vec<(String, u64)>), String> {
+            let page = renderer
+                .hover(&tab_name, node, &loader, memory)
+                .map_err(|e| e.to_string())?;
+            let fresh = page
+                .tiles
+                .iter()
+                .filter(|t| matches!(t, PageTile::Fresh { .. }))
+                .count();
+            let timings = page.summary.timings_us.clone();
+            memory.apply_pass(&page.evicted, page.tiles.iter().map(PageTile::keep));
+            Ok((fresh, timings))
+        };
+
+        // Hovering the link repaints the tiles it covers, and nothing was laid out.
+        let (fresh, timings) = match hover(&mut renderer, &mut memory, Some(link_node)) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("hover failed: {e}");
+                return 1;
+            }
+        };
+        if fresh == 0 || fresh >= first {
+            eprintln!("hovering the link should repaint a few tiles, got {fresh} of {first}");
+            return 1;
+        }
+        if timings.iter().any(|(name, _)| name.starts_with("build.")) {
+            eprintln!("a hover must not parse or lay out again: {timings:?}");
+            return 1;
+        }
+        println!("hover on the link repainted {fresh} tile(s) with no layout");
+
+        // Same node again: nothing to do.
+        match hover(&mut renderer, &mut memory, Some(link_node)) {
+            Ok((0, _)) => {}
+            Ok((n, _)) => {
+                eprintln!("hovering the same node again shipped {n} tiles");
+                return 1;
+            }
+            Err(e) => {
+                eprintln!("repeat hover failed: {e}");
+                return 1;
+            }
+        }
+
+        // Leaving it repaints the same tiles back.
+        match hover(&mut renderer, &mut memory, None) {
+            Ok((n, _)) if n > 0 => println!("leaving the link repainted {n} tile(s)"),
+            Ok(_) => {
+                eprintln!("leaving the link should repaint it un-hovered");
+                return 1;
+            }
+            Err(e) => {
+                eprintln!("un-hover failed: {e}");
+                return 1;
+            }
+        }
+
+        drop(renderer);
+        pool.shutdown_all();
+        pool.fork_server().lock().shutdown();
+        0
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the fork server exists only on Linux");
+        2
+    }
+}
+
+/// A resident renderer that dies is noticed on the next request and replaced:
+/// the failed exchange marks it dead, the pool spawns a fresh one, and the
+/// tab renders there.
+fn renderer_crash<F: FontSystem + Default>() -> i32 {
+    println!("font backend: {}", std::any::type_name::<F>());
+    #[cfg(target_os = "linux")]
+    {
+        use gosub_engine::fork_server::client::ForkServer;
+        use gosub_engine::fork_server::pool::RendererPool;
+        use gosub_engine::fork_server::protocol::ConfinementTier;
+        use gosub_engine::tab::TabId;
+        use gosub_engine::zone::ZoneId;
+
+        let server = match ForkServer::spawn() {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("could not spawn the fork server: {e}");
+                return 1;
+            }
+        };
+        if !matches!(server.confinement(), ConfinementTier::Full) {
+            eprintln!("renderer-crash needs the Full tier, got {:?}", server.confinement());
+            return 2;
+        }
+        let pool = RendererPool::new(Arc::new(parking_lot::Mutex::new(server)), None);
+        let (zone, tab) = (ZoneId::new(), TabId::new());
+        let loader = gosub_interface::resource_loader::NoResourceLoader;
+        let memory = gosub_engine::fork_server::client::TileMemory::default();
+        let html = "<html><body><p>a page that will lose its renderer</p></body></html>";
+        let tab_name = tab.to_string();
+
+        let first_pid = {
+            let renderer = match pool.renderer_for(zone, "https://crash.test", tab) {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("could not get a renderer: {e}");
+                    return 1;
+                }
+            };
+            let mut renderer = renderer.lock();
+            if let Err(e) = renderer.navigate(
+                html,
+                "https://crash.test/",
+                &tab_name,
+                (1280.0, 720.0),
+                0.0,
+                &loader,
+                &memory,
+                None,
+            ) {
+                eprintln!("navigate failed: {e}");
+                return 1;
+            }
+            renderer.pid()
+        };
+        println!("page rendered in renderer pid {first_pid}");
+
+        if pool.crash_renderers_for_test("https://crash.test") != 1 {
+            eprintln!("expected to crash exactly one renderer");
+            return 1;
+        }
+
+        // The next exchange fails and marks the renderer dead ...
+        {
+            let renderer = match pool.renderer_for(zone, "https://crash.test", tab) {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("renderer_for after the crash failed: {e}");
+                    return 1;
+                }
+            };
+            let mut renderer = renderer.lock();
+            match renderer.scroll(&tab_name, 100.0, &loader, &memory) {
+                Ok(_) => {
+                    eprintln!("an exchange with a dead renderer should fail");
+                    return 1;
+                }
+                Err(e) => println!("exchange with the dead renderer failed as expected: {e}"),
+            }
+            if !renderer.is_dead() {
+                eprintln!("a failed exchange must mark the renderer dead");
+                return 1;
+            }
+        }
+
+        // ... and the request after that gets a fresh process that renders.
+        let renderer = match pool.renderer_for(zone, "https://crash.test", tab) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("could not get a replacement renderer: {e}");
+                return 1;
+            }
+        };
+        let mut renderer = renderer.lock();
+        if renderer.pid() == first_pid || renderer.is_dead() {
+            eprintln!(
+                "expected a fresh renderer, got pid {} (dead: {})",
+                renderer.pid(),
+                renderer.is_dead()
+            );
+            return 1;
+        }
+        match renderer.navigate(
+            html,
+            "https://crash.test/",
+            &tab_name,
+            (1280.0, 720.0),
+            0.0,
+            &loader,
+            &memory,
+            None,
+        ) {
+            Ok(page) if page.summary.paint_commands > 0 => {
+                println!("replacement renderer pid {} rendered the page again", renderer.pid());
+            }
+            Ok(page) => {
+                eprintln!("replacement rendered an implausible page: {:?}", page.summary);
+                return 1;
+            }
+            Err(e) => {
+                eprintln!("render in the replacement renderer failed: {e}");
+                return 1;
+            }
+        }
+        drop(renderer);
+        pool.shutdown_all();
+        pool.fork_server().lock().shutdown();
+        0
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the fork server exists only on Linux");
+        2
+    }
+}
+
+/// The same crash through the engine: the tab's renderer dies, the embedder
+/// hears `RendererCrashed`, and the tab comes back in a fresh process on its
+/// next render - never in-process.
+fn engine_renderer_crash<F: FontSystem + Default>() -> i32 {
+    println!("font backend: {}", std::any::type_name::<F>());
+    #[cfg(target_os = "linux")]
+    {
+        use gosub_config::settings::Setting;
+        use gosub_engine::events::{EngineEvent, NavigationEvent, TabCommand};
+        use gosub_engine::storage::{InMemoryLocalStore, InMemorySessionStore, PartitionPolicy, StorageService};
+        use gosub_engine::zone::ZoneServices;
+        use gosub_engine::GosubEngine;
+        use gosub_interface::font_system::Confinement;
+        use gosub_render_pipeline::render::backend::ExternalHandle;
+        use gosub_render_pipeline::render::backends::null::NullBackend;
+        use gosub_render_pipeline::render::DefaultCompositor;
+
+        if !matches!(F::confinement(), Confinement::Full) {
+            eprintln!("engine-renderer-crash needs a Full-tier font system");
+            return 2;
+        }
+        let runtime = match tokio::runtime::Builder::new_multi_thread().enable_all().build() {
+            Ok(rt) => rt,
+            Err(e) => {
+                eprintln!("could not build a runtime: {e}");
+                return 1;
+            }
+        };
+        runtime.block_on(async move {
+            let compositor = Arc::new(DefaultCompositor::default());
+            let mut engine: GosubEngine<TileConfig<F>> =
+                GosubEngine::new(None, Arc::new(NullBackend::new()), Arc::clone(&compositor));
+            if let Err(e) = engine.settings().set("security.renderer_process", Setting::Bool(true)) {
+                eprintln!("could not enable the renderer process: {e}");
+                return 1;
+            }
+            let Ok(run) = engine.start() else {
+                eprintln!("engine failed to start");
+                return 1;
+            };
+            tokio::spawn(run);
+            let Some(pool) = engine.renderer_pool().cloned() else {
+                if !cfg!(feature = "cairo-tiles") {
+                    eprintln!("no forked rasterizer compiled in (engine feature `cairo-tiles`); nothing to spawn");
+                    return 2;
+                }
+                eprintln!("the engine did not start a renderer pool");
+                return 1;
+            };
+
+            let Ok((port, _server)) = serve_once_with(TALL_BODY) else {
+                eprintln!("could not start the test server");
+                return 1;
+            };
+            let mut events = engine.subscribe_events();
+            let services = ZoneServices {
+                storage: Arc::new(StorageService::new(
+                    Arc::new(InMemoryLocalStore::new()),
+                    Arc::new(InMemorySessionStore::new()),
+                )),
+                cookie_store: None,
+                cookie_jar: None,
+                partition_policy: PartitionPolicy::None,
+                places: None,
+            };
+            let Ok(mut zone) = engine.create_zone(None, services, None) else {
+                eprintln!("could not create a zone");
+                return 1;
+            };
+            let Ok(tab) = zone.create_tab(Default::default(), None).await else {
+                eprintln!("could not create a tab");
+                return 1;
+            };
+            let _ = tab
+                .send(TabCommand::SetViewport {
+                    x: 0,
+                    y: 0,
+                    width: 1280,
+                    height: 720,
+                })
+                .await;
+            if tab.navigate(format!("http://127.0.0.1:{port}/")).await.is_err() {
+                eprintln!("navigate failed");
+                return 1;
+            }
+            let _ = tab.send(TabCommand::ResumeDrawing { fps: 30 }).await;
+
+            let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+            loop {
+                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                match tokio::time::timeout(remaining, events.recv()).await {
+                    Ok(Ok(EngineEvent::Navigation {
+                        event: NavigationEvent::Finished { .. },
+                        ..
+                    })) => break,
+                    Ok(Ok(EngineEvent::Navigation {
+                        event: NavigationEvent::Failed { error, .. },
+                        ..
+                    })) => {
+                        eprintln!("navigation failed: {error}");
+                        return 1;
+                    }
+                    Ok(Ok(_)) => continue,
+                    _ => {
+                        eprintln!("timed out waiting for the navigation");
+                        return 1;
+                    }
+                }
+            }
+            loop {
+                if tokio::time::Instant::now() >= deadline {
+                    eprintln!("timed out waiting for the first frame");
+                    return 1;
+                }
+                if matches!(compositor.frame_for(tab.tab_id), Some(ExternalHandle::TileCache { .. })) {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+            let site = "http://127.0.0.1";
+            let Some(before) = pool.snapshot().into_iter().find(|r| r.key.site == site) else {
+                eprintln!("no renderer for {site} in the pool: {:?}", pool.snapshot());
+                return 1;
+            };
+            println!("tab rendered in renderer pid {}", before.pid);
+
+            // Kill it, then give the tab a reason to talk to it.
+            if pool.crash_renderers_for_test(site) != 1 {
+                eprintln!("expected to crash one renderer");
+                return 1;
+            }
+            let _ = tab
+                .send(TabCommand::MouseScroll {
+                    delta_x: 0.0,
+                    delta_y: 6000.0,
+                })
+                .await;
+
+            let crash_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(15);
+            loop {
+                let remaining = crash_deadline.saturating_duration_since(tokio::time::Instant::now());
+                match tokio::time::timeout(remaining, events.recv()).await {
+                    Ok(Ok(EngineEvent::RendererCrashed {
+                        site: crashed, tabs, ..
+                    })) => {
+                        if crashed != site || !tabs.contains(&tab.tab_id) {
+                            eprintln!("RendererCrashed named the wrong site/tabs: {crashed} {tabs:?}");
+                            return 1;
+                        }
+                        println!("embedder heard RendererCrashed for {crashed} ({} tab)", tabs.len());
+                        break;
+                    }
+                    Ok(Ok(_)) => continue,
+                    _ => {
+                        eprintln!("no RendererCrashed event after killing the renderer");
+                        return 1;
+                    }
+                }
+            }
+
+            // Recovery: a fresh process for the site, and the tab rendering in it.
+            let recover_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(15);
+            let after = loop {
+                if tokio::time::Instant::now() >= recover_deadline {
+                    eprintln!("the tab never got a replacement renderer: {:?}", pool.snapshot());
+                    return 1;
+                }
+                match pool.snapshot().into_iter().find(|r| r.key.site == site) {
+                    Some(r) if r.pid != before.pid => break r,
+                    _ => tokio::time::sleep(std::time::Duration::from_millis(50)).await,
+                }
+            };
+            println!("tab recovered in replacement renderer pid {}", after.pid);
+
+            engine.close_zone(zone).await;
+            if engine.shutdown().await.is_err() {
+                eprintln!("engine shutdown failed");
+                return 1;
+            }
+            0
+        })
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the renderer process exists only on Linux");
+        2
+    }
+}
+
+/// A render never waits for an image: a page whose image the server holds
+/// back for seconds must still paint promptly, and paint again - without a
+/// new navigation - once the image has arrived.
+fn engine_renderer_slow_image<F: FontSystem + Default>() -> i32 {
+    println!("font backend: {}", std::any::type_name::<F>());
+    #[cfg(target_os = "linux")]
+    {
+        use gosub_config::settings::Setting;
+        use gosub_engine::events::{EngineEvent, NavigationEvent, TabCommand};
+        use gosub_engine::storage::{InMemoryLocalStore, InMemorySessionStore, PartitionPolicy, StorageService};
+        use gosub_engine::zone::ZoneServices;
+        use gosub_engine::GosubEngine;
+        use gosub_interface::font_system::Confinement;
+        use gosub_render_pipeline::render::backend::ExternalHandle;
+        use gosub_render_pipeline::render::backends::null::NullBackend;
+        use gosub_render_pipeline::render::DefaultCompositor;
+
+        if !matches!(F::confinement(), Confinement::Full) {
+            eprintln!("engine-renderer-slow-image needs a Full-tier font system");
+            return 2;
+        }
+        const IMAGE_DELAY: std::time::Duration = std::time::Duration::from_secs(3);
+        let page = "<html><body style=\"margin:0\"><p>text</p><img src=\"/slow.png\" width=\"64\" height=\"64\"></body></html>";
+        let Ok(port) = serve_routes(vec![
+            ("/", "text/html", page.as_bytes().to_vec(), std::time::Duration::ZERO),
+            ("/slow.png", "image/png", SAMPLE_PNG.to_vec(), IMAGE_DELAY),
+        ]) else {
+            eprintln!("could not start the test server");
+            return 1;
+        };
+
+        let runtime = match tokio::runtime::Builder::new_multi_thread().enable_all().build() {
+            Ok(rt) => rt,
+            Err(e) => {
+                eprintln!("could not build a runtime: {e}");
+                return 1;
+            }
+        };
+        runtime.block_on(async move {
+            let compositor = Arc::new(DefaultCompositor::default());
+            let mut engine: GosubEngine<TileConfig<F>> =
+                GosubEngine::new(None, Arc::new(NullBackend::new()), Arc::clone(&compositor));
+            if let Err(e) = engine.settings().set("security.renderer_process", Setting::Bool(true)) {
+                eprintln!("could not enable the renderer process: {e}");
+                return 1;
+            }
+            let Ok(run) = engine.start() else {
+                eprintln!("engine failed to start");
+                return 1;
+            };
+            tokio::spawn(run);
+            if engine.renderer_pool().is_none() && !cfg!(feature = "cairo-tiles") {
+                eprintln!("no forked rasterizer compiled in (engine feature `cairo-tiles`); nothing to spawn");
+                return 2;
+            }
+            // The firehose says what each render was for.
+            let mut firehose = gosub_engine::telemetry::subscribe();
+
+            let mut events = engine.subscribe_events();
+            let services = ZoneServices {
+                storage: Arc::new(StorageService::new(
+                    Arc::new(InMemoryLocalStore::new()),
+                    Arc::new(InMemorySessionStore::new()),
+                )),
+                cookie_store: None,
+                cookie_jar: None,
+                partition_policy: PartitionPolicy::None,
+                places: None,
+            };
+            let Ok(mut zone) = engine.create_zone(None, services, None) else {
+                eprintln!("could not create a zone");
+                return 1;
+            };
+            let Ok(tab) = zone.create_tab(Default::default(), None).await else {
+                eprintln!("could not create a tab");
+                return 1;
+            };
+            let _ = tab
+                .send(TabCommand::SetViewport {
+                    x: 0,
+                    y: 0,
+                    width: 1280,
+                    height: 720,
+                })
+                .await;
+            let started = tokio::time::Instant::now();
+            if tab.navigate(format!("http://127.0.0.1:{port}/")).await.is_err() {
+                eprintln!("navigate failed");
+                return 1;
+            }
+            let _ = tab.send(TabCommand::ResumeDrawing { fps: 30 }).await;
+
+            let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+            loop {
+                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                match tokio::time::timeout(remaining, events.recv()).await {
+                    Ok(Ok(EngineEvent::Navigation {
+                        event: NavigationEvent::Finished { .. },
+                        ..
+                    })) => break,
+                    Ok(Ok(EngineEvent::Navigation {
+                        event: NavigationEvent::Failed { error, .. },
+                        ..
+                    })) => {
+                        eprintln!("navigation failed: {error}");
+                        return 1;
+                    }
+                    Ok(Ok(_)) => continue,
+                    _ => {
+                        eprintln!("timed out waiting for the navigation");
+                        return 1;
+                    }
+                }
+            }
+            let first_frame = loop {
+                if tokio::time::Instant::now() >= deadline {
+                    eprintln!("timed out waiting for the first frame");
+                    return 1;
+                }
+                if matches!(compositor.frame_for(tab.tab_id), Some(ExternalHandle::TileCache { .. })) {
+                    break started.elapsed();
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            };
+            if first_frame >= IMAGE_DELAY {
+                eprintln!("the first frame waited for the image: {first_frame:?} (image delay {IMAGE_DELAY:?})");
+                return 1;
+            }
+            println!("first frame after {first_frame:?}, before the image could have arrived");
+
+            // Then the image lands and the tab renders again - for that reason.
+            let again = tokio::time::Instant::now() + IMAGE_DELAY + std::time::Duration::from_secs(5);
+            let mut navigates = 0usize;
+            let mut reasons: Vec<String> = Vec::new();
+            let mut rerendered_for_media = false;
+            while tokio::time::Instant::now() < again {
+                let remaining = again.saturating_duration_since(tokio::time::Instant::now());
+                match tokio::time::timeout(remaining, firehose.recv()).await {
+                    Ok(Ok(event)) => {
+                        if event.kind == "tab.invalidate" {
+                            let reason = event.data["reason"].as_str().unwrap_or("?").to_string();
+                            if reason == "remote-media" {
+                                rerendered_for_media = true;
+                            }
+                            reasons.push(reason);
+                        }
+                        if event.kind == "remote.navigate" {
+                            navigates += 1;
+                            if rerendered_for_media {
+                                break;
+                            }
+                        }
+                    }
+                    _ => break,
+                }
+            }
+            println!("renders: {navigates} navigate(s); invalidations: {reasons:?}");
+            if !rerendered_for_media {
+                eprintln!("the tab never re-rendered for the late image (invalidations: {reasons:?})");
+                return 1;
+            }
+
+            engine.close_zone(zone).await;
+            if engine.shutdown().await.is_err() {
+                eprintln!("engine shutdown failed");
+                return 1;
+            }
+            0
+        })
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the renderer process exists only on Linux");
+        2
+    }
+}
+
+/// Standard base64 (RFC 4648, padded); enough for a `data:` URI in a test.
+fn base64(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        let n = chunk
+            .iter()
+            .enumerate()
+            .fold(0u32, |acc, (i, &b)| acc | (u32::from(b) << (16 - 8 * i)));
+        for i in 0..4 {
+            if i <= chunk.len() {
+                out.push(ALPHABET[((n >> (18 - 6 * i)) & 63) as usize] as char);
+            } else {
+                out.push('=');
+            }
+        }
+    }
+    out
+}
+
+/// A long session in one resident renderer: many navigations with fresh
+/// images each, many scroll passes, many tabs opened and closed. Memory must
+/// level off rather than grow with every page, and the process must not
+/// leave zombies behind when its tabs go.
+fn renderer_soak<F: FontSystem + Default>() -> i32 {
+    println!("font backend: {}", std::any::type_name::<F>());
+    #[cfg(target_os = "linux")]
+    {
+        use gosub_engine::fork_server::client::{ForkServer, PageTile};
+        use gosub_engine::fork_server::pool::{memory_of, RendererPool};
+        use gosub_engine::fork_server::protocol::ConfinementTier;
+        use gosub_engine::tab::TabId;
+        use gosub_engine::zone::ZoneId;
+
+        let rounds: usize = std::env::args().nth(3).and_then(|a| a.parse().ok()).unwrap_or(120);
+        // Image edge in px per round (argv[4]); tiny images make the media
+        // cache negligible, so any growth left is the pipeline's own.
+        let image_px: usize = std::env::args().nth(4).and_then(|a| a.parse().ok()).unwrap_or(200);
+        let server = match ForkServer::spawn() {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("could not spawn the fork server: {e}");
+                return 1;
+            }
+        };
+        if !matches!(server.confinement(), ConfinementTier::Full) {
+            eprintln!("renderer-soak needs the Full tier, got {:?}", server.confinement());
+            return 2;
+        }
+        let fork_server_pid = server.pid().unwrap_or(0);
+        let pool = RendererPool::new(Arc::new(parking_lot::Mutex::new(server)), None);
+        let (zone, tab) = (ZoneId::new(), TabId::new());
+        let loader = gosub_interface::resource_loader::NoResourceLoader;
+        let site = "https://soak.test";
+        let tab_name = tab.to_string();
+
+        // A page with a unique inline image per round, so nothing is served
+        // from a cache: every navigation decodes new pixels. 200x200 RGBA.
+        let page_for = |round: usize| -> String {
+            let mut png = Vec::new();
+            {
+                use image::ImageEncoder;
+                let pixels: Vec<u8> = (0..image_px * image_px)
+                    .flat_map(|i| [((i + round) % 251) as u8, (round % 200) as u8, (i % 7) as u8, 255])
+                    .collect();
+                let encoder = image::codecs::png::PngEncoder::new(&mut png);
+                let _ = encoder.write_image(
+                    &pixels,
+                    image_px as u32,
+                    image_px as u32,
+                    image::ExtendedColorType::Rgba8,
+                );
+            }
+            let data = base64(&png);
+            format!(
+                "<html><body style=\"margin:0\"><h1>round {round}</h1><img src=\"data:image/png;base64,{data}\" width=\"200\" height=\"200\">\
+                 <div style=\"height:4000px;background:#eee\">{}</div></body></html>",
+                "lorem ipsum ".repeat(round % 40 + 1)
+            )
+        };
+
+        let mut pid = 0;
+        let mut rss_after_warmup = 0u64;
+        let warmup = (rounds / 5).max(5);
+        for round in 0..rounds {
+            let renderer = match pool.renderer_for(zone, site, tab) {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("round {round}: no renderer: {e}");
+                    return 1;
+                }
+            };
+            let mut renderer = renderer.lock();
+            if pid != 0 && renderer.pid() != pid {
+                eprintln!(
+                    "round {round}: the renderer was replaced (pid {pid} -> {})",
+                    renderer.pid()
+                );
+                return 1;
+            }
+            pid = renderer.pid();
+            let html = page_for(round);
+            let mut memory = gosub_engine::fork_server::client::TileMemory::default();
+            let page = match renderer.navigate(
+                &html,
+                &format!("{site}/{round}"),
+                &tab_name,
+                (1280.0, 720.0),
+                0.0,
+                &loader,
+                &memory,
+                None,
+            ) {
+                Ok(page) => page,
+                Err(e) => {
+                    eprintln!("round {round}: navigate failed: {e}");
+                    return 1;
+                }
+            };
+            memory.replace_with(page.tiles.iter().map(PageTile::keep));
+            // Scroll down and back: passes, evictions, re-ships.
+            for y in [1500.0, 3000.0, 0.0] {
+                match renderer.scroll(&tab_name, y, &loader, &memory) {
+                    Ok(page) => memory.apply_pass(&page.evicted, page.tiles.iter().map(PageTile::keep)),
+                    Err(e) => {
+                        eprintln!("round {round}: scroll failed: {e}");
+                        return 1;
+                    }
+                }
+            }
+            if round + 1 == warmup {
+                rss_after_warmup = memory_of(pid).map(|m| m.0).unwrap_or(0);
+                println!(
+                    "after {warmup} rounds: renderer pid {pid} rss {} MiB",
+                    rss_after_warmup / 1024
+                );
+            } else if (round + 1) % 50 == 0 {
+                let (rss, data) = memory_of(pid).unwrap_or((0, 0));
+                println!(
+                    "round {:>4}: rss {:>4} MiB  data {:>4} MiB",
+                    round + 1,
+                    rss / 1024,
+                    data / 1024
+                );
+            }
+        }
+        let (rss_end, data_end) = memory_of(pid).unwrap_or((0, 0));
+        println!(
+            "after {rounds} rounds: rss {} MiB, data {} MiB (grew {} MiB since round {warmup})",
+            rss_end / 1024,
+            data_end / 1024,
+            rss_end.saturating_sub(rss_after_warmup) / 1024
+        );
+        // Every round decodes a fresh 160 KB image and lays out a new page;
+        // retained state must be replaced, not accumulated. 64 MiB of slack
+        // covers allocator fragmentation and the tile cache.
+        const MAX_GROWTH_KB: u64 = 64 * 1024;
+        if rss_end.saturating_sub(rss_after_warmup) > MAX_GROWTH_KB {
+            eprintln!(
+                "renderer memory keeps growing: {} MiB -> {} MiB over {} rounds",
+                rss_after_warmup / 1024,
+                rss_end / 1024,
+                rounds - warmup
+            );
+            return 1;
+        }
+
+        // Many tabs on one site, opened and closed: the process is shared,
+        // survives, and is gone - reaped, not a zombie - once the last leaves.
+        let extra: Vec<TabId> = (0..30).map(|_| TabId::new()).collect();
+        for t in &extra {
+            let renderer = match pool.renderer_for(zone, site, *t) {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("could not add a tab: {e}");
+                    return 1;
+                }
+            };
+            let mut renderer = renderer.lock();
+            if renderer
+                .navigate(
+                    "<p>tab</p>",
+                    &format!("{site}/tab"),
+                    &t.to_string(),
+                    (640.0, 480.0),
+                    0.0,
+                    &loader,
+                    &Default::default(),
+                    None,
+                )
+                .is_err()
+            {
+                eprintln!("a tab's render failed");
+                return 1;
+            }
+        }
+        if pool.snapshot().first().map(|r| r.tabs) != Some(31) {
+            eprintln!("expected 31 tabs on one renderer, got {:?}", pool.snapshot());
+            return 1;
+        }
+        for t in &extra {
+            pool.release(*t);
+        }
+        pool.release(tab);
+        if !pool.snapshot().is_empty() {
+            eprintln!("renderer should be gone after its last tab: {:?}", pool.snapshot());
+            return 1;
+        }
+        // Give the exit a moment, then look for zombies among the fork
+        // server's children (the pid-namespace anchor is a live child; fine).
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        pool.fork_server().lock().reap_exited();
+        let children = std::fs::read_to_string(format!("/proc/{fork_server_pid}/task/{fork_server_pid}/children"))
+            .unwrap_or_default();
+        let zombies: Vec<&str> = children
+            .split_whitespace()
+            .filter(|child| {
+                std::fs::read_to_string(format!("/proc/{child}/stat"))
+                    .ok()
+                    .and_then(|stat| stat.rsplit(')').next().map(|rest| rest.trim_start().starts_with('Z')))
+                    .unwrap_or(false)
+            })
+            .collect();
+        if !zombies.is_empty() {
+            eprintln!("zombie renderers under the fork server: {zombies:?}");
+            return 1;
+        }
+        println!("30 tabs came and went on one renderer; no zombies under fork server {fork_server_pid}");
+
+        pool.shutdown_all();
+        pool.fork_server().lock().shutdown();
+        0
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the fork server exists only on Linux");
+        2
+    }
+}
+
+/// The firehose names pages in normalized form (`https://example.com/`).
+#[cfg(target_os = "linux")]
+fn same_page(reported: Option<&str>, asked: &str) -> bool {
+    match (
+        reported.and_then(|r| url::Url::parse(r).ok()),
+        url::Url::parse(asked).ok(),
+    ) {
+        (Some(a), Some(b)) => a == b,
+        _ => false,
+    }
+}
+
+fn engine_soak<F: FontSystem + Default>() -> i32 {
+    println!("font backend: {}", std::any::type_name::<F>());
+    #[cfg(target_os = "linux")]
+    {
+        use gosub_config::settings::Setting;
+        use gosub_engine::events::{EngineEvent, NavigationEvent, TabCommand};
+        use gosub_engine::storage::{InMemoryLocalStore, InMemorySessionStore, PartitionPolicy, StorageService};
+        use gosub_engine::zone::ZoneServices;
+        use gosub_engine::GosubEngine;
+        use gosub_render_pipeline::render::backend::ExternalHandle;
+        use gosub_render_pipeline::render::backends::null::NullBackend;
+        use gosub_render_pipeline::render::DefaultCompositor;
+
+        let mut urls: Vec<String> = std::env::args().skip(3).collect();
+        if urls.is_empty() {
+            urls = [
+                "https://en.wikipedia.org/wiki/Main_Page",
+                "https://www.bbc.com/news",
+                "https://www.theverge.com",
+                "https://www.nasa.gov",
+                "https://commons.wikimedia.org/wiki/Main_Page",
+                "https://news.ycombinator.com",
+                "https://www.reddit.com/r/pics/",
+                "https://unsplash.com",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        }
+
+        let runtime = match tokio::runtime::Builder::new_multi_thread().enable_all().build() {
+            Ok(rt) => rt,
+            Err(e) => {
+                eprintln!("could not build a runtime: {e}");
+                return 1;
+            }
+        };
+        runtime.block_on(async move {
+            let compositor = Arc::new(DefaultCompositor::default());
+            let mut engine: GosubEngine<TileConfig<F>> =
+                GosubEngine::new(None, Arc::new(NullBackend::new()), Arc::clone(&compositor));
+            for key in [
+                "security.network_process",
+                "security.image_decoder_process",
+                "security.renderer_process",
+            ] {
+                if let Err(e) = engine.settings().set(key, Setting::Bool(true)) {
+                    eprintln!("could not enable {key}: {e}");
+                    return 1;
+                }
+            }
+            let Ok(run) = engine.start() else {
+                eprintln!("engine failed to start");
+                return 1;
+            };
+            tokio::spawn(run);
+            let Some(pool) = engine.renderer_pool().cloned() else {
+                if !cfg!(feature = "cairo-tiles") {
+                    eprintln!("no forked rasterizer compiled in (engine feature `cairo-tiles`); nothing to spawn");
+                    return 2;
+                }
+                eprintln!("renderer isolation did not start (font system tier?)");
+                return 1;
+            };
+            let mut firehose = gosub_engine::telemetry::subscribe();
+            let mut events = engine.subscribe_events();
+
+            let services = ZoneServices {
+                storage: Arc::new(StorageService::new(
+                    Arc::new(InMemoryLocalStore::new()),
+                    Arc::new(InMemorySessionStore::new()),
+                )),
+                cookie_store: None,
+                cookie_jar: None,
+                partition_policy: PartitionPolicy::None,
+                places: None,
+            };
+            let Ok(mut zone) = engine.create_zone(None, services, None) else {
+                eprintln!("could not create a zone");
+                return 1;
+            };
+            let Ok(tab) = zone.create_tab(Default::default(), None).await else {
+                eprintln!("could not create a tab");
+                return 1;
+            };
+            let _ = tab
+                .send(TabCommand::SetViewport {
+                    x: 0,
+                    y: 0,
+                    width: 1280,
+                    height: 720,
+                })
+                .await;
+            let _ = tab.send(TabCommand::ResumeDrawing { fps: 30 }).await;
+
+            println!(
+                "{:<44} {:>7} {:>7} {:>5} {:>6} {:>8} {:>7} {:>7}  notes",
+                "site", "nav ms", "frame", "tiles", "loads", "KiB", "rndr ms", "rss MiB"
+            );
+            let mut crashes = 0usize;
+            let mut unrendered = 0usize;
+            for url in &urls {
+                let started = tokio::time::Instant::now();
+                let mut notes: Vec<String> = Vec::new();
+                if tab.navigate(url.clone()).await.is_err() {
+                    println!("{url:<44} navigate refused");
+                    continue;
+                }
+                // The navigation, on a clock.
+                let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(40);
+                let mut nav_ms: Option<u128> = None;
+                // Where the navigation ended (redirects): the renderer reports that URL.
+                let mut page_url = url.clone();
+                loop {
+                    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                    if remaining.is_zero() {
+                        notes.push("navigation timed out".into());
+                        break;
+                    }
+                    match tokio::time::timeout(remaining, events.recv()).await {
+                        Ok(Ok(EngineEvent::Navigation {
+                            event: NavigationEvent::Finished { url: finished, .. },
+                            ..
+                        })) => {
+                            nav_ms = Some(started.elapsed().as_millis());
+                            page_url = finished.to_string();
+                            break;
+                        }
+                        Ok(Ok(EngineEvent::Navigation {
+                            event: NavigationEvent::Failed { error, .. },
+                            ..
+                        })) => {
+                            notes.push(format!("navigation failed: {error}"));
+                            break;
+                        }
+                        Ok(Ok(EngineEvent::RendererCrashed { site, error, .. })) => {
+                            crashes += 1;
+                            notes.push(format!("RENDERER CRASHED ({site}: {error})"));
+                        }
+                        Ok(Ok(_)) => continue,
+                        _ => break,
+                    }
+                }
+                // The page's own out-of-process render, seen on the firehose
+                // (`remote.navigate` names the page), then a grace period for
+                // deferred images and the re-render they cause. The compositor
+                // keeps showing the previous page until then, so its frame is
+                // no signal on its own.
+                let render_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(60);
+                let mut frame_ms: Option<u128> = None;
+                let mut tiles = 0usize;
+                let mut dump = std::env::var("GOSUB_SOAK_EVENTS").ok().and_then(|path| {
+                    std::fs::OpenOptions::new().create(true).append(true).open(path).ok()
+                });
+                let (mut loads, mut bytes, mut renderer_us, mut navigates) = (0usize, 0usize, 0u64, 0usize);
+                let mut grace_until: Option<tokio::time::Instant> = None;
+                if nav_ms.is_some() {
+                    loop {
+                        let now = tokio::time::Instant::now();
+                        let until = grace_until.unwrap_or(render_deadline);
+                        if now >= until {
+                            if grace_until.is_none() {
+                                notes.push("no render within 60 s".into());
+                            }
+                            break;
+                        }
+                        let Ok(Ok(event)) = tokio::time::timeout(until - now, firehose.recv()).await else {
+                            continue;
+                        };
+                        if let Some(file) = dump.as_mut() {
+                            use std::io::Write as _;
+                            let _ = writeln!(file, "{}", serde_json::json!({"ts_us": event.ts_us, "site": url, "kind": event.kind, "data": event.data}));
+                        }
+                        match event.kind.as_str() {
+                            "net.load" => {
+                                loads += 1;
+                                bytes += event.data["bytes"].as_u64().unwrap_or(0) as usize;
+                            }
+                            "remote.navigate" | "remote.media" if same_page(event.data["url"].as_str(), &page_url) => {
+                                navigates += 1;
+                                if let Some(map) = event.data["renderer_us"].as_object() {
+                                    renderer_us += map.values().filter_map(|v| v.as_u64()).sum::<u64>();
+                                }
+                                if frame_ms.is_none() {
+                                    frame_ms = Some(started.elapsed().as_millis());
+                                    grace_until = Some(tokio::time::Instant::now() + std::time::Duration::from_secs(3));
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                // Drain the engine events that arrived meanwhile (crashes).
+                while let Ok(event) = events.try_recv() {
+                    if let EngineEvent::RendererCrashed { site, error, .. } = event {
+                        crashes += 1;
+                        notes.push(format!("RENDERER CRASHED ({site}: {error})"));
+                    }
+                }
+                if let Some(ExternalHandle::TileCache { tiles: t, .. }) = compositor.frame_for(tab.tab_id) {
+                    tiles = t.len();
+                }
+                if nav_ms.is_some() && navigates == 0 {
+                    unrendered += 1;
+                    notes.push("NOT RENDERED OUT OF PROCESS".into());
+                } else if navigates > 1 {
+                    notes.push(format!("{navigates} renders"));
+                }
+                let rss = pool
+                    .snapshot()
+                    .into_iter()
+                    .filter_map(|r| r.rss_kb)
+                    .max()
+                    .map(|kb| (kb / 1024).to_string())
+                    .unwrap_or_else(|| "-".into());
+                let short = if url.len() > 43 {
+                    format!("{}…", &url[..42])
+                } else {
+                    url.clone()
+                };
+                println!(
+                    "{short:<44} {:>7} {:>7} {tiles:>5} {loads:>6} {:>8} {:>7} {rss:>7}  {}",
+                    nav_ms.map_or("-".into(), |v| v.to_string()),
+                    frame_ms.map_or("-".into(), |v| v.to_string()),
+                    bytes / 1024,
+                    renderer_us / 1000,
+                    notes.join("; ")
+                );
+            }
+
+            println!();
+            println!("renderers at the end:");
+            for r in pool.snapshot() {
+                println!(
+                    "  pid {:>7}  {:<40} {} tab(s)  rss {} MiB  data {} MiB",
+                    r.pid,
+                    r.key.site,
+                    r.tabs,
+                    r.rss_kb.map_or(0, |kb| kb / 1024),
+                    r.data_kb.map_or(0, |kb| kb / 1024)
+                );
+            }
+            println!("crashes: {crashes}, pages not rendered out of process: {unrendered}");
+
+            engine.close_zone(zone).await;
+            let _ = engine.shutdown().await;
+            i32::from(crashes > 0 || unrendered > 0)
+        })
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the renderer process exists only on Linux");
+        2
+    }
+}
+
+/// An HTTP server on an ephemeral port answering `routes` for as long as the
+/// process lives, one connection at a time; unknown paths get a 404.
+fn serve_routes(routes: Vec<Route>) -> std::io::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else {
+                continue;
+            };
+            let mut buf = [0u8; 4096];
+            let n = stream.read(&mut buf).unwrap_or(0);
+            let request = String::from_utf8_lossy(&buf[..n]);
+            let path = request.split_whitespace().nth(1).unwrap_or("/").to_string();
+            let route = routes.iter().find(|(p, ..)| *p == path);
+            let (status, content_type, body): (&str, &str, &[u8]) = match route {
+                Some((_, content_type, body, delay)) => {
+                    std::thread::sleep(*delay);
+                    ("200 OK", content_type, body)
+                }
+                None => ("404 Not Found", "text/plain", b"no such route"),
+            };
+            let head = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = stream.write_all(head.as_bytes());
+            let _ = stream.write_all(body);
+        }
+    });
+    Ok(port)
+}
+
+/// One route of [`serve_routes`]: path → (content type, body, delay before answering).
+type Route = (&'static str, &'static str, Vec<u8>, std::time::Duration);
 
 /// The follow-up question to the warm-up finding: a page can introduce a font at
 /// any moment with `@font-face`, long after the sandbox is in place. Does that

--- a/crates/gosub_engine/src/engine/context.rs
+++ b/crates/gosub_engine/src/engine/context.rs
@@ -6,9 +6,13 @@
 //! context via `set_document`, after which the context rebuilds whichever render
 //! representation the active backend consumes.
 
+/// How long a landed image waits for the next before the page re-renders.
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+const REMOTE_MEDIA_SETTLE: std::time::Duration = std::time::Duration::from_millis(150);
+
 use crate::engine::events::{CursorShape, HitTestResponse};
 use crate::engine::storage::{StorageArea, StorageHandles};
-use crate::html::{is_text_input, EngineDocument};
+use crate::html::EngineDocument;
 use gosub_config::{Config, HasConfig};
 use gosub_render_pipeline::rasterizer::{
     collect_placed_gpu_tiles, cpu_cached_tiles, rasterize_parallel, rasterize_sequential, BakedTile, RasterStrategy,
@@ -73,6 +77,9 @@ fn hover_matches<C: RenderConfiguration>(fp: &HoverFingerprints, doc: &EngineDoc
     }
     false
 }
+/// True for elements whose content is edited as text (they show the I-beam cursor).
+use crate::html::is_text_input;
+
 /// True for elements that participate in keyboard focus: links, form controls,
 /// editable regions, and anything with a non-negative `tabindex`.
 fn is_focusable<C: RenderConfiguration>(doc: &EngineDocument<C>, node_id: NodeId) -> bool {
@@ -205,7 +212,7 @@ pub struct BrowsingContext<C: RenderConfiguration = crate::html::DefaultRenderCo
     /// The source text of the current document, kept when a renderer process
     /// will re-parse it there. `None` when rendering in-process.
     document_source: Option<std::sync::Arc<str>>,
-    /// The current document's URL.
+    /// The current document's URL, whether or not this process parsed it.
     document_url: Option<Url>,
     /// Tiles from the last remote render, keyed by content hash; offered to the
     /// next render so unchanged tiles are neither rasterized nor shipped again.
@@ -218,24 +225,71 @@ pub struct BrowsingContext<C: RenderConfiguration = crate::html::DefaultRenderCo
     /// (`FontPathsReadable`).
     #[cfg(all(feature = "process-isolation", target_os = "linux"))]
     remote_renderer: Option<RemoteRenderer>,
+
     /// The tab this context renders for, as a display string - sent with each
-    /// remote render for telemetry and logs. Empty until a remote renderer is
-    /// installed.
+    /// remote render so the renderer process can name itself after the tab in
+    /// `ps`/`pstree`. Empty until a remote renderer is installed.
     #[cfg(all(feature = "process-isolation", target_os = "linux"))]
     remote_tab: String,
+    /// The remote page's layers back to front, from its last summary: what
+    /// orders tiles gathered over several passes for the compositor.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    remote_layer_order: Vec<u64>,
+    /// An incremental exchange (scroll, hover) running on its own thread, so
+    /// frames keep compositing the tiles already held; merged by
+    /// [`Self::poll_remote_passes`].
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    remote_inflight: Option<InflightPass>,
+    /// Bumped per remote page render; a pass finishing for an older page is
+    /// dropped rather than merged into the new one.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    remote_generation: u64,
+    /// The hover changed while a pass was in flight; re-raise it once done.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    remote_hover_pending: bool,
     /// Why the last out-of-process render could not happen at all - page
     /// content is never rendered in-process instead; the tab worker takes
     /// this and tells the embedder.
     #[cfg(all(feature = "process-isolation", target_os = "linux"))]
     remote_failure: Option<String>,
+    /// Images fetched for the resident renderer in the background; a render
+    /// proceeds without them and runs again when they land.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    remote_media: std::sync::Arc<crate::fork_server::client::RemoteMediaCache>,
+    /// When the first image of the current batch landed; the re-render waits
+    /// a little for the rest, so a page of photographs costs a few renders,
+    /// not one per photograph.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    remote_media_landed: Option<std::time::Instant>,
+}
+
+/// A scroll or hover exchange the tab is waiting on.
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+struct InflightPass {
+    what: RemotePass,
+    generation: u64,
+    /// The scroll position the pass was asked for: what its window covers.
+    scroll_y: f64,
+    page_url: String,
+    rx: std::sync::mpsc::Receiver<(
+        anyhow::Result<crate::fork_server::client::RenderedPage>,
+        std::time::Duration,
+    )>,
 }
 
 /// The two ways a tab's renders leave this process - which one applies is the
 /// configured font system's confinement tier, decided statically.
 #[cfg(all(feature = "process-isolation", target_os = "linux"))]
 pub enum RemoteRenderer {
+    /// A resident renderer from the engine's pool, one per (zone, site),
+    /// forked from the warmed fork server (tier `Full`).
+    Resident {
+        pool: std::sync::Arc<crate::fork_server::pool::RendererPool>,
+        zone: crate::zone::ZoneId,
+        tab: crate::tab::TabId,
+    },
     /// Fork a throwaway renderer per render from the engine's warmed fork
-    /// server (tier `Full`).
+    /// server (tier `Full`, no pool).
     ForkServer(std::sync::Arc<parking_lot::Mutex<crate::fork_server::client::ForkServer>>),
     /// Spawn a throwaway exec'd renderer per render (tier `FontPathsReadable`:
     /// warming buys nothing when font files stay reachable, and the stack may
@@ -249,6 +303,11 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
         config_store: Config,
         loader: std::sync::Arc<dyn gosub_interface::resource_loader::ResourceLoader>,
     ) -> BrowsingContext<C> {
+        // Raster decoding is the single most dangerous thing done with untrusted
+        // bytes, so where the setting allows it happens in a throwaway process.
+        // Read here rather than passed in: it is a property of how the engine was
+        // configured, not of this tab.
+        let decoder = image_decoder_from(&config_store);
         Self {
             document: None,
             storage: None,
@@ -278,10 +337,7 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
             rasterizer: None,
             raster_strategy: RasterStrategy::None,
             media_store: std::sync::Arc::new(
-                gosub_render_pipeline::common::media::MediaStore::with_loader_and_decoder(
-                    loader.clone(),
-                    image_decoder_from(&config_store),
-                ),
+                gosub_render_pipeline::common::media::MediaStore::with_loader_and_decoder(loader.clone(), decoder),
             ),
             config_store,
             tile_budget: TileBudget::new(),
@@ -295,7 +351,19 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
             #[cfg(all(feature = "process-isolation", target_os = "linux"))]
             remote_tab: String::new(),
             #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            remote_layer_order: Vec::new(),
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            remote_inflight: None,
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            remote_generation: 0,
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            remote_hover_pending: false,
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
             remote_failure: None,
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            remote_media: Default::default(),
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            remote_media_landed: None,
         }
     }
 
@@ -305,6 +373,14 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
     pub fn set_remote_renderer(&mut self, renderer: RemoteRenderer, tab: String) {
         self.remote_renderer = Some(renderer);
         self.remote_tab = tab;
+    }
+
+    /// This tab is closing: let go of whatever renderer process hosts it.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    pub fn release_remote_renderer(&mut self) {
+        if let Some(RemoteRenderer::Resident { pool, tab, .. }) = self.remote_renderer.take() {
+            pool.release(tab);
+        }
     }
 
     /// Whether full renders go out-of-process: a remote renderer is installed
@@ -363,8 +439,23 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
             use gosub_interface::document::Document as _;
             doc.url()
         };
+        self.replace_document(Some(doc), url, source);
+    }
+
+    pub fn document_url(&self) -> Option<&Url> {
+        self.document_url.as_ref()
+    }
+
+    fn replace_document(
+        &mut self,
+        doc: Option<Arc<EngineDocument<C>>>,
+        url: Option<Url>,
+        source: Option<std::sync::Arc<str>>,
+    ) {
+        #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+        self.remote_media.clear();
         self.note_invalidate("document");
-        self.document = Some(doc);
+        self.document = doc;
         self.document_url = url;
         self.document_source = source;
         self.dom_dirty = true;
@@ -475,6 +566,8 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
                     // Remote pages are otherwise unbudgeted: their pixels are shared with the
                     // tile memory that makes re-renders incremental, so evicting here frees nothing.
                     self.tile_budget.note_full_raster();
+                    // A resident renderer rasterized only the window around the
+                    // viewport; scrolling past it asks for more (`try_remote_scroll`).
                     self.note_rastered_window();
                     self.render_dirty = false;
                     self.hover_dirty = false;
@@ -547,8 +640,10 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
             hit_regions,
         } = old_cache;
 
-        // A remotely rendered page has no local layer list to re-tile from, and
-        // the remote render already covers the whole page: nothing to extend.
+        // A remotely rendered page has no local layer list to re-tile from.
+        // A resident renderer retains the page and extends the window on
+        // request; any other remote render already covers the whole page, so
+        // there is nothing to extend. Either way the cache goes back first.
         let Some(layer_list) = layer_list else {
             self.pipeline_cache = Some(PipelineCache {
                 tiles,
@@ -558,6 +653,9 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
                 hit_regions,
                 tile_pixel_cache,
             });
+            // The window is noted when the pass lands (`poll_remote_passes`).
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            self.try_remote_scroll();
             self.raster_dirty = false;
             return;
         };
@@ -580,105 +678,6 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
         self.tile_budget.note_full_raster();
         self.enforce_tile_budget(false);
         self.raster_dirty = false;
-    }
-
-    /// Whether the current document is one of the engine's own pages.
-    pub(crate) fn is_internal_page(&self) -> bool {
-        self.document_url
-            .as_ref()
-            .is_some_and(|url| matches!(url.scheme(), "gosub" | "about"))
-    }
-
-    /// The reason the last out-of-process render could not happen, once.
-    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
-    pub fn take_remote_failure(&mut self) -> Option<String> {
-        self.remote_failure.take()
-    }
-
-    /// Render the current document in a renderer process and adopt the result
-    /// as this tab's pipeline cache.
-    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
-    fn try_remote_pipeline(&mut self) -> Result<(), String> {
-        let (Some(remote), Some(source)) = (&self.remote_renderer, &self.document_source) else {
-            return Err("no remote renderer or no document source".into());
-        };
-
-        // The document's own URL is the renderer's base for relative
-        // subresource URLs; about:blank when it has none.
-        let page_url = self
-            .document_url
-            .as_ref()
-            .map(|url| url.to_string())
-            .unwrap_or_else(|| "about:blank".to_string());
-        let viewport = (self.viewport.width as f64, self.viewport.height as f64);
-        let started = std::time::Instant::now();
-        let resources = crate::fork_server::client::LoaderResources(&self.loader);
-        let loader: &dyn crate::fork_server::client::RenderResources = &resources;
-        // The whole exchange blocks on the renderer's socket (and, relaying its
-        // subresource requests, on the I/O runtime). Blocking a runtime worker
-        // while holding its scheduler core can trap tasks woken into this
-        // worker's unstealable LIFO slot - the brokered loader's reply path
-        // among them - so hand the core to another thread for the duration.
-        let run = || match remote {
-            RemoteRenderer::ForkServer(server) => server.lock().render_page(
-                source,
-                &page_url,
-                &self.remote_tab,
-                viewport,
-                loader,
-                &self.remote_tile_memory,
-                self.hover_leaf.map(|id| id.into()),
-            ),
-            RemoteRenderer::ExecPerRender => crate::render_process::client::render_page(
-                source,
-                &page_url,
-                &self.remote_tab,
-                viewport,
-                loader,
-                &self.remote_tile_memory,
-                self.hover_leaf.map(|id| id.into()),
-            ),
-        };
-        let result = match tokio::runtime::Handle::try_current() {
-            Ok(h) if h.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
-                tokio::task::block_in_place(run)
-            }
-            _ => run(),
-        };
-        match result {
-            Ok(page) => {
-                report_remote_pass(
-                    "remote.navigate",
-                    &self.remote_tab,
-                    &page_url,
-                    self.scroll_y,
-                    &page,
-                    started.elapsed(),
-                );
-                self.adopt_remote_page(page);
-                Ok(())
-            }
-            Err(e) => Err(e.to_string()),
-        }
-    }
-
-    /// A whole page from a renderer replaces what this tab holds.
-    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
-    fn adopt_remote_page(&mut self, page: crate::fork_server::client::RenderedPage) {
-        // This page's tiles are exactly what came back: what an
-        // earlier page of this tab kept cannot help it.
-        self.remote_tile_memory
-            .replace_with(page.tiles.into_iter().map(kept_tile));
-        let baked = self.remote_tile_memory.baked_tiles(&page.summary.layer_order);
-        let cached_tiles = Arc::new(gosub_render_pipeline::rasterizer::cpu_cached_tiles(&baked));
-        self.pipeline_cache = Some(PipelineCache {
-            tiles: baked,
-            page_height: page.summary.page_height,
-            cached_tiles,
-            layer_list: None,
-            hit_regions: page.hit_regions,
-            tile_pixel_cache: Default::default(),
-        });
     }
 
     /// Record the window now rastered, so scrolling can tell when it reaches unbaked content.
@@ -714,6 +713,374 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
         }
     }
 
+    /// Whether the current document is one of the engine's own pages.
+    pub(crate) fn is_internal_page(&self) -> bool {
+        self.document_url
+            .as_ref()
+            .is_some_and(|url| matches!(url.scheme(), "gosub" | "about"))
+    }
+
+    /// The reason the last out-of-process render could not happen, once.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    pub fn take_remote_failure(&mut self) -> Option<String> {
+        self.remote_failure.take()
+    }
+
+    /// Render the current document in a renderer process and adopt the result
+    /// as this tab's pipeline cache. A resident renderer that turns out to be
+    /// dead is replaced and the render tried once more; the error is what
+    /// stopped the last attempt.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    fn try_remote_pipeline(&mut self) -> Result<(), String> {
+        let (Some(remote), Some(source)) = (&self.remote_renderer, &self.document_source) else {
+            return Err("no remote renderer or no document source".into());
+        };
+
+        // The document's own URL is the renderer's base for relative
+        // subresource URLs; about:blank when it has none.
+        let page_url = self
+            .document_url
+            .as_ref()
+            .map(|url| url.to_string())
+            .unwrap_or_else(|| "about:blank".to_string());
+        let viewport = (self.viewport.width as f64, self.viewport.height as f64);
+        let started = std::time::Instant::now();
+        let resources = crate::fork_server::client::TabResources {
+            loader: Arc::clone(&self.loader),
+            media: Arc::clone(&self.remote_media),
+        };
+        // The whole exchange blocks on the renderer's socket (and, relaying its
+        // subresource requests, on the I/O runtime). Blocking a runtime worker
+        // while holding its scheduler core can trap tasks woken into this
+        // worker's unstealable LIFO slot - the brokered loader's reply path
+        // among them - so hand the core to another thread for the duration.
+        let run = || match remote {
+            RemoteRenderer::Resident { pool, zone, tab } => {
+                let site = url::Url::parse(&page_url)
+                    .map(|u| crate::fork_server::site::site_of(&u))
+                    .unwrap_or_else(|_| "about:".to_string());
+                let renderer = pool.renderer_for(*zone, &site, *tab)?;
+                let mut renderer = renderer.lock();
+                renderer.navigate(
+                    source,
+                    &page_url,
+                    &self.remote_tab,
+                    viewport,
+                    self.scroll_y,
+                    &resources,
+                    &self.remote_tile_memory,
+                    self.hover_leaf.map(|id| id.into()),
+                )
+            }
+            RemoteRenderer::ForkServer(server) => server.lock().render_page(
+                source,
+                &page_url,
+                &self.remote_tab,
+                viewport,
+                &resources,
+                &self.remote_tile_memory,
+                self.hover_leaf.map(|id| id.into()),
+            ),
+            RemoteRenderer::ExecPerRender => crate::render_process::client::render_page(
+                source,
+                &page_url,
+                &self.remote_tab,
+                viewport,
+                &resources,
+                &self.remote_tile_memory,
+                self.hover_leaf.map(|id| id.into()),
+            ),
+        };
+        let blocking = |f: &dyn Fn() -> anyhow::Result<crate::fork_server::client::RenderedPage>| {
+            match tokio::runtime::Handle::try_current() {
+                Ok(h) if h.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+                    tokio::task::block_in_place(f)
+                }
+                _ => f(),
+            }
+        };
+        let mut result = blocking(&run);
+        if let (Err(e), RemoteRenderer::Resident { .. }) = (&result, remote) {
+            // The pool replaces a renderer it finds dead on the next request.
+            log::warn!("out-of-process render failed ({e}); retrying in a fresh renderer");
+            result = blocking(&run);
+        }
+        match result {
+            Ok(page) => {
+                report_remote_pass(
+                    "remote.navigate",
+                    &self.remote_tab,
+                    &page_url,
+                    self.scroll_y,
+                    &page,
+                    started.elapsed(),
+                );
+                // A pass still in flight belongs to the page this replaces.
+                self.remote_generation = self.remote_generation.wrapping_add(1);
+                self.remote_inflight = None;
+                self.remote_hover_pending = false;
+                self.adopt_remote_page(page);
+                Ok(())
+            }
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    /// A whole page from a renderer replaces what this tab holds.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    fn adopt_remote_page(&mut self, page: crate::fork_server::client::RenderedPage) {
+        // This page's tiles are exactly what came back: what an
+        // earlier page of this tab kept cannot help it.
+        self.remote_tile_memory
+            .replace_with(page.tiles.into_iter().map(kept_tile));
+        self.remote_layer_order = page.summary.layer_order.clone();
+        let baked = self.remote_tile_memory.baked_tiles(&self.remote_layer_order);
+        let cached_tiles = Arc::new(gosub_render_pipeline::rasterizer::cpu_cached_tiles(&baked));
+        self.pipeline_cache = Some(PipelineCache {
+            tiles: baked,
+            page_height: page.summary.page_height,
+            cached_tiles,
+            layer_list: None,
+            hit_regions: page.hit_regions,
+            tile_pixel_cache: Default::default(),
+        });
+    }
+
+    /// The viewport moved on a page a resident renderer retains: fetch what
+    /// came into its raster window and merge it into this tab's tiles.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    fn try_remote_scroll(&mut self) -> bool {
+        self.try_remote_pass(RemotePass::Scroll)
+    }
+
+    /// The pointer moved on a page a resident renderer retains: fetch the
+    /// tiles it repainted and merge them.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    fn try_remote_hover(&mut self) -> bool {
+        self.try_remote_pass(RemotePass::Hover)
+    }
+
+    /// Start one incremental exchange with the resident renderer on its own
+    /// thread, so this tab keeps compositing what it holds meanwhile; the
+    /// result is merged by [`Self::poll_remote_passes`]. One pass at a time:
+    /// a hover arriving mid-flight is remembered and issued afterwards, a
+    /// scroll is re-checked against the window the pass delivers. False when
+    /// this tab has no resident renderer.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    fn try_remote_pass(&mut self, what: RemotePass) -> bool {
+        let Some(RemoteRenderer::Resident { pool, zone, tab }) = &self.remote_renderer else {
+            return false;
+        };
+        if self.remote_inflight.is_some() {
+            if matches!(what, RemotePass::Hover) {
+                self.remote_hover_pending = true;
+            }
+            return true;
+        }
+        let Some(page_url) = self.document_url.as_ref().map(|url| url.to_string()) else {
+            return false;
+        };
+
+        let (pool, zone, tab) = (Arc::clone(pool), *zone, *tab);
+        let remote_tab = self.remote_tab.clone();
+        let resources = crate::fork_server::client::TabResources {
+            loader: Arc::clone(&self.loader),
+            media: Arc::clone(&self.remote_media),
+        };
+        let scroll_y = self.scroll_y;
+        let hovered = self.hover_leaf.map(|id| id.into());
+        let url = page_url.clone();
+        let source = self.document_source.clone();
+        let viewport = (self.viewport.width as f64, self.viewport.height as f64);
+        let (tx, rx) = std::sync::mpsc::channel();
+        let spawned = std::thread::Builder::new()
+            .name("gosub-remote-pass".into())
+            .spawn(move || {
+                let started = std::time::Instant::now();
+                let result = (|| {
+                    let site = url::Url::parse(&url)
+                        .map(|u| crate::fork_server::site::site_of(&u))
+                        .unwrap_or_else(|_| "about:".to_string());
+                    let renderer = pool.renderer_for(zone, &site, tab)?;
+                    let mut renderer = renderer.lock();
+                    // Incremental passes never answer `TileUnchanged`, so
+                    // there is nothing for the exchange to look up.
+                    let known = crate::fork_server::client::TileMemory::default();
+                    match what {
+                        RemotePass::Scroll => renderer.scroll(&remote_tab, scroll_y, &resources, &known),
+                        RemotePass::Hover => renderer.hover(&remote_tab, hovered, &resources, &known),
+                        RemotePass::Media => {
+                            let Some(source) = source.as_deref() else {
+                                anyhow::bail!("no document source to render again");
+                            };
+                            renderer.navigate(
+                                source,
+                                &url,
+                                &remote_tab,
+                                viewport,
+                                scroll_y,
+                                &resources,
+                                &known,
+                                hovered,
+                            )
+                        }
+                    }
+                })();
+                let _ = tx.send((result, started.elapsed()));
+            });
+        if let Err(e) = spawned {
+            log::warn!("could not start a remote {} pass: {e}", what.event_kind());
+            return false;
+        }
+        self.remote_inflight = Some(InflightPass {
+            what,
+            generation: self.remote_generation,
+            scroll_y,
+            page_url,
+            rx,
+        });
+        true
+    }
+
+    /// Take in whatever out-of-process work landed: an image the renderer
+    /// went without, a finished scroll or hover pass. Called every tick by
+    /// the tab worker (cheap when nothing is pending); true when a frame
+    /// should follow.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    pub fn poll_remote_passes(&mut self) -> bool {
+        use std::sync::mpsc::TryRecvError;
+
+        let mut changed = false;
+        // An image the renderer went without has arrived: render again, once
+        // the ones landing right behind it have had a moment to land too.
+        if self.remote_media.take_completed() {
+            self.remote_media_landed.get_or_insert_with(std::time::Instant::now);
+        }
+        if self
+            .remote_media_landed
+            .is_some_and(|since| since.elapsed() >= REMOTE_MEDIA_SETTLE)
+            && self.remote_inflight.is_none()
+        {
+            self.remote_media_landed = None;
+            self.note_invalidate("remote-media");
+            // Off the tab thread where a resident renderer allows; the
+            // blocking full render is the fallback for the other modes.
+            if !self.try_remote_pass(RemotePass::Media) {
+                self.render_dirty = true;
+            }
+            changed = true;
+        }
+
+        let Some(inflight) = self.remote_inflight.as_ref() else {
+            return changed;
+        };
+        let (result, exchange) = match inflight.rx.try_recv() {
+            Ok(landed) => landed,
+            Err(TryRecvError::Empty) => return changed,
+            // The thread died without answering: treat it as a failed pass.
+            Err(TryRecvError::Disconnected) => (
+                Err(anyhow::anyhow!("the remote pass thread ended silently")),
+                std::time::Duration::ZERO,
+            ),
+        };
+        let Some(inflight) = self.remote_inflight.take() else {
+            return changed;
+        };
+        let stale = inflight.generation != self.remote_generation;
+
+        match result {
+            Ok(page) if !stale => {
+                // A scroll answered with nothing at all means the renderer no
+                // longer has this page (it was replaced after a crash): only
+                // a full render gets the tiles back.
+                if matches!(inflight.what, RemotePass::Scroll)
+                    && page.summary.page_height <= 0.0
+                    && page.tiles.is_empty()
+                    && page.evicted.is_empty()
+                {
+                    log::warn!("resident renderer has no retained page for this tab; rendering it again");
+                    self.render_dirty = true;
+                } else if matches!(inflight.what, RemotePass::Media) {
+                    // A whole page, like a navigate: what came back replaces
+                    // this tab's tiles and geometry.
+                    report_remote_pass(
+                        inflight.what.event_kind(),
+                        &self.remote_tab,
+                        &inflight.page_url,
+                        inflight.scroll_y,
+                        &page,
+                        exchange,
+                    );
+                    self.adopt_remote_page(page);
+                    self.tile_budget.note_full_raster();
+                    self.note_rastered_window();
+                    self.scroll_dirty = true;
+                } else {
+                    report_remote_pass(
+                        inflight.what.event_kind(),
+                        &self.remote_tab,
+                        &inflight.page_url,
+                        inflight.scroll_y,
+                        &page,
+                        exchange,
+                    );
+                    self.merge_remote_pass(page);
+                    if matches!(inflight.what, RemotePass::Scroll) {
+                        if let Some(cache) = self.pipeline_cache.as_ref() {
+                            self.tile_budget.note_rastered_window(
+                                inflight.scroll_y,
+                                self.viewport.height as f64,
+                                cache.page_height,
+                            );
+                        }
+                        self.tile_budget.note_full_raster();
+                        // The viewport may have moved on while this pass ran.
+                        let page_height = self.active_page_height().unwrap_or(0.0);
+                        if self
+                            .tile_budget
+                            .needs_rerender(self.scroll_y, self.viewport.height as f64, page_height)
+                        {
+                            self.raster_dirty = true;
+                        }
+                    }
+                    // A frame with the merged tiles, even if the view is still.
+                    self.scroll_dirty = true;
+                }
+            }
+            Ok(_) => {}
+            Err(e) => {
+                log::warn!(
+                    "out-of-process {} render failed ({e}); rendering this page again",
+                    inflight.what.event_kind()
+                );
+                if !stale {
+                    self.render_dirty = true;
+                }
+            }
+        }
+        if self.remote_hover_pending {
+            self.remote_hover_pending = false;
+            self.hover_dirty = true;
+        }
+        true
+    }
+
+    /// Fold one pass's tiles and evictions into this tab's remote tile set.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    fn merge_remote_pass(&mut self, page: crate::fork_server::client::RenderedPage) {
+        self.remote_tile_memory
+            .apply_pass(&page.evicted, page.tiles.into_iter().map(kept_tile));
+        if !page.summary.layer_order.is_empty() {
+            self.remote_layer_order = page.summary.layer_order;
+        }
+        let baked = self.remote_tile_memory.baked_tiles(&self.remote_layer_order);
+        let Some(cache) = self.pipeline_cache.as_mut() else {
+            return;
+        };
+        cache.cached_tiles = Arc::new(gosub_render_pipeline::rasterizer::cpu_cached_tiles(&baked));
+        cache.tiles = baked;
+    }
+
     /// Rebuild stages 1-6 (pipeline cache) if content has changed, without building a display
     /// list. Used by TileCache backends (Cairo, Skia, Vello) which composite tiles directly
     /// on the host thread and never consume the render list.
@@ -733,13 +1100,16 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
             self.extend_raster_window();
         } else if self.hover_dirty {
             // Paint-only repaint: reuse the cached layout tree, skip stages 1–2.
-            // A remotely rendered page has no layer list to repaint from; hover
-            // there re-renders instead (see `update_hover`).
+            // A remotely rendered page has no layer list to repaint from, so
+            // hover effects are a no-op there (see `PipelineCache::layer_list`).
             let has_layer_list = self
                 .pipeline_cache
                 .as_ref()
                 .is_some_and(|cache| cache.layer_list.is_some());
             if !has_layer_list && self.pipeline_cache.is_some() {
+                // A resident renderer retains the page and repaints for us.
+                #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+                self.try_remote_hover();
                 self.hover_dirty = false;
                 self.scroll_dirty = false;
                 return;
@@ -1044,6 +1414,7 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
         }
         // Style-only change; the pipeline recomputes styles, layout and paint.
         self.style_dirty = true;
+        self.note_invalidate("focus");
         self.invalidate_render();
         true
     }
@@ -1216,8 +1587,8 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
     }
 
     /// Hover over a remotely rendered page: the region carries what the
-    /// renderer resolved (link, cursor); the next render applies `:hover`
-    /// there, so any change of element is visually dirty.
+    /// renderer resolved (link, cursor); the renderer's own `Hover` pass does
+    /// the restyle and repaint, so any change of element is visually dirty.
     #[cfg(all(feature = "process-isolation", target_os = "linux"))]
     fn apply_remote_hover(
         &mut self,
@@ -1238,9 +1609,6 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
         };
         let url_changed = link != self.hover_link_url;
         self.hover_link_url = link.clone();
-        // The renderer re-parses per render and skips tiles whose painted
-        // content did not change, so a hover re-render stays cheap.
-        self.render_dirty = true;
         (true, url_changed, link)
     }
 
@@ -1342,12 +1710,21 @@ impl<C: RenderConfiguration> BrowsingContext<C> {
                 let _t = gosub_shared::timing_guard!("hover.set_hovered");
                 doc.set_hovered_nodes(new_leaf);
             }
-            // Hover-only changes are paint-only (color, background, box-shadow).
-            // Use the cheap hover-dirty path which skips render-tree + layout.
             // A remotely rendered page has no local layout tree to repaint from,
             // so hover falls back to a re-render; the renderer skips tiles with
             // unchanged content, so this stays cheap.
-            if self.remote_render_active() {
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            let remote = self.remote_render_active();
+            #[cfg(not(all(feature = "process-isolation", target_os = "linux")))]
+            let remote = false;
+
+            // Hover-only changes are paint-only (color, background, box-shadow).
+            // Use the cheap hover-dirty path which skips render-tree + layout -
+            // in-process, or in the resident renderer that retains the page.
+            // Only a one-shot remote renderer has nothing to repaint from.
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            let remote = remote && !matches!(self.remote_renderer, Some(RemoteRenderer::Resident { .. }));
+            if remote {
                 self.render_dirty = true;
             } else {
                 self.hover_dirty = true;
@@ -1665,7 +2042,29 @@ fn pipeline_extend_raster(
     }
 }
 
-/// One remote render, onto the telemetry firehose: the exchange as the
+/// The incremental exchanges a resident renderer answers from its retained page.
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+#[derive(Clone, Copy)]
+enum RemotePass {
+    Scroll,
+    Hover,
+    /// Images the renderer went without have arrived: render the page again
+    /// off the tab thread, so the next navigation is not queued behind it.
+    Media,
+}
+
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+impl RemotePass {
+    fn event_kind(self) -> &'static str {
+        match self {
+            RemotePass::Scroll => "remote.scroll",
+            RemotePass::Hover => "remote.hover",
+            RemotePass::Media => "remote.media",
+        }
+    }
+}
+
+/// One remote render pass, onto the telemetry firehose: the exchange as the
 /// broker saw it, plus the stage costs the renderer reported.
 #[cfg(all(feature = "process-isolation", target_os = "linux"))]
 fn report_remote_pass(
@@ -1708,6 +2107,7 @@ fn report_remote_pass(
             "exchange_us": exchange.as_micros() as u64,
             "tiles_fresh": fresh,
             "tiles_reused": page.tiles.len() - fresh,
+            "tiles_evicted": page.evicted.len(),
             "bytes_shipped": bytes,
             "page_height": page.summary.page_height,
             "painted_tiles": page.summary.painted_tiles,
@@ -1730,8 +2130,8 @@ fn kept_tile(tile: crate::fork_server::client::PageTile) -> (u64, crate::fork_se
     }
 }
 
-/// Which node a point lands on, per a remotely rendered page's geometry.
 #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+/// Which node a point lands on, per a remotely rendered page's geometry.
 fn hit_region_at(
     regions: &[crate::fork_server::protocol::HitRegion],
     vp_x: f64,
@@ -2318,6 +2718,8 @@ mod tests {
                 .set("renderer.tile.cache_budget_mb", Setting::UInt(budget_mb))
                 .is_ok());
 
+            // The page has no subresources, so no loader is needed - and no fork server
+            // is installed, so the render stays in-process (`source` is irrelevant).
             let mut ctx: BrowsingContext<DefaultRenderConfig> =
                 BrowsingContext::new(config, Arc::new(gosub_interface::resource_loader::NoResourceLoader));
             let calls = Arc::new(AtomicUsize::new(0));

--- a/crates/gosub_engine/src/engine/engine.rs
+++ b/crates/gosub_engine/src/engine/engine.rs
@@ -83,6 +83,10 @@ pub struct EngineContext {
     /// protocol is strictly serial.
     #[cfg(all(feature = "process-isolation", target_os = "linux"))]
     pub renderer_process: OnceLock<Arc<Mutex<crate::fork_server::client::ForkServer>>>,
+    /// The resident renderers forked from it, one per (zone, site); set
+    /// together with `renderer_process`. Tabs render through this.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    pub renderer_pool: OnceLock<Arc<crate::fork_server::pool::RendererPool>>,
 }
 
 impl Default for EngineContext {
@@ -97,6 +101,8 @@ impl Default for EngineContext {
             tab_identities: Arc::new(TabIdentityRegistry::new()),
             #[cfg(all(feature = "process-isolation", target_os = "linux"))]
             renderer_process: OnceLock::new(),
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            renderer_pool: OnceLock::new(),
         }
     }
 }
@@ -139,6 +145,8 @@ impl<C: RenderConfiguration> GosubEngine<C> {
                 tab_identities: Arc::new(TabIdentityRegistry::new()),
                 #[cfg(all(feature = "process-isolation", target_os = "linux"))]
                 renderer_process: OnceLock::new(),
+                #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+                renderer_pool: OnceLock::new(),
             }),
             render_backend: backend,
             compositor,
@@ -178,7 +186,7 @@ impl<C: RenderConfiguration> GosubEngine<C> {
 
         // Start metrics HTTP server (GET http://127.0.0.1:9090/metrics)
         #[cfg(feature = "metrics")]
-        crate::metrics::start(9090);
+        crate::metrics::start(9090, Arc::clone(&self.context));
 
         // Spawn the renderer fork server if asked to. Blocks briefly (spawn
         // plus font warm-up, ~200 ms typical) - acceptable at startup, and
@@ -208,7 +216,9 @@ impl<C: RenderConfiguration> GosubEngine<C> {
         // only `Full` systems benefit from a warmed fork server.
         // `FontPathsReadable` renders in throwaway exec'd processes spawned
         // per render (see `render_process`) - nothing to start here, and not
-        // by default either: an embedder opts into that mode knowingly.
+        // by default either: that tier has no resident renderers (every scroll
+        // and hover is a full render in a fresh process), so an embedder opts
+        // into it knowingly.
         {
             use gosub_interface::font_system::{Confinement, FontSystem as _};
             match C::FontSystem::confinement() {
@@ -284,7 +294,15 @@ impl<C: RenderConfiguration> GosubEngine<C> {
                     tier => {
                         log::info!("renderer fork server ready (confinement tier: {tier:?})");
                         // Set once, like `io_tx`; `start()` refuses to run twice.
-                        let _ = self.context.renderer_process.set(Arc::new(Mutex::new(server)));
+                        let server = Arc::new(Mutex::new(server));
+                        let _ = self
+                            .context
+                            .renderer_pool
+                            .set(Arc::new(crate::fork_server::pool::RendererPool::new(
+                                Arc::clone(&server),
+                                Some(self.context.event_tx.clone()),
+                            )));
+                        let _ = self.context.renderer_process.set(server);
                     }
                 }
             }
@@ -304,6 +322,14 @@ impl<C: RenderConfiguration> GosubEngine<C> {
     #[cfg(all(feature = "process-isolation", target_os = "linux"))]
     pub fn renderer_process(&self) -> Option<&Arc<Mutex<crate::fork_server::client::ForkServer>>> {
         self.context.renderer_process.get()
+    }
+
+    /// The pool of resident renderers, when `security.renderer_process` is on
+    /// and the fork server started: one process per (zone, site), listable
+    /// for diagnostics.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    pub fn renderer_pool(&self) -> Option<&Arc<crate::fork_server::pool::RendererPool>> {
+        self.context.renderer_pool.get()
     }
 
     /// The confinement tier the renderer fork server announced, when one is
@@ -457,9 +483,15 @@ impl<C: RenderConfiguration> GosubEngine<C> {
         // Ask the fork server for a clean exit (it kills-and-reaps on drop
         // regardless, but a Shutdown lets it leave without a SIGKILL).
         #[cfg(all(feature = "process-isolation", target_os = "linux"))]
-        if let Some(server) = self.context.renderer_process.get() {
-            log::trace!("signal: shutting down the renderer fork server");
-            server.lock().shutdown();
+        {
+            if let Some(pool) = self.context.renderer_pool.get() {
+                log::trace!("signal: shutting down the resident renderers");
+                pool.shutdown_all();
+            }
+            if let Some(server) = self.context.renderer_process.get() {
+                log::trace!("signal: shutting down the renderer fork server");
+                server.lock().shutdown();
+            }
         }
 
         // Shutdown I/O thread

--- a/crates/gosub_engine/src/engine/events.rs
+++ b/crates/gosub_engine/src/engine/events.rs
@@ -680,6 +680,8 @@ pub enum EngineEvent {
     /// something meanwhile.
     RendererCrashed {
         zone_id: ZoneId,
+        /// The (scheme + eTLD+1) site the process served.
+        site: String,
         tabs: Vec<TabId>,
         error: String,
     },

--- a/crates/gosub_engine/src/engine/tab/worker.rs
+++ b/crates/gosub_engine/src/engine/tab/worker.rs
@@ -301,7 +301,16 @@ impl<C: RenderConfiguration> TabWorker<C> {
             use gosub_interface::font_system::{Confinement, FontSystem as _};
             match C::FontSystem::confinement() {
                 Confinement::Full => {
-                    if let Some(server) = zone_context.engine_context.renderer_process.get() {
+                    if let Some(pool) = zone_context.engine_context.renderer_pool.get() {
+                        context.set_remote_renderer(
+                            RemoteRenderer::Resident {
+                                pool: Arc::clone(pool),
+                                zone: zone_id,
+                                tab: tab_id,
+                            },
+                            tab_id.to_string(),
+                        );
+                    } else if let Some(server) = zone_context.engine_context.renderer_process.get() {
                         context.set_remote_renderer(RemoteRenderer::ForkServer(Arc::clone(server)), tab_id.to_string());
                     }
                 }
@@ -478,6 +487,8 @@ impl<C: RenderConfiguration> TabWorker<C> {
         // Drop the jar reference before announcing closure: a fetch that outlives
         // the tab then goes out without cookies rather than against a stale jar.
         self.zone_context.tab_identities.remove(self.tab_id);
+        #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+        self.context.release_remote_renderer();
 
         // Receiver may already be gone at shutdown; that is expected.
         let _ = self.zone_context.event_tx.send(EngineEvent::TabClosed {
@@ -1766,6 +1777,18 @@ impl<C: RenderConfiguration> TabWorker<C> {
             self.runtime.dirty = true;
         }
 
+        // Out-of-process work landing - an image the renderer went without, a
+        // scroll or hover pass, a renderer that died - must wake the loop too.
+        #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+        {
+            if let Some(pool) = self.zone_context.engine_context.renderer_pool.get() {
+                pool.sweep_dead();
+            }
+            if self.context.poll_remote_passes() {
+                self.runtime.dirty = true;
+            }
+        }
+
         // Skip rendering when nothing has changed to avoid burning CPU at the tick rate.
         if !self.runtime.dirty {
             return Ok(());
@@ -1819,8 +1842,14 @@ impl<C: RenderConfiguration> TabWorker<C> {
             self.context.rebuild_pipeline_cache_if_needed();
             #[cfg(all(feature = "process-isolation", target_os = "linux"))]
             if let Some(error) = self.context.take_remote_failure() {
+                let site = self
+                    .current_url
+                    .as_ref()
+                    .map(crate::fork_server::site::site_of)
+                    .unwrap_or_default();
                 self.send_event(EngineEvent::RendererCrashed {
                     zone_id: self.zone_id,
+                    site,
                     tabs: vec![self.tab_id],
                     error,
                 });

--- a/crates/gosub_engine/src/fork_server.rs
+++ b/crates/gosub_engine/src/fork_server.rs
@@ -11,6 +11,12 @@ pub mod child;
 pub mod client;
 #[cfg(all(feature = "process-isolation", target_os = "linux"))]
 pub mod loader;
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+pub mod pool;
 pub mod protocol;
 #[cfg(all(feature = "process-isolation", target_os = "linux"))]
 pub mod renderer;
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+pub mod resident;
+#[cfg(feature = "process-isolation")]
+pub mod site;

--- a/crates/gosub_engine/src/fork_server/child.rs
+++ b/crates/gosub_engine/src/fork_server/child.rs
@@ -5,10 +5,8 @@
 //! copy-on-write, whichever confinement tier applies.
 
 use crate::fork_server::loader::ForkedResourceLoader;
-use crate::fork_server::protocol::{
-    ConfinementTier, FromForkServer, FromRenderer, HitRegion, PageSummary, ProofReply, TileHeader, ToForkServer,
-};
-use crate::fork_server::renderer::{self, RenderedTile};
+use crate::fork_server::protocol::{ConfinementTier, FromForkServer, FromRenderer, ProofReply, ToForkServer};
+use crate::fork_server::{renderer, resident};
 use crate::html::RenderConfiguration;
 use gosub_interface::font_system::{Confinement, FontSystem, TextStyle};
 use gosub_ipc::Endpoint;
@@ -62,10 +60,15 @@ fn serve_warmed<C: RenderConfiguration>(mut link: Endpoint) -> i32 {
         eprintln!("[fork-server] system fontdb was built before it could be pinned; SVG text may fail confined");
     }
     let forked_loader = ForkedResourceLoader::disconnected();
+    // Images load deferred: a render never waits on an image download; the
+    // broker fetches it and re-renders when it has arrived.
     let media_store = Arc::new(gosub_render_pipeline::common::media::MediaStore::with_loader(
-        Arc::clone(&forked_loader) as Arc<dyn gosub_interface::resource_loader::ResourceLoader>,
+        forked_loader.deferred() as Arc<dyn gosub_interface::resource_loader::ResourceLoader>,
     ));
     media_store.set_synchronous_fetch(true);
+    // A renderer lives under a fixed data limit and a page may carry dozens
+    // of photographs: keep this much decoded, re-decode the rest on use.
+    media_store.set_decoded_budget(96 * 1024 * 1024);
 
     // First fork, deliberately: this process sits in a lazily-unshared PID
     // namespace, whose PID 1 is whatever forks first - and must then outlive
@@ -118,6 +121,32 @@ fn serve_warmed<C: RenderConfiguration>(mut link: Endpoint) -> i32 {
                 }
                 _ => fork_and_prove(&mut fonts, font_access, &parent_only),
             },
+            ToForkServer::SpawnRenderer { label } => match &tier {
+                ConfinementTier::Unsupported(reason) => {
+                    FromForkServer::Refused(format!("this font system cannot run isolated: {reason}"))
+                }
+                // Replies for itself (`RendererSpawned` + the link fd).
+                _ => {
+                    match spawn_resident::<C>(
+                        &mut link,
+                        &mut fonts,
+                        &media_store,
+                        &forked_loader,
+                        font_access,
+                        &parent_only,
+                        &label,
+                    ) {
+                        Ok(()) => continue,
+                        Err(e) => FromForkServer::Refused(e),
+                    }
+                }
+            },
+            // Resident renderers exit on their own schedule; only their parent
+            // can collect them, and it has no other occasion to.
+            ToForkServer::ReapExited => {
+                let _ = gosub_sandbox::reap_exited_children();
+                FromForkServer::Pong
+            }
             ToForkServer::RenderPage {
                 html,
                 url,
@@ -162,6 +191,54 @@ fn serve_warmed<C: RenderConfiguration>(mut link: Endpoint) -> i32 {
     }
 }
 
+/// Fork a resident renderer (see [`resident`]) and hand the broker its end of
+/// their private link: `RendererSpawned`, then the fd. The fork server keeps
+/// nothing of it but a child to reap later.
+fn spawn_resident<C: RenderConfiguration>(
+    broker: &mut Endpoint,
+    fonts: &mut Option<C::FontSystem>,
+    media_store: &Arc<gosub_render_pipeline::common::media::MediaStore>,
+    forked_loader: &Arc<ForkedResourceLoader>,
+    font_access: bool,
+    parent_only: &[i32],
+    label: &str,
+) -> Result<(), String> {
+    let (ours, theirs) = match gosub_ipc::channel::Channel::pair() {
+        Ok(pair) => pair,
+        Err(e) => return Err(format!("could not create the renderer link: {e}")),
+    };
+
+    match gosub_sandbox::fork_process() {
+        Err(e) => Err(format!("fork failed: {e}")),
+        Ok(gosub_sandbox::Forked::Child) => {
+            drop(ours);
+            gosub_sandbox::close_inherited(parent_only);
+            let _ = &label;
+            gosub_sandbox::set_process_title(&resident::comm(), &resident::title());
+            let Ok(link) = Endpoint::from_channel(theirs) else {
+                gosub_sandbox::exit_now(1);
+            };
+            gosub_sandbox::lock_down_forked_renderer(font_access);
+            let Some(owned) = fonts.take() else {
+                gosub_sandbox::exit_now(1);
+            };
+            resident::serve::<C>(link, owned, Arc::clone(media_store), Arc::clone(forked_loader), label)
+        }
+        Ok(gosub_sandbox::Forked::Parent { pid }) => {
+            drop(theirs);
+            broker
+                .send(&FromForkServer::RendererSpawned { pid })
+                .map_err(|e| format!("broker unreachable: {e}"))?;
+            broker
+                .tx
+                .send_fd(ours.raw())
+                .map_err(|e| format!("could not hand the renderer link to the broker: {e}"))?;
+            // `ours` drops here: the broker holds the only copy that matters.
+            Ok(())
+        }
+    }
+}
+
 /// A tier with no use for a zygote: report the answer so the broker can act on
 /// it, refuse to fork, and idle confined.
 fn decline(mut link: Endpoint, answer: &Confinement) -> i32 {
@@ -193,9 +270,11 @@ fn decline(mut link: Endpoint, answer: &Confinement) -> i32 {
         let reply = match request {
             ToForkServer::Ping => FromForkServer::Pong,
             ToForkServer::Shutdown => return 0,
-            ToForkServer::ForkProof | ToForkServer::RenderPage { .. } | ToForkServer::Resource(_) => {
-                FromForkServer::Refused(refusal.clone())
-            }
+            ToForkServer::ReapExited => FromForkServer::Pong,
+            ToForkServer::ForkProof
+            | ToForkServer::RenderPage { .. }
+            | ToForkServer::SpawnRenderer { .. }
+            | ToForkServer::Resource(_) => FromForkServer::Refused(refusal.clone()),
         };
         if link.send(&reply).is_err() {
             return 1;
@@ -323,7 +402,7 @@ fn fork_and_render<C: RenderConfiguration>(
             gosub_sandbox::close_inherited(parent_only);
             // Fork keeps the parent's name; say who this really is.
             let _ = (&tab, &page_url);
-            gosub_sandbox::set_process_title(&comm(), &title());
+            gosub_sandbox::set_process_title(&resident::comm(), &resident::title());
             let Ok(link) = Endpoint::from_channel(theirs) else {
                 gosub_sandbox::exit_now(1);
             };
@@ -353,7 +432,7 @@ fn fork_and_render<C: RenderConfiguration>(
                 Arc::clone(forked_loader) as Arc<dyn gosub_interface::resource_loader::ResourceLoader>,
             );
 
-            let ok = stream_rendered(&mut link.lock(), &tiles, summary, hit_regions);
+            let ok = resident::stream_rendered(&mut link.lock(), &tiles, &[], summary, hit_regions);
             gosub_sandbox::exit_now(if ok { 0 } else { 1 });
         }
         Ok(gosub_sandbox::Forked::Parent { pid }) => {
@@ -367,9 +446,9 @@ fn fork_and_render<C: RenderConfiguration>(
                 let mut link = Endpoint::from_channel(ours)?;
                 loop {
                     match link.recv::<FromRenderer>()? {
-                        FromRenderer::NeedResource { url } => {
+                        FromRenderer::NeedResource { url, deferred } => {
                             broker
-                                .send(&FromForkServer::NeedResource { url })
+                                .send(&FromForkServer::NeedResource { url, deferred })
                                 .map_err(|e| std::io::Error::other(format!("broker unreachable: {e}")))?;
                             match broker
                                 .recv::<ToForkServer>()
@@ -405,6 +484,11 @@ fn fork_and_render<C: RenderConfiguration>(
                                 .map_err(|e| std::io::Error::other(format!("broker unreachable: {e}")))?;
                             return Ok(());
                         }
+                        // A one-shot renderer retains nothing and so never
+                        // lets go of anything.
+                        FromRenderer::Evict { .. } => {
+                            return Err(std::io::Error::other("a one-shot renderer sent an eviction"));
+                        }
                     }
                 }
             })();
@@ -415,97 +499,5 @@ fn fork_and_render<C: RenderConfiguration>(
                 (_, Err(e)) => Err(format!("forked renderer could not be reaped: {e}")),
             }
         }
-    }
-}
-
-/// This renderer's `ps` name: `renderer-<6 hex>`, drawn once per process.
-/// Deliberately not the site or tab: the process list is visible to every
-/// user on the machine, and what a renderer renders is not their business.
-fn comm() -> String {
-    static ID: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-    ID.get_or_init(|| {
-        let id = uuid::Uuid::new_v4().simple().to_string();
-        format!("renderer-{}", &id[..6])
-    })
-    .clone()
-}
-
-/// The cmdline to go with [`comm`].
-fn title() -> String {
-    format!("gosub: {}", comm())
-}
-
-/// Stream a render out over `link`: every CPU tile sealed into an immutable
-/// memfd and sent as header + fd, one at a time (so this process never holds
-/// more than one tile fd regardless of page height), then the summary. All
-/// of it - memfd_create, ftruncate, mmap, the seals - is in the renderer
-/// baseline precisely so a confined renderer can hand off pixels. `false`
-/// means the link is gone and the caller should exit.
-fn stream_rendered(
-    link: &mut Endpoint,
-    tiles: &[RenderedTile],
-    summary: PageSummary,
-    hit_regions: Vec<HitRegion>,
-) -> bool {
-    for tile in tiles {
-        let sent = match tile {
-            RenderedTile::Unchanged {
-                page_x,
-                page_y,
-                layer_id,
-                hash,
-            } => link
-                .send(&FromRenderer::TileUnchanged(unchanged_header(
-                    *page_x, *page_y, *layer_id, *hash,
-                )))
-                .is_ok(),
-            RenderedTile::Fresh { tile, hash } => {
-                let gosub_render_pipeline::common::texture::TilePixels::Cpu(bytes) = &tile.pixels else {
-                    // GPU handles are process-local and cannot cross; a
-                    // forked rasterizer should never produce one.
-                    continue;
-                };
-                let Ok(fd) = gosub_ipc::shm::create_sealed_tile(tile.width, tile.height, |buf| {
-                    let n = buf.len().min(bytes.len());
-                    buf[..n].copy_from_slice(&bytes[..n]);
-                }) else {
-                    return false;
-                };
-                let header = TileHeader {
-                    page_x: tile.page_x,
-                    page_y: tile.page_y,
-                    layer_id: tile.layer_id,
-                    width: tile.width,
-                    height: tile.height,
-                    format: tile.format.into(),
-                    content_hash: *hash,
-                    opacity: tile.opacity,
-                    anchor: tile.anchor.into(),
-                };
-                link.send(&FromRenderer::Tile(header)).is_ok() && link.tx.send_fd(fd.as_raw_fd()).is_ok()
-                // `fd` drops here: SCM_RIGHTS duplicated it onward.
-            }
-        };
-        if !sent {
-            return false;
-        }
-    }
-    link.send(&FromRenderer::Rendered { summary, hit_regions }).is_ok()
-}
-
-/// The header for a tile the broker already holds. Its physical dimensions
-/// are left at zero deliberately: nothing rasterized them here, and the
-/// broker fills them from the pixels it kept.
-fn unchanged_header(page_x: f64, page_y: f64, layer_id: u64, hash: u64) -> TileHeader {
-    TileHeader {
-        page_x,
-        page_y,
-        layer_id,
-        width: 0,
-        height: 0,
-        format: crate::fork_server::protocol::TileWireFormat::PreMulArgb32,
-        content_hash: hash,
-        opacity: 1.0,
-        anchor: crate::fork_server::protocol::TileWireAnchor::Scroll,
     }
 }

--- a/crates/gosub_engine/src/fork_server/client.rs
+++ b/crates/gosub_engine/src/fork_server/client.rs
@@ -3,6 +3,7 @@
 
 use crate::fork_server::protocol::{
     ConfinementTier, FromForkServer, FromRenderer, HitRegion, PageSummary, ResourceReply, TileHeader, ToForkServer,
+    ToRenderer,
 };
 use gosub_interface::resource_loader::{LoadError, LoadedResource};
 use gosub_ipc::Endpoint;
@@ -22,6 +23,13 @@ const READY_TIMEOUT: Duration = Duration::from_secs(30);
 /// How long any later request may take. A fork plus one shape is milliseconds.
 const REPLY_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// How long a resident renderer may take to answer one request. Unlike the
+/// fork server's control replies this covers whole renders, and a heavy
+/// page's layout alone runs two-digit seconds today - the timeout is for a
+/// *wedged* renderer, and declaring a merely slow one dead kills it for
+/// nothing (the abandoned link reads as EOF in the child).
+const RESIDENT_REPLY_TIMEOUT: Duration = Duration::from_secs(60);
+
 /// Bounds on one render exchange, so a renderer cannot hold the tab thread
 /// or fill the broker's memory by talking forever. Generous: a heavy page
 /// stays far below every one of them.
@@ -36,9 +44,15 @@ const MAX_LAYER_ORDER: usize = 100_000;
 const MAX_TIMINGS: usize = 64;
 
 /// What answers a renderer's subresource requests during an exchange: the
-/// broker's loader, where identity and cookies live.
+/// broker's loader, plus - for a tab - a cache that lets an image request be
+/// answered at once and fetched in the background.
 pub trait RenderResources {
     fn load(&self, url: &url::Url) -> Result<LoadedResource, LoadError>;
+    /// A resource the render can do without for now (an image). The default
+    /// fetches it anyway - correct, just not asynchronous.
+    fn load_deferred(&self, url: &url::Url) -> Result<LoadedResource, LoadError> {
+        self.load(url)
+    }
 }
 
 impl<T: gosub_interface::resource_loader::ResourceLoader + ?Sized> RenderResources for T {
@@ -47,13 +61,138 @@ impl<T: gosub_interface::resource_loader::ResourceLoader + ?Sized> RenderResourc
     }
 }
 
-/// A shared loader as a render's resources (a `dyn` loader cannot be
-/// re-erased into `dyn RenderResources` directly).
-pub struct LoaderResources<'a>(pub &'a std::sync::Arc<dyn gosub_interface::resource_loader::ResourceLoader>);
+/// Subresources fetched on a tab's behalf, images asynchronously.
+pub struct TabResources {
+    pub loader: std::sync::Arc<dyn gosub_interface::resource_loader::ResourceLoader>,
+    pub media: std::sync::Arc<RemoteMediaCache>,
+}
 
-impl RenderResources for LoaderResources<'_> {
+impl RenderResources for TabResources {
     fn load(&self, url: &url::Url) -> Result<LoadedResource, LoadError> {
-        self.0.load(url)
+        self.loader.load(url)
+    }
+
+    fn load_deferred(&self, url: &url::Url) -> Result<LoadedResource, LoadError> {
+        self.media.lookup_or_fetch(url, std::sync::Arc::clone(&self.loader))
+    }
+}
+
+/// Encoded bytes this cache keeps per tab; past it the oldest entries go and
+/// the renderer asks for them again.
+const MEDIA_CACHE_BUDGET: usize = 64 * 1024 * 1024;
+/// Fetch threads per tab. The rest queue; the renderer re-asks after every
+/// completion anyway.
+const MAX_MEDIA_FETCHERS: usize = 6;
+
+type MediaLoader = std::sync::Arc<dyn gosub_interface::resource_loader::ResourceLoader>;
+
+#[derive(Default)]
+struct MediaEntries {
+    by_url: std::collections::HashMap<String, Result<LoadedResource, String>>,
+    /// Insertion order, for eviction.
+    order: std::collections::VecDeque<String>,
+    bytes: usize,
+}
+
+impl MediaEntries {
+    fn insert(&mut self, key: String, fetched: Result<LoadedResource, String>) {
+        self.bytes += fetched.as_ref().map_or(0, |r| r.body.len());
+        self.order.push_back(key.clone());
+        self.by_url.insert(key, fetched);
+        while self.bytes > MEDIA_CACHE_BUDGET {
+            let Some(oldest) = self.order.pop_front() else {
+                break;
+            };
+            if let Some(Ok(gone)) = self.by_url.remove(&oldest) {
+                self.bytes = self.bytes.saturating_sub(gone.body.len());
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct MediaQueue {
+    waiting: std::collections::VecDeque<(url::Url, MediaLoader)>,
+    fetchers: usize,
+}
+
+/// Images a renderer asked for on a tab's behalf: what has arrived, and what
+/// is still on its way. A miss queues the fetch (a few threads work the
+/// queue) and answers [`LoadError::Pending`]; when the bytes land, `completed`
+/// rises and the tab renders again, this time finding them here.
+#[derive(Default)]
+pub struct RemoteMediaCache {
+    entries: parking_lot::Mutex<MediaEntries>,
+    in_flight: parking_lot::Mutex<std::collections::HashSet<String>>,
+    queue: parking_lot::Mutex<MediaQueue>,
+    completed: std::sync::atomic::AtomicBool,
+}
+
+impl RemoteMediaCache {
+    pub fn lookup_or_fetch(
+        self: &std::sync::Arc<Self>,
+        url: &url::Url,
+        loader: MediaLoader,
+    ) -> Result<LoadedResource, LoadError> {
+        let key = url.to_string();
+        if let Some(entry) = self.entries.lock().by_url.get(&key) {
+            return entry.clone().map_err(LoadError::Failed);
+        }
+        if !self.in_flight.lock().insert(key.clone()) {
+            return Err(LoadError::Pending);
+        }
+        // Start a fetcher or queue for one, decided under the queue lock so a
+        // fetcher finishing right now cannot miss what was just queued.
+        let mut queue = self.queue.lock();
+        if queue.fetchers >= MAX_MEDIA_FETCHERS {
+            queue.waiting.push_back((url.clone(), loader));
+            return Err(LoadError::Pending);
+        }
+        queue.fetchers += 1;
+        drop(queue);
+        let cache = std::sync::Arc::clone(self);
+        let first = (url.clone(), loader);
+        let spawned = std::thread::Builder::new()
+            .name("gosub-remote-media".into())
+            .spawn(move || cache.work(first));
+        if spawned.is_err() {
+            self.queue.lock().fetchers -= 1;
+            self.in_flight.lock().remove(&key);
+            return Err(LoadError::Failed("could not start the image fetch".into()));
+        }
+        Err(LoadError::Pending)
+    }
+
+    /// One fetcher thread: the job it was started for, then the queue until
+    /// it is empty.
+    fn work(&self, first: (url::Url, MediaLoader)) {
+        let mut next = Some(first);
+        while let Some((url, loader)) = next.take() {
+            let fetched = loader.load(&url).map_err(|e| e.to_string());
+            self.entries.lock().insert(url.to_string(), fetched);
+            self.in_flight.lock().remove(url.as_str());
+            self.completed.store(true, std::sync::atomic::Ordering::Release);
+            let mut queue = self.queue.lock();
+            next = queue.waiting.pop_front();
+            if next.is_none() {
+                queue.fetchers -= 1;
+            }
+        }
+    }
+
+    /// Whether an image landed since the last call - the tab should render
+    /// again to pick it up.
+    pub fn take_completed(&self) -> bool {
+        self.completed.swap(false, std::sync::atomic::Ordering::AcqRel)
+    }
+
+    /// Forget everything (a new document). Fetches already running finish
+    /// into the new page's cache, which is harmless.
+    pub fn clear(&self) {
+        *self.entries.lock() = MediaEntries::default();
+        self.in_flight.lock().clear();
+        self.queue.lock().waiting.clear();
+        self.completed.store(false, std::sync::atomic::Ordering::Release);
     }
 }
 
@@ -61,6 +200,7 @@ impl RenderResources for LoaderResources<'_> {
 pub(crate) enum RenderEvent {
     NeedResource {
         url: String,
+        deferred: bool,
     },
     Tile(TileHeader),
     TileUnchanged(TileHeader),
@@ -68,13 +208,14 @@ pub(crate) enum RenderEvent {
         summary: PageSummary,
         hit_regions: Vec<HitRegion>,
     },
+    Evict(Vec<u64>),
     Refused(String),
 }
 
 /// A peer's render-exchange dialect: the fork server relays its forked
 /// child's stream wrapped in [`FromForkServer`] and wants resources wrapped
-/// back; a forked renderer speaks [`FromRenderer`] directly and its loader
-/// reads a bare [`ResourceReply`].
+/// back; a resident renderer (and an exec'd one) speaks [`FromRenderer`]
+/// directly and its loader reads a bare [`ResourceReply`].
 pub(crate) trait RenderStream: serde::de::DeserializeOwned + std::fmt::Debug {
     fn into_event(self) -> anyhow::Result<RenderEvent>;
     fn send_resource(link: &mut Endpoint, reply: ResourceReply) -> std::io::Result<()>;
@@ -83,7 +224,7 @@ pub(crate) trait RenderStream: serde::de::DeserializeOwned + std::fmt::Debug {
 impl RenderStream for FromForkServer {
     fn into_event(self) -> anyhow::Result<RenderEvent> {
         Ok(match self {
-            FromForkServer::NeedResource { url } => RenderEvent::NeedResource { url },
+            FromForkServer::NeedResource { url, deferred } => RenderEvent::NeedResource { url, deferred },
             FromForkServer::Tile(header) => RenderEvent::Tile(header),
             FromForkServer::TileUnchanged(header) => RenderEvent::TileUnchanged(header),
             FromForkServer::PageRendered { summary, hit_regions } => RenderEvent::Rendered { summary, hit_regions },
@@ -100,10 +241,11 @@ impl RenderStream for FromForkServer {
 impl RenderStream for FromRenderer {
     fn into_event(self) -> anyhow::Result<RenderEvent> {
         Ok(match self {
-            FromRenderer::NeedResource { url } => RenderEvent::NeedResource { url },
+            FromRenderer::NeedResource { url, deferred } => RenderEvent::NeedResource { url, deferred },
             FromRenderer::Tile(header) => RenderEvent::Tile(header),
             FromRenderer::TileUnchanged(header) => RenderEvent::TileUnchanged(header),
             FromRenderer::Rendered { summary, hit_regions } => RenderEvent::Rendered { summary, hit_regions },
+            FromRenderer::Evict { hashes } => RenderEvent::Evict(hashes),
         })
     }
 
@@ -124,6 +266,7 @@ pub(crate) fn drive_render_exchange<M: RenderStream>(
     known_tiles: &TileMemory,
 ) -> anyhow::Result<RenderedPage> {
     let mut received = Vec::new();
+    let mut evicted = Vec::new();
     let started = std::time::Instant::now();
     let (mut messages, mut resources, mut tile_bytes) = (0usize, 0usize, 0usize);
     loop {
@@ -135,7 +278,13 @@ pub(crate) fn drive_render_exchange<M: RenderStream>(
             anyhow::bail!("render did not finish within {EXCHANGE_DEADLINE:?}");
         }
         match link.recv::<M>()?.into_event()? {
-            RenderEvent::NeedResource { url } => {
+            RenderEvent::Evict(hashes) => {
+                evicted.extend(hashes);
+                if evicted.len() > MAX_EXCHANGE_MESSAGES {
+                    anyhow::bail!("renderer evicted more than {MAX_EXCHANGE_MESSAGES} tiles in one render");
+                }
+            }
+            RenderEvent::NeedResource { url, deferred } => {
                 resources += 1;
                 if resources > MAX_EXCHANGE_RESOURCES {
                     anyhow::bail!("renderer asked for more than {MAX_EXCHANGE_RESOURCES} resources in one render");
@@ -143,16 +292,22 @@ pub(crate) fn drive_render_exchange<M: RenderStream>(
                 let asked = std::time::Instant::now();
                 let reply = match url::Url::parse(&url) {
                     Ok(parsed) => {
-                        let loaded = loader.load(&parsed);
+                        let loaded = if deferred {
+                            loader.load_deferred(&parsed)
+                        } else {
+                            loader.load(&parsed)
+                        };
                         if crate::telemetry::enabled() {
                             let (outcome, bytes) = match &loaded {
                                 Ok(resource) => ("served", resource.body.len()),
+                                Err(LoadError::Pending) => ("pending", 0),
                                 Err(_) => ("failed", 0),
                             };
                             crate::telemetry::emit(
                                 "remote.resource",
                                 serde_json::json!({
                                     "url": url,
+                                    "deferred": deferred,
                                     "outcome": outcome,
                                     "bytes": bytes,
                                     "renderer_waited_us": asked.elapsed().as_micros() as u64,
@@ -165,6 +320,7 @@ pub(crate) fn drive_render_exchange<M: RenderStream>(
                                 content_type: resource.content_type,
                                 body: resource.body.to_vec(),
                             },
+                            Err(LoadError::Pending) => ResourceReply::Pending,
                             Err(e) => ResourceReply::Failed(e.to_string()),
                         }
                     }
@@ -201,6 +357,7 @@ pub(crate) fn drive_render_exchange<M: RenderStream>(
                     summary,
                     tiles: received,
                     hit_regions,
+                    evicted,
                 });
             }
             RenderEvent::Refused(reason) => anyhow::bail!("{reason}"),
@@ -252,6 +409,9 @@ pub struct RenderedPage {
     pub summary: crate::fork_server::protocol::PageSummary,
     pub tiles: Vec<PageTile>,
     pub hit_regions: Vec<crate::fork_server::protocol::HitRegion>,
+    /// Content hashes of tiles the renderer let go of (retained pages only);
+    /// the broker drops them from its memory.
+    pub evicted: Vec<u64>,
 }
 
 /// A tile of a rendered page: either pixels that just crossed, or pixels the
@@ -392,6 +552,15 @@ impl TileMemory {
         self.tiles = tiles.into_iter().collect();
     }
 
+    /// Merge one pass of a retained page: what the renderer let go of leaves,
+    /// what it shipped arrives.
+    pub fn apply_pass(&mut self, evicted: &[u64], tiles: impl IntoIterator<Item = (u64, KeptTile)>) {
+        for hash in evicted {
+            self.tiles.remove(hash);
+        }
+        self.tiles.extend(tiles);
+    }
+
     /// Every kept tile as compositor input, back to front: `layer_order` is
     /// the renderer's (a layer it does not name sorts last), then top-down
     /// within a layer - tiles of one layer never overlap, so that order is
@@ -458,7 +627,7 @@ impl ForkServer {
                 // and still needs room for one large image decode on top.
                 data_limit: Some(RENDERER_DATA_LIMIT),
                 extra_fds: &[],
-                // Every forked renderer lives under this one.
+                // Every resident renderer and its threads live under this one.
                 max_tasks: 4096,
                 file_size_limit: None,
             },
@@ -536,6 +705,36 @@ impl ForkServer {
         drive_render_exchange::<FromForkServer>(&mut self.link, loader, known_tiles)
     }
 
+    /// Fork a resident renderer and take over its link: from here on the
+    /// broker talks to it directly. `label` only names it in `ps`.
+    pub fn spawn_renderer(&mut self, label: &str) -> anyhow::Result<ResidentRenderer> {
+        self.link.send(&ToForkServer::SpawnRenderer {
+            label: label.to_string(),
+        })?;
+        let pid = match self.link.recv::<FromForkServer>()? {
+            FromForkServer::RendererSpawned { pid } => pid,
+            FromForkServer::Refused(reason) => anyhow::bail!("{reason}"),
+            other => anyhow::bail!("unexpected reply to SpawnRenderer: {other:?}"),
+        };
+        let fd = self.link.rx.recv_fd()?;
+        let channel = gosub_ipc::channel::Channel::from_stream(std::os::unix::net::UnixStream::from(fd));
+        let mut link = Endpoint::from_channel(channel)?;
+        let _ = link.tx.set_write_timeout(Some(REPLY_TIMEOUT));
+        let _ = link.rx.set_read_timeout(Some(RESIDENT_REPLY_TIMEOUT));
+        Ok(ResidentRenderer {
+            link,
+            pid,
+            dead: Default::default(),
+        })
+    }
+
+    /// Have the fork server collect resident renderers that have exited.
+    pub fn reap_exited(&mut self) {
+        if self.link.send(&ToForkServer::ReapExited).is_ok() {
+            let _ = self.link.recv::<FromForkServer>();
+        }
+    }
+
     /// Ask for a clean exit, then make sure of it. `&mut self` rather than
     /// consuming, so a handle shared behind a lock (the engine's) can be shut
     /// down in place; afterwards the handle is inert and Drop has nothing to
@@ -545,6 +744,165 @@ impl ForkServer {
         if let Some(mut child) = self.child.take() {
             let _ = child.wait();
         }
+    }
+}
+
+/// The broker's link to one resident renderer (see `fork_server::resident`):
+/// a forked, confined child that outlives its renders. Request/reply is
+/// strictly serial, so a handle is used from behind a lock.
+pub struct ResidentRenderer {
+    link: Endpoint,
+    pid: i32,
+    /// Set once the link failed: nothing sent afterwards can be trusted to
+    /// arrive, and the pool replaces the process on the next request.
+    /// Shared and atomic so the pool can read it without taking the lock a
+    /// failing exchange may be holding.
+    dead: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl std::fmt::Debug for ResidentRenderer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResidentRenderer")
+            .field("pid", &self.pid)
+            .field("dead", &self.is_dead())
+            .finish_non_exhaustive()
+    }
+}
+
+impl ResidentRenderer {
+    /// The renderer's pid as this (the broker's) pid namespace numbers it:
+    /// `fork` in the fork server returns the number its own namespace sees,
+    /// which is the broker's too. Inside the renderers' own namespace the
+    /// process has a different, small number (`NSpid` in /proc shows both).
+    pub fn pid(&self) -> i32 {
+        self.pid
+    }
+
+    pub fn is_dead(&self) -> bool {
+        self.dead.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    /// A handle to the dead flag, readable without this renderer's lock.
+    pub fn dead_flag(&self) -> std::sync::Arc<std::sync::atomic::AtomicBool> {
+        std::sync::Arc::clone(&self.dead)
+    }
+
+    fn mark_dead(&self) {
+        self.dead.store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    fn send(&mut self, msg: &ToRenderer) -> anyhow::Result<()> {
+        if self.is_dead() {
+            anyhow::bail!("renderer process is gone");
+        }
+        if let Err(e) = self.link.send(msg) {
+            self.mark_dead();
+            anyhow::bail!("renderer link failed: {e}");
+        }
+        Ok(())
+    }
+
+    pub fn open_tab(&mut self, tab: &str) -> anyhow::Result<()> {
+        self.send(&ToRenderer::OpenTab { tab: tab.to_string() })
+    }
+
+    pub fn close_tab(&mut self, tab: &str) -> anyhow::Result<()> {
+        self.send(&ToRenderer::CloseTab { tab: tab.to_string() })
+    }
+
+    /// Render `html` for `tab` - the raster window around `scroll_y` of it -
+    /// and have the renderer retain the page for later [`Self::scroll`]s.
+    /// Any failure marks the renderer dead: the exchange strictly alternates,
+    /// so a broken one leaves the link in no state a later request could
+    /// rely on.
+    #[allow(clippy::too_many_arguments)] // one wire message, spelled out
+    pub fn navigate(
+        &mut self,
+        html: &str,
+        url: &str,
+        tab: &str,
+        viewport: (f64, f64),
+        scroll_y: f64,
+        loader: &dyn RenderResources,
+        known_tiles: &TileMemory,
+        hovered_node: Option<u64>,
+    ) -> anyhow::Result<RenderedPage> {
+        self.send(&ToRenderer::Navigate {
+            tab: tab.to_string(),
+            html: html.to_string(),
+            url: url.to_string(),
+            viewport_width: viewport.0,
+            viewport_height: viewport.1,
+            scroll_y,
+            known_tiles: known_tiles.hashes(),
+            hovered_node,
+        })?;
+        self.exchange(loader, known_tiles)
+    }
+
+    /// The viewport of `tab`'s retained page moved: collect what came into
+    /// the raster window (and what the renderer let go of).
+    pub fn scroll(
+        &mut self,
+        tab: &str,
+        scroll_y: f64,
+        loader: &dyn RenderResources,
+        known_tiles: &TileMemory,
+    ) -> anyhow::Result<RenderedPage> {
+        self.send(&ToRenderer::Scroll {
+            tab: tab.to_string(),
+            scroll_y,
+        })?;
+        self.exchange(loader, known_tiles)
+    }
+
+    /// The pointer moved on `tab`'s retained page: collect the repainted tiles.
+    pub fn hover(
+        &mut self,
+        tab: &str,
+        node: Option<u64>,
+        loader: &dyn RenderResources,
+        known_tiles: &TileMemory,
+    ) -> anyhow::Result<RenderedPage> {
+        self.send(&ToRenderer::Hover {
+            tab: tab.to_string(),
+            node,
+        })?;
+        self.exchange(loader, known_tiles)
+    }
+
+    fn exchange(&mut self, loader: &dyn RenderResources, known_tiles: &TileMemory) -> anyhow::Result<RenderedPage> {
+        let result = drive_render_exchange::<FromRenderer>(&mut self.link, loader, known_tiles);
+        if result.is_err() {
+            self.mark_dead();
+        }
+        result
+    }
+
+    /// Whether the process is still there, without sending anything: a closed
+    /// link reads as end-of-file. Only meaningful between exchanges (the
+    /// caller holds the lock, so none is in flight).
+    pub fn check_alive(&mut self) -> bool {
+        if self.is_dead() {
+            return false;
+        }
+        let alive = self.link.rx.peer_alive();
+        if !alive {
+            self.mark_dead();
+        }
+        alive
+    }
+
+    /// Make the renderer die mid-life, for tests of what the broker does then.
+    pub fn crash_for_test(&mut self) {
+        let _ = self.send(&ToRenderer::CrashForTest);
+    }
+
+    /// Ask for a clean exit. The process is the fork server's child; it is
+    /// reaped there (see [`ForkServer::reap_exited`]).
+    pub fn shutdown(&mut self) {
+        let _ = self.send(&ToRenderer::Shutdown);
+        self.mark_dead();
     }
 }
 

--- a/crates/gosub_engine/src/fork_server/loader.rs
+++ b/crates/gosub_engine/src/fork_server/loader.rs
@@ -37,7 +37,14 @@ impl ForkedResourceLoader {
         *self.link.lock() = Some(link);
     }
 
-    fn load_with(&self, url: &Url) -> Result<LoadedResource, LoadError> {
+    /// The same link, asking for resources the render can do without for
+    /// now (images): the broker answers immediately, with the bytes or
+    /// [`LoadError::Pending`], and fetches in the background.
+    pub fn deferred(self: &Arc<Self>) -> Arc<DeferredForkedLoader> {
+        Arc::new(DeferredForkedLoader(Arc::clone(self)))
+    }
+
+    fn load_with(&self, url: &Url, deferred: bool) -> Result<LoadedResource, LoadError> {
         let slot = self.link.lock();
         let Some(link) = slot.as_ref() else {
             return Err(LoadError::Failed(
@@ -46,8 +53,11 @@ impl ForkedResourceLoader {
         };
         let mut link = link.lock();
 
-        link.send(&FromRenderer::NeedResource { url: url.to_string() })
-            .map_err(|e| LoadError::Failed(format!("could not reach the broker: {e}")))?;
+        link.send(&FromRenderer::NeedResource {
+            url: url.to_string(),
+            deferred,
+        })
+        .map_err(|e| LoadError::Failed(format!("could not reach the broker: {e}")))?;
         // No timeout on this recv: the renderer filter has no `setsockopt`.
         // A dead parent is an EOF; a wedged one is bounded by the broker's
         // clocks, which tear this whole process family down.
@@ -65,12 +75,28 @@ impl ForkedResourceLoader {
                 body: bytes::Bytes::from(body),
             }),
             ResourceReply::Failed(reason) => Err(LoadError::Failed(reason)),
+            ResourceReply::Pending => Err(LoadError::Pending),
         }
+    }
+}
+
+/// [`ForkedResourceLoader`] in deferred mode; see [`ForkedResourceLoader::deferred`].
+pub struct DeferredForkedLoader(Arc<ForkedResourceLoader>);
+
+impl std::fmt::Debug for DeferredForkedLoader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("DeferredForkedLoader").field(&self.0).finish()
+    }
+}
+
+impl ResourceLoader for DeferredForkedLoader {
+    fn load(&self, url: &Url) -> Result<LoadedResource, LoadError> {
+        self.0.load_with(url, true)
     }
 }
 
 impl ResourceLoader for ForkedResourceLoader {
     fn load(&self, url: &Url) -> Result<LoadedResource, LoadError> {
-        self.load_with(url)
+        self.load_with(url, false)
     }
 }

--- a/crates/gosub_engine/src/fork_server/pool.rs
+++ b/crates/gosub_engine/src/fork_server/pool.rs
@@ -1,0 +1,410 @@
+//! Resident renderers, one per (zone, site), shared by that site's tabs.
+//!
+//! The site is Chromium's (scheme + eTLD+1, see [`super::site`]): tabs on one
+//! site in one zone share a process, a tab that navigates cross-site moves to
+//! another, and a process whose last tab leaves is shut down. A process that
+//! died is noticed on the next request for it and replaced.
+
+use crate::fork_server::client::{ForkServer, ResidentRenderer};
+use crate::tab::TabId;
+use crate::zone::ZoneId;
+use parking_lot::Mutex;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+/// What one renderer process serves.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct RendererKey {
+    pub zone: ZoneId,
+    pub site: String,
+}
+
+/// One running renderer, for anyone listing the pool.
+#[derive(Clone, Debug)]
+pub struct RendererStatus {
+    pub key: RendererKey,
+    pub pid: i32,
+    pub tabs: usize,
+    /// Resident set and data segment in KiB, from `/proc`, when readable.
+    pub rss_kb: Option<u64>,
+    pub data_kb: Option<u64>,
+}
+
+/// `VmRSS` and `VmData` of a process in KiB, from `/proc/<pid>/status`.
+pub fn memory_of(pid: i32) -> Option<(u64, u64)> {
+    let status = std::fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+    let field = |name: &str| -> Option<u64> {
+        status
+            .lines()
+            .find(|l| l.starts_with(name))
+            .and_then(|l| l.split_whitespace().nth(1))
+            .and_then(|v| v.parse().ok())
+    };
+    Some((field("VmRSS:")?, field("VmData:")?))
+}
+
+pub struct RendererPool {
+    fork_server: Arc<Mutex<ForkServer>>,
+    state: Mutex<State>,
+    /// When [`Self::sweep_dead`] last looked; it is called per frame per tab.
+    last_sweep: Mutex<Option<std::time::Instant>>,
+    /// When memory was last reported to the firehose.
+    last_memory_report: Mutex<Option<std::time::Instant>>,
+    /// Where a crash is announced (`EngineEvent::RendererCrashed`), if the
+    /// pool belongs to an engine.
+    events: Option<crate::engine::types::EventChannel>,
+}
+
+#[derive(Default)]
+struct State {
+    renderers: HashMap<RendererKey, Arc<Mutex<ResidentRenderer>>>,
+    /// Each renderer's pid, kept here so listing the pool never waits on a
+    /// renderer that is mid-exchange.
+    pids: HashMap<RendererKey, i32>,
+    /// Each renderer's dead flag, readable without its lock: a renderer that
+    /// died mid-exchange must never be handed to the next tab.
+    dead_flags: HashMap<RendererKey, Arc<std::sync::atomic::AtomicBool>>,
+    tabs: HashMap<RendererKey, HashSet<TabId>>,
+    /// Where each tab currently lives.
+    placement: HashMap<TabId, RendererKey>,
+    /// `OpenTab`s / `CloseTab`s not yet delivered: the renderer was busy when
+    /// the tab arrived or left, and the pool never waits on a renderer.
+    pending_opens: HashMap<RendererKey, Vec<TabId>>,
+    pending_closes: HashMap<RendererKey, Vec<TabId>>,
+    /// A renderer was let go of while busy; its exit needs collecting later.
+    needs_reap: bool,
+}
+
+impl std::fmt::Debug for RendererPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RendererPool")
+            .field("renderers", &self.state.lock().renderers.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl RendererPool {
+    pub fn new(fork_server: Arc<Mutex<ForkServer>>, events: Option<crate::engine::types::EventChannel>) -> Self {
+        Self {
+            fork_server,
+            state: Mutex::new(State::default()),
+            last_sweep: Mutex::new(None),
+            last_memory_report: Mutex::new(None),
+            events,
+        }
+    }
+
+    pub fn fork_server(&self) -> &Arc<Mutex<ForkServer>> {
+        &self.fork_server
+    }
+
+    /// The renderer `tab` renders `site` in: spawned if the site has none,
+    /// replaced if it died, and `tab` moved into it if it lived elsewhere.
+    /// The returned lock is held by the caller for the render - requests to
+    /// one process are strictly serial, so same-site tabs take turns.
+    pub fn renderer_for(&self, zone: ZoneId, site: &str, tab: TabId) -> anyhow::Result<Arc<Mutex<ResidentRenderer>>> {
+        let key = RendererKey {
+            zone,
+            site: site.to_string(),
+        };
+        let mut state = self.state.lock();
+
+        if let Some(old) = state.placement.get(&tab).cloned() {
+            if old != key {
+                self.detach(&mut state, &old, tab);
+            }
+        }
+        // Lock-free on purpose: the pool lock is held, and a renderer that
+        // died mid-exchange is exactly one whose lock is still taken by the
+        // failing exchange - it must be replaced now, not handed out again.
+        if state
+            .dead_flags
+            .get(&key)
+            .is_some_and(|dead| dead.load(std::sync::atomic::Ordering::Acquire))
+        {
+            self.bury(&mut state, &key);
+        }
+
+        let renderer = match state.renderers.get(&key) {
+            Some(renderer) => Arc::clone(renderer),
+            None => {
+                // Spawning is a round trip to the fork server: other tabs'
+                // lookups must not wait on it, so the pool lock is let go and
+                // retaken. Two tabs racing for one new site both spawn; the
+                // loser's renderer is dropped unused.
+                drop(state);
+                // The `ps` name wants the host, not the scheme.
+                let label = site.rsplit("://").next().unwrap_or(site);
+                let spawned = self.fork_server.lock().spawn_renderer(label)?;
+                state = self.state.lock();
+                match state.renderers.get(&key) {
+                    Some(renderer) => Arc::clone(renderer),
+                    None => {
+                        state.pids.insert(key.clone(), spawned.pid());
+                        state.dead_flags.insert(key.clone(), spawned.dead_flag());
+                        let renderer = Arc::new(Mutex::new(spawned));
+                        state.renderers.insert(key.clone(), Arc::clone(&renderer));
+                        renderer
+                    }
+                }
+            }
+        };
+        if state.placement.get(&tab) != Some(&key) {
+            state.tabs.entry(key.clone()).or_default().insert(tab);
+            state.placement.insert(tab, key.clone());
+            // Announced when the caller's own lock on the renderer is taken:
+            // the pool must not wait for a renderer mid-exchange for another tab.
+            state.pending_opens.entry(key).or_default().push(tab);
+        }
+        drop(state);
+        self.flush_pending(&renderer);
+        Ok(renderer)
+    }
+
+    /// `tab` is gone: tell its renderer, and shut the renderer down if that
+    /// was its last tab.
+    pub fn release(&self, tab: TabId) {
+        let mut state = self.state.lock();
+        if let Some(key) = state.placement.get(&tab).cloned() {
+            self.detach(&mut state, &key, tab);
+        }
+    }
+
+    /// Notice renderers that died since the last look - a closed link, seen
+    /// without sending anything - and replace them on their tabs' next
+    /// request, announcing each now rather than then. Cheap enough to call
+    /// per frame: it actually looks at most every quarter second, and skips
+    /// a renderer that is busy with an exchange (one that dies mid-exchange
+    /// is found by the exchange). Returns how many were found dead.
+    pub fn sweep_dead(&self) -> usize {
+        const INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
+        {
+            let mut last = self.last_sweep.lock();
+            if last.is_some_and(|t| t.elapsed() < INTERVAL) {
+                return 0;
+            }
+            *last = Some(std::time::Instant::now());
+        }
+        let mut state = self.state.lock();
+        let dead: Vec<RendererKey> = state
+            .renderers
+            .iter()
+            .filter(|(_, renderer)| renderer.try_lock().is_some_and(|mut r| !r.check_alive()))
+            .map(|(key, _)| key.clone())
+            .collect();
+        for key in &dead {
+            self.bury(&mut state, key);
+        }
+        if std::mem::take(&mut state.needs_reap) {
+            self.fork_server.lock().reap_exited();
+        }
+        let idle: Vec<Arc<Mutex<ResidentRenderer>>> = state.renderers.values().map(Arc::clone).collect();
+        drop(state);
+        for renderer in idle {
+            self.flush_pending(&renderer);
+        }
+        self.report_memory();
+        dead.len()
+    }
+
+    /// Every renderer's memory onto the firehose, every couple of seconds -
+    /// what a long session does to a long-lived process.
+    fn report_memory(&self) {
+        const INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+        if !crate::telemetry::enabled() {
+            return;
+        }
+        {
+            let mut last = self.last_memory_report.lock();
+            if last.is_some_and(|t| t.elapsed() < INTERVAL) {
+                return;
+            }
+            *last = Some(std::time::Instant::now());
+        }
+        for status in self.snapshot() {
+            crate::telemetry::emit(
+                "renderer.memory",
+                serde_json::json!({
+                    "pid": status.pid,
+                    "site": status.key.site,
+                    "tabs": status.tabs,
+                    "rss_kb": status.rss_kb,
+                    "data_kb": status.data_kb,
+                }),
+            );
+        }
+    }
+
+    /// A renderer found dead: drop it, reap it, and say so.
+    fn bury(&self, state: &mut State, key: &RendererKey) {
+        log::warn!(
+            "renderer for {} in zone {:?} died; its tabs get a fresh one",
+            key.site,
+            key.zone
+        );
+        let tabs: Vec<TabId> = state
+            .tabs
+            .get(key)
+            .map(|t| t.iter().copied().collect())
+            .unwrap_or_default();
+        self.discard(state, key);
+        if let Some(events) = &self.events {
+            let _ = events.send(crate::engine::events::EngineEvent::RendererCrashed {
+                zone_id: key.zone,
+                site: key.site.clone(),
+                tabs,
+                error: "renderer process died".into(),
+            });
+        }
+    }
+
+    /// Kill every renderer serving `site`, in any zone, the way a crash
+    /// would; returns how many were told to die. Their tabs recover on their
+    /// next render. For tests.
+    pub fn crash_renderers_for_test(&self, site: &str) -> usize {
+        let state = self.state.lock();
+        let mut count = 0;
+        for (key, renderer) in &state.renderers {
+            if key.site != site {
+                continue;
+            }
+            renderer.lock().crash_for_test();
+            count += 1;
+        }
+        count
+    }
+
+    /// Every running renderer and how many tabs it hosts.
+    pub fn snapshot(&self) -> Vec<RendererStatus> {
+        // The `/proc` reads happen after the lock is released.
+        let listed: Vec<(RendererKey, i32, usize)> = {
+            let state = self.state.lock();
+            state
+                .renderers
+                .keys()
+                .map(|key| {
+                    (
+                        key.clone(),
+                        state.pids.get(key).copied().unwrap_or(0),
+                        state.tabs.get(key).map_or(0, HashSet::len),
+                    )
+                })
+                .collect()
+        };
+        let mut out: Vec<RendererStatus> = listed
+            .into_iter()
+            .map(|(key, pid, tabs)| {
+                let memory = memory_of(pid);
+                RendererStatus {
+                    key,
+                    pid,
+                    tabs,
+                    rss_kb: memory.map(|m| m.0),
+                    data_kb: memory.map(|m| m.1),
+                }
+            })
+            .collect();
+        out.sort_by(|a, b| a.key.site.cmp(&b.key.site));
+        out
+    }
+
+    /// Shut every renderer down (engine shutdown).
+    pub fn shutdown_all(&self) {
+        let mut state = self.state.lock();
+        let keys: Vec<RendererKey> = state.renderers.keys().cloned().collect();
+        for key in keys {
+            self.discard(&mut state, &key);
+        }
+        state.placement.clear();
+    }
+
+    /// Deliver what a renderer could not be told while it was busy. Called
+    /// with no pool lock held, by whoever is about to use the renderer. Lock
+    /// order is strictly pool → renderer (try), never the reverse: the
+    /// pending messages are collected first, and pushed back if the renderer
+    /// turns out to be mid-exchange.
+    fn flush_pending(&self, renderer: &Arc<Mutex<ResidentRenderer>>) {
+        let (key, opens, closes) = {
+            let mut state = self.state.lock();
+            let key = state
+                .renderers
+                .iter()
+                .find(|(_, r)| Arc::ptr_eq(r, renderer))
+                .map(|(k, _)| k.clone());
+            let Some(key) = key else {
+                return;
+            };
+            let opens = state.pending_opens.remove(&key).unwrap_or_default();
+            let closes = state.pending_closes.remove(&key).unwrap_or_default();
+            (key, opens, closes)
+        };
+        if opens.is_empty() && closes.is_empty() {
+            return;
+        }
+        match renderer.try_lock() {
+            Some(mut guard) => {
+                for tab in &opens {
+                    let _ = guard.open_tab(&tab.to_string());
+                }
+                for tab in &closes {
+                    let _ = guard.close_tab(&tab.to_string());
+                }
+            }
+            None => {
+                // Mid-exchange: put them back for the next opportunity.
+                let mut state = self.state.lock();
+                let front = state.pending_opens.entry(key.clone()).or_default();
+                for (i, tab) in opens.into_iter().enumerate() {
+                    front.insert(i, tab);
+                }
+                let front = state.pending_closes.entry(key).or_default();
+                for (i, tab) in closes.into_iter().enumerate() {
+                    front.insert(i, tab);
+                }
+            }
+        }
+    }
+
+    fn detach(&self, state: &mut State, key: &RendererKey, tab: TabId) {
+        state.placement.remove(&tab);
+        let last = {
+            let tabs = state.tabs.entry(key.clone()).or_default();
+            tabs.remove(&tab);
+            tabs.is_empty()
+        };
+        // Told now if the renderer is free, later if it is mid-exchange -
+        // the pool never waits on a renderer.
+        if let Some(renderer) = state.renderers.get(key) {
+            match renderer.try_lock() {
+                Some(mut guard) => {
+                    let _ = guard.close_tab(&tab.to_string());
+                }
+                None => state.pending_closes.entry(key.clone()).or_default().push(tab),
+            }
+        }
+        if last {
+            self.discard(state, key);
+        }
+    }
+
+    fn discard(&self, state: &mut State, key: &RendererKey) {
+        state.tabs.remove(key);
+        state.pids.remove(key);
+        state.dead_flags.remove(key);
+        state.pending_opens.remove(key);
+        state.pending_closes.remove(key);
+        if let Some(renderer) = state.renderers.remove(key) {
+            match renderer.try_lock() {
+                Some(mut guard) => guard.shutdown(),
+                // Busy with an exchange: the thread running it holds the last
+                // handle; when that drops, the link closes and the process
+                // exits on end-of-file. Its exit is collected by the sweep.
+                None => {
+                    state.needs_reap = true;
+                    return;
+                }
+            }
+        }
+        self.fork_server.lock().reap_exited();
+    }
+}

--- a/crates/gosub_engine/src/fork_server/protocol.rs
+++ b/crates/gosub_engine/src/fork_server/protocol.rs
@@ -63,12 +63,73 @@ pub enum ToForkServer {
         /// whose painted content actually changed.
         hovered_node: Option<u64>,
     },
+    /// Fork a *resident* renderer - one that stays alive and serves
+    /// [`ToRenderer`] requests until told to stop - confine it to the announced
+    /// tier, and hand its end of a private link to the broker: the reply is
+    /// [`FromForkServer::RendererSpawned`] followed immediately by the link's
+    /// file descriptor. From then on the broker and that renderer talk
+    /// directly; the fork server is out of the loop.
+    SpawnRenderer {
+        /// The pool's key for this renderer (zone + site). Display only; the
+        /// process names itself `renderer-<id>`.
+        label: String,
+    },
+    /// Collect any resident renderers that have exited (they are this
+    /// process's children, so only it can reap them). The broker sends this
+    /// after it observed a renderer's link close.
+    ReapExited,
     /// Exit cleanly.
     Shutdown,
     /// The broker's answer to [`FromForkServer::NeedResource`], relayed on to
     /// the renderer that is blocked waiting for it. Only ever sent while a
     /// [`RenderPage`](ToForkServer::RenderPage) exchange is in flight.
     Resource(ResourceReply),
+}
+
+/// Broker → resident renderer, over the private link
+/// [`ToForkServer::SpawnRenderer`] handed over. One renderer hosts every tab
+/// of one (zone, site), so requests name their tab.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ToRenderer {
+    /// A tab now lives in this renderer.
+    OpenTab { tab: String },
+    /// The tab left (closed, or moved to another site's renderer).
+    CloseTab { tab: String },
+    /// Render this tab's page: the same one-shot pipeline as
+    /// [`ToForkServer::RenderPage`], answered with the same streamed
+    /// [`FromRenderer`] sequence ending in [`FromRenderer::Rendered`]. A
+    /// [`FromRenderer::NeedResource`] mid-render is answered with a bare
+    /// [`ResourceReply`] frame (the renderer's loader reads exactly that),
+    /// so the link strictly alternates for the whole exchange.
+    Navigate {
+        tab: String,
+        html: String,
+        url: String,
+        viewport_width: f64,
+        viewport_height: f64,
+        /// Where the viewport is: only the raster window around it is
+        /// rasterized and shipped (see [`ToRenderer::Scroll`]).
+        scroll_y: f64,
+        known_tiles: Vec<u64>,
+        hovered_node: Option<u64>,
+    },
+    /// The viewport moved on a page this renderer retains: rasterize what
+    /// came into the raster window and ship it, and announce
+    /// ([`FromRenderer::Evict`]) tiles that drifted too far to keep. Answered
+    /// with the same streamed sequence as `Navigate`; the summary's tile
+    /// counts cover this pass only.
+    Scroll { tab: String, scroll_y: f64 },
+    /// The pointer moved to `node` (a DOM node id the broker hit-tested, or
+    /// nothing) on a page this renderer retains: restyle the hover chains and
+    /// repaint just the tiles they cover. Same streamed answer as `Scroll`.
+    Hover { tab: String, node: Option<u64> },
+    /// Die without replying, the way a crashing renderer would. For tests
+    /// of the broker's recovery; a renderer that obeys it was going to be
+    /// trusted with nothing anyway.
+    CrashForTest,
+    /// Exit cleanly. The broker sends this when the renderer's last tab
+    /// closes; a closed link means the same.
+    Shutdown,
 }
 
 /// Fork server → broker.
@@ -101,6 +162,10 @@ pub enum FromForkServer {
         summary: PageSummary,
         hit_regions: Vec<HitRegion>,
     },
+    /// A resident renderer was forked; the broker's end of its link follows
+    /// immediately as a file descriptor. `pid` is the number the fork
+    /// server's own namespace - and so the broker's - sees.
+    RendererSpawned { pid: i32 },
     /// The request could not be served; the string says why (e.g. forking is
     /// refused under `Unsupported`, or the forked child died).
     Refused(String),
@@ -109,7 +174,7 @@ pub enum FromForkServer {
     /// wants, the broker performs the fetch where identity and cookies live,
     /// and only bytes come back. Sent mid-[`RenderPage`](ToForkServer::RenderPage);
     /// the broker answers with [`ToForkServer::Resource`] before anything else.
-    NeedResource { url: String },
+    NeedResource { url: String, deferred: bool },
 }
 
 /// What a forked renderer sends its parent over their private pair before
@@ -137,8 +202,9 @@ pub struct PageSummary {
     pub layer_count: u64,
     pub painted_tiles: u64,
     pub paint_commands: u64,
-    /// Layer ids back to front: the order the broker composites the tiles
-    /// in; the renderer's tile list is the only thing that knows it.
+    /// Layer ids back to front. A broker holding tiles from several passes
+    /// (a retained page scrolled about) composites them in this order; the
+    /// renderer's tile list is the only thing that knows it.
     pub layer_order: Vec<u64>,
     /// What the renderer spent on this pass, per stage, in microseconds. It
     /// has no way to report anywhere itself; the broker relays these to the
@@ -157,7 +223,7 @@ pub struct HitRegion {
     pub width: f64,
     pub height: f64,
     /// The node in the renderer's DOM; only meaningful back in that renderer
-    /// (`RenderPage { hovered_node }`).
+    /// (`Hover { node }`).
     pub node_id: u64,
     /// How the region's layer responds to scroll; the broker inverts the same
     /// composite mapping the tiles use.
@@ -308,19 +374,29 @@ impl From<TileWireAnchor> for gosub_interface::render::backend::TileAnchor {
     }
 }
 
-/// Everything a forked renderer can say over its private link to the fork
-/// server, which relays it to the broker.
+/// Everything a renderer can say over its private link - to the fork server
+/// (one-shot renderers) or straight to the broker (resident ones).
 #[derive(Debug, Serialize, Deserialize)]
 pub enum FromRenderer {
     /// Mid-render: fetch this for me. The parent relays it to the broker and
     /// sends the [`ResourceReply`] back; the renderer is blocked until then.
-    NeedResource { url: String },
+    /// With `deferred`, the renderer can do without it for now: the broker
+    /// answers at once - the bytes if it has them, [`ResourceReply::Pending`]
+    /// otherwise - and fetches in the background, re-rendering the tab when
+    /// they land. Images ask this way; stylesheets and fonts, which layout
+    /// cannot proceed without, do not.
+    NeedResource { url: String, deferred: bool },
     /// One rasterized tile; its sealed memfd follows immediately. The
     /// renderer seals, sends, and drops each before baking the next into a
     /// memfd, so it never holds more than one tile fd itself.
     Tile(TileHeader),
     /// A tile the broker already holds - no fd, no rasterization.
     TileUnchanged(TileHeader),
+    /// Tiles the broker holds that the renderer will no longer account for:
+    /// they drifted too far from the viewport of a retained page. The broker
+    /// drops them; scrolling back there ships them afresh. Only a resident
+    /// renderer sends this.
+    Evict { hashes: Vec<u64> },
     /// The final message: the render is complete, with the page's hit-test
     /// geometry.
     Rendered {
@@ -340,4 +416,6 @@ pub enum ResourceReply {
         body: Vec<u8>,
     },
     Failed(String),
+    /// A deferred request the broker is still fetching; render without it.
+    Pending,
 }

--- a/crates/gosub_engine/src/fork_server/resident.rs
+++ b/crates/gosub_engine/src/fork_server/resident.rs
@@ -1,0 +1,249 @@
+//! The resident renderer: a forked, confined child that stays alive and
+//! renders for every tab of one (zone, site) until its last tab closes.
+//!
+//! Each tab's page is retained after `Navigate` (see
+//! [`renderer::RetainedPage`]), so a `Scroll` only tiles, paints and
+//! rasterizes what came into the raster window - no parse, no layout.
+
+use crate::fork_server::loader::ForkedResourceLoader;
+use crate::fork_server::protocol::{FromRenderer, HitRegion, PageSummary, TileHeader, ToRenderer};
+use crate::fork_server::renderer::{self, RenderedTile, RetainedPage};
+use crate::html::RenderConfiguration;
+use gosub_interface::font_system::FontSystem;
+use gosub_ipc::Endpoint;
+use parking_lot::Mutex;
+use std::collections::{HashMap, HashSet};
+use std::os::fd::AsRawFd;
+use std::sync::Arc;
+
+/// Decoded media a resident renderer keeps between pages. Above this, a new
+/// page starts with an empty media cache; the broker still holds the bytes.
+const MEDIA_CACHE_BUDGET: usize = 64 * 1024 * 1024;
+
+/// Retained pages one renderer holds at once. A heavy site with many tabs
+/// would otherwise stack a laid-out page per tab until the process's memory
+/// limit kills it; past the cap the least recently used tab's page is let go
+/// of, and its next scroll comes back empty - which makes the broker render
+/// it afresh.
+const MAX_RETAINED_PAGES: usize = 3;
+
+/// One incremental request, bound to run against a tab's retained page.
+type PagePass = Box<dyn FnOnce(&mut RetainedPage) -> renderer::RenderPass>;
+
+/// This renderer's `ps` name: `renderer-<6 hex>`, drawn once per process.
+/// Deliberately not the site or tab: the process list is visible to every
+/// user on the machine, and what a renderer renders is not their business.
+pub(super) fn comm() -> String {
+    static ID: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    ID.get_or_init(|| {
+        let id = uuid::Uuid::new_v4().simple().to_string();
+        format!("renderer-{}", &id[..6])
+    })
+    .clone()
+}
+
+/// The cmdline to go with [`comm`].
+pub(super) fn title() -> String {
+    format!("gosub: {}", comm())
+}
+
+/// Serve [`ToRenderer`] requests over `link` until told to stop or the link
+/// closes. Runs in a forked child that has already confined itself; never
+/// returns, since a forked child must leave through `exit_now`.
+pub fn serve<C: RenderConfiguration>(
+    link: Endpoint,
+    fonts: C::FontSystem,
+    media_store: Arc<gosub_render_pipeline::common::media::MediaStore>,
+    forked_loader: Arc<ForkedResourceLoader>,
+    label: &str,
+) -> ! {
+    // Shared between the loader (mid-render round trips) and the request
+    // loop - safe because this process is single-threaded and strictly
+    // alternates: nothing else touches the link while a render runs.
+    let link = Arc::new(Mutex::new(link));
+    forked_loader.connect(Arc::clone(&link));
+    let fonts: Arc<Mutex<dyn FontSystem>> = Arc::new(Mutex::new(fonts));
+    let _ = label; // the pool's key; the process is named after itself
+    let comm = comm();
+
+    let mut pages: HashMap<String, RetainedPage> = HashMap::new();
+    // Tab names, most recently used last; parallel to `pages`.
+    let mut recent: Vec<String> = Vec::new();
+    let touch = |recent: &mut Vec<String>, tab: &str| {
+        recent.retain(|t| t != tab);
+        recent.push(tab.to_string());
+    };
+    loop {
+        let request = link.lock().recv::<ToRenderer>();
+        let request = match request {
+            Ok(request) => request,
+            // The broker went away (or closed the link on purpose).
+            Err(_) => gosub_sandbox::exit_now(0),
+        };
+        match request {
+            ToRenderer::OpenTab { .. } => {}
+            ToRenderer::CloseTab { tab } => {
+                pages.remove(&tab);
+                recent.retain(|t| t != &tab);
+            }
+            ToRenderer::Shutdown => gosub_sandbox::exit_now(0),
+            ToRenderer::CrashForTest => gosub_sandbox::exit_now(139),
+            ToRenderer::Navigate {
+                tab,
+                html,
+                url,
+                viewport_width,
+                viewport_height,
+                scroll_y,
+                known_tiles,
+                hovered_node,
+            } => {
+                let _ = &url;
+                gosub_sandbox::set_process_title(&comm, &title());
+                // A new page: what earlier pages decoded is dead weight past
+                // the budget, and this process lives as long as the site's tabs.
+                media_store.trim(MEDIA_CACHE_BUDGET);
+                let known_tiles: HashSet<u64> = known_tiles.into_iter().collect();
+                let mut page = RetainedPage::build::<C>(
+                    renderer::PageRequest {
+                        html: &html,
+                        page_url: &url,
+                        viewport_width,
+                        viewport_height,
+                        known_tiles: &known_tiles,
+                        hovered_node,
+                    },
+                    Arc::clone(&fonts),
+                    Arc::clone(&media_store),
+                    Arc::clone(&forked_loader) as Arc<dyn gosub_interface::resource_loader::ResourceLoader>,
+                );
+                let pass = page.render(Some(scroll_y), &known_tiles);
+                let hit_regions = page.hit_regions.clone();
+                touch(&mut recent, &tab);
+                pages.insert(tab, page);
+                while pages.len() > MAX_RETAINED_PAGES {
+                    let Some(oldest) = recent.first().cloned() else {
+                        break;
+                    };
+                    recent.remove(0);
+                    pages.remove(&oldest);
+                }
+                if !stream_rendered(&mut link.lock(), &pass.tiles, &pass.evicted, pass.summary, hit_regions) {
+                    gosub_sandbox::exit_now(1);
+                }
+            }
+            ToRenderer::Scroll { .. } | ToRenderer::Hover { .. } => {
+                let (tab, run): (String, PagePass) = match request {
+                    ToRenderer::Scroll { tab, scroll_y } => {
+                        (tab, Box::new(move |page| page.render(Some(scroll_y), &HashSet::new())))
+                    }
+                    ToRenderer::Hover { tab, node } => (tab, Box::new(move |page| page.hover(node))),
+                    _ => unreachable!("matched above"),
+                };
+                // A tab with no retained page (never navigated, or closed)
+                // gets an empty pass, so the exchange still completes.
+                let pass = match pages.get_mut(&tab) {
+                    Some(page) => {
+                        touch(&mut recent, &tab);
+                        run(page)
+                    }
+                    None => renderer::RenderPass {
+                        summary: PageSummary::default(),
+                        tiles: Vec::new(),
+                        evicted: Vec::new(),
+                    },
+                };
+                // Hit regions travel with the navigate pass only; the broker
+                // keeps those and ignores any sent here.
+                if !stream_rendered(&mut link.lock(), &pass.tiles, &pass.evicted, pass.summary, Vec::new()) {
+                    gosub_sandbox::exit_now(1);
+                }
+            }
+        }
+    }
+}
+
+/// Stream a render pass out over `link`: evictions first, then every CPU tile
+/// sealed into an immutable memfd and sent as header + fd, one at a time (so
+/// this process never holds more than one tile fd regardless of page height),
+/// then the summary. All of it - memfd_create, ftruncate, mmap, the seals -
+/// is in the renderer baseline precisely so a confined renderer can hand off
+/// pixels. `false` means the link is gone and the caller should exit.
+pub(super) fn stream_rendered(
+    link: &mut Endpoint,
+    tiles: &[RenderedTile],
+    evicted: &[u64],
+    summary: PageSummary,
+    hit_regions: Vec<HitRegion>,
+) -> bool {
+    if !evicted.is_empty()
+        && link
+            .send(&FromRenderer::Evict {
+                hashes: evicted.to_vec(),
+            })
+            .is_err()
+    {
+        return false;
+    }
+    for tile in tiles {
+        let sent = match tile {
+            RenderedTile::Unchanged {
+                page_x,
+                page_y,
+                layer_id,
+                hash,
+            } => link
+                .send(&FromRenderer::TileUnchanged(unchanged_header(
+                    *page_x, *page_y, *layer_id, *hash,
+                )))
+                .is_ok(),
+            RenderedTile::Fresh { tile, hash } => {
+                let gosub_render_pipeline::common::texture::TilePixels::Cpu(bytes) = &tile.pixels else {
+                    // GPU handles are process-local and cannot cross; a
+                    // forked rasterizer should never produce one.
+                    continue;
+                };
+                let Ok(fd) = gosub_ipc::shm::create_sealed_tile(tile.width, tile.height, |buf| {
+                    let n = buf.len().min(bytes.len());
+                    buf[..n].copy_from_slice(&bytes[..n]);
+                }) else {
+                    return false;
+                };
+                let header = TileHeader {
+                    page_x: tile.page_x,
+                    page_y: tile.page_y,
+                    layer_id: tile.layer_id,
+                    width: tile.width,
+                    height: tile.height,
+                    format: tile.format.into(),
+                    content_hash: *hash,
+                    opacity: tile.opacity,
+                    anchor: tile.anchor.into(),
+                };
+                link.send(&FromRenderer::Tile(header)).is_ok() && link.tx.send_fd(fd.as_raw_fd()).is_ok()
+                // `fd` drops here: SCM_RIGHTS duplicated it onward.
+            }
+        };
+        if !sent {
+            return false;
+        }
+    }
+    link.send(&FromRenderer::Rendered { summary, hit_regions }).is_ok()
+}
+
+/// The header for a tile the broker already holds. Its physical dimensions
+/// are left at zero deliberately: nothing rasterized them here, and the
+/// broker fills them from the pixels it kept.
+fn unchanged_header(page_x: f64, page_y: f64, layer_id: u64, hash: u64) -> TileHeader {
+    TileHeader {
+        page_x,
+        page_y,
+        layer_id,
+        width: 0,
+        height: 0,
+        format: crate::fork_server::protocol::TileWireFormat::PreMulArgb32,
+        content_hash: hash,
+        opacity: 1.0,
+        anchor: crate::fork_server::protocol::TileWireAnchor::Scroll,
+    }
+}

--- a/crates/gosub_engine/src/fork_server/site.rs
+++ b/crates/gosub_engine/src/fork_server/site.rs
@@ -1,0 +1,49 @@
+//! The unit renderer processes are keyed by.
+
+use psl::Psl as _;
+use url::Url;
+
+/// The "site" of a URL, Chromium's definition: scheme plus registrable domain
+/// (eTLD+1), so `https://news.example.co.uk` and `https://example.co.uk` are
+/// one site while `http://` and `https://` are two. Hosts with no registrable
+/// portion (IP addresses, `localhost`, unknown suffixes) are their own site.
+/// URLs without a host (`about:`, `data:`) key on the scheme alone.
+pub fn site_of(url: &Url) -> String {
+    let scheme = url.scheme();
+    let Some(host) = url.host_str() else {
+        return format!("{scheme}:");
+    };
+    // Only names go through the suffix list: it happily reads `127.0.0.1`
+    // as the domain `0.1`.
+    let registrable = match url.host() {
+        Some(url::Host::Domain(name)) => psl::List
+            .domain(name.as_bytes())
+            .and_then(|d| std::str::from_utf8(d.as_bytes()).ok())
+            .unwrap_or(host),
+        _ => host,
+    };
+    format!("{scheme}://{registrable}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn site(s: &str) -> String {
+        site_of(&Url::parse(s).expect("test url"))
+    }
+
+    #[test]
+    fn subdomains_share_a_site_but_schemes_do_not() {
+        assert_eq!(site("https://news.example.co.uk/x"), "https://example.co.uk");
+        assert_eq!(site("https://example.co.uk/"), "https://example.co.uk");
+        assert_ne!(site("http://example.com/"), site("https://example.com/"));
+    }
+
+    #[test]
+    fn hosts_without_a_registrable_domain_stand_alone() {
+        assert_eq!(site("http://localhost:8080/"), "http://localhost");
+        assert_eq!(site("http://127.0.0.1/"), "http://127.0.0.1");
+        assert_eq!(site("about:blank"), "about:");
+    }
+}

--- a/crates/gosub_engine/src/metrics.rs
+++ b/crates/gosub_engine/src/metrics.rs
@@ -9,34 +9,36 @@
 //! | GET    | `/metrics`        | JSON snapshot of all timing namespaces               |
 //! | GET    | `/metrics/reset`  | Clear all timing counters                            |
 //! | GET    | `/events`         | The telemetry firehose, streamed as NDJSON           |
-//! | GET    | `/renderers`      | Renderer processes (none yet; reserved for the viewer)  |
+//! | GET    | `/renderers`      | Resident renderer processes and their tabs           |
 //! | GET    | `/health`         | Liveness probe (`{"status":"ok"}`)                   |
 
+use crate::engine::EngineContext;
+use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
 /// Spawn the metrics HTTP server on `127.0.0.1:{port}` in a background Tokio task.
 ///
 /// The function returns immediately; the server runs until the process exits.
-pub fn start(port: u16) {
+pub fn start(port: u16, context: Arc<EngineContext>) {
     tokio::spawn(async move {
-        if let Err(e) = serve(port).await {
+        if let Err(e) = serve(port, context).await {
             log::error!("[metrics] server stopped: {e}");
         }
     });
     log::info!("[metrics] server starting on http://127.0.0.1:{port}/metrics");
 }
 
-async fn serve(port: u16) -> std::io::Result<()> {
+async fn serve(port: u16, context: Arc<EngineContext>) -> std::io::Result<()> {
     let listener = TcpListener::bind(format!("127.0.0.1:{port}")).await?;
     log::info!("[metrics] listening on http://127.0.0.1:{port}");
     loop {
         let (stream, _addr) = listener.accept().await?;
-        tokio::spawn(handle(stream));
+        tokio::spawn(handle(stream, Arc::clone(&context)));
     }
 }
 
-async fn handle(mut stream: TcpStream) {
+async fn handle(mut stream: TcpStream, context: Arc<EngineContext>) {
     let mut buf = vec![0u8; 2048];
     let n = stream.read(&mut buf).await.unwrap_or(0);
     let req = std::str::from_utf8(&buf[..n]).unwrap_or("");
@@ -54,7 +56,7 @@ async fn handle(mut stream: TcpStream) {
     } else if first_line.starts_with("GET /metrics") || first_line.starts_with("HEAD /metrics") {
         (200, "OK", build_metrics_json())
     } else if first_line.starts_with("GET /renderers") {
-        (200, "OK", r#"{"renderers":[]}"#.to_string())
+        (200, "OK", build_renderers_json(&context))
     } else if first_line.starts_with("GET /health") {
         (200, "OK", r#"{"status":"ok"}"#.to_string())
     } else {
@@ -99,6 +101,39 @@ async fn stream_events(mut stream: TcpStream) {
             return;
         }
     }
+}
+
+/// The resident renderer pool: one entry per process, with its tab count.
+fn build_renderers_json(context: &EngineContext) -> String {
+    use serde_json::json;
+
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    let renderers: Vec<serde_json::Value> = context
+        .renderer_pool
+        .get()
+        .map(|pool| {
+            pool.snapshot()
+                .into_iter()
+                .map(|r| {
+                    json!({
+                        "pid": r.pid,
+                        "zone": r.key.zone.to_string(),
+                        "site": r.key.site,
+                        "tabs": r.tabs,
+                        "rss_kb": r.rss_kb,
+                        "data_kb": r.data_kb,
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    #[cfg(not(all(feature = "process-isolation", target_os = "linux")))]
+    let renderers: Vec<serde_json::Value> = {
+        let _ = context;
+        Vec::new()
+    };
+
+    serde_json::to_string_pretty(&json!({ "renderers": renderers })).unwrap_or_else(|_| "{}".to_string())
 }
 
 fn build_metrics_json() -> String {

--- a/crates/gosub_engine/src/net/brokered_loader.rs
+++ b/crates/gosub_engine/src/net/brokered_loader.rs
@@ -32,6 +32,10 @@ pub struct BrokeredLoader {
     /// navigation superseded, a tab closed. Without it a cancelled page's
     /// stylesheets and fonts would keep downloading.
     cancel: CancellationToken,
+    /// The runtime this loader relays replies on, captured at construction.
+    /// Loads are issued from plain threads too (the media store's fetch
+    /// threads), where `Handle::try_current` finds nothing to spawn on.
+    runtime: Option<tokio::runtime::Handle>,
 }
 
 impl BrokeredLoader {
@@ -41,6 +45,7 @@ impl BrokeredLoader {
             tab_id,
             io_tx,
             cancel: CancellationToken::new(),
+            runtime: tokio::runtime::Handle::try_current().ok(),
         }
     }
 
@@ -66,6 +71,7 @@ impl ResourceLoader for BrokeredLoader {
                 Ok(resource) => ("ok", Some(resource.status), resource.body.len()),
                 Err(LoadError::UnsupportedUrl(_)) => ("refused-scheme", None, 0),
                 Err(LoadError::TimedOut) => ("timeout", None, 0),
+                Err(LoadError::Pending) => ("pending", None, 0),
                 Err(LoadError::Failed(_)) => ("failed", None, 0),
             };
             crate::telemetry::emit(
@@ -98,20 +104,33 @@ impl BrokeredLoader {
             .with_auto_decode(true)
             .build();
 
+        let cancel = self.cancel.child_token();
         let handle = FetchHandle {
             req_id: req.req_id,
-            cancel: self.cancel.child_token(),
+            cancel: cancel.clone(),
         };
 
         // A std channel, not a tokio one: the receiver blocks a plain thread and
-        // must not need a runtime of its own to be woken.
+        // must not need a runtime of its own to be woken. The relay is spawned
+        // on whichever runtime is at hand: the current one, or the one captured
+        // at construction when this load comes from a plain thread (the media
+        // store's fetch threads do).
         let (reply_tx, reply_rx) = std::sync::mpsc::sync_channel::<FetchResult>(1);
         let (io_tx, io_rx) = tokio::sync::oneshot::channel::<FetchResult>();
-        crate::util::spawn_named("brokered-load", async move {
+        let relay = async move {
             if let Ok(result) = io_rx.await {
                 let _ = reply_tx.send(result);
             }
-        });
+        };
+        match tokio::runtime::Handle::try_current()
+            .ok()
+            .or_else(|| self.runtime.clone())
+        {
+            Some(handle) => {
+                handle.spawn(relay);
+            }
+            None => return Err(LoadError::Failed("no runtime to relay the reply on".into())),
+        }
 
         self.io_tx
             .send(IoCommand::Fetch {
@@ -123,8 +142,24 @@ impl BrokeredLoader {
             })
             .map_err(|_| LoadError::Failed("the I/O runtime has shut down".into()))?;
 
-        let result = reply_rx.recv_timeout(BROKER_REPLY_TIMEOUT).map_err(|_| {
+        // The blocking wait must not hold this worker's scheduler core: the
+        // send above has just woken the I/O task into this worker's LIFO slot,
+        // which no other worker can steal - blocking here directly would trap
+        // the very task that produces the reply until the timeout expires.
+        // `block_in_place` hands the core (and that slot) to another thread
+        // for the duration. Outside a multi-thread runtime worker there is no
+        // core to hand over, and a plain blocking wait is correct.
+        let wait = || reply_rx.recv_timeout(BROKER_REPLY_TIMEOUT);
+        let result = match tokio::runtime::Handle::try_current() {
+            Ok(h) if h.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+                tokio::task::block_in_place(wait)
+            }
+            _ => wait(),
+        };
+        let result = result.map_err(|_| {
             log::warn!("brokered load of {url} produced no reply within {BROKER_REPLY_TIMEOUT:?}");
+            // Nobody is waiting anymore: free the in-flight slot and the child's work.
+            cancel.cancel();
             LoadError::TimedOut
         })?;
 

--- a/crates/gosub_engine/src/render_process/child.rs
+++ b/crates/gosub_engine/src/render_process/child.rs
@@ -28,8 +28,11 @@ impl std::fmt::Debug for DirectBrokeredLoader {
 impl ResourceLoader for DirectBrokeredLoader {
     fn load(&self, url: &Url) -> Result<LoadedResource, LoadError> {
         let mut link = self.link.lock();
-        link.send(&FromForkServer::NeedResource { url: url.to_string() })
-            .map_err(|e| LoadError::Failed(format!("could not reach the broker: {e}")))?;
+        link.send(&FromForkServer::NeedResource {
+            url: url.to_string(),
+            deferred: false,
+        })
+        .map_err(|e| LoadError::Failed(format!("could not reach the broker: {e}")))?;
         match link
             .recv::<ToForkServer>()
             .map_err(|e| LoadError::Failed(format!("the broker never answered: {e}")))?
@@ -43,6 +46,7 @@ impl ResourceLoader for DirectBrokeredLoader {
                 content_type,
                 body: bytes::Bytes::from(body),
             }),
+            ToForkServer::Resource(ResourceReply::Pending) => Err(LoadError::Pending),
             ToForkServer::Resource(ResourceReply::Failed(reason)) => Err(LoadError::Failed(reason)),
             other => Err(LoadError::Failed(format!("expected a resource, got {other:?}"))),
         }

--- a/crates/gosub_engine/tests/process_isolation.rs
+++ b/crates/gosub_engine/tests/process_isolation.rs
@@ -250,6 +250,133 @@ fn the_fork_server_forks_a_confined_renderer_with_cosmic_text() {
     );
 }
 
+/// Resident renderers: one process per (zone, site) shared by its tabs, a
+/// cross-site navigation moving a tab to another process, and the last tab
+/// leaving shutting the process down.
+#[cfg(target_os = "linux")]
+#[test]
+fn resident_renderers_are_keyed_by_site_and_live_with_their_tabs() {
+    let out = run("renderer-lifecycle");
+
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: {}", String::from_utf8_lossy(&out.stderr).trim());
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "the resident renderer lifecycle failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A resident renderer rasterizes around the viewport, extends on scroll and
+/// evicts what falls far behind - the tile budget, out of process.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_resident_renderer_rasterizes_a_viewport_window_and_extends_on_scroll() {
+    let out = run("renderer-scroll-window");
+
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: {}", String::from_utf8_lossy(&out.stderr).trim());
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "the resident renderer's scroll window failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Hover on a retained page repaints the hovered element's tiles without a
+/// parse or layout, and does nothing when the pointer stays put.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_resident_renderer_repaints_hover_without_relayout() {
+    let out = run("renderer-hover");
+
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: {}", String::from_utf8_lossy(&out.stderr).trim());
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "the resident renderer's hover repaint failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A resident renderer that dies is replaced on the next request, and the
+/// tab renders again in the replacement.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_dead_resident_renderer_is_replaced() {
+    let out = run("renderer-crash");
+
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: {}", String::from_utf8_lossy(&out.stderr).trim());
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "renderer crash recovery failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Through the engine: a renderer crash reaches the embedder as
+/// `RendererCrashed`, and the tab comes back in a fresh process.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_renderer_crash_is_announced_and_the_tab_recovers() {
+    let out = run("engine-renderer-crash");
+
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: {}", String::from_utf8_lossy(&out.stderr).trim());
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "engine-level renderer crash handling failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A remote render never waits for an image download: the page paints without
+/// it and paints again once it has arrived.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_remote_render_does_not_wait_for_images() {
+    let out = run("engine-renderer-slow-image");
+
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: {}", String::from_utf8_lossy(&out.stderr).trim());
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "deferred image loading failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A resident renderer over a long session: memory levels off across many
+/// navigations, and tabs coming and going leave no zombies.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_resident_renderer_survives_a_long_session_without_growing() {
+    let out = run("renderer-soak");
+
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: {}", String::from_utf8_lossy(&out.stderr).trim());
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "the renderer soak failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 /// The render pipeline - parse, style, layout, layering, tiling, paint -
 /// under the strictest renderer sandbox, in-process (no fork machinery), so a
 /// pipeline-vs-sandbox regression is directly attributable.

--- a/crates/gosub_interface/src/resource_loader.rs
+++ b/crates/gosub_interface/src/resource_loader.rs
@@ -1,6 +1,4 @@
 //! How a subsystem asks for bytes it cannot fetch itself.
-//!
-//! ## Why blocking
 
 use std::fmt;
 use url::Url;
@@ -33,6 +31,10 @@ pub enum LoadError {
     /// because it usually means the broker is starved rather than the resource
     /// being unavailable.
     TimedOut,
+    /// The resource is being fetched but is not here yet; ask again later.
+    /// A loader that answers this never blocks on the network, and the
+    /// caller must not treat it as a failure (in particular, not cache it).
+    Pending,
 }
 
 impl fmt::Display for LoadError {
@@ -41,6 +43,7 @@ impl fmt::Display for LoadError {
             LoadError::UnsupportedUrl(url) => write!(f, "unsupported url: {url}"),
             LoadError::Failed(why) => write!(f, "load failed: {why}"),
             LoadError::TimedOut => write!(f, "load timed out"),
+            LoadError::Pending => write!(f, "load pending"),
         }
     }
 }

--- a/crates/gosub_render_pipeline/src/common/media/media_store.rs
+++ b/crates/gosub_render_pipeline/src/common/media/media_store.rs
@@ -4,7 +4,7 @@ use crate::common::media::{
 };
 use bytes::Bytes;
 use gosub_interface::media_decoder::{BrokeredDecode, ImageDecoder};
-use gosub_interface::resource_loader::{NoResourceLoader, ResourceLoader};
+use gosub_interface::resource_loader::{LoadError, NoResourceLoader, ResourceLoader};
 use parking_lot::RwLock;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -53,6 +53,29 @@ pub struct MediaStore {
     /// Where raster decoding happens. `None` decodes in this process, which is
     /// the default; the engine installs one to move it out.
     decoder: Option<Arc<dyn ImageDecoder>>,
+    /// The bytes each raster image was decoded from, so its pixels can be let
+    /// go of under [`decoded_budget`](Self::set_decoded_budget) and decoded
+    /// again when next drawn - what bounds a page of photographs.
+    encoded: RwLock<HashMap<MediaId, EncodedSource>>,
+    /// Most recent use per media id, for choosing what to let go of.
+    recent: parking_lot::Mutex<Recency>,
+    /// Decoded raster bytes to keep resident; 0 (the default) keeps everything.
+    decoded_budget: AtomicU64,
+}
+
+/// What a raster image can be decoded from again.
+struct EncodedSource {
+    src: String,
+    mime: Option<String>,
+    bytes: Bytes,
+    /// Its size for layout, so asking is never a reason to decode.
+    intrinsic: (u32, u32),
+}
+
+#[derive(Default)]
+struct Recency {
+    tick: u64,
+    last_used: HashMap<MediaId, u64>,
 }
 
 impl Default for MediaStore {
@@ -121,6 +144,9 @@ impl MediaStore {
             decoders,
             loader,
             decoder,
+            encoded: RwLock::new(HashMap::new()),
+            recent: parking_lot::Mutex::new(Recency::default()),
+            decoded_budget: AtomicU64::new(0),
         }
     }
 
@@ -179,6 +205,112 @@ impl MediaStore {
         MediaRequest::Pending
     }
 
+    /// Decoded bytes held for loaded media (RGBA for images; an estimate for SVG trees).
+    pub fn resident_bytes(&self) -> usize {
+        self.entries
+            .read()
+            .values()
+            .map(|media| match &**media {
+                Media::Image(image) => image.image.as_raw().len(),
+                Media::Svg(_) => 64 * 1024,
+            })
+            .sum()
+    }
+
+    /// Bound the decoded raster pixels kept resident. Above it, the least
+    /// recently used images give up their pixels (their encoded bytes stay)
+    /// and are decoded again on their next use. A long-lived process with a
+    /// fixed memory limit needs this; `0` keeps everything.
+    pub fn set_decoded_budget(&self, bytes: u64) {
+        self.decoded_budget.store(bytes, Ordering::Relaxed);
+    }
+
+    fn touch(&self, media_id: MediaId) {
+        let mut recent = self.recent.lock();
+        recent.tick += 1;
+        let tick = recent.tick;
+        recent.last_used.insert(media_id, tick);
+    }
+
+    /// Let go of least recently used decoded images until the resident total
+    /// fits the budget; `keep` (just decoded, about to be used) survives.
+    fn enforce_decoded_budget(&self, keep: MediaId) {
+        let budget = self.decoded_budget.load(Ordering::Relaxed);
+        if budget == 0 {
+            return;
+        }
+        let encoded = self.encoded.read();
+        let mut entries = self.entries.write();
+        let mut resident: u64 = entries
+            .iter()
+            .filter(|(id, _)| encoded.contains_key(id))
+            .map(|(_, media)| match &**media {
+                Media::Image(image) => image.image.as_raw().len() as u64,
+                Media::Svg(_) => 0,
+            })
+            .sum();
+        if resident <= budget {
+            return;
+        }
+        let mut recent = self.recent.lock();
+        let mut candidates: Vec<(u64, MediaId)> = entries
+            .keys()
+            .filter(|id| **id != keep && encoded.contains_key(id))
+            .map(|id| (recent.last_used.get(id).copied().unwrap_or(0), *id))
+            .collect();
+        candidates.sort_unstable_by_key(|(tick, id)| (*tick, id.as_u64()));
+        for (_, id) in candidates {
+            if resident <= budget {
+                break;
+            }
+            if let Some(media) = entries.remove(&id) {
+                if let Media::Image(image) = &*media {
+                    resident = resident.saturating_sub(image.image.as_raw().len() as u64);
+                }
+            }
+            recent.last_used.remove(&id);
+        }
+    }
+
+    /// Decode an image whose pixels were let go of, from the bytes kept for it.
+    fn revive(&self, media_id: MediaId) -> Option<Arc<Media>> {
+        let (src, mime, bytes) = {
+            let encoded = self.encoded.read();
+            let source = encoded.get(&media_id)?;
+            (source.src.clone(), source.mime.clone(), source.bytes.clone())
+        };
+        let media = match self.decode_media(&src, mime.as_deref(), &bytes) {
+            Ok(media) => Arc::new(media),
+            Err(e) => {
+                log::warn!("could not decode '{src}' again: {e}");
+                return None;
+            }
+        };
+        self.entries.write().insert(media_id, Arc::clone(&media));
+        self.touch(media_id);
+        self.enforce_decoded_budget(media_id);
+        Some(media)
+    }
+
+    /// Drop every loaded media once more than `budget_bytes` is held, keeping the
+    /// compiled-in placeholders. All-or-nothing on purpose: a long-lived process
+    /// (a resident renderer) calls this between pages, when nothing it holds is
+    /// known to be needed again and re-fetching what is comes from the broker's
+    /// cache anyway. Returns how many bytes were released.
+    pub fn trim(&self, budget_bytes: usize) -> usize {
+        let held = self.resident_bytes();
+        if held <= budget_bytes {
+            return 0;
+        }
+        let mut entries = self.entries.write();
+        let mut cache = self.cache.write();
+        entries.retain(|id, _| *id == DEFAULT_SVG_ID || *id == DEFAULT_IMAGE_ID);
+        cache.clear();
+        self.encoded.write().clear();
+        *self.recent.lock() = Recency::default();
+        held
+    }
+
     /// Returns and clears the "background fetch completed" flag; `true` means the engine should
     /// re-lay-out the page to pick up the new media.
     pub fn take_completed(&self) -> bool {
@@ -225,6 +357,9 @@ impl MediaStore {
 
         let media_id = match result {
             Ok(media_id) => media_id,
+            // Not here yet, not a failure: nothing is cached, and the loader's
+            // owner re-renders once the bytes arrive.
+            Err(e) if is_pending(&e) => return Err(e),
             Err(e) => {
                 log::warn!("Failed to load media from '{}': {}", src, e);
                 // Cache the failure as the default image placeholder so the same URL is
@@ -295,16 +430,62 @@ impl MediaStore {
     fn load_media_from_source(&self, src: &str) -> anyhow::Result<MediaId> {
         log::debug!("Loading non-cached media from path: {}", src);
         // `data:` URIs carry the bytes inline - decode them directly instead of going to the network.
-        let media = if let Some(rest) = src.strip_prefix("data:") {
+        let (mime, bytes) = if let Some(rest) = src.strip_prefix("data:") {
             let (mime, bytes) = decode_data_uri(rest)?;
-            self.decode_media(src, mime.as_deref(), &bytes)?
+            (mime, Bytes::from(bytes))
         } else {
-            let (content_type, raw_data) = self.fetch_resource(src)?;
-            self.decode_media(src, content_type.as_deref(), &raw_data)?
+            self.fetch_resource(src)?
         };
 
+        // A synchronous fetch runs on the layout thread (the resident renderer), where
+        // decoding every image of a page as its bytes land costs seconds. Layout only needs
+        // the size: take it from the header and leave the pixels to `get` on first paint -
+        // which, with a raster window, most images off-screen never reach. The asynchronous
+        // path decodes here as before: that is a background thread, and the pixels are wanted
+        // by the reflow that follows.
+        if self.synchronous_fetch.load(Ordering::Relaxed) {
+            // Header parsing is decoding too: through the decoder when there is one.
+            let intrinsic = match &self.decoder {
+                Some(decoder) => decoder.dimensions(mime.as_deref(), &bytes).ok(),
+                None => self.decoders.dimensions(mime.as_deref(), &bytes),
+            };
+            if let Some(intrinsic) = intrinsic {
+                let media_id = self.allocate_media_id();
+                self.encoded.write().insert(
+                    media_id,
+                    EncodedSource {
+                        src: src.to_string(),
+                        mime,
+                        bytes,
+                        intrinsic,
+                    },
+                );
+                return Ok(media_id);
+            }
+        }
+
+        let media = self.decode_media(src, mime.as_deref(), &bytes)?;
+
         let media_id = self.allocate_media_id();
+        let intrinsic = match &media {
+            Media::Image(image) => Some((image.image.intrinsic_width(), image.image.intrinsic_height())),
+            Media::Svg(_) => None,
+        };
         self.entries.write().insert(media_id, Arc::new(media));
+        if let Some(intrinsic) = intrinsic {
+            // Kept so the pixels can be given up and brought back (see `set_decoded_budget`).
+            self.encoded.write().insert(
+                media_id,
+                EncodedSource {
+                    src: src.to_string(),
+                    mime,
+                    bytes,
+                    intrinsic,
+                },
+            );
+            self.touch(media_id);
+            self.enforce_decoded_budget(media_id);
+        }
 
         Ok(media_id)
     }
@@ -352,14 +533,42 @@ impl MediaStore {
         entries.insert(media_id, media);
     }
 
-    /// Falls back to `media_type`'s default resource if `media_id` does not exist.
-    pub fn get(&self, media_id: MediaId, media_type: MediaType) -> Arc<Media> {
-        let entries = self.entries.read();
-
-        match entries.get(&media_id) {
-            Some(media) => media.clone(),
-            None => self.default_media(media_type),
+    /// A raster image's size for layout, without decoding it: resident or not.
+    /// `None` for SVGs, placeholders and unknown ids.
+    pub fn image_intrinsic_size(&self, media_id: MediaId) -> Option<(u32, u32)> {
+        if let Some(source) = self.encoded.read().get(&media_id) {
+            return Some(source.intrinsic);
         }
+        match self.entries.read().get(&media_id).map(|m| &**m) {
+            Some(Media::Image(image)) => Some((image.image.intrinsic_width(), image.image.intrinsic_height())),
+            _ => None,
+        }
+    }
+
+    /// Whether every pixel of a raster image is transparent - known only
+    /// while its pixels are resident; an image let go of under the budget
+    /// answers `false` rather than being decoded for the question.
+    pub fn is_fully_transparent(&self, media_id: MediaId) -> bool {
+        match self.entries.read().get(&media_id).map(|m| &**m) {
+            Some(Media::Image(image)) => {
+                image.image.intrinsic_width() > 0 && image.image.as_raw().as_chunks::<4>().0.iter().all(|px| px[3] == 0)
+            }
+            _ => false,
+        }
+    }
+
+    /// Falls back to `media_type`'s default resource if `media_id` does not exist.
+    /// An image whose pixels were let go of under the decoded budget is decoded
+    /// again here.
+    pub fn get(&self, media_id: MediaId, media_type: MediaType) -> Arc<Media> {
+        let resident = self.entries.read().get(&media_id).cloned();
+        if let Some(media) = resident {
+            if self.decoded_budget.load(Ordering::Relaxed) != 0 {
+                self.touch(media_id);
+            }
+            return media;
+        }
+        self.revive(media_id).unwrap_or_else(|| self.default_media(media_type))
     }
 
     fn default_media(&self, media_type: MediaType) -> Arc<Media> {
@@ -373,7 +582,7 @@ impl MediaStore {
     /// the decoder registry, which treats the content type as a hint only.
     fn fetch_resource(&self, src: &str) -> anyhow::Result<(Option<String>, Bytes)> {
         let url = Url::parse(src)?;
-        let response = self.loader.load(&url).map_err(|e| anyhow::anyhow!("{e}"))?;
+        let response = self.loader.load(&url)?;
 
         if !response.is_ok() {
             anyhow::bail!("HTTP {} fetching resource", response.status);
@@ -381,6 +590,12 @@ impl MediaStore {
 
         Ok((response.content_type, response.body))
     }
+}
+
+/// Whether a load error says "not yet" rather than "no".
+fn is_pending(e: &anyhow::Error) -> bool {
+    e.chain()
+        .any(|cause| matches!(cause.downcast_ref::<LoadError>(), Some(LoadError::Pending)))
 }
 
 /// Decodes a `data:` URI body (everything after `data:`) in its `[<mime>][;base64],<data>` form.
@@ -505,5 +720,86 @@ mod tests {
         let svg = store.get_svg(media_id);
         let size = svg.svg.tree.size();
         assert_eq!((size.width() as u32, size.height() as u32), (20, 10));
+    }
+}
+
+#[cfg(test)]
+mod decoded_budget_tests {
+    use super::*;
+
+    fn data_uri(width: u32, height: u32, seed: u8) -> String {
+        use image::ImageEncoder;
+        let pixels = vec![seed; (width * height * 4) as usize];
+        let mut png = Vec::new();
+        image::codecs::png::PngEncoder::new(&mut png)
+            .write_image(&pixels, width, height, image::ExtendedColorType::Rgba8)
+            .expect("encode");
+        let mut b64 = String::new();
+        const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        for chunk in png.chunks(3) {
+            let n = chunk
+                .iter()
+                .enumerate()
+                .fold(0u32, |acc, (i, &b)| acc | (u32::from(b) << (16 - 8 * i)));
+            for i in 0..4 {
+                b64.push(if i <= chunk.len() {
+                    ALPHABET[((n >> (18 - 6 * i)) & 63) as usize] as char
+                } else {
+                    '='
+                });
+            }
+        }
+        format!("data:image/png;base64,{b64}")
+    }
+
+    #[test]
+    fn synchronous_loads_decode_on_first_use_not_on_load() {
+        let store = Arc::new(MediaStore::new());
+        store.set_synchronous_fetch(true);
+        let before = store.resident_bytes();
+        let MediaRequest::Ready(id) = store.request_media(&data_uri(64, 32, 7)) else {
+            panic!("synchronous load should be ready");
+        };
+        // Layout gets the size; nothing was decoded for it.
+        assert_eq!(store.image_intrinsic_size(id), Some((64, 32)));
+        assert_eq!(store.resident_bytes(), before);
+        assert!(!store.entries.read().contains_key(&id));
+        // Paint asks for pixels: decoded now, at the real size.
+        let image = store.get_image(id);
+        assert_eq!((image.image.width(), image.image.height()), (64, 32));
+        assert!(store.entries.read().contains_key(&id));
+    }
+
+    #[test]
+    fn decoded_pixels_are_bounded_and_come_back_on_use() {
+        let store = Arc::new(MediaStore::new());
+        // Each image is 100x100x4 = 40 000 bytes; room for two.
+        store.set_decoded_budget(90_000);
+        store.set_synchronous_fetch(true);
+        let ids: Vec<MediaId> = (0..4u8)
+            .map(|seed| match store.request_media(&data_uri(100, 100, seed)) {
+                MediaRequest::Ready(id) => id,
+                MediaRequest::Pending => panic!("synchronous load should be ready"),
+            })
+            .collect();
+
+        let resident = |store: &MediaStore| -> usize {
+            let entries = store.entries.read();
+            ids.iter().filter(|id| entries.contains_key(id)).count()
+        };
+        assert!(resident(&store) <= 2, "budget must hold: {} resident", resident(&store));
+        // The first ones loaded were the ones let go of.
+        assert!(!store.entries.read().contains_key(&ids[0]));
+
+        // Using an evicted image decodes it again, at its own size, and the
+        // hash→id mapping still answers Ready for its source.
+        let Media::Image(back) = &*store.get(ids[0], MediaType::Image) else {
+            panic!("expected an image");
+        };
+        assert_eq!((back.image.width(), back.image.height()), (100, 100));
+        assert_eq!(back.image.as_raw()[0], 0);
+        assert!(store.entries.read().contains_key(&ids[0]));
+        assert!(resident(&store) <= 2);
+        assert!(matches!(store.request_media(&data_uri(100, 100, 0)), MediaRequest::Ready(id) if id == ids[0]));
     }
 }

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -91,9 +91,8 @@ pub struct TaffyLayouter {
     dom_to_layout_mapping: HashMap<DomNodeId, LayoutElementId>,
 }
 
-/// Apply the CSS `text-transform` keyword to a text run. `uppercase`/`lowercase` map the whole
-/// string; `capitalize` uppercases the first letter of each whitespace-separated word. `none`
-/// (and any unsupported keyword such as `full-width`) leaves the text unchanged.
+/// Apply the CSS `text-transform` keyword to a text run. Unsupported keywords (e.g. `full-width`)
+/// leave the text unchanged.
 fn apply_text_transform(text: String, transform: Value) -> String {
     let Value::Keyword(id) = transform else {
         return text;
@@ -183,9 +182,6 @@ impl Default for TaffyLayouter {
 
 impl TaffyLayouter {
     /// Create a layouter with its own font system.
-    ///
-    /// To share the font collection with other components (e.g. a `VelloRasterizer`)
-    /// use [`TaffyLayouter::with_font_system`] and pass the same `Arc` to both.
     pub fn new() -> Self {
         Self::with_font_system(Arc::new(Mutex::new(ParleyFontSystem::new())))
     }
@@ -218,9 +214,8 @@ impl TaffyLayouter {
         Arc::clone(&self.font_system)
     }
 
-    /// Share an external media store with this layouter. Resources loaded during layout are
-    /// stored here; passing the same store to the rasterizer lets it resolve those resources
-    /// by id. Without this they live in two separate stores and images render as placeholders.
+    /// Share an external media store with this layouter. The rasterizer must share the same
+    /// store to resolve resources by id; otherwise images render as placeholders.
     pub fn set_media_store(&mut self, media_store: Arc<MediaStore>) {
         self.media_store = media_store;
     }
@@ -256,7 +251,6 @@ impl CanLayout for TaffyLayouter {
         // let root_id = RenderNodeId::new(2);
         let mut layout_tree = self.generate_tree(render_tree, root_id);
 
-        // // Compute the layout based on the viewport
         let size = match viewport {
             Some(viewport) => Size {
                 width: AvailableSpace::Definite(viewport.width as f32),
@@ -361,9 +355,7 @@ impl CanLayout for TaffyLayouter {
         }
         self.measure_cache = measure_cache;
 
-        // Since we are not interested in taffy layout after this stage in the pipeline, we convert
-        // the taffy layout to a box model layout tree. This makes the rest of the pipeline
-        // layout-engine agnostic.
+        // Convert to the box-model tree so the rest of the pipeline is layout-engine agnostic.
         let root_id = layout_tree.root_id;
         let root_width = layout_tree.root_dimension.width;
         self.populate_boxmodel(&mut layout_tree, root_id, Coordinate::ZERO, root_width);
@@ -872,8 +864,7 @@ impl TaffyLayouter {
             }
         }
 
-        // Create a mapping between the layout element id and the taffy node id. We need this to generate
-        // the boxmodel at a later time in this pipeline stage.
+        // Needed by populate_boxmodel later in this stage.
         self.layout_taffy_mapping.insert(layout_element_id, leaf_id);
         self.dom_to_layout_mapping.insert(dom_node.node_id, layout_element_id);
 
@@ -909,6 +900,14 @@ impl TaffyLayouter {
         // length) so it reuses the single raster path for repeat / cover / contain; `compute_bg_tiling`
         // then scales that raster for cover/contain once the box is known. (An SVG intrinsic size is
         // typically large - e.g. 400×300 - so cover/contain downscale and stay crisp.)
+        // A raster background's size is known without decoding it (see the <img> path).
+        if let Some((w, h)) = self.media_store.image_intrinsic_size(media_id) {
+            return Some(BackgroundMedia::Image {
+                media_id,
+                natural: (w as f32, h as f32),
+                layout,
+            });
+        }
         match &*self.media_store.get(media_id, MediaType::Image) {
             Media::Image(mi) => Some(BackgroundMedia::Image {
                 media_id,
@@ -964,50 +963,59 @@ impl TaffyLayouter {
                     // completes and installs the real intrinsic size.
                     match self.media_store.request_media(src.as_str()) {
                         MediaRequest::Ready(media_id) => {
-                            let media = self.media_store.get(media_id, MediaType::Image);
                             // When the media is a placeholder (load failed), use a small fixed
                             // size so the broken-image icon doesn't blow up the layout. The
                             // rasterizer scales the icon to whatever rect the element actually
                             // occupies, so display quality is unaffected.
                             let is_placeholder = self.media_store.is_placeholder(media_id);
+                            // A raster image's size is known without its pixels: asking for
+                            // them here would decode every image on the page during layout,
+                            // and under a decoded-pixel budget evict the rest while doing so.
+                            let known = if is_placeholder {
+                                None
+                            } else {
+                                self.media_store.image_intrinsic_size(media_id)
+                            };
+                            let media = if known.is_some() {
+                                None
+                            } else {
+                                Some(self.media_store.get(media_id, MediaType::Image))
+                            };
                             // Resolve the intrinsic size, whether this is an SVG, and whether the
-                            // decoded raster is fully transparent (nothing visible to paint) - all
-                            // in one borrow.
-                            let (dimension, is_svg, is_transparent) = match media.borrow() {
-                                // Use the SVG's intrinsic size so the element gets a non-zero box.
-                                // A failed/placeholder load uses the same small fixed size as images.
-                                Media::Svg(media_svg) => {
-                                    let d = if is_placeholder {
-                                        geo::Dimension::new(32.0, 32.0)
-                                    } else {
-                                        let size = media_svg.svg.tree.size();
-                                        geo::Dimension::new(size.width() as f64, size.height() as f64)
-                                    };
-                                    (d, true, false)
-                                }
-                                Media::Image(media_image) => {
-                                    let d = if is_placeholder {
-                                        geo::Dimension::new(32.0, 32.0)
-                                    } else {
-                                        geo::Dimension::new(
-                                            media_image.image.width() as f64,
-                                            media_image.image.height() as f64,
-                                        )
-                                    };
-                                    // `.all()` short-circuits on the first opaque pixel, so this is
-                                    // cheap for the common (visible) image and only scans fully when
-                                    // the image really is transparent.
-                                    let transparent = !is_placeholder
-                                        && media_image.image.width() > 0
-                                        && media_image
-                                            .image
-                                            .as_raw()
-                                            .as_chunks::<4>()
-                                            .0
-                                            .iter()
-                                            .all(|px| px[3] == 0);
-                                    (d, false, transparent)
-                                }
+                            // decoded raster is fully transparent (nothing visible to paint).
+                            let (dimension, is_svg, is_transparent) = match (known, media.as_deref()) {
+                                (Some((w, h)), _) => (
+                                    geo::Dimension::new(w as f64, h as f64),
+                                    false,
+                                    self.media_store.is_fully_transparent(media_id),
+                                ),
+                                (None, None) => (geo::Dimension::new(32.0, 32.0), false, false),
+                                (None, Some(media)) => match media {
+                                    // Use the SVG's intrinsic size so the element gets a non-zero box.
+                                    // A failed/placeholder load uses the same small fixed size as images.
+                                    Media::Svg(media_svg) => {
+                                        let d = if is_placeholder {
+                                            geo::Dimension::new(32.0, 32.0)
+                                        } else {
+                                            let size = media_svg.svg.tree.size();
+                                            geo::Dimension::new(size.width() as f64, size.height() as f64)
+                                        };
+                                        (d, true, false)
+                                    }
+                                    Media::Image(media_image) => {
+                                        let d = if is_placeholder {
+                                            geo::Dimension::new(32.0, 32.0)
+                                        } else {
+                                            geo::Dimension::new(
+                                                media_image.image.intrinsic_width() as f64,
+                                                media_image.image.intrinsic_height() as f64,
+                                            )
+                                        };
+                                        let transparent =
+                                            !is_placeholder && self.media_store.is_fully_transparent(media_id);
+                                        (d, false, transparent)
+                                    }
+                                },
                             };
 
                             // Pin the intrinsic aspect ratio so a block-level replaced element keeps


### PR DESCRIPTION

Base: `07-fork-server`. Renderers now outlive one render.

### What is in here

1. **`RendererPool`** keyed by zone + site (scheme + eTLD+1 via `psl`,
   `fork_server::site`): the fork server hands the broker a resident renderer's
   socket over `SCM_RIGHTS`; tabs move between processes on cross-site
   navigation; the process is shut down and reaped when its last tab leaves;
   `OpenTab`/`CloseTab` are delivered when the renderer is free (the pool never
   waits on a busy renderer). `GET /renderers` lists them.
2. **Retained pages** (`renderer::RetainedPage`): stages 1-3 kept per tab;
   `Navigate` rasterizes only the raster window around the viewport, `Scroll`
   extends it and `Evict`s tiles that drifted far, `Hover` restyles two
   ancestor chains and repaints only the touched tiles. A retained-page cap per
   renderer and a decoded-image budget (LRU, re-decode on use) bound memory;
   layout takes image sizes from headers so a page of photographs does not
   decode during layout.
3. **Async scroll/hover passes**: exchanges run on a helper thread while the
   tab keeps compositing what it holds; merged per frame; stale results dropped
   by generation.
4. **Crash handling**: eager dead-renderer detection (liveness probe, lock-free
   dead flag so a dead-but-locked renderer is never handed out again),
   `EngineEvent::RendererCrashed { site, tabs }`, transparent replacement on
   the next render, `CrashForTest` hook.
5. **Deferred image loads**: images ask `NeedResource { deferred: true }`; the
   broker answers instantly from a per-tab cache (`RemoteMediaCache`, bounded,
   a few fetch threads) or `Pending`, fetches in the background, and re-renders
   once the batch has settled. The brokered loader captures its runtime handle
   so loads from plain threads can relay replies.
6. `renderer.memory` and `remote.*` telemetry; per-role `RLIMIT_DATA`
   (1 GiB for the renderer family).

### Testing

```
cargo test -p gosub_engine --test process_isolation --features cairo-tiles   # 25
./target/debug/isolation-harness renderer-lifecycle parley
./target/debug/isolation-harness renderer-scroll-window parley
./target/debug/isolation-harness renderer-hover parley
./target/debug/isolation-harness engine-renderer-crash parley
./target/debug/isolation-harness engine-renderer-slow-image parley
./target/release/isolation-harness engine-soak parley https://example.com https://www.rust-lang.org
```

### Deliberate limits

Same-site tabs serialize on their renderer (one socket, request/reply).
Tiles are CPU pixels; the GPU path is documented, not built.