### PR TITLE
Net policy: private-network protection and opaque-response blocking for subresources

### DIFF
--- a/crates/gosub_engine/src/bin/isolation-harness.rs
+++ b/crates/gosub_engine/src/bin/isolation-harness.rs
@@ -231,13 +231,16 @@ fn resolve() -> i32 {
         return 1;
     };
     let cancel = tokio_util::sync::CancellationToken::new();
-    let fetch = |url: String| {
-        let out = gosub_engine::net::process::client::Outbound::get(url);
+    let fetch = |url: String, refuse_private: bool| {
+        let out = gosub_engine::net::process::client::Outbound {
+            refuse_private,
+            ..gosub_engine::net::process::client::Outbound::get(url)
+        };
         runtime.block_on(net.fetch(out, &cancel)).outcome
     };
 
-    // 1. A name that cannot exist (RFC 2606).
-    match fetch("http://gosub-hostname-probe.invalid/".into()) {
+    // 1. A name that cannot exist (RFC 2606), through the permissive fetcher.
+    match fetch("http://gosub-hostname-probe.invalid/".into(), false) {
         FetchOutcome::Ok { status, .. } => {
             eprintln!("a .invalid name must not resolve, got status {status}");
             net.shutdown();
@@ -246,8 +249,25 @@ fn resolve() -> i32 {
         FetchOutcome::Error(e) => println!("resolution failed as it should: {e}"),
     }
 
-    // 2. The process is still alive and serving.
-    let outcome = fetch(format!("http://127.0.0.1:{port}/"));
+    // 2. The strict fetcher classifies the loopback literal at the hop.
+    match fetch(format!("http://127.0.0.1:{port}/"), true) {
+        FetchOutcome::Ok { .. } => {
+            eprintln!("the strict fetcher reached loopback");
+            net.shutdown();
+            return 1;
+        }
+        FetchOutcome::Error(e) if e.contains("blocked") || e.contains("policy") => {
+            println!("strict fetcher refused loopback: {e}");
+        }
+        FetchOutcome::Error(e) => {
+            eprintln!("strict fetcher failed for the wrong reason: {e}");
+            net.shutdown();
+            return 1;
+        }
+    }
+
+    // 3. The process is still alive and serving.
+    let outcome = fetch(format!("http://127.0.0.1:{port}/"), false);
     net.shutdown();
     drop(server);
     match outcome {

--- a/crates/gosub_engine/src/net.rs
+++ b/crates/gosub_engine/src/net.rs
@@ -58,12 +58,14 @@ pub mod events;
 mod fetcher;
 mod file_loader;
 mod io_runtime;
+pub mod orb;
 /// The network stack running as a separate, sandboxed process.
 #[cfg(feature = "process-isolation")]
 pub mod process;
 pub mod req_ref_tracker;
 mod router;
 mod shared_body;
+pub mod ssrf;
 pub mod tab_identity;
 pub mod types;
 mod utils;

--- a/crates/gosub_engine/src/net/brokered_loader.rs
+++ b/crates/gosub_engine/src/net/brokered_loader.rs
@@ -98,8 +98,12 @@ impl BrokeredLoader {
         }
         warn_if_current_thread_runtime();
 
+        // A subresource on a page's behalf: the I/O side applies the
+        // private-network and opaque-response policies to it.
         let req = FetchRequest::builder(Method::GET, url.clone())
             .with_req_id(RequestId::new())
+            .with_kind(gosub_sonar::net::types::ResourceKind::Asset)
+            .with_initiator(gosub_sonar::net::types::Initiator::Application)
             .with_streaming(false)
             .with_auto_decode(true)
             .build();

--- a/crates/gosub_engine/src/net/fetcher.rs
+++ b/crates/gosub_engine/src/net/fetcher.rs
@@ -89,6 +89,20 @@ pub struct EngineNetContext {
     pub event_tx: EventChannel,
     pub request_reference_map: Arc<RwLock<RequestReferenceMap>>,
     pub request_ref_tracker: Arc<RequestRefTracker>,
+    /// This fetcher serves subresources of public documents: refuse private
+    /// destinations at every hop (see [`crate::net::ssrf`]). Hostnames are
+    /// refused by the strict resolver; this covers the IP literals it never sees.
+    pub refuse_private: bool,
+}
+
+/// The configuration of a fetcher that may not reach the private network:
+/// `cfg` with the strict resolver, which fails closed on any private answer
+/// and, being the only resolver the client has, cannot be rebound around.
+pub fn strict_config(cfg: &FetcherConfig) -> FetcherConfig {
+    FetcherConfig {
+        dns_resolver: Some(Arc::new(crate::net::ssrf::StrictResolver)),
+        ..cfg.clone()
+    }
 }
 
 impl FetcherContext for EngineNetContext {
@@ -124,6 +138,19 @@ impl FetcherContext for EngineNetContext {
                 log::trace!("Cannot find the request reference for reference {:?}", reference);
                 Arc::new(NullEmitter) as Arc<dyn NetObserver + Send + Sync>
             }
+        }
+    }
+
+    fn is_url_allowed(&self, url: &url::Url) -> bool {
+        if !self.refuse_private {
+            return true;
+        }
+        match crate::net::ssrf::literal_verdict(url) {
+            Some(reason) => {
+                log::info!("blocked {url}: {reason}");
+                false
+            }
+            None => true,
         }
     }
 

--- a/crates/gosub_engine/src/net/io_runtime.rs
+++ b/crates/gosub_engine/src/net/io_runtime.rs
@@ -3,8 +3,9 @@ use crate::engine::types::IoChannel;
 use crate::engine::EngineContext;
 use crate::events::IoCommand;
 use crate::net::decision_hub::DecisionHub;
-use crate::net::fetcher::{EngineNetContext, Fetcher, FetcherConfig};
+use crate::net::fetcher::{strict_config, EngineNetContext, Fetcher, FetcherConfig};
 use crate::net::req_ref_tracker::RequestRefTracker;
+use crate::net::ssrf::{AddressSpace, AddressSpaceCache};
 use crate::net::tab_identity::{TabIdentity, TabIdentityRegistry};
 use crate::net::types::{FetchHandle, FetchRequest, FetchResult};
 use crate::tab::TabId;
@@ -80,6 +81,10 @@ impl IoHandle {
 
 pub struct ZoneEntry {
     fetcher: Arc<Fetcher>,
+    /// Same zone, may not reach the private network: serves subresources of
+    /// public documents (see `net::ssrf`). Its own connection pool, on purpose:
+    /// a pooled connection is a resolution already made.
+    strict: Arc<Fetcher>,
     shutdown: CancellationToken,
     join: JoinHandle<()>,
 }
@@ -98,6 +103,8 @@ pub struct IoRouter {
     /// Observer factory for requests the engine serves itself (the `file://` scheme),
     /// so they emit the same resource events a gosub-sonar fetch would.
     local_ctx: EngineNetContext,
+    /// Which documents live on the private network, for the subresource policy.
+    address_space: Arc<AddressSpaceCache>,
     /// The network process, if `security.network_process` is on and it started.
     /// One for the whole engine: it holds no per-zone state, and the connection
     /// pooling that *is* per-zone lives inside it.
@@ -111,6 +118,7 @@ impl IoRouter {
             event_tx: engine_ctx.event_tx.clone(),
             request_reference_map: engine_ctx.request_reference_map.clone(),
             request_ref_tracker: Arc::new(RequestRefTracker::new()),
+            refuse_private: false,
         };
         #[cfg(feature = "process-isolation")]
         let net_process = start_net_process(&engine_ctx);
@@ -121,6 +129,7 @@ impl IoRouter {
             engine_ctx,
             decision_hub: Arc::new(DecisionHub::new()),
             local_ctx,
+            address_space: Arc::new(AddressSpaceCache::new()),
             #[cfg(feature = "process-isolation")]
             net_process,
         }
@@ -156,37 +165,59 @@ impl IoRouter {
         None
     }
 
-    /// The zone's fetcher, spawned on first use.
-    pub fn get_or_spawn_zone_fetcher(&self, zone_id: ZoneId) -> Result<Arc<Fetcher>, EngineError> {
+    /// The zone's fetcher; the strict one when the request may not reach the
+    /// private network.
+    pub fn get_or_spawn_zone_fetcher(
+        &self,
+        zone_id: ZoneId,
+        refuse_private: bool,
+    ) -> Result<Arc<Fetcher>, EngineError> {
+        let pick = |entry: &ZoneEntry| {
+            if refuse_private {
+                entry.strict.clone()
+            } else {
+                entry.fetcher.clone()
+            }
+        };
         if let Some(entry) = self.zones.get(&zone_id) {
-            return Ok(entry.fetcher.clone());
+            return Ok(pick(&entry));
         }
 
         let zone_shutdown = CancellationToken::new();
-        let context = Arc::new(EngineNetContext {
-            event_tx: self.engine_ctx.event_tx.clone(),
-            request_reference_map: self.engine_ctx.request_reference_map.clone(),
-            request_ref_tracker: Arc::new(RequestRefTracker::new()),
-        });
-        let f =
-            Arc::new(Fetcher::new(self.cfg.clone(), context).map_err(|e| EngineError::NetworkError(e.to_string()))?);
 
-        let f_run = f.clone();
+        let context = |refuse_private: bool| {
+            Arc::new(EngineNetContext {
+                event_tx: self.engine_ctx.event_tx.clone(),
+                request_reference_map: self.engine_ctx.request_reference_map.clone(),
+                request_ref_tracker: Arc::new(RequestRefTracker::new()),
+                refuse_private,
+            })
+        };
+        let f = Arc::new(
+            Fetcher::new(self.cfg.clone(), context(false)).map_err(|e| EngineError::NetworkError(e.to_string()))?,
+        );
+        let strict = Arc::new(
+            Fetcher::new(strict_config(&self.cfg), context(true))
+                .map_err(|e| EngineError::NetworkError(e.to_string()))?,
+        );
+
+        let (f_run, strict_run) = (f.clone(), strict.clone());
         let cancel = zone_shutdown.clone();
         let title = format!("I/O Fetcher Zone {}", zone_id);
         let join_handle = spawn_named(&title, async move {
-            f_run.run(cancel).await;
+            tokio::join!(f_run.run(cancel.clone()), strict_run.run(cancel));
         });
 
-        self.zones.insert(
-            zone_id,
-            ZoneEntry {
-                fetcher: f.clone(),
-                shutdown: zone_shutdown,
-                join: join_handle,
-            },
-        );
-        Ok(f)
+        let entry = ZoneEntry {
+            fetcher: f,
+            strict,
+            shutdown: zone_shutdown,
+            join: join_handle,
+        };
+        let picked = pick(&entry);
+        self.zones.insert(zone_id, entry);
+
+        Ok(picked)
     }
 
     #[instrument(
@@ -261,6 +292,7 @@ fn start_net_process(engine_ctx: &Arc<EngineContext>) -> Option<Arc<crate::net::
 fn dispatch_to_net_process(
     net: Arc<crate::net::process::client::NetProcess>,
     req: FetchRequest,
+    refuse_private: bool,
     cancel: tokio_util::sync::CancellationToken,
     reply_tx: oneshot::Sender<FetchResult>,
 ) {
@@ -307,6 +339,7 @@ fn dispatch_to_net_process(
             method,
             headers,
             body,
+            refuse_private,
         };
         let reply = net.fetch(out, &cancel).await;
         crate::net::req_ref_tracker::REF_REGISTRY.forget_request(req_id);
@@ -324,6 +357,7 @@ fn dispatch_to_net_process(
 fn dispatch_to_net_process(
     _net: std::convert::Infallible,
     _req: FetchRequest,
+    _refuse_private: bool,
     _cancel: tokio_util::sync::CancellationToken,
     _reply_tx: oneshot::Sender<FetchResult>,
 ) {
@@ -394,6 +428,56 @@ fn store_response_cookies_then_forward(
     inner_tx
 }
 
+/// Wrap a reply channel so a cross-origin body that must not reach a page is
+/// withheld here (see [`crate::net::orb`]); the requester sees an error instead.
+fn block_opaque_responses_then_forward(
+    document: url::Url,
+    reply_tx: oneshot::Sender<FetchResult>,
+) -> oneshot::Sender<FetchResult> {
+    let (inner_tx, inner_rx) = oneshot::channel::<FetchResult>();
+
+    spawn_named("io-orb", async move {
+        let Ok(result) = inner_rx.await else {
+            return;
+        };
+        let _ = reply_tx.send(apply_orb(&document, result));
+    });
+
+    inner_tx
+}
+
+/// The ORB verdict applied to one result: unchanged when allowed, an error
+/// carrying the reason when not.
+fn apply_orb(document: &url::Url, result: FetchResult) -> FetchResult {
+    use crate::net::orb::{verdict, OrbVerdict};
+
+    let (meta, peek): (&gosub_sonar::net::types::FetchResultMeta, &[u8]) = match &result {
+        FetchResult::Buffered { meta, body } => (meta, body.as_ref()),
+        FetchResult::Stream { meta, peek_buf, .. } => (meta, peek_buf.as_ref()),
+        FetchResult::Error(_) => return result,
+    };
+    let same_origin = document.origin() == meta.final_url.origin();
+    let content_type = meta
+        .headers
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok());
+    let nosniff = meta
+        .headers
+        .get("x-content-type-options")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.trim().eq_ignore_ascii_case("nosniff"));
+    match verdict(same_origin, content_type, nosniff, meta.status, peek) {
+        OrbVerdict::Allow => result,
+        OrbVerdict::Block(reason) => {
+            log::info!("opaque response blocked for {document}: {} ({reason})", meta.final_url);
+            let url = meta.final_url.clone();
+            FetchResult::Error(gosub_sonar::net::types::NetError::Other(Arc::new(anyhow::anyhow!(
+                "opaque response blocked ({reason}): {url}"
+            ))))
+        }
+    }
+}
+
 /// Submit a fetch on behalf of `tab_id`.
 pub async fn submit_to_io(
     zone_id: ZoneId,
@@ -456,21 +540,38 @@ pub fn spawn_io_thread(cfg: FetcherConfig, engine_ctx: Arc<EngineContext>) -> Io
                             // registered, which sends no cookies (see `net::tab_identity`).
                             let identity = tab_id.and_then(|id| router.tab_identities().get(id));
                             let net = router.net_process();
-                            let fetcher = match &net {
+                            let fetchers = match &net {
                                 Some(_) => None,
-                                None => match router.get_or_spawn_zone_fetcher(zone_id) {
-                                    Ok(fetcher) => Some(fetcher),
-                                    Err(e) => {
+                                None => match (
+                                    router.get_or_spawn_zone_fetcher(zone_id, false),
+                                    router.get_or_spawn_zone_fetcher(zone_id, true),
+                                ) {
+                                    (Ok(lenient), Ok(strict)) => Some((lenient, strict)),
+                                    (Err(e), _) | (_, Err(e)) => {
                                         log::error!("Failed to create fetcher for zone {zone_id}: {e}");
                                         continue;
                                     }
                                 },
                             };
+                            let address_space = Arc::clone(&router.address_space);
 
-                            // The cookie lookup may block, so it runs off this loop,
-                            // which must stay free for every other tab's requests.
+                            // The rest may block - the cookie lookup, a DNS lookup for the
+                            // policy - so it runs off this loop, which must stay free for
+                            // every other tab's requests.
                             spawn_named("io-fetch", async move {
+                                let subresource = req.kind != gosub_sonar::net::types::ResourceKind::Primary;
+                                let document = identity.as_ref().and_then(|id| id.top_level.clone());
                                 attach_request_cookies(&mut req, identity.as_ref()).await;
+
+                                // Policy for what a page loads, decided from the tab's own
+                                // document - never from anything the requester sent. A
+                                // subresource of a public document may not reach the private
+                                // network, and its cross-origin bytes pass through ORB.
+                                let refuse_private = subresource
+                                    && match &document {
+                                        Some(top) => address_space.classify(top).await == AddressSpace::Public,
+                                        None => true,
+                                    };
 
                                 // The reply is intercepted so `Set-Cookie` is stored on this
                                 // side too; the requester still receives the untouched result.
@@ -478,12 +579,21 @@ pub fn spawn_io_thread(cfg: FetcherConfig, engine_ctx: Arc<EngineContext>) -> Io
                                     Some(id) => store_response_cookies_then_forward(id, reply_tx),
                                     None => reply_tx,
                                 };
+                                let reply_tx = match (subresource, document) {
+                                    (true, Some(top)) => block_opaque_responses_then_forward(top, reply_tx),
+                                    _ => reply_tx,
+                                };
 
-                                match (net, fetcher) {
-                                    (Some(net), _) => {
-                                        dispatch_to_net_process(net, req, handle.cancel.clone(), reply_tx)
-                                    }
-                                    (None, Some(fetcher)) => {
+                                match (net, fetchers) {
+                                    (Some(net), _) => dispatch_to_net_process(
+                                        net,
+                                        req,
+                                        refuse_private,
+                                        handle.cancel.clone(),
+                                        reply_tx,
+                                    ),
+                                    (None, Some((lenient, strict))) => {
+                                        let fetcher = if refuse_private { strict } else { lenient };
                                         fetcher.submit(req, handle.cancel.clone(), reply_tx).await;
                                     }
                                     (None, None) => {}
@@ -699,7 +809,7 @@ mod tests {
         let router = IoRouter::new(cfg, ctx);
         let z = ZoneId::new();
 
-        let f = router.get_or_spawn_zone_fetcher(z).unwrap();
+        let f = router.get_or_spawn_zone_fetcher(z, false).unwrap();
         assert!(Arc::strong_count(&f) >= 1, "fetcher Arc should be alive");
 
         let stopped = router.shutdown_zone(z).await;
@@ -716,13 +826,13 @@ mod tests {
         let z1 = ZoneId::new();
         let z2 = ZoneId::new();
 
-        let _f1 = router.get_or_spawn_zone_fetcher(z1).unwrap();
-        let f2 = router.get_or_spawn_zone_fetcher(z2).unwrap();
+        let _f1 = router.get_or_spawn_zone_fetcher(z1, false).unwrap();
+        let f2 = router.get_or_spawn_zone_fetcher(z2, false).unwrap();
 
         let stopped = router.shutdown_zone(z1).await;
         assert!(stopped, "z1 should have been stopped");
 
-        let f2_again = router.get_or_spawn_zone_fetcher(z2).unwrap();
+        let f2_again = router.get_or_spawn_zone_fetcher(z2, false).unwrap();
         assert!(Arc::ptr_eq(&f2, &f2_again), "z2 fetcher must remain the same instance");
 
         // Clean up remaining zones to avoid leaking tasks in test

--- a/crates/gosub_engine/src/net/orb.rs
+++ b/crates/gosub_engine/src/net/orb.rs
@@ -1,0 +1,284 @@
+//! Opaque Response Blocking: which response bodies may enter a renderer.
+//!
+//! Process isolation puts a site's rendering in its own process so that a bug
+//! (or a Spectre gadget) there can only read that process's memory. That is
+//! worth something only if cross-origin secrets never get *into* that memory.
+//! Pages load cross-origin subresources constantly - images, scripts,
+//! stylesheets, fonts - so the network layer cannot refuse them; ORB is the line
+//! it draws instead, decided here in the broker before bytes are handed on:
+//!
+//! - **Same-origin** bodies are the page's own.
+//! - Cross-origin bodies of **embeddable** types (images, media, CSS, scripts,
+//!   fonts) are delivered: the renderer can paint or run them, and the engine
+//!   gives it no way to read them back as data.
+//! - Cross-origin bodies that are **data** - HTML, JSON, XML - or that sniff as
+//!   such never leave the broker. A cross-origin `secret.json` pulled in through
+//!   `<img src>` is exactly how a compromised renderer would try to read another
+//!   origin's data.
+//!
+//! The decision follows the shape of the WHATWG ORB algorithm: MIME type first,
+//! then a sniff of the body's first bytes for the unknown cases, with an image
+//! sniff as the escape hatch for mislabelled images (common in the wild).
+//! There is no CORS input yet: every subresource the engine issues today is a
+//! no-cors load; `fetch()` will add the CORS-approved branch.
+
+/// What may happen to a cross-origin response body.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrbVerdict {
+    Allow,
+    /// Withhold the body; the reason names what was recognised.
+    Block(&'static str),
+}
+
+/// Bytes of the body the sniff looks at.
+const SNIFF_LEN: usize = 1024;
+
+/// Decide for one response. `same_origin` compares the requesting document's
+/// origin with the response's final (post-redirect) URL; `content_type` is the
+/// raw header value; `nosniff` is `X-Content-Type-Options: nosniff`; `body` is
+/// the start of the body (only its first [`SNIFF_LEN`] bytes are examined).
+pub fn verdict(same_origin: bool, content_type: Option<&str>, nosniff: bool, status: u16, body: &[u8]) -> OrbVerdict {
+    if same_origin {
+        return OrbVerdict::Allow;
+    }
+    let essence = content_type.map(essence_of).unwrap_or_default();
+    let body = &body[..body.len().min(SNIFF_LEN)];
+
+    if is_opaque_safelisted(&essence) {
+        return OrbVerdict::Allow;
+    }
+    if is_blocklisted(&essence) {
+        return OrbVerdict::Block("cross-origin data type");
+    }
+    if nosniff && essence == "text/plain" {
+        return OrbVerdict::Block("cross-origin text/plain with nosniff");
+    }
+    if !(200..300).contains(&status) {
+        return OrbVerdict::Block("cross-origin error response");
+    }
+    if sniffs_as_image(body) {
+        return OrbVerdict::Allow;
+    }
+    if sniffs_as_html(body) {
+        return OrbVerdict::Block("cross-origin body sniffs as HTML");
+    }
+    if sniffs_as_xml(body) {
+        return OrbVerdict::Block("cross-origin body sniffs as XML");
+    }
+    if sniffs_as_json(body) {
+        return OrbVerdict::Block("cross-origin body sniffs as JSON");
+    }
+    OrbVerdict::Allow
+}
+
+/// `type/subtype`, lowercased, parameters dropped.
+fn essence_of(content_type: &str) -> String {
+    use cow_utils::CowUtils;
+    content_type
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .cow_to_ascii_lowercase()
+        .into_owned()
+}
+
+/// Types a page may embed cross-origin without CORS.
+fn is_opaque_safelisted(essence: &str) -> bool {
+    if essence.starts_with("image/")
+        || essence.starts_with("video/")
+        || essence.starts_with("audio/")
+        || essence.starts_with("font/")
+    {
+        return true;
+    }
+    matches!(
+        essence,
+        "text/css"
+            | "text/javascript"
+            | "application/javascript"
+            | "application/x-javascript"
+            | "application/ecmascript"
+            | "text/ecmascript"
+            | "application/wasm"
+            | "text/vtt"
+            | "application/ogg"
+            | "application/x-font-ttf"
+            | "application/x-font-otf"
+            | "application/x-font-woff"
+            | "application/font-woff"
+            | "application/font-woff2"
+            | "application/vnd.ms-fontobject"
+            | "application/octet-stream"
+    )
+}
+
+/// Types that are data by declaration: never sniffed, never delivered.
+fn is_blocklisted(essence: &str) -> bool {
+    matches!(
+        essence,
+        "text/html" | "text/xml" | "application/xml" | "application/json" | "text/json"
+    ) || essence.ends_with("+xml")
+        || essence.ends_with("+json")
+}
+
+fn sniffs_as_image(body: &[u8]) -> bool {
+    body.starts_with(b"\x89PNG\r\n\x1a\n")
+        || body.starts_with(b"\xff\xd8\xff")
+        || body.starts_with(b"GIF87a")
+        || body.starts_with(b"GIF89a")
+        || (body.len() >= 12 && &body[..4] == b"RIFF" && &body[8..12] == b"WEBP")
+        || body.starts_with(b"BM")
+        || body.starts_with(b"\x00\x00\x01\x00")
+        || body.starts_with(b"<svg")
+}
+
+fn leading_text(body: &[u8]) -> &[u8] {
+    let start = body
+        .iter()
+        .position(|b| !matches!(b, b' ' | b'\t' | b'\n' | b'\r' | 0x0c))
+        .unwrap_or(body.len());
+    let body = &body[start..];
+    body.strip_prefix(b"\xef\xbb\xbf").unwrap_or(body)
+}
+
+fn sniffs_as_html(body: &[u8]) -> bool {
+    let text = leading_text(body);
+    if !text.starts_with(b"<") {
+        return false;
+    }
+    let tag: String = text[1..]
+        .iter()
+        .take(12)
+        .take_while(|b| b.is_ascii_alphabetic() || **b == b'!')
+        .map(|b| b.to_ascii_lowercase() as char)
+        .collect();
+    matches!(
+        tag.as_str(),
+        "!doctype"
+            | "html"
+            | "head"
+            | "body"
+            | "script"
+            | "iframe"
+            | "title"
+            | "meta"
+            | "link"
+            | "style"
+            | "div"
+            | "p"
+            | "table"
+            | "a"
+            | "!--"
+    )
+}
+
+fn sniffs_as_xml(body: &[u8]) -> bool {
+    leading_text(body).starts_with(b"<?xml")
+}
+
+fn sniffs_as_json(body: &[u8]) -> bool {
+    let text = leading_text(body);
+    // The anti-hijacking prefix some APIs emit, or an object/array opener.
+    text.starts_with(b")]}'") || text.starts_with(b"{") || text.starts_with(b"[")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PNG: &[u8] = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR";
+
+    #[test]
+    fn same_origin_is_always_delivered() {
+        for (ct, body) in [
+            (Some("application/json"), b"{\"secret\":1}".as_slice()),
+            (Some("text/html"), b"<!doctype html>".as_slice()),
+            (None, b"anything".as_slice()),
+        ] {
+            assert_eq!(verdict(true, ct, false, 200, body), OrbVerdict::Allow);
+        }
+    }
+
+    #[test]
+    fn cross_origin_data_types_are_blocked() {
+        for ct in [
+            "text/html",
+            "text/html; charset=utf-8",
+            "application/json",
+            "application/ld+json",
+            "text/xml",
+            "application/xml",
+        ] {
+            assert!(
+                matches!(verdict(false, Some(ct), false, 200, b"..."), OrbVerdict::Block(_)),
+                "{ct}"
+            );
+        }
+    }
+
+    #[test]
+    fn cross_origin_embeddable_types_are_delivered() {
+        for ct in [
+            "image/png",
+            "image/jpeg",
+            "text/css",
+            "application/javascript",
+            "text/javascript; charset=utf-8",
+            "font/woff2",
+            "application/font-woff",
+            "video/mp4",
+            "application/octet-stream",
+            // SVG is an image: safelisted despite the +xml suffix.
+            "image/svg+xml",
+        ] {
+            assert_eq!(
+                verdict(false, Some(ct), false, 200, b"<!doctype html>"),
+                OrbVerdict::Allow,
+                "{ct}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_types_are_sniffed() {
+        // A mislabelled image is still an image.
+        assert_eq!(verdict(false, Some("text/plain"), false, 200, PNG), OrbVerdict::Allow);
+        assert_eq!(verdict(false, None, false, 200, PNG), OrbVerdict::Allow);
+        // Data hiding behind an unknown or absent type is caught by its shape.
+        for body in [
+            b"<!DOCTYPE html><html>".as_slice(),
+            b"\n\n  <html lang=en>".as_slice(),
+            b"<?xml version=\"1.0\"?>".as_slice(),
+            b" {\"token\": \"x\"}".as_slice(),
+            b")]}'\n{}".as_slice(),
+            b"[1,2,3]".as_slice(),
+        ] {
+            assert!(matches!(verdict(false, None, false, 200, body), OrbVerdict::Block(_)));
+            assert!(matches!(
+                verdict(false, Some("text/plain"), false, 200, body),
+                OrbVerdict::Block(_)
+            ));
+        }
+        // Plain text that is none of those passes.
+        assert_eq!(
+            verdict(false, Some("text/plain"), false, 200, b"hello world"),
+            OrbVerdict::Allow
+        );
+        assert_eq!(verdict(false, None, false, 200, b"\x00\x01binary"), OrbVerdict::Allow);
+    }
+
+    #[test]
+    fn nosniff_and_errors_are_blocked_cross_origin() {
+        assert!(matches!(
+            verdict(false, Some("text/plain"), true, 200, b"hello"),
+            OrbVerdict::Block(_)
+        ));
+        assert!(matches!(
+            verdict(false, None, false, 404, b"nope"),
+            OrbVerdict::Block(_)
+        ));
+        // ...but a safelisted type survives both.
+        assert_eq!(verdict(false, Some("image/png"), true, 404, b""), OrbVerdict::Allow);
+    }
+}

--- a/crates/gosub_engine/src/net/process/child.rs
+++ b/crates/gosub_engine/src/net/process/child.rs
@@ -58,19 +58,30 @@ pub fn serve(link: Endpoint) -> i32 {
     // resolve against - this process holds no tab map, no jar, no event bus - so
     // progress reporting stays the broker's job. `cookies_for` in particular must
     // stay silent: answering it would mean this process kept a jar.
-    let fetcher = match Fetcher::new(FetcherConfig::default(), Arc::new(NetProcessContext)) {
-        Ok(f) => Arc::new(f),
-        Err(e) => {
+    let build = |refuse_private: bool| {
+        let cfg = if refuse_private {
+            crate::net::fetcher::strict_config(&FetcherConfig::default())
+        } else {
+            FetcherConfig::default()
+        };
+        Fetcher::new(cfg, Arc::new(NetProcessContext { refuse_private })).map(Arc::new)
+    };
+    // Two fetchers: one that may reach anything the user navigates to, and a
+    // strict one for subresources of public documents (see `net::ssrf`); the
+    // broker says which serves a request.
+    let (fetcher, strict) = match (build(false), build(true)) {
+        (Ok(f), Ok(s)) => (f, s),
+        (Err(e), _) | (_, Err(e)) => {
             eprintln!("[net] could not build the fetcher: {e}");
             return 1;
         }
     };
 
     let shutdown = CancellationToken::new();
-    let fetcher_run = fetcher.clone();
+    let (fetcher_run, strict_run) = (fetcher.clone(), strict.clone());
     let cancel = shutdown.clone();
     runtime.spawn(async move {
-        fetcher_run.run(cancel).await;
+        tokio::join!(fetcher_run.run(cancel.clone()), strict_run.run(cancel));
     });
 
     // Requests run concurrently: each Fetch is spawned onto the runtime and
@@ -104,7 +115,11 @@ pub fn serve(link: Endpoint) -> i32 {
                 let tag = fetch.tag;
                 let token = CancellationToken::new();
                 cancels.lock().insert(tag, token.clone());
-                let fetcher = fetcher.clone();
+                let fetcher = if fetch.refuse_private {
+                    strict.clone()
+                } else {
+                    fetcher.clone()
+                };
                 let link_tx = link_tx.clone();
                 let cancels = cancels.clone();
                 let handle = runtime.spawn(async move {
@@ -136,8 +151,11 @@ pub fn serve(link: Endpoint) -> i32 {
 }
 
 /// The network process has no engine around it: no events, no cookies (the
-/// broker attaches those).
-struct NetProcessContext;
+/// broker attaches those). What it does enforce is the per-hop URL policy of
+/// its strict fetcher.
+struct NetProcessContext {
+    refuse_private: bool,
+}
 
 impl gosub_sonar::net::fetcher_context::FetcherContext for NetProcessContext {
     fn observer_for(
@@ -151,8 +169,17 @@ impl gosub_sonar::net::fetcher_context::FetcherContext for NetProcessContext {
     }
     fn on_ref_active(&self, _: gosub_sonar::RequestReference) {}
     fn on_ref_done(&self, _: gosub_sonar::RequestReference) {}
-    fn is_url_allowed(&self, _url: &Url) -> bool {
-        true
+    fn is_url_allowed(&self, url: &Url) -> bool {
+        if !self.refuse_private {
+            return true;
+        }
+        match crate::net::ssrf::literal_verdict(url) {
+            Some(reason) => {
+                eprintln!("[net] blocked {url}: {reason}");
+                false
+            }
+            None => true,
+        }
     }
 }
 

--- a/crates/gosub_engine/src/net/process/client.rs
+++ b/crates/gosub_engine/src/net/process/client.rs
@@ -18,6 +18,9 @@ pub struct Outbound {
     pub method: String,
     pub headers: Vec<(String, String)>,
     pub body: Option<Vec<u8>>,
+    /// Serve through the strict fetcher: a subresource of a public document
+    /// may not reach the private network (see `net::ssrf`).
+    pub refuse_private: bool,
 }
 
 impl Outbound {
@@ -28,6 +31,7 @@ impl Outbound {
             method: "GET".into(),
             headers: Vec::new(),
             body: None,
+            refuse_private: false,
         }
     }
 }
@@ -198,6 +202,7 @@ impl NetProcess {
             method,
             headers,
             body,
+            refuse_private,
         } = out;
         let permit = tokio::select! {
             _ = cancel.cancelled() => return NetReply::error("cancelled"),
@@ -218,6 +223,7 @@ impl NetProcess {
             method,
             headers,
             body,
+            refuse_private,
         });
         // The link write can block on a full pipe (bodies can be large), so it
         // runs on a blocking thread rather than a runtime worker.

--- a/crates/gosub_engine/src/net/process/protocol.rs
+++ b/crates/gosub_engine/src/net/process/protocol.rs
@@ -35,6 +35,10 @@ pub struct NetFetch {
     /// the PoC's `vault` component.
     pub headers: Vec<(String, String)>,
     pub body: Option<Vec<u8>>,
+    /// A subresource of a public document: served by the strict fetcher, which
+    /// refuses private-network destinations at every hop (`net::ssrf`). The
+    /// broker decides this from the tab's document, never the requester.
+    pub refuse_private: bool,
     // Only these cross. `FetchRequest::origin` / `referrer` / `mixed_content`
     // (sonar 0.2.0) do not: the engine sets none of them yet. When it does, add
     // them here - otherwise the network process rebuilds the request without

--- a/crates/gosub_engine/src/net/ssrf.rs
+++ b/crates/gosub_engine/src/net/ssrf.rs
@@ -1,0 +1,418 @@
+//! Private-network protection: which destinations a page may make the engine
+//! connect to.
+//!
+//! A page from the public internet must not be able to use the browser as a
+//! foothold into the network it runs on - `http://169.254.169.254/` (cloud
+//! metadata), `http://10.0.0.5/admin`, `http://localhost:9200/` - through an
+//! `<img>`, a stylesheet or a script tag. That is the classic SSRF shape, made
+//! worse by process isolation: the network process is the one component allowed
+//! to open sockets, so it is exactly where a compromised renderer would aim.
+//!
+//! The policy is the one browsers converge on (Private Network Access): a
+//! *subresource* request from a **public** document may not reach a **private**
+//! address. Navigations are never restricted - the user typing `localhost` is
+//! not an attack - and a document that itself came from the private network may
+//! load its own neighbours.
+//!
+//! ## Deciding and connecting are one step
+//!
+//! "Is this URL allowed?" cannot be made safe for hostnames on its own: the
+//! caller still connects, connecting resolves the name again, and the attacker
+//! controls the second answer (DNS rebinding). So the decision is not a
+//! pre-check but a property of the *connection*: a strict fetcher resolves
+//! through [`StrictResolver`], which classifies every answer and refuses the
+//! name if any is private, and gosub-sonar looks names up per connection and
+//! per redirect hop through that resolver alone. There is no second lookup to
+//! poison. IP literals never reach a resolver; [`literal_verdict`] classifies
+//! them per hop through the fetcher's URL policy.
+//!
+//! The classification is deliberately wide: every range a renderer must never
+//! reach, plus the alternate IPv4 spellings (`2130706433`, `0x7f000001`,
+//! `127.1`) and IPv6 embeddings (NAT64, 6to4, IPv4-mapped) that naive filters
+//! miss.
+
+use gosub_sonar::{DnsError, DnsResolver, Resolving};
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::time::{Duration, Instant};
+use url::Url;
+
+/// How long a hostname's classification is remembered. Long enough that the
+/// document's own address space is not re-resolved for every subresource;
+/// short enough that a legitimately re-addressed host recovers.
+const CLASSIFICATION_TTL: Duration = Duration::from_secs(300);
+
+/// Classify an IP against the ranges that must never be reachable from a
+/// public page. Returns the category name, or `None` if the address is public.
+pub fn blocked_ip_reason(ip: IpAddr) -> Option<&'static str> {
+    match ip {
+        IpAddr::V4(v4) => blocked_v4(v4),
+        IpAddr::V6(v6) => {
+            // An IPv4-mapped address (::ffff:a.b.c.d) reaches an IPv4 host.
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return blocked_v4(v4);
+            }
+            let seg = v6.segments();
+            if v6.is_loopback() {
+                Some("IPv6 loopback (::1)")
+            } else if v6.is_unspecified() {
+                Some("IPv6 unspecified (::)")
+            } else if seg[0] & 0xfe00 == 0xfc00 {
+                Some("IPv6 unique-local (fc00::/7)")
+            } else if seg[0] & 0xffc0 == 0xfe80 {
+                Some("IPv6 link-local (fe80::/10)")
+            } else if v6.is_multicast() {
+                Some("IPv6 multicast")
+            } else if seg[0] == 0x64 && seg[1] == 0xff9b && seg[2..6] == [0, 0, 0, 0] {
+                // NAT64 (64:ff9b::/96): what gets reached is the embedded IPv4.
+                blocked_v4(embedded_v4(seg))
+            } else if seg[..6] == [0, 0, 0, 0, 0, 0] {
+                // Deprecated IPv4-compatible (::a.b.c.d): same reach as the
+                // embedded IPv4 on stacks that still honor it.
+                blocked_v4(embedded_v4(seg))
+            } else if seg[0] == 0x2002 {
+                // 6to4 (2002:AABB:CCDD::): the IPv4 sits in the next 32 bits.
+                let v4 = Ipv4Addr::new((seg[1] >> 8) as u8, seg[1] as u8, (seg[2] >> 8) as u8, seg[2] as u8);
+                blocked_v4(v4)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// The IPv4 address in the low 32 bits of an IPv6 address (NAT64 and
+/// IPv4-compatible embeddings).
+fn embedded_v4(seg: [u16; 8]) -> Ipv4Addr {
+    Ipv4Addr::new((seg[6] >> 8) as u8, seg[6] as u8, (seg[7] >> 8) as u8, seg[7] as u8)
+}
+
+fn blocked_v4(v4: Ipv4Addr) -> Option<&'static str> {
+    let o = v4.octets();
+    if v4.is_loopback() {
+        Some("loopback (127.0.0.0/8)")
+    } else if v4.is_private() {
+        Some("private (10/8, 172.16/12, 192.168/16)")
+    } else if v4.is_link_local() {
+        Some("link-local 169.254.0.0/16 (cloud metadata)")
+    } else if v4.is_unspecified() || o[0] == 0 {
+        Some("\"this host\" (0.0.0.0/8)")
+    } else if v4.is_broadcast() {
+        Some("broadcast (255.255.255.255)")
+    } else if o[0] == 100 && o[1] & 0xc0 == 64 {
+        Some("shared/CGNAT (100.64.0.0/10)")
+    } else if v4.is_multicast() {
+        Some("IPv4 multicast (224.0.0.0/4)")
+    } else if o[0] >= 240 {
+        Some("reserved class E (240.0.0.0/4)")
+    } else if o[0] == 192 && o[1] == 0 && o[2] == 0 {
+        Some("IETF protocol assignments (192.0.0.0/24)")
+    } else if o[0] == 192 && o[1] == 88 && o[2] == 99 {
+        Some("6to4 relay anycast (192.88.99.0/24)")
+    } else if o[0] == 198 && o[1] & 0xfe == 18 {
+        Some("benchmarking (198.18.0.0/15)")
+    } else if (o[0] == 192 && o[1] == 0 && o[2] == 2)
+        || (o[0] == 198 && o[1] == 51 && o[2] == 100)
+        || (o[0] == 203 && o[1] == 0 && o[2] == 113)
+    {
+        Some("documentation TEST-NET (192.0.2/24, 198.51.100/24, 203.0.113/24)")
+    } else {
+        None
+    }
+    // Deliberately NOT blocked: subnet-directed broadcast (x.y.z.255) - which
+    // addresses are broadcasts depends on the local netmask, and refusing
+    // every .255 would break legitimate public hosts.
+}
+
+/// Parse a host as an IP literal, accepting the alternate IPv4 encodings that
+/// `inet_aton(3)` and browsers accept (a single decimal/octal/hex number, or
+/// fewer than four dotted parts) - the encodings SSRF filters classically miss.
+pub fn parse_ip_literal(host: &str) -> Option<IpAddr> {
+    let host = host.strip_prefix('[').and_then(|h| h.strip_suffix(']')).unwrap_or(host);
+    // Strip an IPv6 zone id (`fe80::1%eth0`, or percent-encoded `%25eth0`) so a
+    // scoped link-local literal is classified numerically.
+    let host = host.split('%').next().unwrap_or(host);
+    let host = host.trim_end_matches('.');
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return Some(ip);
+    }
+    parse_ipv4_inet_aton(host).map(IpAddr::V4)
+}
+
+fn parse_ipv4_inet_aton(host: &str) -> Option<Ipv4Addr> {
+    let parts: Vec<u32> = host.split('.').map(parse_c_integer).collect::<Option<_>>()?;
+    // 1-4 parts; the final part fills all remaining low-order bytes.
+    let value: u32 = match parts.as_slice() {
+        [a] => *a,
+        [a, b] if *a <= 0xff && *b <= 0x00ff_ffff => (a << 24) | b,
+        [a, b, c] if *a <= 0xff && *b <= 0xff && *c <= 0xffff => (a << 24) | (b << 16) | c,
+        [a, b, c, d] if [a, b, c, d].iter().all(|&&x| x <= 0xff) => (a << 24) | (b << 16) | (c << 8) | d,
+        _ => return None,
+    };
+    Some(Ipv4Addr::from(value))
+}
+
+/// A C-style integer: `0x`/`0X` hex, a leading `0` octal, otherwise decimal.
+fn parse_c_integer(s: &str) -> Option<u32> {
+    if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        u32::from_str_radix(hex, 16).ok()
+    } else if s.len() > 1 && s.starts_with('0') {
+        u32::from_str_radix(&s[1..], 8).ok()
+    } else {
+        s.parse::<u32>().ok()
+    }
+}
+
+/// Why a URL with an IP-literal host may not be fetched by a strict fetcher,
+/// or `None` when it is a hostname (the resolver's business) or a public
+/// literal. This is the per-hop URL policy; it also refuses non-HTTP schemes,
+/// which a strict fetcher never has business with.
+pub fn literal_verdict(url: &Url) -> Option<String> {
+    if !matches!(url.scheme(), "http" | "https") {
+        return Some(format!("scheme {}:// is not allowed for a subresource", url.scheme()));
+    }
+    let host = url.host_str()?;
+    let ip = parse_ip_literal(host)?;
+    blocked_ip_reason(ip).map(|category| format!("host {host} is {category} (private network policy)"))
+}
+
+/// Resolves through the system resolver and refuses any name with a private
+/// answer - the whole name, not just the offending address: which answer the
+/// OS would connect to is not this code's choice, so a name answering
+/// `[1.2.3.4, 127.0.0.1]` is one round-robin away from loopback.
+#[derive(Debug, Default)]
+pub struct StrictResolver;
+
+impl DnsResolver for StrictResolver {
+    fn resolve(&self, host: &str) -> Resolving {
+        let host = host.to_string();
+        Box::pin(async move {
+            let addrs = lookup(&host).await.map_err(|e| -> DnsError { e.into() })?;
+            if addrs.is_empty() {
+                return Err(format!("host {host} did not resolve").into());
+            }
+            for ip in &addrs {
+                if let Some(category) = blocked_ip_reason(*ip) {
+                    return Err(
+                        format!("host {host} resolves to {ip}, which is {category} (private network policy)").into(),
+                    );
+                }
+            }
+            Ok(addrs.into_iter().map(|ip| SocketAddr::new(ip, 0)).collect())
+        })
+    }
+}
+
+async fn lookup(host: &str) -> std::io::Result<Vec<IpAddr>> {
+    Ok(tokio::net::lookup_host((host, 0u16)).await?.map(|sa| sa.ip()).collect())
+}
+
+/// Where a URL's host lives, as the private-network policy sees it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AddressSpace {
+    Public,
+    /// Loopback, private, link-local, ... - anything in [`blocked_ip_reason`]'s
+    /// ranges. A name with one private answer is private.
+    Private,
+}
+
+/// Remembers which address space a host was classified into, so a document's
+/// own host is not resolved again for every subresource it loads.
+#[derive(Debug, Default)]
+pub struct AddressSpaceCache {
+    hosts: Mutex<HashMap<String, (Instant, AddressSpace)>>,
+}
+
+impl AddressSpaceCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The address space of `url`'s host. IP literals are classified directly;
+    /// names are resolved once (any private answer makes the name private) and
+    /// remembered. A name that does not resolve counts as public: the policy
+    /// then applies to what it loads, which is the safe direction.
+    pub async fn classify(&self, url: &Url) -> AddressSpace {
+        let Some(host) = url.host_str() else {
+            return AddressSpace::Public;
+        };
+        if let Some(ip) = parse_ip_literal(host) {
+            return space_of(std::iter::once(ip));
+        }
+        let key = cow_utils::CowUtils::cow_to_ascii_lowercase(host).into_owned();
+        if let Some((seen, space)) = self.hosts.lock().get(&key) {
+            if seen.elapsed() < CLASSIFICATION_TTL {
+                return *space;
+            }
+        }
+        let space = match lookup(&key).await {
+            Ok(addrs) => space_of(addrs.into_iter()),
+            Err(_) => AddressSpace::Public,
+        };
+        self.hosts.lock().insert(key, (Instant::now(), space));
+        space
+    }
+}
+
+fn space_of(mut addrs: impl Iterator<Item = IpAddr>) -> AddressSpace {
+    if addrs.any(|ip| blocked_ip_reason(ip).is_some()) {
+        AddressSpace::Private
+    } else {
+        AddressSpace::Public
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    fn url(s: &str) -> Url {
+        Url::parse(s).unwrap()
+    }
+
+    #[test]
+    fn blocks_internal_ranges_and_encoding_bypasses() {
+        for u in [
+            // Standard internal ranges (incl. 172.16/12).
+            "http://127.0.0.1/",
+            "http://10.0.0.5/",
+            "http://172.16.0.1/",
+            "http://172.31.255.9/",
+            "http://192.168.1.1/",
+            "http://169.254.169.254/",
+            "http://0.0.0.0/",
+            "http://100.64.0.1/",
+            "http://255.255.255.255/",
+            // Alternate IPv4 encodings for 127.0.0.1 (the URL parser normalizes
+            // these to dotted quads; the literal parser handles them raw too).
+            "http://2130706433/",
+            "http://0x7f000001/",
+            "http://017700000001/",
+            "http://127.1/",
+            // IPv6 internal, IPv4-mapped, scoped.
+            "http://[::1]/",
+            "http://[::ffff:169.254.169.254]/",
+            "http://[fc00::1]/",
+            "http://[fe80::1]/",
+            // Multicast, class E, and the special-purpose IPv4 registry blocks.
+            "http://224.0.0.1/",
+            "http://239.255.255.250/",
+            "http://240.0.0.1/",
+            "http://192.0.0.5/",
+            "http://192.88.99.1/",
+            "http://198.18.0.1/",
+            "http://198.19.255.1/",
+            "http://192.0.2.1/",
+            "http://198.51.100.7/",
+            "http://203.0.113.9/",
+            // IPv6 embeddings that reach internal IPv4: NAT64, IPv4-compatible, 6to4.
+            "http://[64:ff9b::7f00:1]/",
+            "http://[64:ff9b::a00:1]/",
+            "http://[::127.0.0.1]/",
+            "http://[2002:c0a8:0101::]/",
+            "http://[2002:7f00:0001::]/",
+            // Parser confusion: userinfo and trailing dot.
+            "http://real.com@127.0.0.1/",
+            "http://127.0.0.1.:80/",
+            // Non-HTTP schemes are refused outright, whatever the host.
+            "ftp://127.0.0.1/",
+        ] {
+            let verdict = literal_verdict(&url(u));
+            assert!(verdict.is_some(), "should block {u}");
+        }
+    }
+
+    #[test]
+    fn allows_public_addresses_and_hostnames() {
+        for u in [
+            "http://93.184.216.34/",
+            "http://example.com/",
+            "http://8.8.8.8/",
+            "http://172.32.0.1/",    // just outside 172.16/12
+            "http://100.128.0.1/",   // just outside 100.64/10
+            "http://223.255.255.1/", // just below multicast
+            "http://198.20.0.1/",    // just outside benchmarking 198.18/15
+            "http://[2606:2800:220:1::1]/",
+            "http://[64:ff9b::808:808]/",  // NAT64 embedding a public v4 (8.8.8.8)
+            "http://[2002:5db8:d822::1]/", // 6to4 embedding a public v4
+        ] {
+            assert_eq!(literal_verdict(&url(u)), None, "should allow {u}");
+        }
+    }
+
+    #[test]
+    fn alternate_ipv4_encodings_parse_to_loopback() {
+        let loopback = ip("127.0.0.1");
+        for h in [
+            "2130706433",
+            "0x7f000001",
+            "017700000001",
+            "127.1",
+            "[::ffff:127.0.0.1]",
+        ] {
+            let parsed = parse_ip_literal(h).map(|ip| match ip {
+                IpAddr::V6(v6) => v6.to_ipv4_mapped().map_or(ip, IpAddr::V4),
+                v4 => v4,
+            });
+            assert_eq!(parsed, Some(loopback), "{h}");
+        }
+        assert_eq!(parse_ip_literal("example.com"), None);
+        assert_eq!(
+            parse_ip_literal("[fe80::1%25eth0]").map(|ip| blocked_ip_reason(ip).is_some()),
+            Some(true)
+        );
+    }
+
+    #[tokio::test]
+    async fn literals_classify_without_resolving() {
+        let cache = AddressSpaceCache::new();
+        assert_eq!(cache.classify(&url("http://10.1.2.3/")).await, AddressSpace::Private);
+        assert_eq!(cache.classify(&url("http://[::1]:8080/")).await, AddressSpace::Private);
+        assert_eq!(
+            cache.classify(&url("http://93.184.216.34/")).await,
+            AddressSpace::Public
+        );
+    }
+
+    #[tokio::test]
+    async fn loopback_names_are_private_and_strictly_refused() {
+        // `localhost` resolves without any network; the system answers loopback.
+        let cache = AddressSpaceCache::new();
+        assert_eq!(cache.classify(&url("http://localhost/")).await, AddressSpace::Private);
+        let err = StrictResolver
+            .resolve("localhost")
+            .await
+            .expect_err("loopback must be refused");
+        assert!(err.to_string().contains("private network policy"), "{err}");
+    }
+
+    /// Deterministic stand-in for a fuzz target: the literal parser must classify
+    /// or reject any string without panicking - a parser panic in the one
+    /// process allowed to open sockets is itself a bug.
+    #[test]
+    fn literal_parsing_never_panics_on_arbitrary_hosts() {
+        let alpha = b"[]%:.0123456789abcdefABCDEFxX-";
+        let mut s = 0xdead_beef_cafe_babeu64;
+        for _ in 0..50_000 {
+            let len = (xorshift(&mut s) % 40) as usize;
+            let host: String = (0..len)
+                .map(|_| alpha[(xorshift(&mut s) as usize) % alpha.len()] as char)
+                .collect();
+            let _ = parse_ip_literal(&host);
+        }
+    }
+
+    fn xorshift(s: &mut u64) -> u64 {
+        let mut x = *s;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        *s = x;
+        x
+    }
+}


### PR DESCRIPTION

Base: `08-resident-renderers` (depends only on the network process).

### What is in here

- **Private-network protection** (`net::ssrf`): IP classification (loopback,
  private, link-local/metadata, CGNAT, multicast, class E, the special-purpose
  IPv4 blocks; NAT64/6to4/IPv4-mapped IPv6 embeddings; `inet_aton` spellings)
  with Private Network Access semantics: a subresource of a *public* document
  may not reach a private address; navigations are never restricted.
  Decide-and-connect in one step through gosub-sonar's `DnsResolver` seam: a
  **strict fetcher** per zone (and a second one in the network process,
  selected by `NetFetch.refuse_private`) whose resolver fails closed on any
  private answer, plus `is_url_allowed` per redirect hop for IP literals. The
  document's address space is classified once and cached.
- **Opaque-response blocking** (`net::orb`): spec-shaped decision (opaque
  safelist → blocklist → nosniff/status → image/HTML/XML/JSON sniff of the
  first bytes), applied to the reply of every non-navigation request with a
  known document: cross-origin HTML/JSON/XML never leaves the broker; the
  requester gets an error naming the reason. `BrokeredLoader` requests are
  classed `Asset`/`Application` so renderer-side loads are covered.
- The policy is decided in the per-request `io-fetch` task from the tab's own
  document, never from anything the requester sent.

### Testing

```
cargo test -p gosub_engine --lib net::          # ssrf + orb unit tests
./target/debug/isolation-harness resolve         # the strict fetcher refuses loopback at the hop
```

### Deliberate limits

No CORS input yet: every load the engine issues is a no-cors subresource load,
so the CORS-approved ORB branch waits for `fetch()`. Neither policy is a
setting; a blocked load shows up as a failed resource.