### PR TITLE
Network process: streamed bodies cross the boundary through the shared-memory ring

### DIFF
--- a/crates/gosub_engine/src/bin/isolation-harness.rs
+++ b/crates/gosub_engine/src/bin/isolation-harness.rs
@@ -138,6 +138,7 @@ fn main() {
         "engine-renderer-slow-image" => with_font_backend!(engine_renderer_slow_image),
         "renderer-soak" => with_font_backend!(renderer_soak),
         "engine-soak" => with_font_backend!(engine_soak),
+        "stream" => stream(),
         "engine" => engine(),
         "guard" => guard(),
         other => {
@@ -241,7 +242,7 @@ fn resolve() -> i32 {
 
     // 1. A name that cannot exist (RFC 2606), through the permissive fetcher.
     match fetch("http://gosub-hostname-probe.invalid/".into(), false) {
-        FetchOutcome::Ok { status, .. } => {
+        FetchOutcome::Ok { status, .. } | FetchOutcome::Streaming { status, .. } => {
             eprintln!("a .invalid name must not resolve, got status {status}");
             net.shutdown();
             return 1;
@@ -251,7 +252,7 @@ fn resolve() -> i32 {
 
     // 2. The strict fetcher classifies the loopback literal at the hop.
     match fetch(format!("http://127.0.0.1:{port}/"), true) {
-        FetchOutcome::Ok { .. } => {
+        FetchOutcome::Ok { .. } | FetchOutcome::Streaming { .. } => {
             eprintln!("the strict fetcher reached loopback");
             net.shutdown();
             return 1;
@@ -3164,6 +3165,103 @@ fn decode_garbage() -> i32 {
     }
 }
 
+/// A deterministic body larger than the ring window, so a stream wraps the
+/// ring several times and every byte's position is checkable.
+fn streamed_body() -> Vec<u8> {
+    (0..(1024 * 1024 + 12345usize))
+        .map(|i| (i.wrapping_mul(131) ^ (i >> 7)) as u8)
+        .collect()
+}
+
+/// A streamed body through the network process: the head comes back in-band,
+/// the ring fd right behind it, and the bytes arrive through the ring as the
+/// child produces them - the whole body never sits in a message.
+fn stream() -> i32 {
+    use gosub_engine::net::process::client::NetProcess;
+    use gosub_engine::net::process::protocol::FetchOutcome;
+
+    let expected = streamed_body();
+    let Ok((port, server)) = serve_once_bytes(expected.clone(), "application/octet-stream") else {
+        eprintln!("could not start the test server");
+        return 1;
+    };
+    let net = match NetProcess::spawn() {
+        Ok(n) => n,
+        Err(e) => {
+            eprintln!("could not spawn the network process: {e}");
+            return 1;
+        }
+    };
+    let Ok(runtime) = tokio::runtime::Builder::new_current_thread().enable_all().build() else {
+        eprintln!("could not start a runtime");
+        return 1;
+    };
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let out = gosub_engine::net::process::client::Outbound {
+        streaming: true,
+        ..gosub_engine::net::process::client::Outbound::get(format!("http://127.0.0.1:{port}/"))
+    };
+    let reply = runtime.block_on(net.fetch(out, &cancel));
+    let result = match reply.outcome {
+        FetchOutcome::Streaming { status, peek, .. } => {
+            let Some(ring) = reply.ring else {
+                eprintln!("streamed head arrived without its ring fd");
+                net.shutdown();
+                return 1;
+            };
+            #[cfg(target_os = "linux")]
+            {
+                let mut consumer = match gosub_ipc::ring::RingConsumer::open(ring) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("could not open the ring: {e}");
+                        net.shutdown();
+                        return 1;
+                    }
+                };
+                let mut body = peek.clone();
+                let mut buf = [0u8; 4096];
+                loop {
+                    match consumer.read(&mut buf) {
+                        Ok(0) => break,
+                        Ok(n) => body.extend_from_slice(&buf[..n]),
+                        Err(e) => {
+                            eprintln!("ring read failed: {e}");
+                            net.shutdown();
+                            return 1;
+                        }
+                    }
+                }
+                println!("streamed {} bytes ({} peeked), status {status}", body.len(), peek.len());
+                (status == 200 && body == expected).then_some(()).ok_or_else(|| {
+                    format!(
+                        "body did not survive the ring ({} of {} bytes)",
+                        body.len(),
+                        expected.len()
+                    )
+                })
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                let _ = (status, peek, ring);
+                let _ = ring;
+                Err("streaming is Linux-only".to_string())
+            }
+        }
+        FetchOutcome::Ok { .. } => Err("expected a streamed reply, got a buffered one".into()),
+        FetchOutcome::Error(e) => Err(format!("fetch failed: {e}")),
+    };
+    net.shutdown();
+    drop(server);
+    match result {
+        Ok(()) => 0,
+        Err(e) => {
+            eprintln!("{e}");
+            1
+        }
+    }
+}
+
 /// The transport on its own: does a request survive the round trip through a
 /// separate, sandboxed process and come back intact?
 fn direct() -> i32 {
@@ -3212,6 +3310,10 @@ fn direct() -> i32 {
                 return 1;
             }
             0
+        }
+        FetchOutcome::Streaming { .. } => {
+            eprintln!("a buffered request came back streamed");
+            1
         }
         FetchOutcome::Error(e) => {
             eprintln!("fetch through the network process failed: {e}");

--- a/crates/gosub_engine/src/engine/settings.json
+++ b/crates/gosub_engine/src/engine/settings.json
@@ -434,7 +434,7 @@
       "key": "network_process",
       "type": "b",
       "default": "b:true",
-      "description": "Run the network stack in a sandboxed child process. Needs the embedder to dispatch child roles; turned off at start when it cannot apply."
+      "description": "Run the network stack in a sandboxed child process. Needs the embedder to dispatch child roles; turned off at start when it cannot apply. Streamed bodies cross the process boundary through a shared-memory ring on Linux, and are buffered on other platforms."
     },
     {
       "key": "image_decoder_process",

--- a/crates/gosub_engine/src/net/io_runtime.rs
+++ b/crates/gosub_engine/src/net/io_runtime.rs
@@ -301,6 +301,7 @@ fn dispatch_to_net_process(
 
     let url = req.url.to_string();
     let method = req.method.as_str().to_string();
+    let streaming = req.streaming;
     // No in-process fetcher emits the terminal event that would drop this.
     let req_id = req.req_id;
     let mut headers: Vec<(String, String)> = req
@@ -340,6 +341,7 @@ fn dispatch_to_net_process(
             headers,
             body,
             refuse_private,
+            streaming,
         };
         let reply = net.fetch(out, &cancel).await;
         crate::net::req_ref_tracker::REF_REGISTRY.forget_request(req_id);

--- a/crates/gosub_engine/src/net/process/child.rs
+++ b/crates/gosub_engine/src/net/process/child.rs
@@ -1,5 +1,8 @@
 //! The network process: the only part of the engine that may open a socket.
 //!
+//! What only Linux can do - pass a ring fd for a streamed body - lives in
+//! `platform`; the same API elsewhere declines, so this file has no platform
+//! branches of its own.
 
 use crate::net::fetcher::{Fetcher, FetcherConfig};
 use crate::net::process::protocol::{FetchOutcome, FromNet, NetFetch, RequestTag, ToNet};
@@ -12,6 +15,15 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use url::Url;
+
+#[cfg(target_os = "linux")]
+#[path = "child/linux.rs"]
+mod platform;
+#[cfg(not(target_os = "linux"))]
+#[path = "child/portable.rs"]
+mod platform;
+
+use platform::Streamed;
 
 /// How long a shutdown drain waits for in-flight requests before giving up.
 /// Shorter than the broker's `SHUTDOWN_GRACE`, so a draining child exits on
@@ -123,11 +135,16 @@ pub fn serve(link: Endpoint) -> i32 {
                 let link_tx = link_tx.clone();
                 let cancels = cancels.clone();
                 let handle = runtime.spawn(async move {
-                    let outcome = perform(&fetcher, fetch, token).await;
+                    let performed = perform(&fetcher, fetch, token).await;
                     cancels.lock().remove(&tag);
                     // A write error means the broker went away; the recv loop
                     // notices the same and ends the process.
-                    let _ = link_tx.lock().send(&FromNet::Reply { tag, outcome });
+                    match performed {
+                        Performed::Done(outcome) => {
+                            let _ = link_tx.lock().send(&FromNet::Reply { tag, outcome });
+                        }
+                        Performed::Streaming(streamed) => streamed.deliver(tag, &link_tx).await,
+                    }
                 });
                 let mut tasks = tasks.lock();
                 tasks.retain(|h| !h.is_finished());
@@ -183,6 +200,13 @@ impl gosub_sonar::net::fetcher_context::FetcherContext for NetProcessContext {
     }
 }
 
+/// What `perform` produced: a reply that travels whole, or a response head
+/// whose body is still arriving and will follow it (see [`Streamed`]).
+enum Performed {
+    Done(FetchOutcome),
+    Streaming(Streamed),
+}
+
 fn flat_headers(headers: &http::HeaderMap) -> Vec<(String, String)> {
     headers
         .iter()
@@ -191,8 +215,9 @@ fn flat_headers(headers: &http::HeaderMap) -> Vec<(String, String)> {
 }
 
 /// Perform one request and flatten the result to something that can travel.
-async fn perform(fetcher: &Arc<Fetcher>, fetch: NetFetch, cancel: CancellationToken) -> FetchOutcome {
-    let done = |o: FetchOutcome| o;
+async fn perform(fetcher: &Arc<Fetcher>, fetch: NetFetch, cancel: CancellationToken) -> Performed {
+    let streaming = fetch.streaming && platform::STREAMING;
+    let done = Performed::Done;
     let url = match Url::parse(&fetch.url) {
         Ok(u) => u,
         Err(e) => return done(FetchOutcome::Error(format!("bad url {}: {e}", fetch.url))),
@@ -209,10 +234,9 @@ async fn perform(fetcher: &Arc<Fetcher>, fetch: NetFetch, cancel: CancellationTo
             headers.insert(name, value);
         }
     }
-
     let mut builder = FetchRequest::builder(method, url)
         .with_headers(headers)
-        .with_streaming(false)
+        .with_streaming(streaming)
         .with_auto_decode(true);
     if let Some(body) = fetch.body {
         // Plain bytes: the Content-Type already travelled in the headers.
@@ -235,8 +259,25 @@ async fn perform(fetcher: &Arc<Fetcher>, fetch: NetFetch, cancel: CancellationTo
             headers: flat_headers(&meta.headers),
             body: body.to_vec(),
         }),
-        // Never streamed: the request asked for a buffered body.
-        Ok(FetchResult::Stream { .. }) => done(FetchOutcome::Error("unexpected streamed body".into())),
+        Ok(FetchResult::Stream { meta, peek_buf, shared }) => {
+            // What `Content-Length` promises past the peek, when it says.
+            let expected = meta
+                .headers
+                .get(http::header::CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok()?.trim().parse::<u64>().ok())
+                .map(|len| len.saturating_sub(peek_buf.len() as u64));
+            let head = FetchOutcome::Streaming {
+                status: meta.status,
+                status_text: meta.status_text,
+                final_url: meta.final_url.to_string(),
+                headers: flat_headers(&meta.headers),
+                peek: peek_buf.as_ref().to_vec(),
+            };
+            match platform::begin_stream(head, expected, shared) {
+                Ok(streamed) => Performed::Streaming(streamed),
+                Err(e) => done(FetchOutcome::Error(format!("could not set up a body stream: {e}"))),
+            }
+        }
         Ok(FetchResult::Error(e)) => done(FetchOutcome::Error(e.to_string())),
         Err(_) => done(FetchOutcome::Error("the fetcher dropped the request".into())),
     }

--- a/crates/gosub_engine/src/net/process/child/linux.rs
+++ b/crates/gosub_engine/src/net/process/child/linux.rs
@@ -1,0 +1,203 @@
+//! Linux: a streamed body crosses to the broker through a shared-memory ring
+//! whose fd is passed on the link. The API here is what `super` calls;
+//! `portable.rs` is its stand-in.
+
+use crate::net::process::protocol::{FetchOutcome, FromNet, RequestTag};
+use gosub_ipc::EndpointTx;
+use gosub_sonar::net::shared_body::SharedBody;
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+/// Bodies may stream: the link carries the ring's fd.
+pub(super) const STREAMING: bool = true;
+
+/// Ring window for streamed bodies. Small on purpose: a large body wraps
+/// through it many times, and neither side ever holds more than this (plus one
+/// chunk) for the transport.
+const RING_CAPACITY: u32 = 256 * 1024;
+
+/// How many chunks the pump may fall behind the fetcher before the body drops
+/// it as a slow subscriber. The ring's backpressure stalls the pump whenever
+/// the broker is not draining; this queue absorbs that stall (16 KiB chunks:
+/// at most 16 MiB held) so backpressure costs memory here, never bytes.
+const PUMP_QUEUE: usize = 1024;
+
+type BodyChunks = futures_util::stream::BoxStream<'static, Result<bytes::Bytes, gosub_sonar::net::types::NetError>>;
+
+/// A response head whose body is still arriving: sent first, then the ring's
+/// fd, then the body pumped into the ring for as long as it lasts.
+pub(super) struct Streamed {
+    head: FetchOutcome,
+    ring: std::os::fd::OwnedFd,
+    producer: gosub_ipc::ring::RingProducer,
+    body: BodyPump,
+}
+
+/// The fetcher's side of a streamed body, as the pump needs it.
+struct BodyPump {
+    /// Subscribed the moment the response arrived: the body has no replay,
+    /// so a later subscription would miss its first chunks.
+    chunks: BodyChunks,
+    /// What `Content-Length` promises past the peek, when it says.
+    expected: Option<u64>,
+}
+
+/// Subscribe to the body - first thing, before anything can yield: the
+/// fetcher is already pushing chunks, and nobody replays them - and set up
+/// the ring it will be pumped into.
+pub(super) fn begin_stream(
+    head: FetchOutcome,
+    expected: Option<u64>,
+    shared: Arc<SharedBody>,
+) -> Result<Streamed, String> {
+    let chunks = shared.subscribe_with_cap(PUMP_QUEUE);
+    let (producer, ring) = gosub_ipc::ring::RingProducer::create(RING_CAPACITY).map_err(|e| e.to_string())?;
+    Ok(Streamed {
+        head,
+        ring,
+        producer,
+        body: BodyPump { chunks, expected },
+    })
+}
+
+impl Streamed {
+    /// Head and ring fd back to back, under one lock, so nothing else on the
+    /// link comes between them; then the body. A write error means the broker
+    /// went away, which the recv loop notices too.
+    pub(super) async fn deliver(self, tag: RequestTag, link_tx: &Arc<Mutex<EndpointTx>>) {
+        use std::os::fd::AsRawFd as _;
+        {
+            let mut tx = link_tx.lock();
+            if tx
+                .send(&FromNet::Reply {
+                    tag,
+                    outcome: self.head,
+                })
+                .is_err()
+                || tx.send_fd(self.ring.as_raw_fd()).is_err()
+            {
+                return;
+            }
+        }
+        drop(self.ring); // the broker holds its duplicate; the mapping keeps ours
+        pump(self.producer, self.body).await;
+    }
+}
+
+/// Move a body from the fetcher into the ring as it arrives. The producer's
+/// `write_all` blocks (bounded) when the ring is full - the backpressure that
+/// keeps this process from buffering - so it runs off the async worker. An
+/// error from the fetcher, or a consumer that stopped draining, abandons the
+/// stream: the producer drops unfinished and the consumer sees an abort.
+///
+/// A subscriber the body dropped for falling behind gets an error (sonar
+/// 0.4), which ends the pump without `finish`; the byte count against
+/// `Content-Length` is the second check: a truncated body must abort, never
+/// look complete.
+async fn pump(mut producer: gosub_ipc::ring::RingProducer, body: BodyPump) {
+    use futures_util::StreamExt as _;
+    let BodyPump { mut chunks, expected } = body;
+    let mut pumped = 0u64;
+    while let Some(chunk) = chunks.next().await {
+        let Ok(chunk) = chunk else {
+            return;
+        };
+        pumped += chunk.len() as u64;
+        if tokio::task::block_in_place(|| producer.write_all(&chunk)).is_err() {
+            return;
+        }
+    }
+    if expected.is_some_and(|expected| pumped != expected) {
+        eprintln!("[net] body stream fell behind the fetcher ({pumped} bytes pumped); aborting it");
+        return;
+    }
+    producer.finish();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn drain(ring: std::os::fd::OwnedFd) -> std::io::Result<Vec<u8>> {
+        let mut consumer = gosub_ipc::ring::RingConsumer::open(ring)?;
+        let mut out = Vec::new();
+        let mut buf = [0u8; 4096];
+        loop {
+            match consumer.read(&mut buf)? {
+                0 => return Ok(out),
+                n => out.extend_from_slice(&buf[..n]),
+            }
+        }
+    }
+
+    fn body(shared: &Arc<SharedBody>, cap: usize, expected: Option<u64>) -> BodyPump {
+        BodyPump {
+            chunks: shared.subscribe_with_cap(cap),
+            expected,
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_complete_body_finishes_the_ring() {
+        let shared = Arc::new(SharedBody::new(8));
+        let pump_body = body(&shared, 8, Some(6));
+        let (producer, ring) = gosub_ipc::ring::RingProducer::create(1 << 16).unwrap();
+        let drained = std::thread::spawn(move || drain(ring));
+        shared.push(bytes::Bytes::from_static(b"abc"));
+        shared.push(bytes::Bytes::from_static(b"def"));
+        shared.finish();
+        pump(producer, pump_body).await;
+        assert_eq!(drained.join().unwrap().unwrap(), b"abcdef");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_body_short_of_its_content_length_aborts_the_ring() {
+        let shared = Arc::new(SharedBody::new(1));
+        // A one-slot queue nobody reads yet: the second push drops the subscriber.
+        let pump_body = body(&shared, 1, Some(6));
+        let (producer, ring) = gosub_ipc::ring::RingProducer::create(1 << 16).unwrap();
+        let drained = std::thread::spawn(move || drain(ring));
+        shared.push(bytes::Bytes::from_static(b"abc"));
+        shared.push(bytes::Bytes::from_static(b"def"));
+        shared.finish();
+        pump(producer, pump_body).await;
+        assert!(
+            drained.join().unwrap().is_err(),
+            "a truncated body must not read as EOF"
+        );
+    }
+
+    /// A chunked body (no Content-Length) that finishes right after dropping
+    /// the pump: only sonar's lag error tells this from a complete body.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_body_that_finishes_after_dropping_the_pump_aborts_the_ring() {
+        let shared = Arc::new(SharedBody::new(1));
+        let pump_body = body(&shared, 1, None);
+        let (producer, ring) = gosub_ipc::ring::RingProducer::create(1 << 16).unwrap();
+        let drained = std::thread::spawn(move || drain(ring));
+        shared.push(bytes::Bytes::from_static(b"abc"));
+        shared.push(bytes::Bytes::from_static(b"def"));
+        shared.finish();
+        pump(producer, pump_body).await;
+        assert!(
+            drained.join().unwrap().is_err(),
+            "a body finished after the drop must not read as EOF"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_dropped_subscriber_of_a_live_body_aborts_the_ring() {
+        let shared = Arc::new(SharedBody::new(1));
+        let pump_body = body(&shared, 1, None);
+        let (producer, ring) = gosub_ipc::ring::RingProducer::create(1 << 16).unwrap();
+        let drained = std::thread::spawn(move || drain(ring));
+        shared.push(bytes::Bytes::from_static(b"abc"));
+        shared.push(bytes::Bytes::from_static(b"def"));
+        // Not finished: the body is still streaming when the pump's stream ends.
+        pump(producer, pump_body).await;
+        assert!(
+            drained.join().unwrap().is_err(),
+            "a dropped subscriber must not read as EOF"
+        );
+    }
+}

--- a/crates/gosub_engine/src/net/process/child/portable.rs
+++ b/crates/gosub_engine/src/net/process/child/portable.rs
@@ -1,0 +1,28 @@
+//! Off Linux: no fd passing, so no streamed bodies. The broker buffers
+//! bodies; this is `linux.rs`'s API declining.
+
+use crate::net::process::protocol::{FetchOutcome, RequestTag};
+use gosub_ipc::EndpointTx;
+use gosub_sonar::net::shared_body::SharedBody;
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+/// Bodies never stream: the broker asks for them buffered.
+pub(super) const STREAMING: bool = false;
+
+/// Never constructed here; the type exists so the caller has no branch.
+pub(super) enum Streamed {}
+
+pub(super) fn begin_stream(
+    _head: FetchOutcome,
+    _expected: Option<u64>,
+    _shared: Arc<SharedBody>,
+) -> Result<Streamed, String> {
+    Err("body streaming needs fd passing, which only Linux has".into())
+}
+
+impl Streamed {
+    pub(super) async fn deliver(self, _tag: RequestTag, _link_tx: &Arc<Mutex<EndpointTx>>) {
+        match self {}
+    }
+}

--- a/crates/gosub_engine/src/net/process/client.rs
+++ b/crates/gosub_engine/src/net/process/client.rs
@@ -18,9 +18,10 @@ pub struct Outbound {
     pub method: String,
     pub headers: Vec<(String, String)>,
     pub body: Option<Vec<u8>>,
-    /// Serve through the strict fetcher: a subresource of a public document
-    /// may not reach the private network (see `net::ssrf`).
+    /// Serve through the strict fetcher (see `net::ssrf`).
     pub refuse_private: bool,
+    /// Deliver the body through a ring as it arrives, where the link can carry one.
+    pub streaming: bool,
 }
 
 impl Outbound {
@@ -32,22 +33,45 @@ impl Outbound {
             headers: Vec::new(),
             body: None,
             refuse_private: false,
+            streaming: false,
         }
     }
 }
 
-/// A reply as the broker sees it: the wire outcome.
+/// The ring's descriptor, where one can exist; nothing where it cannot.
+#[cfg(target_os = "linux")]
+type RingFd = std::os::fd::OwnedFd;
+#[cfg(not(target_os = "linux"))]
+type RingFd = std::convert::Infallible;
+
+/// A reply as the broker sees it: the wire outcome plus, for a streamed body,
+/// the ring fd that followed it on the link.
 #[derive(Debug)]
 pub struct NetReply {
     pub outcome: FetchOutcome,
+    pub ring: Option<RingFd>,
 }
 
 impl NetReply {
     fn error(msg: impl Into<String>) -> Self {
         Self {
             outcome: FetchOutcome::Error(msg.into()),
+            ring: None,
         }
     }
+}
+
+#[cfg(target_os = "linux")]
+fn recv_ring(rx: &mut gosub_ipc::EndpointRx) -> std::io::Result<RingFd> {
+    rx.recv_fd()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn recv_ring(_rx: &mut gosub_ipc::EndpointRx) -> std::io::Result<RingFd> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "no fd passing on this platform",
+    ))
 }
 
 /// The argv role name the broker re-execs itself with.
@@ -104,6 +128,7 @@ impl NetProcess {
 
         let exe = std::env::current_exe()?;
         let (ours, theirs) = gosub_ipc::channel::Channel::pair()?;
+
         let args: [&str; 2] = [crate::child_process::ROLE_FLAG, NET_ROLE];
 
         let child = gosub_sandbox::spawn::spawn(
@@ -123,6 +148,7 @@ impl NetProcess {
                 file_size_limit: None,
             },
         )?;
+
         if let Err(e) = gosub_sandbox::confine_spawned_child(&child) {
             log::warn!("could not apply parent-side confinement to the network process: {e}");
         }
@@ -148,8 +174,20 @@ impl NetProcess {
                             let _ = ready_tx.send(());
                         }
                         FromNet::Reply { tag, outcome } => {
+                            // A streamed head is followed by its ring fd; take it
+                            // now, before the next message, whoever is waiting.
+                            let reply = match outcome {
+                                FetchOutcome::Streaming { .. } => match recv_ring(&mut rx) {
+                                    Ok(ring) => NetReply {
+                                        outcome,
+                                        ring: Some(ring),
+                                    },
+                                    Err(e) => NetReply::error(format!("body stream fd did not arrive: {e}")),
+                                },
+                                outcome => NetReply { outcome, ring: None },
+                            };
                             if let Some(waiter) = waiters.lock().remove(&tag) {
-                                let _ = waiter.send(NetReply { outcome });
+                                let _ = waiter.send(reply);
                             }
                         }
                     }
@@ -203,6 +241,7 @@ impl NetProcess {
             headers,
             body,
             refuse_private,
+            streaming,
         } = out;
         let permit = tokio::select! {
             _ = cancel.cancelled() => return NetReply::error("cancelled"),
@@ -224,6 +263,7 @@ impl NetProcess {
             headers,
             body,
             refuse_private,
+            streaming,
         });
         // The link write can block on a full pipe (bodies can be large), so it
         // runs on a blocking thread rather than a runtime worker.
@@ -268,7 +308,7 @@ impl NetProcess {
     /// the child's word; only the broker following redirects itself could fix that.
     fn plausible_reply(reply: NetReply, requested: &str) -> NetReply {
         let final_url = match &reply.outcome {
-            FetchOutcome::Ok { final_url, .. } => final_url,
+            FetchOutcome::Ok { final_url, .. } | FetchOutcome::Streaming { final_url, .. } => final_url,
             FetchOutcome::Error(_) => return reply,
         };
         let Ok(parsed) = url::Url::parse(final_url) else {
@@ -334,7 +374,19 @@ pub fn outcome_to_result(reply: NetReply) -> Result<crate::net::types::FetchResu
             final_url,
             headers,
             body,
-        } => (status, status_text, final_url, headers, body),
+        } => (status, status_text, final_url, headers, Body::Whole(body)),
+        FetchOutcome::Streaming {
+            status,
+            status_text,
+            final_url,
+            headers,
+            peek,
+        } => {
+            let Some(ring) = reply.ring else {
+                return Err(net_error("streamed reply without its ring"));
+            };
+            (status, status_text, final_url, headers, Body::Ring { peek, ring })
+        }
         FetchOutcome::Error(e) => return Err(net_error(e)),
     };
 
@@ -369,10 +421,88 @@ pub fn outcome_to_result(reply: NetReply) -> Result<crate::net::types::FetchResu
         has_body,
         tainting: gosub_sonar::ResponseTainting::Basic,
     };
-    Ok(crate::net::types::FetchResult::Buffered {
-        meta: meta(!body.is_empty()),
-        body: bytes::Bytes::from(body),
+    Ok(match body {
+        Body::Whole(body) => crate::net::types::FetchResult::Buffered {
+            meta: meta(!body.is_empty()),
+            body: bytes::Bytes::from(body),
+        },
+        Body::Ring { peek, ring } => crate::net::types::FetchResult::Stream {
+            meta: meta(true),
+            peek_buf: gosub_sonar::types::PeekBuf::from_vec(peek),
+            shared: drain_ring(ring),
+        },
     })
+}
+
+/// A reply's body as it came off the wire.
+enum Body {
+    Whole(Vec<u8>),
+    /// The head arrived; the body streams through this ring.
+    Ring {
+        peek: Vec<u8>,
+        ring: RingFd,
+    },
+}
+
+/// Per-subscriber queue for a ring-fed body, in chunks: the same order of
+/// magnitude gosub-sonar uses for its own streamed responses.
+const RING_BODY_QUEUE: usize = 64;
+
+/// Feed a [`SharedBody`] from a ring on a thread of its own: the ring's reads
+/// block (bounded by its stall timeout), so this is not runtime work. The
+/// body ends when the producer finishes; a producer that aborts or stalls
+/// ends it with an error.
+///
+/// [`SharedBody`]: gosub_sonar::net::shared_body::SharedBody
+fn drain_ring(ring: RingFd) -> Arc<gosub_sonar::net::shared_body::SharedBody> {
+    use gosub_sonar::net::shared_body::SharedBody;
+    let shared = Arc::new(SharedBody::new(RING_BODY_QUEUE));
+    let sink = Arc::clone(&shared);
+    let spawned = std::thread::Builder::new()
+        .name("net-ring-consumer".into())
+        .spawn(move || {
+            #[cfg(target_os = "linux")]
+            {
+                let mut consumer = match gosub_ipc::ring::RingConsumer::open(ring) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        sink.error(net_error(format!("body stream could not be opened: {e}")));
+                        return;
+                    }
+                };
+                let mut buf = vec![0u8; 64 * 1024];
+                let mut total: u64 = 0;
+                loop {
+                    match consumer.read(&mut buf) {
+                        Ok(0) => {
+                            sink.finish();
+                            return;
+                        }
+                        Ok(n) => {
+                            total += n as u64;
+                            if total > gosub_ipc::ring::MAX_BODY_LEN {
+                                sink.error(net_error("body stream exceeded the size cap"));
+                                return;
+                            }
+                            sink.push(bytes::Bytes::copy_from_slice(&buf[..n]));
+                        }
+                        Err(e) => {
+                            sink.error(net_error(format!("body stream failed: {e}")));
+                            return;
+                        }
+                    }
+                }
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                let _ = ring;
+                sink.error(net_error("body streams are not carried on this platform"));
+            }
+        });
+    if spawned.is_err() {
+        shared.error(net_error("could not start the body stream consumer"));
+    }
+    shared
 }
 
 /// A failure that came from (or about) the network process, as the engine's own

--- a/crates/gosub_engine/src/net/process/protocol.rs
+++ b/crates/gosub_engine/src/net/process/protocol.rs
@@ -39,6 +39,9 @@ pub struct NetFetch {
     /// refuses private-network destinations at every hop (`net::ssrf`). The
     /// broker decides this from the tab's document, never the requester.
     pub refuse_private: bool,
+    /// The requester wants the body as it arrives. Honoured where the link can
+    /// carry a ring fd (Linux); elsewhere the reply is buffered as usual.
+    pub streaming: bool,
     // Only these cross. `FetchRequest::origin` / `referrer` / `mixed_content`
     // (sonar 0.2.0) do not: the engine sets none of them yet. When it does, add
     // them here - otherwise the network process rebuilds the request without
@@ -67,6 +70,17 @@ pub enum FetchOutcome {
         final_url: String,
         headers: Vec<(String, String)>,
         body: Vec<u8>,
+    },
+    /// The response head; the body streams through a shared-memory ring
+    /// (`gosub_ipc::ring`) whose fd follows this message on the link, right
+    /// behind it. `peek` is what the network process had already read of the
+    /// body when it answered, for content sniffing before the stream is drained.
+    Streaming {
+        status: u16,
+        status_text: String,
+        final_url: String,
+        headers: Vec<(String, String)>,
+        peek: Vec<u8>,
     },
     /// The request failed. A string rather than a typed error: the broker only
     /// reports it, and a rich error type would be one more thing whose

--- a/crates/gosub_engine/tests/process_isolation.rs
+++ b/crates/gosub_engine/tests/process_isolation.rs
@@ -45,6 +45,20 @@ fn a_request_completes_through_the_network_process() {
     );
 }
 
+/// A streamed body crosses the network-process boundary through a
+/// shared-memory ring: head in-band, ring fd right behind it, bytes intact.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_body_streams_through_the_network_process() {
+    let out = run("stream");
+    assert!(
+        out.status.success(),
+        "streaming scenario failed:\n{}\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 /// Resolving a real hostname inside the sandboxed network process: a
 /// reserved `.invalid` name must fail to resolve without taking the process
 /// down (the NSS `dlopen` and resolver syscalls that `127.0.0.1` never


### PR DESCRIPTION

Base: `09-net-policy`.

### What is in here

- `gosub_ipc::ring` is finally used: `NetFetch.streaming`,
  `FetchOutcome::Streaming` (head + peek) followed by the ring fd on the link;
  the network process pumps sonar's body into the ring as it arrives (with the
  ring's backpressure, off the async worker), the broker drains it on a thread
  into a `SharedBody`, so `FetchResult::Stream` looks exactly like an
  in-process one.
- A body that fell behind the fetcher aborts the ring instead of finishing
  short (sonar 0.4's lag error plus the `Content-Length` count): a truncated
  body must never read as EOF. Unit tests in `child/linux.rs` cover complete,
  short, late-finishing and dropped-subscriber bodies.
- The net child splits into `child.rs` (portable core) + `child/linux.rs`
  (ring pump) + `child/portable.rs` (declines); no platform branches in the core.

### Testing

```
cargo test -p gosub_engine --lib net::
./target/debug/isolation-harness stream          # 1 MiB through a 256 KiB ring, every byte checked
```

Linux only; elsewhere bodies stay buffered.