### PR TITLE
Cookie vault: jars in a sandboxed process, tickets for the network process's direct line, respawn

### DIFF
--- a/crates/gosub_engine/src/bin/isolation-harness.rs
+++ b/crates/gosub_engine/src/bin/isolation-harness.rs
@@ -138,6 +138,8 @@ fn main() {
         "engine-renderer-slow-image" => with_font_backend!(engine_renderer_slow_image),
         "renderer-soak" => with_font_backend!(renderer_soak),
         "engine-soak" => with_font_backend!(engine_soak),
+        "vault" => vault(),
+        "engine-cookie-vault" => engine_cookie_vault(),
         "stream" => stream(),
         "engine" => engine(),
         "guard" => guard(),
@@ -157,7 +159,7 @@ fn guard() -> i32 {
         return 2;
     }
 
-    match NetProcess::spawn() {
+    match NetProcess::spawn(None) {
         Ok(_) => {
             eprintln!("spawning should have been refused: an undispatched child must not spawn more");
             1
@@ -220,7 +222,7 @@ fn resolve() -> i32 {
         eprintln!("could not start the test server");
         return 1;
     };
-    let net = match NetProcess::spawn() {
+    let net = match NetProcess::spawn(None) {
         Ok(n) => n,
         Err(e) => {
             eprintln!("could not spawn the network process: {e}");
@@ -3185,7 +3187,7 @@ fn stream() -> i32 {
         eprintln!("could not start the test server");
         return 1;
     };
-    let net = match NetProcess::spawn() {
+    let net = match NetProcess::spawn(None) {
         Ok(n) => n,
         Err(e) => {
             eprintln!("could not spawn the network process: {e}");
@@ -3262,6 +3264,472 @@ fn stream() -> i32 {
     }
 }
 
+/// The cookie vault on its own: a jar that forwards, the HttpOnly split, zone
+/// partitioning, and persistence brokered through a real SQLite store - the
+/// vault never opens the file, the broker does, from the snapshots it is sent.
+#[cfg(target_os = "linux")]
+fn line_channel(line: gosub_engine::cookie_vault::client::NetVaultLink) -> gosub_ipc::channel::Channel {
+    line.0
+}
+
+fn vault() -> i32 {
+    #[cfg(target_os = "linux")]
+    {
+        use gosub_engine::cookie_vault::client::{CookieVault, VaultCookieJar};
+        use gosub_engine::cookie_vault::protocol::{CookieScope, SameSite};
+        use gosub_engine::cookies::{CookieJar as _, CookieStoreHandle, SameSiteContext, SqliteCookieStore};
+        use gosub_engine::zone::ZoneId;
+
+        let (vault, _) = match CookieVault::spawn(false) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("could not spawn the vault: {e}");
+                return 1;
+            }
+        };
+        let vault = Arc::new(vault);
+        let Ok(url) = url::Url::parse("https://example.test/app") else {
+            eprintln!("bad test url");
+            return 1;
+        };
+        let set_cookie = |values: &[&str]| {
+            let mut headers = http::HeaderMap::new();
+            for value in values {
+                if let Ok(value) = value.parse() {
+                    headers.append(http::header::SET_COOKIE, value);
+                }
+            }
+            headers
+        };
+
+        // A zone with no store: in-memory in the vault.
+        let zone = ZoneId::new();
+        vault.open_zone(zone, None);
+        let mut jar = VaultCookieJar::new(Arc::clone(&vault), zone);
+        let headers = set_cookie(&["sid=abc; HttpOnly; Path=/", "theme=dark; Path=/"]);
+        jar.store_response_cookies(&url, &headers, None);
+
+        let attach = jar
+            .get_request_cookies(&url, None, SameSiteContext::SameSite)
+            .unwrap_or_default();
+        if !(attach.contains("sid=abc") && attach.contains("theme=dark")) {
+            eprintln!("the attachable set should hold both cookies, got {attach:?}");
+            return 1;
+        }
+        let scope = CookieScope {
+            ticket: 0,
+            zone: zone.to_string(),
+            top_level: None,
+            samesite: SameSite::SameSite,
+        };
+        let visible = vault.get(scope.clone(), &url, true).unwrap_or_default();
+        if visible.contains("sid=") || !visible.contains("theme=dark") {
+            eprintln!("the document.cookie view must hide HttpOnly, got {visible:?}");
+            return 1;
+        }
+        let other = ZoneId::new();
+        vault.open_zone(other, None);
+        let foreign = CookieScope {
+            zone: other.to_string(),
+            ..scope
+        };
+        if vault.get(foreign, &url, false).is_some() {
+            eprintln!("another zone must not see this zone's cookies");
+            return 1;
+        }
+        let listed = jar
+            .get_all_cookies()
+            .into_iter()
+            .map(|(_, cookies)| cookies)
+            .collect::<Vec<_>>()
+            .join("; ");
+        if !(listed.contains("sid=abc") && listed.contains("theme=dark")) {
+            eprintln!("get_all_cookies should list both cookies, got {listed:?}");
+            return 1;
+        }
+        println!("attach/visible/partition views correct");
+
+        // The network process's line answers granted tickets only, and from
+        // the grant's scope - not from what the line claims.
+        let (net_vault, net_line) = match CookieVault::spawn(true) {
+            Ok((v, Some(line))) => (Arc::new(v), line),
+            _ => {
+                eprintln!("could not spawn a vault with a network line");
+                return 1;
+            }
+        };
+        let Ok(mut net_link) = gosub_ipc::Endpoint::from_channel(line_channel(net_line)) else {
+            eprintln!("could not open the network line");
+            return 1;
+        };
+        net_vault.open_zone(zone, None);
+        let mut net_jar = VaultCookieJar::new(Arc::clone(&net_vault), zone);
+        net_jar.store_response_cookies(&url, &set_cookie(&["sid=abc; Path=/"]), None);
+        use gosub_engine::cookie_vault::protocol::{FromVault, ToVault};
+        let ask = |link: &mut gosub_ipc::Endpoint, scope: CookieScope| -> Option<String> {
+            link.send(&ToVault::Get {
+                tag: 7,
+                scope,
+                url: url.to_string(),
+                visible_only: false,
+            })
+            .ok()?;
+            match link.recv::<FromVault>().ok()? {
+                FromVault::Cookies { header, .. } => header,
+                _ => None,
+            }
+        };
+        let claimed = CookieScope {
+            ticket: 424242,
+            zone: zone.to_string(),
+            top_level: None,
+            samesite: SameSite::SameSite,
+        };
+        if ask(&mut net_link, claimed.clone()).is_some() {
+            eprintln!("the network line answered a ticket nobody granted");
+            return 1;
+        }
+        if !net_vault.grant(&claimed) {
+            eprintln!("the broker could not grant a ticket");
+            return 1;
+        }
+        // Under the grant, the zone the line names is ignored: the grant's counts.
+        let lying = CookieScope {
+            zone: other.to_string(),
+            ..claimed.clone()
+        };
+        let got = ask(&mut net_link, lying).unwrap_or_default();
+        if !got.contains("sid=abc") {
+            eprintln!("a granted ticket should answer from the grant's zone, got {got:?}");
+            return 1;
+        }
+        net_vault.revoke(&claimed);
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        if ask(&mut net_link, claimed).is_some() {
+            eprintln!("the network line answered a revoked ticket");
+            return 1;
+        }
+        println!("network line honours grants only");
+
+        // A zone with a SQLite store: the vault's snapshots reach the file
+        // through the broker, and a fresh store on the same file has them.
+        let dir = std::env::temp_dir().join(format!("gosub-vault-{}", std::process::id()));
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            eprintln!("no temp dir: {e}");
+            return 1;
+        }
+        let path = dir.join("cookies.db");
+        let store = match SqliteCookieStore::new(path.clone()) {
+            Ok(s) => CookieStoreHandle::from(s),
+            Err(e) => {
+                eprintln!("could not open the sqlite store: {e}");
+                return 1;
+            }
+        };
+        let persisted = ZoneId::new();
+        vault.open_zone(persisted, Some(store.clone()));
+        let mut jar = VaultCookieJar::new(Arc::clone(&vault), persisted);
+        let headers = set_cookie(&["durable=1; Path=/"]);
+        jar.store_response_cookies(&url, &headers, None);
+        // Reading back through the vault orders after the store (same link),
+        // and the snapshot precedes the reply on the broker link.
+        let _ = jar.get_request_cookies(&url, None, SameSiteContext::SameSite);
+        store.persist_all();
+        drop(store);
+        let reopened = match SqliteCookieStore::new(path) {
+            Ok(s) => CookieStoreHandle::from(s),
+            Err(e) => {
+                eprintln!("could not reopen the sqlite store: {e}");
+                return 1;
+            }
+        };
+        let back = reopened
+            .jar_for(persisted)
+            .and_then(|jar| jar.read().get_request_cookies(&url, None, SameSiteContext::SameSite))
+            .unwrap_or_default();
+        vault.shutdown();
+        drop(reopened);
+        let _ = std::fs::remove_dir_all(&dir);
+        if !back.contains("durable=1") {
+            eprintln!("the cookie did not reach the store through the broker, got {back:?}");
+            return 1;
+        }
+        println!("brokered persistence reached sqlite: {back}");
+        0
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the cookie vault is Linux-only");
+        2
+    }
+}
+
+/// The whole chain: engine with the vault and the network process on, a page
+/// whose response sets an HttpOnly cookie, and a stylesheet the page loads
+/// next. The second request must carry the cookie - which only the vault and
+/// the network process ever handled - and the first must not.
+fn engine_cookie_vault() -> i32 {
+    use gosub_config::settings::Setting;
+    use gosub_engine::storage::{InMemoryLocalStore, InMemorySessionStore, PartitionPolicy, StorageService};
+    use gosub_engine::zone::ZoneServices;
+    use gosub_engine::GosubEngine;
+    use gosub_render_pipeline::render::backends::null::NullBackend;
+    use gosub_render_pipeline::render::DefaultCompositor;
+    use parking_lot::Mutex;
+
+    let modes: Vec<String> = std::env::args().skip(2).collect();
+    let in_process = modes.iter().any(|m| m == "in-process");
+    // `respawn`: kill the vault after the first flow; the cookie must still
+    // reach the next request, from the store the respawned vault reopens.
+    let respawn = modes.iter().any(|m| m == "respawn");
+    let seen: SeenRequests = Arc::new(Mutex::new(Vec::new()));
+    let Ok(port) = serve_cookie_pages(Arc::clone(&seen)) else {
+        eprintln!("could not start the test server");
+        return 1;
+    };
+
+    let runtime = match tokio::runtime::Builder::new_multi_thread().enable_all().build() {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("could not build a runtime: {e}");
+            return 1;
+        }
+    };
+    let seen_after = Arc::clone(&seen);
+    // Requests recorded from this index on came after the vault was killed.
+    let after_kill = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let after_kill_seen = Arc::clone(&after_kill);
+    let code = runtime.block_on(async move {
+        let mut engine: GosubEngine = GosubEngine::new(
+            None,
+            Arc::new(NullBackend::new()),
+            Arc::new(DefaultCompositor::default()),
+        );
+        for (key, on) in [
+            ("security.cookie_vault", true),
+            ("security.network_process", !in_process),
+            ("security.image_decoder_process", false),
+            ("security.renderer_process", false),
+        ] {
+            if let Err(e) = engine.settings().set(key, Setting::Bool(on)) {
+                eprintln!("could not set {key}: {e}");
+                return 1;
+            }
+        }
+        // The engine's event bus refuses to send without a subscriber.
+        let _events = engine.subscribe_events();
+        let Ok(run) = engine.start() else {
+            eprintln!("engine failed to start");
+            return 1;
+        };
+        tokio::spawn(run);
+        if !engine.settings().get_bool("security.cookie_vault") {
+            eprintln!("the vault did not start");
+            return 1;
+        }
+
+        // A real store when the vault is to be killed: what comes back must
+        // come from disk, not from the process that died.
+        let cookie_store = if respawn {
+            let dir = std::env::temp_dir().join(format!("gosub-vault-respawn-{}", std::process::id()));
+            if let Err(e) = std::fs::create_dir_all(&dir) {
+                eprintln!("no temp dir: {e}");
+                return 1;
+            }
+            match gosub_engine::cookies::SqliteCookieStore::new(dir.join("cookies.db")) {
+                Ok(store) => Some(gosub_engine::cookies::CookieStoreHandle::from(store)),
+                Err(e) => {
+                    eprintln!("could not open the sqlite store: {e}");
+                    return 1;
+                }
+            }
+        } else {
+            None
+        };
+        let services = ZoneServices {
+            storage: Arc::new(StorageService::new(
+                Arc::new(InMemoryLocalStore::new()),
+                Arc::new(InMemorySessionStore::new()),
+            )),
+            cookie_store,
+            cookie_jar: None,
+            partition_policy: PartitionPolicy::None,
+            places: None,
+        };
+        let mut zone = match engine.create_zone(None, services, None) {
+            Ok(zone) => zone,
+            Err(e) => {
+                eprintln!("could not create a zone: {e}");
+                return 1;
+            }
+        };
+        let Ok(tab) = zone.create_tab(Default::default(), None).await else {
+            eprintln!("could not create a tab");
+            return 1;
+        };
+        if tab.navigate(format!("http://127.0.0.1:{port}/")).await.is_err() {
+            eprintln!("navigate failed");
+            return 1;
+        }
+
+        // Two requests: the page, then its stylesheet.
+        let wait_for = |n: usize| {
+            let seen = Arc::clone(&seen);
+            async move {
+                let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
+                while seen.lock().len() < n {
+                    if tokio::time::Instant::now() > deadline {
+                        eprintln!("timed out waiting for request {n}; seen {:?}", seen.lock());
+                        return false;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+                true
+            }
+        };
+        if !wait_for(2).await {
+            return 1;
+        }
+        // The favicon follows the page; give it time to be *sent* before
+        // shutdown removes the tab's identity, so the request log is stable.
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        #[cfg(target_os = "linux")]
+        if respawn {
+            // Let the first navigation's trailing requests (favicon, a
+            // repeated stylesheet) land before counting from here.
+            tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+            let after_kill_from = seen.lock().len();
+            after_kill_seen.store(after_kill_from, std::sync::atomic::Ordering::Relaxed);
+            let Some(vault) = engine.cookie_vault() else {
+                eprintln!("no vault to kill");
+                return 1;
+            };
+            let Some(pid) = vault.pid() else {
+                eprintln!("the vault has no pid");
+                return 1;
+            };
+            let _ = std::process::Command::new("kill")
+                .args(["-9", &pid.to_string()])
+                .status();
+            let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+            while vault.is_alive() {
+                if tokio::time::Instant::now() > deadline {
+                    eprintln!("the broker never noticed the vault dying");
+                    return 1;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+            // Straight to the stylesheet: nothing sets the cookie again, so it
+            // has to come out of the store through the respawned vault.
+            if tab
+                .navigate(format!("http://127.0.0.1:{port}/style.css"))
+                .await
+                .is_err()
+            {
+                eprintln!("second navigate failed");
+                return 1;
+            }
+            if !wait_for(after_kill_from + 1).await {
+                return 1;
+            }
+            let Some(new_pid) = vault.pid() else {
+                eprintln!("no vault after the respawn");
+                return 1;
+            };
+            if new_pid == pid || !vault.is_alive() {
+                eprintln!(
+                    "the vault was not respawned (pid {pid} -> {new_pid}, alive {})",
+                    vault.is_alive()
+                );
+                return 1;
+            }
+            println!("vault respawned: pid {pid} -> {new_pid}");
+        }
+        #[cfg(not(target_os = "linux"))]
+        let _ = (respawn, &after_kill_seen);
+        let _ = engine.shutdown().await;
+        0
+    });
+    if code != 0 {
+        return code;
+    }
+    let after_kill_from = after_kill.load(std::sync::atomic::Ordering::Relaxed);
+    let seen = seen_after.lock().clone();
+    println!("requests: {seen:?}");
+    let first_clean = seen.first().is_some_and(|(_, cookie)| cookie.is_none());
+    let second_has = seen
+        .get(1)
+        .is_some_and(|(path, cookie)| path == "/style.css" && cookie.as_deref().is_some_and(|c| c.contains("sid=abc")));
+    if !first_clean || !second_has {
+        eprintln!("the stylesheet request must carry the cookie the page set, and the page request must not");
+        return 1;
+    }
+    if respawn {
+        let third_has = seen.get(after_kill_from..).is_some_and(|later| {
+            later
+                .iter()
+                .any(|(path, cookie)| path == "/style.css" && cookie.as_deref().is_some_and(|c| c.contains("sid=abc")))
+        });
+        if !third_has {
+            eprintln!("after the vault died, the next request must still carry the cookie (from the store)");
+            return 1;
+        }
+    }
+    println!(
+        "cookie set by the page reached the next request through the vault{}{}",
+        if in_process {
+            " (in-process fetch)"
+        } else {
+            " and the network process"
+        },
+        if respawn { ", across a vault respawn" } else { "" }
+    );
+    0
+}
+
+/// Every request a test server saw: its path and `Cookie` header.
+type SeenRequests = Arc<parking_lot::Mutex<Vec<(String, Option<String>)>>>;
+
+/// A server whose page sets an HttpOnly cookie and references a stylesheet;
+/// every request's path and `Cookie` header are recorded in `seen`.
+fn serve_cookie_pages(seen: SeenRequests) -> std::io::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else {
+                continue;
+            };
+            let mut buf = [0u8; 8192];
+            let n = stream.read(&mut buf).unwrap_or(0);
+            let request = String::from_utf8_lossy(&buf[..n]).into_owned();
+            let path = request.split_whitespace().nth(1).unwrap_or("/").to_string();
+            let cookie = request
+                .lines()
+                .find(|l| l.get(..7).is_some_and(|p| p.eq_ignore_ascii_case("cookie:")))
+                .map(|l| l[7..].trim().to_string());
+            seen.lock().push((path.clone(), cookie));
+            let (content_type, extra, body): (&str, &str, &str) = if path == "/style.css" {
+                ("text/css", "", "body { color: rgb(1, 2, 3); }")
+            } else {
+                (
+                    "text/html",
+                    "Set-Cookie: sid=abc; HttpOnly; Path=/\r\n",
+                    "<html><head><link rel=\"stylesheet\" href=\"/style.css\"></head><body>vaulted</body></html>",
+                )
+            };
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\n{extra}Content-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = stream.write_all(head.as_bytes());
+            let _ = stream.write_all(body.as_bytes());
+        }
+    });
+    Ok(port)
+}
+
 /// The transport on its own: does a request survive the round trip through a
 /// separate, sandboxed process and come back intact?
 fn direct() -> i32 {
@@ -3273,7 +3741,7 @@ fn direct() -> i32 {
         return 1;
     };
 
-    let net = match NetProcess::spawn() {
+    let net = match NetProcess::spawn(None) {
         Ok(n) => n,
         Err(e) => {
             eprintln!("could not spawn the network process: {e}");

--- a/crates/gosub_engine/src/child_process.rs
+++ b/crates/gosub_engine/src/child_process.rs
@@ -124,12 +124,32 @@ fn run_role(role: &str, args: &[String]) -> i32 {
             Err(code) => code,
         },
         NET_ROLE => match adopt_link(role, args) {
-            Ok(endpoint) => crate::net::process::child::serve(endpoint),
+            Ok(endpoint) => crate::net::process::child::serve(endpoint, adopt_extra(role, args)),
+            Err(code) => code,
+        },
+        #[cfg(target_os = "linux")]
+        crate::cookie_vault::protocol::VAULT_ROLE => match adopt_link(role, args) {
+            Ok(endpoint) => crate::cookie_vault::child::serve(endpoint, adopt_extra(role, args)),
             Err(code) => code,
         },
         other => {
             eprintln!("[gosub] unknown child role '{other}'");
             2
+        }
+    }
+}
+
+/// The second inherited channel, when the spawner named one before the
+/// primary link. Failing to adopt it is reported and treated as absent.
+fn adopt_extra(role: &str, args: &[String]) -> Option<gosub_ipc::Endpoint> {
+    if args.len() < 2 {
+        return None;
+    }
+    match gosub_ipc::Endpoint::adopt_inherited(&args[0]) {
+        Ok(endpoint) => Some(endpoint),
+        Err(e) => {
+            eprintln!("[gosub] child role '{role}' could not adopt its second link: {e}");
+            None
         }
     }
 }

--- a/crates/gosub_engine/src/cookie_vault.rs
+++ b/crates/gosub_engine/src/cookie_vault.rs
@@ -1,0 +1,8 @@
+//! The cookie vault: the engine's cookie jars in a process of their own, so a
+//! bug in the broker (which deserializes frames from every other child) is not
+//! a bug with the session tokens in reach. See [`child`] for the model and
+//! [`client`] for the broker's side; `security.cookie_vault` turns it on.
+
+pub mod child;
+pub mod client;
+pub mod protocol;

--- a/crates/gosub_engine/src/cookie_vault/child.rs
+++ b/crates/gosub_engine/src/cookie_vault/child.rs
@@ -1,0 +1,306 @@
+//! The vault process: the cookie jars, and nothing else.
+//!
+//! The governing principle: no one process should hold both large secrets and
+//! a large hostile-input surface. The broker deserializes untrusted frames from
+//! every child, so the jars leave it and live here, in the least-authority
+//! process of the model - the bare content baseline: no network, no files, no
+//! devices; it moves bytes on the links it inherited and touches its own
+//! memory. Compromised, it can answer the narrow questions below and nothing
+//! more.
+//!
+//! Persistence is brokered: after every change the vault sends the broker a
+//! snapshot of the zone's jar, and the broker writes it through the zone's
+//! cookie store. That keeps the vault's filter at its tightest (it never opens
+//! a file) at the cost of the broker seeing cookie state pass by - the
+//! trade-off the PoC left open, decided this way because it works with any
+//! embedder-supplied store and costs no capability.
+//!
+//! Two links: the broker's (control, embedder-API queries, snapshots out) and,
+//! when the engine runs a network process, that process's own - so the cookie
+//! *values* attached to requests flow network process ↔ vault directly and
+//! never through the broker.
+
+use crate::cookie_vault::protocol::{CookieScope, FromVault, Ticket, ToVault};
+use crate::engine::cookies::{CookieJar as _, DefaultCookieJar};
+use gosub_ipc::{Endpoint, EndpointTx};
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use url::Url;
+
+/// Every zone's jar, keyed by the zone id the broker stamps.
+type Jars = Arc<Mutex<HashMap<String, DefaultCookieJar>>>;
+
+/// Tickets the broker granted, each for one request of the network process.
+type Grants = Arc<Mutex<HashMap<Ticket, (CookieScope, Instant)>>>;
+
+/// Longer than any request may live; a grant the broker never revoked
+/// (it died mid-request) goes away on its own.
+const GRANT_TTL: Duration = Duration::from_secs(300);
+/// More outstanding grants than this is a broker gone wrong, not load.
+const MAX_GRANTS: usize = 4096;
+
+/// Entry point for the `vault` role. `net_link` is the network process's
+/// direct line, when there is one.
+pub fn serve(broker: Endpoint, net_link: Option<Endpoint>) -> i32 {
+    gosub_sandbox::capture_process_title_region();
+    gosub_sandbox::set_process_title("gosub-vault", "gosub: cookie vault");
+    let jars: Jars = Arc::new(Mutex::new(HashMap::new()));
+    let grants: Grants = Arc::new(Mutex::new(HashMap::new()));
+    let (broker_tx, mut broker_rx) = broker.split();
+    let broker_tx = Arc::new(Mutex::new(broker_tx));
+
+    // Threads before lockdown - and *running* before it: a thread's own
+    // start-up makes syscalls (`rseq`, `set_robust_list`) the allowlist does
+    // not carry, so the filter waits until the thread says it is past them.
+    if let Some(link) = net_link {
+        let jars = Arc::clone(&jars);
+        let grants = Arc::clone(&grants);
+        let snapshots = Arc::clone(&broker_tx);
+        let (started_tx, started_rx) = std::sync::mpsc::sync_channel::<()>(1);
+        let spawned = std::thread::Builder::new().name("vault-net".into()).spawn(move || {
+            let _ = started_tx.send(());
+            serve_net(link, jars, grants, snapshots)
+        });
+        if let Err(e) = spawned {
+            eprintln!("[vault] could not start the network link: {e}");
+            return 1;
+        }
+        if started_rx.recv_timeout(std::time::Duration::from_secs(5)).is_err() {
+            eprintln!("[vault] the network link thread did not start");
+            return 1;
+        }
+    }
+
+    gosub_sandbox::lock_down_vault();
+
+    // The broker link ends with the broker (recv error) or on Shutdown.
+    while let Ok(msg) = broker_rx.recv::<ToVault>() {
+        match msg {
+            ToVault::Ping => {
+                if broker_tx.lock().send(&FromVault::Pong).is_err() {
+                    break;
+                }
+            }
+            ToVault::Shutdown => break,
+            ToVault::Grant { tag, scope } => {
+                let mut grants = grants.lock();
+                grants.retain(|_, (_, since)| since.elapsed() < GRANT_TTL);
+                let reply = if grants.len() >= MAX_GRANTS {
+                    eprintln!("[vault] refusing a grant: {MAX_GRANTS} outstanding");
+                    FromVault::Refused { tag }
+                } else {
+                    grants.insert(scope.ticket, (scope, Instant::now()));
+                    FromVault::Granted { tag }
+                };
+                drop(grants);
+                if broker_tx.lock().send(&reply).is_err() {
+                    break;
+                }
+            }
+            ToVault::Revoke { ticket } => {
+                grants.lock().remove(&ticket);
+            }
+            msg => {
+                if let Some(reply) = handle(msg, &jars, &broker_tx) {
+                    if broker_tx.lock().send(&reply).is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    0
+}
+
+/// The network process's line: `Get`/`Store` only, each under a granted
+/// ticket, and acted on with the grant's scope - the zone and document the
+/// broker recorded, whatever the message claims. A `Store` still publishes
+/// its snapshot on the broker link, which is where persistence happens.
+fn serve_net(link: Endpoint, jars: Jars, grants: Grants, snapshots: Arc<Mutex<EndpointTx>>) {
+    let (tx, mut rx) = link.split();
+    let tx = Arc::new(Mutex::new(tx));
+    let granted = |claimed: &CookieScope| -> Option<CookieScope> {
+        let grants = grants.lock();
+        let (scope, since) = grants.get(&claimed.ticket)?;
+        (since.elapsed() < GRANT_TTL).then(|| scope.clone())
+    };
+    while let Ok(msg) = rx.recv::<ToVault>() {
+        match msg {
+            ToVault::Ping => {
+                if tx.lock().send(&FromVault::Pong).is_err() {
+                    return;
+                }
+            }
+            ToVault::Get {
+                tag,
+                scope,
+                url,
+                visible_only,
+            } => {
+                let reply = match granted(&scope) {
+                    Some(scope) => handle(
+                        ToVault::Get {
+                            tag,
+                            scope,
+                            url,
+                            visible_only,
+                        },
+                        &jars,
+                        &snapshots,
+                    ),
+                    None => {
+                        eprintln!("[vault] cookies asked for without a grant; none given");
+                        Some(FromVault::Cookies { tag, header: None })
+                    }
+                };
+                if let Some(reply) = reply {
+                    if tx.lock().send(&reply).is_err() {
+                        return;
+                    }
+                }
+            }
+            ToVault::Store {
+                tag,
+                scope,
+                url,
+                set_cookie,
+            } => {
+                match granted(&scope) {
+                    Some(scope) => {
+                        handle(
+                            ToVault::Store {
+                                tag,
+                                scope,
+                                url,
+                                set_cookie,
+                            },
+                            &jars,
+                            &snapshots,
+                        );
+                    }
+                    None => eprintln!("[vault] cookies stored without a grant; dropped"),
+                }
+                // Acknowledged either way: the asker is waiting.
+                if tx.lock().send(&FromVault::Stored { tag }).is_err() {
+                    return;
+                }
+            }
+            // Anything else is the broker's business; a network process asking
+            // for it is confused or compromised, and gets nothing.
+            other => eprintln!("[vault] refused {other:?} on the network link"),
+        }
+    }
+}
+
+/// One request against the jars. Replies go back on the asking link;
+/// snapshots always go to the broker.
+fn handle(msg: ToVault, jars: &Jars, snapshots: &Arc<Mutex<EndpointTx>>) -> Option<FromVault> {
+    match msg {
+        ToVault::OpenZone { zone, snapshot } => {
+            jars.lock().insert(zone, snapshot.unwrap_or_default());
+            None
+        }
+        ToVault::CloseZone { zone } => {
+            jars.lock().remove(&zone);
+            None
+        }
+        ToVault::Get {
+            tag,
+            scope,
+            url,
+            visible_only,
+        } => {
+            let header = Url::parse(&url).ok().and_then(|url| {
+                let top = scope.top_level.as_deref().and_then(|t| Url::parse(t).ok());
+                let jars = jars.lock();
+                let jar = jars.get(&scope.zone)?;
+                if visible_only {
+                    // The document.cookie view: the same matching, over a jar
+                    // with the HttpOnly cookies removed.
+                    let mut visible = jar.clone();
+                    for cookies in visible.entries.values_mut() {
+                        cookies.retain(|c| !c.http_only);
+                    }
+                    visible.get_request_cookies(&url, top.as_ref(), scope.samesite.into())
+                } else {
+                    jar.get_request_cookies(&url, top.as_ref(), scope.samesite.into())
+                }
+            });
+            Some(FromVault::Cookies { tag, header })
+        }
+        ToVault::Store {
+            tag: _,
+            scope,
+            url,
+            set_cookie,
+        } => {
+            let Ok(url) = Url::parse(&url) else {
+                return None;
+            };
+            let zone = scope.zone;
+            let top = scope.top_level.as_deref().and_then(|t| Url::parse(t).ok());
+            let mut headers = http::HeaderMap::new();
+            for value in set_cookie {
+                if let Ok(value) = http::HeaderValue::from_str(&value) {
+                    headers.append(http::header::SET_COOKIE, value);
+                }
+            }
+            let snapshot = {
+                let mut jars = jars.lock();
+                let jar = jars.get_mut(&zone)?;
+                jar.store_response_cookies(&url, &headers, top.as_ref());
+                jar.clone()
+            };
+            let _ = snapshots.lock().send(&FromVault::Snapshot { zone, jar: snapshot });
+            None
+        }
+        ToVault::GetAll { tag, zone } => {
+            let cookies = jars
+                .lock()
+                .get(&zone)
+                .map(|jar| {
+                    jar.get_all_cookies()
+                        .into_iter()
+                        .map(|(url, cookie)| (url.to_string(), cookie))
+                        .collect()
+                })
+                .unwrap_or_default();
+            Some(FromVault::All { tag, cookies })
+        }
+        ToVault::Clear { zone } => mutate(jars, snapshots, &zone, |jar| jar.clear()),
+        ToVault::Remove { zone, url, name } => mutate(jars, snapshots, &zone, |jar| {
+            if let Ok(url) = Url::parse(&url) {
+                jar.remove_cookie(&url, &name);
+            }
+        }),
+        ToVault::RemoveForUrl { zone, url } => mutate(jars, snapshots, &zone, |jar| {
+            if let Ok(url) = Url::parse(&url) {
+                jar.remove_cookies_for_url(&url);
+            }
+        }),
+        ToVault::PurgeExpired { zone } => mutate(jars, snapshots, &zone, |jar| jar.purge_expired()),
+        ToVault::Ping | ToVault::Shutdown | ToVault::Grant { .. } | ToVault::Revoke { .. } => None,
+    }
+}
+
+/// Apply `change` to a zone's jar and publish the result.
+fn mutate(
+    jars: &Jars,
+    snapshots: &Arc<Mutex<EndpointTx>>,
+    zone: &str,
+    change: impl FnOnce(&mut DefaultCookieJar),
+) -> Option<FromVault> {
+    let snapshot = {
+        let mut jars = jars.lock();
+        let jar = jars.get_mut(zone)?;
+        change(jar);
+        jar.clone()
+    };
+    let _ = snapshots.lock().send(&FromVault::Snapshot {
+        zone: zone.to_string(),
+        jar: snapshot,
+    });
+    None
+}

--- a/crates/gosub_engine/src/cookie_vault/client.rs
+++ b/crates/gosub_engine/src/cookie_vault/client.rs
@@ -1,0 +1,665 @@
+//! The broker's side of the cookie vault: spawn it, talk to it, persist what
+//! it reports, and stand in for it as a [`CookieJar`] for everything in the
+//! engine that expects one.
+
+use crate::cookie_vault::protocol::{CookieScope, FromVault, SameSite, Tag, ToVault, VAULT_ROLE};
+use crate::engine::cookies::{CookieJar, CookieJarHandle, CookieStoreHandle, DefaultCookieJar, SameSiteContext};
+use crate::engine::zone::ZoneId;
+use gosub_ipc::{Endpoint, EndpointTx};
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use url::Url;
+
+/// How long a query waits for the vault. Generous: the vault does no I/O, so
+/// anything near this means it is gone.
+const REPLY_TIMEOUT: Duration = Duration::from_secs(10);
+/// How long to wait for the child to identify itself.
+const READY_TIMEOUT: Duration = Duration::from_secs(10);
+/// How long shutdown waits before killing a lingering vault.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(2);
+
+/// A reply the reader thread routed to a waiting query.
+enum Reply {
+    Cookies(Option<String>),
+    All(Vec<(String, String)>),
+    Granted(bool),
+}
+
+/// Why a zone's snapshot would be expected right now. A snapshot for a zone
+/// with none of these is the vault's claim alone, and is dropped: a
+/// compromised vault must not write into arbitrary zones' stores.
+#[derive(Default)]
+struct Activity {
+    /// Requests granted a ticket and not yet revoked.
+    grants: usize,
+    /// When the last grant was revoked: its snapshot may still be in flight.
+    released: Option<Instant>,
+    /// Mutations this side sent, each answered by one snapshot.
+    credits: usize,
+}
+
+/// How long after a request ends its `Store` snapshot may still arrive.
+const RELEASE_GRACE: Duration = Duration::from_secs(10);
+
+type Activities = Arc<Mutex<HashMap<String, Activity>>>;
+
+/// A running vault and the broker's link to it. A vault that dies is
+/// respawned on the next use: zones are reopened from their stores'
+/// persisted snapshots and the network process is handed a fresh line.
+pub struct CookieVault {
+    tx: Mutex<EndpointTx>,
+    pending: Arc<Mutex<HashMap<Tag, mpsc::SyncSender<Reply>>>>,
+    next_tag: AtomicU64,
+    /// The zones' persisting stores, for the snapshots the vault sends back.
+    stores: Arc<Mutex<HashMap<String, (ZoneId, CookieStoreHandle)>>>,
+    /// Per zone, what makes a snapshot expected (see [`Activity`]).
+    activity: Activities,
+    child: Mutex<Option<gosub_sandbox::spawn::Child>>,
+    /// Whether a network process was given its own line to this vault.
+    net_linked: bool,
+    /// Cleared by the reader thread of the current link when it ends.
+    alive: Mutex<Arc<AtomicBool>>,
+    /// Every zone opened and not closed, to reopen after a respawn.
+    open_zones: Mutex<HashMap<String, (ZoneId, Option<CookieStoreHandle>)>>,
+    /// How to hand the network process a new line after a respawn.
+    relink: Mutex<Option<Relink>>,
+    /// Serializes respawns and remembers the last attempt.
+    respawn: Mutex<Option<Instant>>,
+    /// Set by `shutdown`: no respawn after the engine let go.
+    closed: AtomicBool,
+}
+
+impl std::fmt::Debug for CookieVault {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CookieVault").finish_non_exhaustive()
+    }
+}
+
+/// The network process's end of its direct line to the vault, to hand over at
+/// its spawn.
+pub struct NetVaultLink(pub gosub_ipc::channel::Channel);
+
+/// A freshly spawned vault process, before anything was sent to it.
+struct Launched {
+    tx: EndpointTx,
+    rx: gosub_ipc::EndpointRx,
+    child: gosub_sandbox::spawn::Child,
+    net_link: Option<NetVaultLink>,
+}
+
+/// How the network process is handed a new vault line.
+pub type Relink = Box<dyn Fn(NetVaultLink) + Send + Sync>;
+
+/// A vault that died is respawned at most this often.
+const RESPAWN_COOLDOWN: Duration = Duration::from_secs(5);
+
+/// Re-exec this binary as the vault; the link is connected, nothing sent.
+fn launch(with_net_link: bool) -> anyhow::Result<Launched> {
+    if crate::child_process::is_child_process() {
+        anyhow::bail!(
+            "this process was started as an engine child role but is running embedder startup, \
+             which means gosub_engine::child_process::dispatch() was not called at the top of \
+             main(); refusing to spawn further processes"
+        );
+    }
+
+    let exe = std::env::current_exe()?;
+    let (ours, theirs) = gosub_ipc::channel::Channel::pair()?;
+    let net_pair = if with_net_link {
+        Some(gosub_ipc::channel::Channel::pair()?)
+    } else {
+        None
+    };
+
+    // The vault's end of the network line rides along as an extra inherited
+    // fd, named in argv before the primary link (which `spawn` appends).
+    let net_spec = net_pair.as_ref().map(|(vault_end, _)| vault_end.to_argv());
+    let mut args: Vec<&str> = vec![crate::child_process::ROLE_FLAG, VAULT_ROLE];
+    if let Some(spec) = net_spec.as_deref() {
+        args.push(spec);
+    }
+    let extra_fds: Vec<i32> = net_pair.iter().map(|(vault_end, _)| vault_end.raw()).collect();
+
+    let child = gosub_sandbox::spawn::spawn(
+        &exe,
+        &args,
+        theirs,
+        // No PID namespace: the vault serves its two links on two threads,
+        // and a process that unshared its PID namespace cannot create one.
+        gosub_sandbox::NamespaceIsolation::NoPidNamespace,
+        gosub_sandbox::spawn::ContainerProfile {
+            name: "gosub-vault",
+            internet: false,
+            fs_grant: None,
+            data_limit: None,
+            extra_fds: &extra_fds,
+            max_tasks: 16,
+            file_size_limit: None,
+        },
+    )?;
+    if let Err(e) = gosub_sandbox::confine_spawned_child(&child) {
+        log::warn!("could not confine the cookie vault: {e}");
+    }
+    let net_link = net_pair.map(|(vault_end, net_end)| {
+        drop(vault_end); // the child holds its copy
+        NetVaultLink(net_end)
+    });
+
+    let endpoint = Endpoint::from_channel(ours)?;
+    let (mut tx, rx) = endpoint.split();
+    let _ = tx.set_write_timeout(Some(REPLY_TIMEOUT));
+    Ok(Launched {
+        tx,
+        rx,
+        child,
+        net_link,
+    })
+}
+
+/// The reader thread of one link: routes replies to waiters, persists
+/// snapshots, and clears `alive` when the link ends.
+#[allow(clippy::too_many_arguments)]
+fn start_reader(
+    mut rx: gosub_ipc::EndpointRx,
+    waiters: Arc<Mutex<HashMap<Tag, mpsc::SyncSender<Reply>>>>,
+    persist: Arc<Mutex<HashMap<String, (ZoneId, CookieStoreHandle)>>>,
+    expected: Activities,
+    ready_tx: mpsc::SyncSender<()>,
+    alive: Arc<AtomicBool>,
+) -> std::io::Result<()> {
+    std::thread::Builder::new()
+        .name("cookie-vault-reader".into())
+        .spawn(move || {
+            while let Ok(msg) = rx.recv::<FromVault>() {
+                match msg {
+                    FromVault::Pong => {
+                        let _ = ready_tx.send(());
+                    }
+                    FromVault::Cookies { tag, header } => {
+                        if let Some(waiter) = waiters.lock().remove(&tag) {
+                            let _ = waiter.send(Reply::Cookies(header));
+                        }
+                    }
+                    FromVault::All { tag, cookies } => {
+                        if let Some(waiter) = waiters.lock().remove(&tag) {
+                            let _ = waiter.send(Reply::All(cookies));
+                        }
+                    }
+                    FromVault::Granted { tag } => {
+                        if let Some(waiter) = waiters.lock().remove(&tag) {
+                            let _ = waiter.send(Reply::Granted(true));
+                        }
+                    }
+                    // The broker's own stores are fire-and-forget.
+                    FromVault::Stored { .. } => {}
+                    FromVault::Refused { tag } => {
+                        if let Some(waiter) = waiters.lock().remove(&tag) {
+                            let _ = waiter.send(Reply::Granted(false));
+                        }
+                    }
+                    FromVault::Snapshot { zone, jar } => {
+                        if snapshot_expected(&expected, &zone) {
+                            persist_snapshot(&persist, &zone, jar);
+                        } else {
+                            log::warn!("the cookie vault sent a snapshot for zone {zone} nothing asked for; dropped");
+                        }
+                    }
+                }
+            }
+            alive.store(false, Ordering::Release);
+            waiters.lock().clear();
+        })
+        .map(|_| ())
+}
+
+impl CookieVault {
+    /// Re-exec this binary as the vault. With `with_net_link`, a second channel
+    /// is created whose far end the network process is to inherit, so cookie
+    /// values on requests never pass through this process.
+    pub fn spawn(with_net_link: bool) -> anyhow::Result<(Self, Option<NetVaultLink>)> {
+        let launched = launch(with_net_link)?;
+        let pending: Arc<Mutex<HashMap<Tag, mpsc::SyncSender<Reply>>>> = Arc::new(Mutex::new(HashMap::new()));
+        let stores: Arc<Mutex<HashMap<String, (ZoneId, CookieStoreHandle)>>> = Arc::new(Mutex::new(HashMap::new()));
+        let activity: Activities = Arc::new(Mutex::new(HashMap::new()));
+        let alive = Arc::new(AtomicBool::new(true));
+        let (ready_tx, ready_rx) = mpsc::sync_channel::<()>(1);
+        start_reader(
+            launched.rx,
+            Arc::clone(&pending),
+            Arc::clone(&stores),
+            Arc::clone(&activity),
+            ready_tx,
+            Arc::clone(&alive),
+        )?;
+
+        let vault = Self {
+            tx: Mutex::new(launched.tx),
+            pending,
+            next_tag: AtomicU64::new(1),
+            stores,
+            activity,
+            child: Mutex::new(Some(launched.child)),
+            net_linked: launched.net_link.is_some(),
+            alive: Mutex::new(alive),
+            open_zones: Mutex::new(HashMap::new()),
+            relink: Mutex::new(None),
+            respawn: Mutex::new(None),
+            closed: AtomicBool::new(false),
+        };
+        vault.tx.lock().send(&ToVault::Ping)?;
+        if ready_rx.recv_timeout(READY_TIMEOUT).is_err() {
+            vault.kill();
+            anyhow::bail!("the spawned process did not answer as a cookie vault within {READY_TIMEOUT:?}");
+        }
+        Ok((vault, launched.net_link))
+    }
+
+    /// The vault process's pid, while it has one.
+    pub fn pid(&self) -> Option<u32> {
+        self.child.lock().as_ref().map(gosub_sandbox::spawn::Child::id)
+    }
+
+    /// Register how the network process is given a new line when the vault
+    /// is respawned.
+    pub fn on_relink(&self, relink: Relink) {
+        *self.relink.lock() = Some(relink);
+    }
+
+    /// Whether the current link is up.
+    pub fn is_alive(&self) -> bool {
+        self.alive.lock().load(Ordering::Acquire)
+    }
+
+    /// Respawn a dead vault before an operation: a new process, the zones
+    /// reopened from what their stores hold (session cookies of a zone
+    /// without a store are gone), the network process re-linked. At most once
+    /// per cooldown; a vault that cannot come back leaves every request
+    /// without cookies until it can.
+    fn ensure_alive(&self) {
+        if self.is_alive() || self.closed.load(Ordering::Acquire) {
+            return;
+        }
+        let mut last = self.respawn.lock();
+        if self.is_alive() {
+            return;
+        }
+        if last.is_some_and(|at| at.elapsed() < RESPAWN_COOLDOWN) {
+            return;
+        }
+        *last = Some(Instant::now());
+        log::warn!("the cookie vault died; respawning it");
+        self.kill();
+
+        let launched = match launch(self.net_linked) {
+            Ok(launched) => launched,
+            Err(e) => {
+                log::error!("the cookie vault could not be respawned ({e}); requests go without cookies");
+                return;
+            }
+        };
+        let alive = Arc::new(AtomicBool::new(true));
+        let (ready_tx, ready_rx) = mpsc::sync_channel::<()>(1);
+        if let Err(e) = start_reader(
+            launched.rx,
+            Arc::clone(&self.pending),
+            Arc::clone(&self.stores),
+            Arc::clone(&self.activity),
+            ready_tx,
+            Arc::clone(&alive),
+        ) {
+            log::error!("the cookie vault reader could not start ({e}); requests go without cookies");
+            return;
+        }
+        *self.tx.lock() = launched.tx;
+        *self.child.lock() = Some(launched.child);
+        *self.alive.lock() = alive;
+        if self.tx.lock().send(&ToVault::Ping).is_err() || ready_rx.recv_timeout(READY_TIMEOUT).is_err() {
+            log::error!("the respawned cookie vault did not answer; requests go without cookies");
+            self.kill();
+            return;
+        }
+
+        let zones: Vec<(String, ZoneId, Option<CookieStoreHandle>)> = self
+            .open_zones
+            .lock()
+            .iter()
+            .map(|(key, (id, store))| (key.clone(), *id, store.clone()))
+            .collect();
+        for (key, id, store) in zones {
+            let snapshot = store.as_ref().and_then(|store| persisted_snapshot(store, id));
+            if store.is_none() {
+                log::warn!("zone {key}: its session cookies did not survive the vault");
+            }
+            let _ = self.tx.lock().send(&ToVault::OpenZone { zone: key, snapshot });
+        }
+        // Grants of the old vault are gone with it; requests in flight will
+        // find no cookies, the next ones ask again.
+        self.activity.lock().clear();
+
+        match (launched.net_link, self.relink.lock().as_ref()) {
+            (Some(link), Some(relink)) => relink(link),
+            (Some(_), None) => log::warn!("no way to hand the network process the new vault line; it keeps none"),
+            (None, _) => {}
+        }
+        log::info!("the cookie vault is back");
+    }
+
+    /// Whether the network process talks to this vault directly.
+    pub fn net_linked(&self) -> bool {
+        self.net_linked
+    }
+
+    /// Start holding `zone`'s cookies. Seeded from `store`'s persisted state
+    /// when there is one, which also receives every later snapshot.
+    pub fn open_zone(&self, zone: ZoneId, store: Option<CookieStoreHandle>) {
+        self.ensure_alive();
+        let key = zone.to_string();
+        let snapshot = store.as_ref().and_then(|store| persisted_snapshot(store, zone));
+        if let Some(store) = &store {
+            self.stores.lock().insert(key.clone(), (zone, store.clone()));
+        }
+        self.open_zones.lock().insert(key.clone(), (zone, store));
+        let _ = self.tx.lock().send(&ToVault::OpenZone { zone: key, snapshot });
+    }
+
+    pub fn close_zone(&self, zone: ZoneId) {
+        let key = zone.to_string();
+        self.stores.lock().remove(&key);
+        self.open_zones.lock().remove(&key);
+        let _ = self.tx.lock().send(&ToVault::CloseZone { zone: key });
+    }
+
+    fn ask(&self, build: impl FnOnce(Tag) -> ToVault) -> Option<Reply> {
+        self.ensure_alive();
+        let tag = self.next_tag.fetch_add(1, Ordering::Relaxed);
+        let (reply_tx, reply_rx) = mpsc::sync_channel::<Reply>(1);
+        self.pending.lock().insert(tag, reply_tx);
+        if self.tx.lock().send(&build(tag)).is_err() {
+            self.pending.lock().remove(&tag);
+            return None;
+        }
+        match reply_rx.recv_timeout(REPLY_TIMEOUT) {
+            Ok(reply) => Some(reply),
+            Err(_) => {
+                self.pending.lock().remove(&tag);
+                log::warn!("the cookie vault did not answer");
+                None
+            }
+        }
+    }
+
+    /// The `Cookie` header for a request.
+    pub fn get(&self, scope: CookieScope, url: &Url, visible_only: bool) -> Option<String> {
+        match self.ask(|tag| ToVault::Get {
+            tag,
+            scope,
+            url: url.to_string(),
+            visible_only,
+        })? {
+            Reply::Cookies(header) => header,
+            Reply::All(_) | Reply::Granted(_) => None,
+        }
+    }
+
+    pub fn store(&self, zone: &str, url: &Url, top_level: Option<&Url>, set_cookie: Vec<String>) {
+        if set_cookie.is_empty() {
+            return;
+        }
+        self.ensure_alive();
+        self.expect_snapshot(zone);
+        let _ = self.tx.lock().send(&ToVault::Store {
+            tag: 0,
+            scope: CookieScope {
+                ticket: 0,
+                zone: zone.to_string(),
+                top_level: top_level.map(|u| u.to_string()),
+                samesite: SameSite::SameSite,
+            },
+            url: url.to_string(),
+            set_cookie,
+        });
+    }
+
+    /// Let the network process act on `scope` for one request. `false` means
+    /// the request goes without cookies.
+    pub fn grant(&self, scope: &CookieScope) -> bool {
+        let granted = matches!(
+            self.ask(|tag| ToVault::Grant {
+                tag,
+                scope: scope.clone(),
+            }),
+            Some(Reply::Granted(true))
+        );
+        if granted {
+            self.activity.lock().entry(scope.zone.clone()).or_default().grants += 1;
+        }
+        granted
+    }
+
+    /// The request is over; its `Store` snapshot, if any, may still be on its way.
+    pub fn revoke(&self, scope: &CookieScope) {
+        {
+            let mut activity = self.activity.lock();
+            let zone = activity.entry(scope.zone.clone()).or_default();
+            zone.grants = zone.grants.saturating_sub(1);
+            zone.released = Some(Instant::now());
+        }
+        let _ = self.tx.lock().send(&ToVault::Revoke { ticket: scope.ticket });
+    }
+
+    /// A mutation sent from this side is answered by one snapshot.
+    fn expect_snapshot(&self, zone: &str) {
+        self.activity.lock().entry(zone.to_string()).or_default().credits += 1;
+    }
+
+    fn get_all(&self, zone: &str) -> Vec<(String, String)> {
+        match self.ask(|tag| ToVault::GetAll {
+            tag,
+            zone: zone.to_string(),
+        }) {
+            Some(Reply::All(cookies)) => cookies,
+            _ => Vec::new(),
+        }
+    }
+
+    /// A mutation on the broker's link (every `tell` is one).
+    fn tell(&self, msg: ToVault) {
+        self.ensure_alive();
+        if let ToVault::Clear { zone }
+        | ToVault::Remove { zone, .. }
+        | ToVault::RemoveForUrl { zone, .. }
+        | ToVault::PurgeExpired { zone } = &msg
+        {
+            self.expect_snapshot(zone);
+        }
+        let _ = self.tx.lock().send(&msg);
+    }
+
+    /// Ask the vault to exit, then make sure it did.
+    pub fn shutdown(&self) {
+        self.closed.store(true, Ordering::Release);
+        let _ = self.tx.lock().send(&ToVault::Shutdown);
+        let Some(mut child) = self.child.lock().take() else {
+            return;
+        };
+        let deadline = std::time::Instant::now() + SHUTDOWN_GRACE;
+        while std::time::Instant::now() < deadline {
+            match child.try_wait() {
+                Ok(true) => return,
+                Ok(false) => std::thread::sleep(Duration::from_millis(20)),
+                Err(_) => break,
+            }
+        }
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    fn kill(&self) {
+        if let Some(mut child) = self.child.lock().take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+impl Drop for CookieVault {
+    fn drop(&mut self) {
+        self.kill();
+    }
+}
+
+/// What the store has for `zone`: the persisting jar's current state.
+fn persisted_snapshot(store: &CookieStoreHandle, zone: ZoneId) -> Option<DefaultCookieJar> {
+    let jar = store.jar_for(zone)?;
+    let guard = jar.read();
+    if let Some(persisting) = guard
+        .as_any()
+        .downcast_ref::<crate::engine::cookies::PersistentCookieJar>()
+    {
+        let inner = persisting.inner.read();
+        return inner.as_any().downcast_ref::<DefaultCookieJar>().cloned();
+    }
+    guard.as_any().downcast_ref::<DefaultCookieJar>().cloned()
+}
+
+/// Whether a snapshot for `zone` answers something this side caused: a
+/// live (or just-ended) granted request, or a mutation credit, which it consumes.
+fn snapshot_expected(activity: &Activities, zone: &str) -> bool {
+    let mut activity = activity.lock();
+    let Some(zone) = activity.get_mut(zone) else {
+        return false;
+    };
+    if zone.credits > 0 {
+        zone.credits -= 1;
+        return true;
+    }
+    zone.grants > 0 || zone.released.is_some_and(|at| at.elapsed() < RELEASE_GRACE)
+}
+
+/// A snapshot from the vault: written through the zone's store, and mirrored
+/// into the store's own cached jar so its `release_zone`/`persist_all` paths
+/// (which snapshot that cache) cannot resurrect stale state.
+fn persist_snapshot(stores: &Mutex<HashMap<String, (ZoneId, CookieStoreHandle)>>, zone: &str, jar: DefaultCookieJar) {
+    let Some((zone_id, store)) = stores.lock().get(zone).cloned() else {
+        return;
+    };
+    if let Some(cached) = store.jar_for(zone_id) {
+        let mut guard = cached.write();
+        if let Some(persisting) = guard
+            .as_any_mut()
+            .downcast_mut::<crate::engine::cookies::PersistentCookieJar>()
+        {
+            let mut inner = persisting.inner.write();
+            if let Some(inner) = inner.as_any_mut().downcast_mut::<DefaultCookieJar>() {
+                *inner = jar.clone();
+            }
+        } else if let Some(inner) = guard.as_any_mut().downcast_mut::<DefaultCookieJar>() {
+            *inner = jar.clone();
+        }
+    }
+    store.persist_zone_from_snapshot(zone_id, &jar);
+}
+
+/// A [`CookieJar`] whose cookies live in the vault: every method is a message
+/// across. This is what a vaulted zone's tabs hold as their jar, so the rest
+/// of the engine (and the embedder API) is unchanged.
+pub struct VaultCookieJar {
+    vault: Arc<CookieVault>,
+    zone: String,
+}
+
+impl VaultCookieJar {
+    pub fn new(vault: Arc<CookieVault>, zone: ZoneId) -> Self {
+        Self {
+            vault,
+            zone: zone.to_string(),
+        }
+    }
+
+    /// Who this jar answers for, for a request that carries its scope instead.
+    pub fn zone(&self) -> &str {
+        &self.zone
+    }
+
+    pub fn vault(&self) -> &Arc<CookieVault> {
+        &self.vault
+    }
+
+    pub fn handle(self) -> CookieJarHandle {
+        self.into()
+    }
+}
+
+impl std::fmt::Debug for VaultCookieJar {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VaultCookieJar").field("zone", &self.zone).finish()
+    }
+}
+
+impl CookieJar for VaultCookieJar {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn store_response_cookies(&mut self, url: &Url, headers: &http::HeaderMap, top_level: Option<&Url>) {
+        let set_cookie: Vec<String> = headers
+            .get_all(http::header::SET_COOKIE)
+            .iter()
+            .filter_map(|v| v.to_str().ok().map(str::to_string))
+            .collect();
+        self.vault.store(&self.zone, url, top_level, set_cookie);
+    }
+
+    fn get_request_cookies(&self, url: &Url, top_level: Option<&Url>, samesite: SameSiteContext) -> Option<String> {
+        let scope = CookieScope {
+            ticket: 0,
+            zone: self.zone.clone(),
+            top_level: top_level.map(|u| u.to_string()),
+            samesite: SameSite::from(samesite),
+        };
+        self.vault.get(scope, url, false)
+    }
+
+    fn clear(&mut self) {
+        self.vault.tell(ToVault::Clear {
+            zone: self.zone.clone(),
+        });
+    }
+
+    fn get_all_cookies(&self) -> Vec<(Url, String)> {
+        self.vault
+            .get_all(&self.zone)
+            .into_iter()
+            .filter_map(|(url, cookie)| Url::parse(&url).ok().map(|url| (url, cookie)))
+            .collect()
+    }
+
+    fn remove_cookie(&mut self, url: &Url, cookie_name: &str) {
+        self.vault.tell(ToVault::Remove {
+            zone: self.zone.clone(),
+            url: url.to_string(),
+            name: cookie_name.to_string(),
+        });
+    }
+
+    fn remove_cookies_for_url(&mut self, url: &Url) {
+        self.vault.tell(ToVault::RemoveForUrl {
+            zone: self.zone.clone(),
+            url: url.to_string(),
+        });
+    }
+
+    fn purge_expired(&mut self) {
+        self.vault.tell(ToVault::PurgeExpired {
+            zone: self.zone.clone(),
+        });
+    }
+}

--- a/crates/gosub_engine/src/cookie_vault/protocol.rs
+++ b/crates/gosub_engine/src/cookie_vault/protocol.rs
@@ -1,0 +1,120 @@
+//! The wire vocabulary of the cookie vault: what the broker (and, directly,
+//! the network process) may ask of it.
+//!
+//! Identity is never a claim. On the broker's link the `zone` is the broker's
+//! own bookkeeping. On the network process's link every `Get`/`Store` names a
+//! ticket the broker granted for that one request, and the vault answers from
+//! the grant's scope, not the caller's. `visible_only` is the HttpOnly split -
+//! the `document.cookie` view versus the full set that goes on the wire -
+//! enforced here rather than in whoever asks.
+
+use crate::engine::cookies::DefaultCookieJar;
+use serde::{Deserialize, Serialize};
+
+/// The argv role name the broker re-execs itself with.
+pub const VAULT_ROLE: &str = "vault";
+
+/// Correlates a reply with its request on a link. Assigned by the asker; the
+/// vault only echoes it back.
+pub type Tag = u64;
+
+pub use crate::net::process::protocol::{CookieScope, SameSite, Ticket};
+
+/// Broker (or network process) → vault.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ToVault {
+    /// Prove the child is a vault before anything is entrusted to it.
+    Ping,
+    /// Start holding a zone's cookies, seeded from what the broker's store had
+    /// persisted for it (`None` starts empty).
+    OpenZone {
+        zone: String,
+        snapshot: Option<DefaultCookieJar>,
+    },
+    /// The zone closed; its jar is dropped here (the broker persisted the last
+    /// snapshot it was sent).
+    CloseZone {
+        zone: String,
+    },
+    /// The `Cookie` header value for a request, or `None` when nothing applies.
+    Get {
+        tag: Tag,
+        scope: CookieScope,
+        url: String,
+        /// Only cookies a script may see (no HttpOnly): the `document.cookie` view.
+        visible_only: bool,
+    },
+    /// Record a response's `Set-Cookie` headers. Answered with
+    /// [`FromVault::Stored`] once the jar holds them - the network process
+    /// waits for that before it reports the response, so the store is done
+    /// before the broker revokes the ticket. The jar's new state follows as a
+    /// [`FromVault::Snapshot`] on the broker link.
+    Store {
+        tag: Tag,
+        scope: CookieScope,
+        url: String,
+        set_cookie: Vec<String>,
+    },
+    /// Broker only: let the network process act on `scope` under its ticket
+    /// for the length of one request. Answered with [`FromVault::Granted`]
+    /// before the request is dispatched, so the grant is in place first.
+    Grant {
+        tag: Tag,
+        scope: CookieScope,
+    },
+    /// Broker only: the request is over.
+    Revoke {
+        ticket: Ticket,
+    },
+    /// Every cookie of a zone, `(url, "name=value")`, for the embedder API.
+    GetAll {
+        tag: Tag,
+        zone: String,
+    },
+    Clear {
+        zone: String,
+    },
+    Remove {
+        zone: String,
+        url: String,
+        name: String,
+    },
+    RemoveForUrl {
+        zone: String,
+        url: String,
+    },
+    PurgeExpired {
+        zone: String,
+    },
+    Shutdown,
+}
+
+/// Vault → broker (or network process).
+#[derive(Debug, Serialize, Deserialize)]
+pub enum FromVault {
+    Pong,
+    Granted {
+        tag: Tag,
+    },
+    /// The grant was not made; the request goes without cookies.
+    Refused {
+        tag: Tag,
+    },
+    Stored {
+        tag: Tag,
+    },
+    Cookies {
+        tag: Tag,
+        header: Option<String>,
+    },
+    All {
+        tag: Tag,
+        cookies: Vec<(String, String)>,
+    },
+    /// A zone's jar changed: the broker persists this through the zone's
+    /// cookie store. The vault itself never touches a file.
+    Snapshot {
+        zone: String,
+        jar: DefaultCookieJar,
+    },
+}

--- a/crates/gosub_engine/src/engine/engine.rs
+++ b/crates/gosub_engine/src/engine/engine.rs
@@ -87,6 +87,14 @@ pub struct EngineContext {
     /// together with `renderer_process`. Tabs render through this.
     #[cfg(all(feature = "process-isolation", target_os = "linux"))]
     pub renderer_pool: OnceLock<Arc<crate::fork_server::pool::RendererPool>>,
+    /// The cookie vault, when `security.cookie_vault` started one: zones the
+    /// engine provisions jars for keep them there.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    pub cookie_vault: OnceLock<Arc<crate::cookie_vault::client::CookieVault>>,
+    /// The network process's end of its line to the vault, waiting for the I/O
+    /// thread to spawn that process.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    pub net_vault_link: Arc<Mutex<Option<crate::cookie_vault::client::NetVaultLink>>>,
 }
 
 impl Default for EngineContext {
@@ -103,6 +111,10 @@ impl Default for EngineContext {
             renderer_process: OnceLock::new(),
             #[cfg(all(feature = "process-isolation", target_os = "linux"))]
             renderer_pool: OnceLock::new(),
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            cookie_vault: OnceLock::new(),
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            net_vault_link: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -147,6 +159,10 @@ impl<C: RenderConfiguration> GosubEngine<C> {
                 renderer_process: OnceLock::new(),
                 #[cfg(all(feature = "process-isolation", target_os = "linux"))]
                 renderer_pool: OnceLock::new(),
+                #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+                cookie_vault: OnceLock::new(),
+                #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+                net_vault_link: Arc::new(Mutex::new(None)),
             }),
             render_backend: backend,
             compositor,
@@ -179,6 +195,11 @@ impl<C: RenderConfiguration> GosubEngine<C> {
         #[cfg(feature = "process-isolation")]
         self.resolve_isolation_settings();
 
+        // The vault before the I/O thread: the network process, spawned there,
+        // inherits its line to the vault.
+        #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+        self.start_cookie_vault();
+
         let io_handle = spawn_io_thread(io_cfg, self.context.clone());
         // Set once; `start()` already refuses to run twice, so this never races or overwrites.
         let _ = self.context.io_tx.set(io_handle.subscribe());
@@ -198,6 +219,37 @@ impl<C: RenderConfiguration> GosubEngine<C> {
         // spawning it ourselves. `run()` yields `None` only if the loop was already taken, which
         // cannot happen here since `self.running` was false above.
         self.run().ok_or(EngineError::AlreadyRunning)
+    }
+
+    /// Spawn the cookie vault when `security.cookie_vault` asks for it. With
+    /// the network process also on, the two get a direct line so cookie values
+    /// on requests bypass this process entirely.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    fn start_cookie_vault(&self) {
+        use crate::cookie_vault::client::CookieVault;
+        let store = &self.context.config_store;
+        if !store.get_bool("security.cookie_vault") {
+            return;
+        }
+        let with_net = store.get_bool("security.network_process");
+        match CookieVault::spawn(with_net) {
+            Ok((vault, net_link)) => {
+                log::info!(
+                    "cookie jars live in a separate, sandboxed vault process{}",
+                    if with_net {
+                        " (the network process talks to it directly)"
+                    } else {
+                        ""
+                    }
+                );
+                *self.context.net_vault_link.lock() = net_link;
+                let _ = self.context.cookie_vault.set(Arc::new(vault));
+            }
+            Err(e) => {
+                log::error!("security.cookie_vault is on but the vault could not start ({e}); cookies stay in-process");
+                self.turn_off("security.cookie_vault");
+            }
+        }
     }
 
     /// Spawn the fork server when `security.renderer_process` asks for it.
@@ -324,6 +376,12 @@ impl<C: RenderConfiguration> GosubEngine<C> {
         self.context.renderer_process.get()
     }
 
+    /// The cookie vault, when one runs (tools and tests).
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    pub fn cookie_vault(&self) -> Option<&Arc<crate::cookie_vault::client::CookieVault>> {
+        self.context.cookie_vault.get()
+    }
+
     /// The pool of resident renderers, when `security.renderer_process` is on
     /// and the fork server started: one process per (zone, site), listable
     /// for diagnostics.
@@ -385,10 +443,11 @@ impl<C: RenderConfiguration> GosubEngine<C> {
     /// in CI.
     #[cfg(feature = "process-isolation")]
     fn resolve_isolation_settings(&self) {
-        const PROCESS_SETTINGS: [&str; 3] = [
+        const PROCESS_SETTINGS: [&str; 4] = [
             "security.network_process",
             "security.image_decoder_process",
             "security.renderer_process",
+            "security.cookie_vault",
         ];
         let store = &self.context.config_store;
 
@@ -492,6 +551,10 @@ impl<C: RenderConfiguration> GosubEngine<C> {
                 log::trace!("signal: shutting down the renderer fork server");
                 server.lock().shutdown();
             }
+            if let Some(vault) = self.context.cookie_vault.get() {
+                log::trace!("signal: shutting down the cookie vault");
+                vault.shutdown();
+            }
         }
 
         // Shutdown I/O thread
@@ -551,6 +614,36 @@ impl<C: RenderConfiguration> GosubEngine<C> {
         let config = config.unwrap_or_else(|| self.context.config.default_zone_config.clone());
         let cookie_store = services.cookie_store.clone();
 
+        // A zone whose jar the engine provisions keeps it in the vault, behind a
+        // jar handle that forwards; an embedder-supplied jar is the embedder's.
+        #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+        let services = match self.context.cookie_vault.get() {
+            Some(vault) if services.cookie_jar.is_none() => {
+                let id = zone_id.unwrap_or_default();
+                vault.open_zone(id, cookie_store.clone());
+                let jar = crate::cookie_vault::client::VaultCookieJar::new(Arc::clone(vault), id).handle();
+                return self.create_zone_with_services(
+                    config,
+                    ZoneServices {
+                        cookie_jar: Some(jar),
+                        ..services
+                    },
+                    Some(id),
+                    cookie_store,
+                );
+            }
+            _ => services,
+        };
+        self.create_zone_with_services(config, services, zone_id, cookie_store)
+    }
+
+    fn create_zone_with_services(
+        &mut self,
+        config: ZoneConfig,
+        services: ZoneServices,
+        zone_id: Option<ZoneId>,
+        cookie_store: Option<crate::cookies::CookieStoreHandle>,
+    ) -> Result<Zone<C>, EngineError> {
         let zone = match zone_id {
             Some(zone_id) => Zone::new_with_id(
                 zone_id,
@@ -597,6 +690,12 @@ impl<C: RenderConfiguration> GosubEngine<C> {
 
         // Stop all tab workers first, so nothing fetches or mutates cookies below.
         zone.close().await;
+
+        // The vault drops the zone's jar; its last snapshot is already with the store.
+        #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+        if let Some(vault) = self.context.cookie_vault.get() {
+            vault.close_zone(zone_id);
+        }
 
         // Shut down the zone's fetcher on the I/O thread (ack'd).
         if let Some(io) = &self.io_handle {

--- a/crates/gosub_engine/src/engine/settings.json
+++ b/crates/gosub_engine/src/engine/settings.json
@@ -443,6 +443,12 @@
       "description": "Decode raster images in a throwaway, sandboxed process, one per image. Needs the embedder to dispatch child roles. SVG is rasterized in that process at its intrinsic size (without system fonts), since a parsed vector tree cannot cross a process boundary; a decode the process refuses or cannot start is a failed image, never decoded in-process instead."
     },
     {
+      "key": "cookie_vault",
+      "type": "b",
+      "default": "b:true",
+      "description": "Keep the engine's cookie jars in a separate, sandboxed vault process (Linux). Tabs and the embedder API see an ordinary jar that forwards; the network process, when it runs, gets a direct line to the vault so cookie values attached to requests never pass through the engine process. Persistence stays with the zone's cookie store: the vault sends it a snapshot after every change and never touches a file itself. Takes effect only when the embedder calls gosub_engine::child_process::dispatch() first thing in main(), and falls back to in-process jars with a warning if the vault cannot start."
+    },
+    {
       "key": "renderer_process",
       "type": "b",
       "default": "b:true",

--- a/crates/gosub_engine/src/lib.rs
+++ b/crates/gosub_engine/src/lib.rs
@@ -150,6 +150,10 @@ pub mod child_process;
 #[cfg(feature = "process-isolation")]
 pub mod decoder_process;
 
+/// The cookie vault: every vaulted zone's jar, in a process of its own.
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+pub mod cookie_vault;
+
 /// The fork server renderers are forked from: warmed fonts, tier-chosen
 /// sandbox. The processes are Linux only - no other platform has a fork to
 /// serve - but the wire protocol is plain data and stays available everywhere,

--- a/crates/gosub_engine/src/net/io_runtime.rs
+++ b/crates/gosub_engine/src/net/io_runtime.rs
@@ -269,10 +269,28 @@ fn start_net_process(engine_ctx: &Arc<EngineContext>) -> Option<Arc<crate::net::
         return None;
     }
 
-    match crate::net::process::client::NetProcess::spawn() {
+    // The vault's line for this process, if the engine started a vault with one.
+    #[cfg(target_os = "linux")]
+    let vault_line = engine_ctx
+        .net_vault_link
+        .lock()
+        .take()
+        .map(|link| crate::net::process::client::VaultLine(link.0));
+    #[cfg(not(target_os = "linux"))]
+    let vault_line = None;
+    match crate::net::process::client::NetProcess::spawn(vault_line) {
         Ok(net) => {
             log::info!("network stack running in a separate, sandboxed process");
-            Some(Arc::new(net))
+            let net = Arc::new(net);
+            // A respawned vault hands this process a new line through here.
+            #[cfg(target_os = "linux")]
+            if let (Some(vault), true) = (engine_ctx.cookie_vault.get(), net.vault_linked()) {
+                let relinked = Arc::clone(&net);
+                vault.on_relink(Box::new(move |line| {
+                    relinked.relink_vault(crate::net::process::client::VaultLine(line.0));
+                }));
+            }
+            Some(net)
         }
         Err(e) => {
             log::error!(
@@ -293,6 +311,7 @@ fn dispatch_to_net_process(
     net: Arc<crate::net::process::client::NetProcess>,
     req: FetchRequest,
     refuse_private: bool,
+    cookies: Option<CookieScope>,
     cancel: tokio_util::sync::CancellationToken,
     reply_tx: oneshot::Sender<FetchResult>,
 ) {
@@ -342,6 +361,7 @@ fn dispatch_to_net_process(
             body,
             refuse_private,
             streaming,
+            cookies,
         };
         let reply = net.fetch(out, &cancel).await;
         crate::net::req_ref_tracker::REF_REGISTRY.forget_request(req_id);
@@ -355,16 +375,90 @@ fn dispatch_to_net_process(
     });
 }
 
+/// Whose cookies a request is about; nothing where no network process exists.
+#[cfg(feature = "process-isolation")]
+type CookieScope = crate::net::process::protocol::CookieScope;
+#[cfg(not(feature = "process-isolation"))]
+type CookieScope = std::convert::Infallible;
+
 #[cfg(not(feature = "process-isolation"))]
 fn dispatch_to_net_process(
     _net: std::convert::Infallible,
     _req: FetchRequest,
     _refuse_private: bool,
+    _cookies: Option<CookieScope>,
     _cancel: tokio_util::sync::CancellationToken,
     _reply_tx: oneshot::Sender<FetchResult>,
 ) {
 }
 
+/// The scope a request carries instead of a cookie header: only when the
+/// network process has its own line to the vault *and* this tab's jar is a
+/// vault jar (an embedder-supplied jar stays the broker's business).
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+fn cookie_scope_for(router: &IoRouter, identity: Option<&TabIdentity>, req: &FetchRequest) -> Option<CookieScope> {
+    let identity = identity?;
+    if !router.net_process().is_some_and(|net| net.vault_linked()) {
+        return None;
+    }
+    let jar = identity.cookie_jar.read();
+    let vaulted = jar
+        .as_any()
+        .downcast_ref::<crate::cookie_vault::client::VaultCookieJar>()?;
+    Some(CookieScope {
+        ticket: uuid::Uuid::new_v4().as_u128(),
+        zone: vaulted.zone().to_string(),
+        top_level: identity.top_level.as_ref().map(|u| u.to_string()),
+        samesite: same_site_context(identity.top_level.as_ref(), &req.url).into(),
+    })
+}
+
+/// What a granted scope hands back: the scope to send, and the wrapper that
+/// revokes the grant once the reply has passed through.
+type Revoke = Box<dyn FnOnce(oneshot::Sender<FetchResult>) -> oneshot::Sender<FetchResult> + Send>;
+
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+async fn grant_scope(identity: Option<&TabIdentity>, scope: CookieScope) -> Option<(CookieScope, Revoke)> {
+    let vault = {
+        let jar = identity?.cookie_jar.read();
+        Arc::clone(
+            jar.as_any()
+                .downcast_ref::<crate::cookie_vault::client::VaultCookieJar>()?
+                .vault(),
+        )
+    };
+    let granting = Arc::clone(&vault);
+    let granted_scope = scope.clone();
+    let granted = tokio::task::spawn_blocking(move || granting.grant(&granted_scope)).await;
+    if !matches!(granted, Ok(true)) {
+        return None;
+    }
+    let revoke_scope = scope.clone();
+    let revoke: Revoke = Box::new(move |reply_tx| {
+        let (inner_tx, inner_rx) = oneshot::channel::<FetchResult>();
+        spawn_named("io-cookie-revoke", async move {
+            let result = inner_rx.await;
+            vault.revoke(&revoke_scope);
+            if let Ok(result) = result {
+                let _ = reply_tx.send(result);
+            }
+        });
+        inner_tx
+    });
+    Some((scope, revoke))
+}
+
+#[cfg(not(all(feature = "process-isolation", target_os = "linux")))]
+async fn grant_scope(_identity: Option<&TabIdentity>, _scope: CookieScope) -> Option<(CookieScope, Revoke)> {
+    None
+}
+
+#[cfg(not(all(feature = "process-isolation", target_os = "linux")))]
+fn cookie_scope_for(_router: &IoRouter, _identity: Option<&TabIdentity>, _req: &FetchRequest) -> Option<CookieScope> {
+    None
+}
+
+/// Put the requesting tab's cookies on an outbound request.
 /// A vault jar answers over IPC, so the lookup runs on a blocking thread.
 async fn attach_request_cookies(req: &mut FetchRequest, identity: Option<&TabIdentity>) {
     req.headers.remove(http::header::COOKIE);
@@ -541,7 +635,13 @@ pub fn spawn_io_thread(cfg: FetcherConfig, engine_ctx: Arc<EngineContext>) -> Io
                             // `identity` is None for a tab that has closed or never
                             // registered, which sends no cookies (see `net::tab_identity`).
                             let identity = tab_id.and_then(|id| router.tab_identities().get(id));
+                            // With a vault the network process talks to directly, the
+                            // request carries whose cookies it wants and this process
+                            // neither attaches nor stores any.
+                            let cookie_scope = cookie_scope_for(&router, identity.as_ref(), &req);
                             let net = router.net_process();
+                            // Both of the zone's fetchers: which one serves the request
+                            // is decided in the task, after the address-space lookup.
                             let fetchers = match &net {
                                 Some(_) => None,
                                 None => match (
@@ -557,13 +657,26 @@ pub fn spawn_io_thread(cfg: FetcherConfig, engine_ctx: Arc<EngineContext>) -> Io
                             };
                             let address_space = Arc::clone(&router.address_space);
 
-                            // The rest may block - the cookie lookup, a DNS lookup for the
-                            // policy - so it runs off this loop, which must stay free for
-                            // every other tab's requests.
+                            // The rest may block - a vault round trip for the cookies, a
+                            // DNS lookup for the policy - so it runs off this loop, which
+                            // must stay free for every other tab's requests.
                             spawn_named("io-fetch", async move {
                                 let subresource = req.kind != gosub_sonar::net::types::ResourceKind::Primary;
                                 let document = identity.as_ref().and_then(|id| id.top_level.clone());
-                                attach_request_cookies(&mut req, identity.as_ref()).await;
+                                // The vault must hold the grant before the network process
+                                // can ask under it; a refused grant means no cookies at all.
+                                let (cookie_scope, reply_tx) = match cookie_scope {
+                                    Some(scope) => match grant_scope(identity.as_ref(), scope).await {
+                                        Some((scope, revoke)) => (Some(scope), revoke(reply_tx)),
+                                        None => (None, reply_tx),
+                                    },
+                                    None => (None, reply_tx),
+                                };
+                                if cookie_scope.is_some() {
+                                    req.headers.remove(http::header::COOKIE);
+                                } else {
+                                    attach_request_cookies(&mut req, identity.as_ref()).await;
+                                }
 
                                 // Policy for what a page loads, decided from the tab's own
                                 // document - never from anything the requester sent. A
@@ -577,9 +690,9 @@ pub fn spawn_io_thread(cfg: FetcherConfig, engine_ctx: Arc<EngineContext>) -> Io
 
                                 // The reply is intercepted so `Set-Cookie` is stored on this
                                 // side too; the requester still receives the untouched result.
-                                let reply_tx = match identity {
-                                    Some(id) => store_response_cookies_then_forward(id, reply_tx),
-                                    None => reply_tx,
+                                let reply_tx = match (identity, cookie_scope.is_some()) {
+                                    (Some(id), false) => store_response_cookies_then_forward(id, reply_tx),
+                                    _ => reply_tx,
                                 };
                                 let reply_tx = match (subresource, document) {
                                     (true, Some(top)) => block_opaque_responses_then_forward(top, reply_tx),
@@ -591,6 +704,7 @@ pub fn spawn_io_thread(cfg: FetcherConfig, engine_ctx: Arc<EngineContext>) -> Io
                                         net,
                                         req,
                                         refuse_private,
+                                        cookie_scope,
                                         handle.cancel.clone(),
                                         reply_tx,
                                     ),

--- a/crates/gosub_engine/src/net/process/child.rs
+++ b/crates/gosub_engine/src/net/process/child.rs
@@ -1,8 +1,8 @@
 //! The network process: the only part of the engine that may open a socket.
 //!
-//! What only Linux can do - pass a ring fd for a streamed body - lives in
-//! `platform`; the same API elsewhere declines, so this file has no platform
-//! branches of its own.
+//! What only Linux can do - pass a ring fd for a streamed body, hold a direct
+//! line to the cookie vault - lives in `platform`; the same API elsewhere
+//! declines, so this file has no platform branches of its own.
 
 use crate::net::fetcher::{Fetcher, FetcherConfig};
 use crate::net::process::protocol::{FetchOutcome, FromNet, NetFetch, RequestTag, ToNet};
@@ -23,7 +23,7 @@ mod platform;
 #[path = "child/portable.rs"]
 mod platform;
 
-use platform::Streamed;
+use platform::{Streamed, VaultLink};
 
 /// How long a shutdown drain waits for in-flight requests before giving up.
 /// Shorter than the broker's `SHUTDOWN_GRACE`, so a draining child exits on
@@ -31,7 +31,10 @@ use platform::Streamed;
 const DRAIN_GRACE: std::time::Duration = std::time::Duration::from_secs(3);
 
 /// Run as the network process until the broker disconnects or says to stop.
-pub fn serve(link: Endpoint) -> i32 {
+pub fn serve(link: Endpoint, vault: Option<Endpoint>) -> i32 {
+    // A vault that stops answering must cost one request its cookies, not
+    // wedge every request behind the mutex.
+    let vault: Arc<Mutex<Option<VaultLink>>> = Arc::new(Mutex::new(vault.map(VaultLink::new)));
     gosub_sandbox::capture_process_title_region();
     gosub_sandbox::set_process_title("gosub-net", "gosub: network process");
 
@@ -123,6 +126,11 @@ pub fn serve(link: Endpoint) -> i32 {
                     token.cancel();
                 }
             }
+            // The vault was respawned: its new line follows on the link.
+            ToNet::VaultLine => match platform::adopt_vault_line(&mut link_rx) {
+                Ok(line) => *vault.lock() = Some(line),
+                Err(e) => eprintln!("[net] the new vault line did not arrive: {e}"),
+            },
             ToNet::Fetch(fetch) => {
                 let tag = fetch.tag;
                 let token = CancellationToken::new();
@@ -134,8 +142,9 @@ pub fn serve(link: Endpoint) -> i32 {
                 };
                 let link_tx = link_tx.clone();
                 let cancels = cancels.clone();
+                let vault = vault.clone();
                 let handle = runtime.spawn(async move {
-                    let performed = perform(&fetcher, fetch, token).await;
+                    let performed = perform(&fetcher, fetch, token, &vault).await;
                     cancels.lock().remove(&tag);
                     // A write error means the broker went away; the recv loop
                     // notices the same and ends the process.
@@ -215,9 +224,21 @@ fn flat_headers(headers: &http::HeaderMap) -> Vec<(String, String)> {
 }
 
 /// Perform one request and flatten the result to something that can travel.
-async fn perform(fetcher: &Arc<Fetcher>, fetch: NetFetch, cancel: CancellationToken) -> Performed {
+async fn perform(
+    fetcher: &Arc<Fetcher>,
+    fetch: NetFetch,
+    cancel: CancellationToken,
+    vault: &Mutex<Option<VaultLink>>,
+) -> Performed {
     let streaming = fetch.streaming && platform::STREAMING;
     let done = Performed::Done;
+    // Cookies come from the vault, never from the broker, when this process
+    // has its own line to it. The scope is the broker's word on whose they are.
+    let scope = fetch.cookies.clone();
+    let cookie_header = match &scope {
+        Some(scope) => tokio::task::block_in_place(|| platform::vault_cookies(vault, scope, &fetch.url)),
+        None => None,
+    };
     let url = match Url::parse(&fetch.url) {
         Ok(u) => u,
         Err(e) => return done(FetchOutcome::Error(format!("bad url {}: {e}", fetch.url))),
@@ -234,6 +255,11 @@ async fn perform(fetcher: &Arc<Fetcher>, fetch: NetFetch, cancel: CancellationTo
             headers.insert(name, value);
         }
     }
+    headers.remove(http::header::COOKIE);
+    if let Some(value) = cookie_header.as_deref().and_then(|v| v.parse().ok()) {
+        headers.insert(http::header::COOKIE, value);
+    }
+
     let mut builder = FetchRequest::builder(method, url)
         .with_headers(headers)
         .with_streaming(streaming)
@@ -251,6 +277,10 @@ async fn perform(fetcher: &Arc<Fetcher>, fetch: NetFetch, cancel: CancellationTo
         _ = cancel.cancelled() => return done(FetchOutcome::Error("cancelled by the broker".into())),
         r = rx => r,
     };
+    // `Set-Cookie` goes to the vault from here; the broker never sees it.
+    if let (Some(scope), Some(meta)) = (&scope, result.as_ref().ok().and_then(|r| r.meta())) {
+        tokio::task::block_in_place(|| platform::vault_store(vault, scope, meta));
+    }
     match result {
         Ok(FetchResult::Buffered { meta, body }) => done(FetchOutcome::Ok {
             status: meta.status,

--- a/crates/gosub_engine/src/net/process/child/linux.rs
+++ b/crates/gosub_engine/src/net/process/child/linux.rs
@@ -1,12 +1,15 @@
 //! Linux: a streamed body crosses to the broker through a shared-memory ring
-//! whose fd is passed on the link. The API here is what `super` calls;
-//! `portable.rs` is its stand-in.
+//! whose fd is passed on the link, and cookies come from a direct line to the
+//! vault. The API here is what `super` calls; `portable.rs` is its stand-in.
 
-use crate::net::process::protocol::{FetchOutcome, FromNet, RequestTag};
-use gosub_ipc::EndpointTx;
+use crate::cookie_vault::protocol::{FromVault, ToVault};
+use crate::net::process::protocol::{CookieScope, FetchOutcome, FromNet, RequestTag};
+use gosub_ipc::{Endpoint, EndpointRx, EndpointTx};
 use gosub_sonar::net::shared_body::SharedBody;
+use gosub_sonar::net::types::FetchResultMeta;
 use parking_lot::Mutex;
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Bodies may stream: the link carries the ring's fd.
 pub(super) const STREAMING: bool = true;
@@ -21,6 +24,8 @@ const RING_CAPACITY: u32 = 256 * 1024;
 /// the broker is not draining; this queue absorbs that stall (16 KiB chunks:
 /// at most 16 MiB held) so backpressure costs memory here, never bytes.
 const PUMP_QUEUE: usize = 1024;
+
+const VAULT_TIMEOUT: Duration = Duration::from_secs(5);
 
 type BodyChunks = futures_util::stream::BoxStream<'static, Result<bytes::Bytes, gosub_sonar::net::types::NetError>>;
 
@@ -112,6 +117,90 @@ async fn pump(mut producer: gosub_ipc::ring::RingProducer, body: BodyPump) {
         return;
     }
     producer.finish();
+}
+
+/// The direct line to the vault: one request in flight at a time, each
+/// answer checked against the tag it was asked with.
+pub(super) struct VaultLink {
+    link: Endpoint,
+    next_tag: u64,
+}
+
+impl VaultLink {
+    pub(super) fn new(mut link: Endpoint) -> Self {
+        let _ = link.rx.set_read_timeout(Some(VAULT_TIMEOUT));
+        let _ = link.tx.set_write_timeout(Some(VAULT_TIMEOUT));
+        Self { link, next_tag: 1 }
+    }
+
+    /// One tagged exchange. Any failure - timeout, a reply for another tag -
+    /// is `None`; replies for an earlier, timed-out request are skipped.
+    fn exchange(&mut self, build: impl FnOnce(u64) -> ToVault) -> Option<FromVault> {
+        let tag = self.next_tag;
+        self.next_tag += 1;
+        self.link.send(&build(tag)).ok()?;
+        loop {
+            let reply = self.link.recv::<FromVault>().ok()?;
+            let got = match &reply {
+                FromVault::Cookies { tag, .. } | FromVault::Stored { tag } => *tag,
+                _ => return None,
+            };
+            if got == tag {
+                return Some(reply);
+            }
+            if got > tag {
+                return None;
+            }
+        }
+    }
+}
+
+/// A respawned vault's line: the fd arrives twice, one per half, because this
+/// process may not `dup`.
+pub(super) fn adopt_vault_line(rx: &mut EndpointRx) -> Result<VaultLink, String> {
+    let tx_fd = rx.recv_fd().map_err(|e| e.to_string())?;
+    let rx_fd = rx.recv_fd().map_err(|e| e.to_string())?;
+    Ok(VaultLink::new(Endpoint::from_halves(
+        std::os::unix::net::UnixStream::from(tx_fd),
+        std::os::unix::net::UnixStream::from(rx_fd),
+    )))
+}
+
+/// The `Cookie` header for a request, from the vault; any failure is "no cookies".
+pub(super) fn vault_cookies(vault: &Mutex<Option<VaultLink>>, scope: &CookieScope, url: &str) -> Option<String> {
+    match vault.lock().as_mut()?.exchange(|tag| ToVault::Get {
+        tag,
+        scope: scope.clone(),
+        url: url.to_string(),
+        visible_only: false,
+    })? {
+        FromVault::Cookies { header, .. } => header,
+        _ => None,
+    }
+}
+
+/// Hand a response's `Set-Cookie` headers to the vault. Waited for: the reply
+/// to the broker must not overtake the store.
+pub(super) fn vault_store(vault: &Mutex<Option<VaultLink>>, scope: &CookieScope, meta: &FetchResultMeta) {
+    let set_cookie: Vec<String> = meta
+        .headers
+        .get_all(http::header::SET_COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok().map(str::to_string))
+        .collect();
+    if set_cookie.is_empty() {
+        return;
+    }
+    let mut guard = vault.lock();
+    let Some(link) = guard.as_mut() else {
+        return;
+    };
+    let _ = link.exchange(|tag| ToVault::Store {
+        tag,
+        scope: scope.clone(),
+        url: meta.final_url.to_string(),
+        set_cookie,
+    });
 }
 
 #[cfg(test)]

--- a/crates/gosub_engine/src/net/process/child/portable.rs
+++ b/crates/gosub_engine/src/net/process/child/portable.rs
@@ -1,9 +1,11 @@
-//! Off Linux: no fd passing, so no streamed bodies. The broker buffers
-//! bodies; this is `linux.rs`'s API declining.
+//! Off Linux: no fd passing, so no streamed bodies and no vault line. The
+//! broker buffers bodies and attaches cookies itself; this is `linux.rs`'s
+//! API declining.
 
-use crate::net::process::protocol::{FetchOutcome, RequestTag};
-use gosub_ipc::EndpointTx;
+use crate::net::process::protocol::{CookieScope, FetchOutcome, RequestTag};
+use gosub_ipc::{Endpoint, EndpointRx, EndpointTx};
 use gosub_sonar::net::shared_body::SharedBody;
+use gosub_sonar::net::types::FetchResultMeta;
 use parking_lot::Mutex;
 use std::sync::Arc;
 
@@ -26,3 +28,22 @@ impl Streamed {
         match self {}
     }
 }
+
+/// A line that is never used: cookies come from the broker on these platforms.
+pub(super) struct VaultLink;
+
+impl VaultLink {
+    pub(super) fn new(_link: Endpoint) -> Self {
+        Self
+    }
+}
+
+pub(super) fn adopt_vault_line(_rx: &mut EndpointRx) -> Result<VaultLink, String> {
+    Err("a vault line is a Linux thing".into())
+}
+
+pub(super) fn vault_cookies(_vault: &Mutex<Option<VaultLink>>, _scope: &CookieScope, _url: &str) -> Option<String> {
+    None
+}
+
+pub(super) fn vault_store(_vault: &Mutex<Option<VaultLink>>, _scope: &CookieScope, _meta: &FetchResultMeta) {}

--- a/crates/gosub_engine/src/net/process/client.rs
+++ b/crates/gosub_engine/src/net/process/client.rs
@@ -1,7 +1,7 @@
 //! The broker's side of the network process: spawn it, talk to it, notice when
 //! it dies.
 
-use crate::net::process::protocol::{FetchOutcome, FromNet, NetFetch, RequestTag, ToNet};
+use crate::net::process::protocol::{CookieScope, FetchOutcome, FromNet, NetFetch, RequestTag, ToNet};
 use crate::net::types::NetError;
 use gosub_ipc::{Endpoint, EndpointTx};
 use parking_lot::Mutex;
@@ -22,6 +22,9 @@ pub struct Outbound {
     pub refuse_private: bool,
     /// Deliver the body through a ring as it arrives, where the link can carry one.
     pub streaming: bool,
+    /// Whose cookies to attach, resolved by the network process against the
+    /// cookie vault. `None` when the broker attached the header itself.
+    pub cookies: Option<CookieScope>,
 }
 
 impl Outbound {
@@ -34,6 +37,7 @@ impl Outbound {
             body: None,
             refuse_private: false,
             streaming: false,
+            cookies: None,
         }
     }
 }
@@ -77,6 +81,10 @@ fn recv_ring(_rx: &mut gosub_ipc::EndpointRx) -> std::io::Result<RingFd> {
 /// The argv role name the broker re-execs itself with.
 pub const NET_ROLE: &str = "net";
 
+/// The network process's end of a line to the cookie vault (Linux); an opaque
+/// channel elsewhere, never created.
+pub struct VaultLine(pub gosub_ipc::channel::Channel);
+
 /// How long a caller waits for a reply before giving up on the network process.
 const REPLY_TIMEOUT: Duration = Duration::from_secs(120);
 
@@ -102,6 +110,9 @@ pub struct NetProcess {
     child: Mutex<Option<gosub_sandbox::spawn::Child>>,
     /// Bounds concurrent requests (see [`MAX_INFLIGHT`]).
     inflight: Arc<tokio::sync::Semaphore>,
+    /// The child holds a direct line to the cookie vault: requests may carry a
+    /// cookie scope instead of a header.
+    vault_linked: bool,
 }
 
 impl std::fmt::Debug for NetProcess {
@@ -111,8 +122,9 @@ impl std::fmt::Debug for NetProcess {
 }
 
 impl NetProcess {
-    /// Re-exec this binary as the network process and connect to it.
-    pub fn spawn() -> anyhow::Result<Self> {
+    /// Re-exec this binary as the network process and connect to it. With
+    /// `vault`, the child also inherits its line to the cookie vault.
+    pub fn spawn(vault: Option<VaultLine>) -> anyhow::Result<Self> {
         // A process that carries a child role but is running broker code got here
         // because the embedder never dispatched, so re-exec put it into its own
         // `main`. Spawning from here would do the same thing again, and again:
@@ -129,7 +141,17 @@ impl NetProcess {
         let exe = std::env::current_exe()?;
         let (ours, theirs) = gosub_ipc::channel::Channel::pair()?;
 
-        let args: [&str; 2] = [crate::child_process::ROLE_FLAG, NET_ROLE];
+        // The vault line rides along as an extra inherited fd, named in argv
+        // before the primary link (which `spawn` appends).
+        let vault_spec = vault.as_ref().map(|line| line.0.to_argv());
+        let mut args: Vec<&str> = vec![crate::child_process::ROLE_FLAG, NET_ROLE];
+        if let Some(spec) = vault_spec.as_deref() {
+            args.push(spec);
+        }
+        #[cfg(target_os = "linux")]
+        let extra_fds: Vec<i32> = vault.iter().map(|line| line.0.raw()).collect();
+        #[cfg(not(target_os = "linux"))]
+        let extra_fds: Vec<i32> = Vec::new();
 
         let child = gosub_sandbox::spawn::spawn(
             &exe,
@@ -142,12 +164,13 @@ impl NetProcess {
                 internet: true,
                 fs_grant: None,
                 data_limit: None,
-                extra_fds: &[],
+                extra_fds: &extra_fds,
                 // A multi-thread runtime plus its blocking pool.
                 max_tasks: 1024,
                 file_size_limit: None,
             },
         )?;
+        drop(vault); // the child holds its copy of the vault line
 
         if let Err(e) = gosub_sandbox::confine_spawned_child(&child) {
             log::warn!("could not apply parent-side confinement to the network process: {e}");
@@ -204,6 +227,7 @@ impl NetProcess {
             next_tag: AtomicU64::new(1),
             child: Mutex::new(Some(child)),
             inflight: Arc::new(tokio::sync::Semaphore::new(MAX_INFLIGHT)),
+            vault_linked: !extra_fds.is_empty(),
         };
 
         // Confirm the child really is a network process before returning it as
@@ -231,6 +255,23 @@ impl NetProcess {
         Ok(net)
     }
 
+    /// Whether the child resolves cookies against the vault itself.
+    pub fn vault_linked(&self) -> bool {
+        self.vault_linked
+    }
+
+    /// Hand the child a new line to a respawned vault, over its own link. The
+    /// fd goes twice: the child may not `dup`, and an endpoint is two halves.
+    #[cfg(target_os = "linux")]
+    pub fn relink_vault(&self, line: VaultLine) {
+        let mut tx = self.tx.lock();
+        if tx.send(&ToNet::VaultLine).is_err() || tx.send_fd(line.0.raw()).is_err() || tx.send_fd(line.0.raw()).is_err()
+        {
+            log::warn!("could not hand the network process its new vault line");
+        }
+        // `line` drops here: the child holds its duplicates.
+    }
+
     /// Send a request and wait for the network process to answer. Bounded by
     /// [`MAX_INFLIGHT`]; a caller past the bound waits for a slot. Cancelling
     /// `cancel` abandons the wait and tells the child to drop the request.
@@ -242,6 +283,7 @@ impl NetProcess {
             body,
             refuse_private,
             streaming,
+            cookies,
         } = out;
         let permit = tokio::select! {
             _ = cancel.cancelled() => return NetReply::error("cancelled"),
@@ -264,6 +306,7 @@ impl NetProcess {
             body,
             refuse_private,
             streaming,
+            cookies,
         });
         // The link write can block on a full pipe (bodies can be large), so it
         // runs on a blocking thread rather than a runtime worker.

--- a/crates/gosub_engine/src/net/process/protocol.rs
+++ b/crates/gosub_engine/src/net/process/protocol.rs
@@ -19,6 +19,9 @@ pub enum ToNet {
     /// Finish in-flight work and exit. The broker still waits for the process to
     /// go away and kills it if it does not.
     Shutdown,
+    /// A new line to the cookie vault follows as a file descriptor (the vault
+    /// was respawned); it replaces the one inherited at spawn.
+    VaultLine,
 }
 
 /// One request, flattened to what actually has to travel.
@@ -42,10 +45,60 @@ pub struct NetFetch {
     /// The requester wants the body as it arrives. Honoured where the link can
     /// carry a ring fd (Linux); elsewhere the reply is buffered as usual.
     pub streaming: bool,
+    /// Whose cookies to attach, when the network process has its own line to
+    /// the cookie vault: the broker then sends no `Cookie` header at all, and
+    /// the network process stores `Set-Cookie` in the vault itself.
+    pub cookies: Option<CookieScope>,
     // Only these cross. `FetchRequest::origin` / `referrer` / `mixed_content`
     // (sonar 0.2.0) do not: the engine sets none of them yet. When it does, add
     // them here - otherwise the network process rebuilds the request without
     // them and mixed-content blocking silently disappears out-of-process.
+}
+
+/// `SameSiteContext` as it travels.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SameSite {
+    SameSite,
+    CrossSiteNavigation,
+    CrossSite,
+}
+
+impl From<crate::engine::cookies::SameSiteContext> for SameSite {
+    fn from(value: crate::engine::cookies::SameSiteContext) -> Self {
+        use crate::engine::cookies::SameSiteContext as C;
+        match value {
+            C::SameSite => Self::SameSite,
+            C::CrossSiteNavigation => Self::CrossSiteNavigation,
+            C::CrossSite => Self::CrossSite,
+        }
+    }
+}
+
+impl From<SameSite> for crate::engine::cookies::SameSiteContext {
+    fn from(value: SameSite) -> Self {
+        match value {
+            SameSite::SameSite => Self::SameSite,
+            SameSite::CrossSiteNavigation => Self::CrossSiteNavigation,
+            SameSite::CrossSite => Self::CrossSite,
+        }
+    }
+}
+
+/// A random, single-use request capability (see [`CookieScope::ticket`]).
+pub type Ticket = u128;
+
+/// Whose cookies a request is about: the tab's zone and the document it is
+/// loading, as the broker recorded them. Travels in place of the cookie
+/// header when the network process asks the cookie vault itself.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CookieScope {
+    /// A per-request capability the broker granted to the vault before
+    /// dispatch; the vault answers the network process for granted tickets
+    /// only, and from the grant's own scope. `0` on the broker's link.
+    pub ticket: Ticket,
+    pub zone: String,
+    pub top_level: Option<String>,
+    pub samesite: SameSite,
 }
 
 /// Network process → broker.

--- a/crates/gosub_engine/tests/process_isolation.rs
+++ b/crates/gosub_engine/tests/process_isolation.rs
@@ -45,6 +45,70 @@ fn a_request_completes_through_the_network_process() {
     );
 }
 
+/// The cookie vault on its own: jar that forwards, HttpOnly split, zone
+/// partitioning, persistence brokered through a real SQLite store.
+#[cfg(target_os = "linux")]
+#[test]
+fn the_cookie_vault_holds_partitioned_jars_and_persists_through_the_broker() {
+    let out = run("vault");
+    assert!(
+        out.status.success(),
+        "vault scenario failed:\n{}\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A vault that dies is respawned on the next use: the zone comes back from
+/// its store and the network process gets a new line, so the cookie still
+/// reaches the next request.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_dead_cookie_vault_is_respawned_with_its_zones() {
+    for mode in [
+        &["engine-cookie-vault", "respawn"][..],
+        &["engine-cookie-vault", "respawn", "in-process"][..],
+    ] {
+        let out = Command::new(harness())
+            .args(mode)
+            .output()
+            .expect("spawn isolation-harness");
+        assert!(
+            out.status.success(),
+            "{mode:?} failed:\n{}\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}
+
+/// With the vault and the network process on, a cookie a page sets reaches the
+/// page's next request without the engine process ever attaching it.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_cookie_flows_from_the_vault_through_the_network_process() {
+    let out = run("engine-cookie-vault");
+    assert!(
+        out.status.success(),
+        "engine cookie vault scenario failed:\n{}\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The same with in-process fetching: the broker's forwarding jar asks the vault.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_cookie_flows_from_the_vault_with_in_process_fetching() {
+    let out = run_with_backend("engine-cookie-vault", "in-process");
+    assert!(
+        out.status.success(),
+        "engine cookie vault (in-process) scenario failed:\n{}\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 /// A streamed body crosses the network-process boundary through a
 /// shared-memory ring: head in-band, ring fd right behind it, bytes intact.
 #[cfg(target_os = "linux")]


### PR DESCRIPTION

Base: `10-streaming`.

### What is in here

- `cookie_vault` (`security.cookie_vault`): `gosub-vault`, a process in the
  least-authority profile holding every vaulted zone's jar. Tabs and the
  embedder API keep an ordinary `CookieJar` (`VaultCookieJar` forwards); the
  network process inherits its own line to the vault
  (`ContainerProfile.extra_fds`) so cookie values on the wire never pass
  through the engine process.
- That line is not trusted to name zones: the broker grants the vault a random
  per-request **ticket** (acked before dispatch, revoked after the reply), the
  network process asks under it, the vault answers from the grant's scope;
  `Store` is acknowledged so a reply cannot overtake it.
- Persistence is brokered: snapshots after every change, written through the
  zone's `CookieStore`, accepted only for a zone with a live request or a
  mutation of the broker's own outstanding.
- A vault that dies is respawned on the next use, zones reopened from their
  stores, the network process re-linked over its own link (the fd twice: it
  may not `dup`; `Endpoint::from_halves`).
- Engine wiring: `start_cookie_vault` before the I/O thread; zones the engine
  provisions jars for keep them in the vault; embedder-supplied jars stay the
  embedder's.

### Testing

```
cargo test -p gosub_engine --test process_isolation --features cairo-tiles   # 30
./target/debug/isolation-harness vault                    # HttpOnly split, partitioning, grants, SQLite persistence via the broker
./target/debug/isolation-harness engine-cookie-vault      # both fetch modes, each across a kill of the vault
```