### PR TITLE
Storage service: localStorage served from a sandboxed process confined to one directory, respawn

### DIFF
--- a/crates/gosub_engine/src/bin/isolation-harness.rs
+++ b/crates/gosub_engine/src/bin/isolation-harness.rs
@@ -138,6 +138,8 @@ fn main() {
         "engine-renderer-slow-image" => with_font_backend!(engine_renderer_slow_image),
         "renderer-soak" => with_font_backend!(renderer_soak),
         "engine-soak" => with_font_backend!(engine_soak),
+        "storage" => storage(),
+        "engine-storage-service" => engine_storage_service(),
         "vault" => vault(),
         "engine-cookie-vault" => engine_cookie_vault(),
         "stream" => stream(),
@@ -3728,6 +3730,255 @@ fn serve_cookie_pages(seen: SeenRequests) -> std::io::Result<u16> {
         }
     });
     Ok(port)
+}
+
+/// A zone built with a plain `FileLocalStore` gets its local storage served
+/// by the storage process without the embedder asking: the setting's default.
+fn engine_storage_service() -> i32 {
+    #[cfg(target_os = "linux")]
+    {
+        use gosub_engine::storage::{
+            FileLocalStore, InMemorySessionStore, PartitionKey, PartitionPolicy, StorageService,
+        };
+        use gosub_engine::zone::ZoneServices;
+        use gosub_engine::GosubEngine;
+        use gosub_render_pipeline::render::backends::null::NullBackend;
+        use gosub_render_pipeline::render::DefaultCompositor;
+
+        let dir = std::env::temp_dir().join(format!("gosub-engine-storage-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let Ok(store) = FileLocalStore::open(&dir) else {
+            eprintln!("could not open the file store");
+            return 1;
+        };
+        let Ok(origin) = url::Url::parse("https://app.test").map(|u| u.origin()) else {
+            return 1;
+        };
+        let runtime = match tokio::runtime::Builder::new_multi_thread().enable_all().build() {
+            Ok(rt) => rt,
+            Err(e) => {
+                eprintln!("could not build a runtime: {e}");
+                return 1;
+            }
+        };
+        let code = runtime.block_on(async move {
+            let mut engine: GosubEngine = GosubEngine::new(
+                None,
+                Arc::new(NullBackend::new()),
+                Arc::new(DefaultCompositor::default()),
+            );
+            let _events = engine.subscribe_events();
+            let Ok(run) = engine.start() else {
+                eprintln!("engine failed to start");
+                return 1;
+            };
+            tokio::spawn(run);
+            let storage = Arc::new(StorageService::new(
+                Arc::new(store),
+                Arc::new(InMemorySessionStore::new()),
+            ));
+            let services = ZoneServices {
+                storage: Arc::clone(&storage),
+                cookie_store: None,
+                cookie_jar: None,
+                partition_policy: PartitionPolicy::None,
+                places: None,
+            };
+            let zone = match engine.create_zone(None, services, None) {
+                Ok(zone) => zone,
+                Err(e) => {
+                    eprintln!("could not create a zone: {e}");
+                    return 1;
+                }
+            };
+            // The embedder's own handle sees the routed store.
+            let area = match storage.local_for(zone.id, &PartitionKey::None, &origin) {
+                Ok(area) => area,
+                Err(e) => {
+                    eprintln!("no area: {e}");
+                    return 1;
+                }
+            };
+            if let Err(e) = area.set_item("k", "v") {
+                eprintln!("set failed: {e}");
+                return 1;
+            }
+            if area.get_item("k").as_deref() != Some("v") {
+                eprintln!("get did not round-trip");
+                return 1;
+            }
+            if !has_child_named("gosub-storage") {
+                eprintln!(
+                    "no gosub-storage child process: storage stayed in-process (children: {:?}, routed dir: {:?})",
+                    child_names(),
+                    storage.local_store().service_directory()
+                );
+                return 1;
+            }
+            println!("localStorage of a FileLocalStore zone is served by gosub-storage");
+
+            // Kill it: the next request brings a new one, reading the same files.
+            let Some(pid) = storage.local_store().service_pid() else {
+                eprintln!("the routed store has no service pid");
+                return 1;
+            };
+            let _ = std::process::Command::new("kill")
+                .args(["-9", &pid.to_string()])
+                .status();
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            if area.get_item("k").as_deref() != Some("v") {
+                eprintln!("the value did not survive the storage service dying");
+                return 1;
+            }
+            match storage.local_store().service_pid() {
+                Some(new_pid) if new_pid != pid => println!("storage service respawned: pid {pid} -> {new_pid}"),
+                other => {
+                    eprintln!("the storage service was not respawned (pid {pid} -> {other:?})");
+                    return 1;
+                }
+            }
+            let _ = engine.shutdown().await;
+            0
+        });
+        let files = std::fs::read_dir(&dir).map(|d| d.count()).unwrap_or(0);
+        let _ = std::fs::remove_dir_all(&dir);
+        if code == 0 && files == 0 {
+            eprintln!("the service wrote nothing to the storage directory");
+            return 1;
+        }
+        code
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the storage service is Linux-only");
+        2
+    }
+}
+
+/// The `comm` of every direct child of this process.
+#[cfg(target_os = "linux")]
+fn child_names() -> Vec<String> {
+    let me = std::process::id().to_string();
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let status = std::fs::read_to_string(entry.path().join("status")).ok()?;
+            let mut comm = String::new();
+            let mut ppid = String::new();
+            for line in status.lines() {
+                if let Some(v) = line.strip_prefix("Name:\t") {
+                    comm = v.trim().to_string();
+                } else if let Some(v) = line.strip_prefix("PPid:\t") {
+                    ppid = v.trim().to_string();
+                }
+            }
+            (ppid == me).then_some(comm)
+        })
+        .collect()
+}
+
+/// Whether this process has a direct child whose `comm` is `name`.
+#[cfg(target_os = "linux")]
+fn has_child_named(name: &str) -> bool {
+    let me = std::process::id().to_string();
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        let status = std::fs::read_to_string(entry.path().join("status")).unwrap_or_default();
+        let mut comm = "";
+        let mut ppid = "";
+        for line in status.lines() {
+            if let Some(v) = line.strip_prefix("Name:\t") {
+                comm = v.trim();
+            } else if let Some(v) = line.strip_prefix("PPid:\t") {
+                ppid = v.trim();
+            }
+        }
+        ppid == me && comm == name
+    })
+}
+
+/// Storage service round trip, origin isolation, a refused oversize write,
+/// persistence across a restart of the service.
+fn storage() -> i32 {
+    #[cfg(target_os = "linux")]
+    {
+        use gosub_engine::storage::{LocalStore as _, PartitionKey, ServiceLocalStore};
+        use gosub_engine::zone::ZoneId;
+
+        let dir = std::env::temp_dir().join(format!("gosub-storage-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let origin = |s: &str| url::Url::parse(s).map(|u| u.origin());
+        let (Ok(a_origin), Ok(b_origin)) = (origin("https://a.test"), origin("https://b.test")) else {
+            eprintln!("bad test origins");
+            return 1;
+        };
+        let zone = ZoneId::new();
+
+        let run = |expect_remote: bool| -> Result<(), String> {
+            let store = ServiceLocalStore::new(&dir).map_err(|e| e.to_string())?;
+            let a = store
+                .area(zone, &PartitionKey::None, &a_origin)
+                .map_err(|e| e.to_string())?;
+            if expect_remote && !store.is_remote() {
+                return Err("the storage service did not start; areas are in-process".into());
+            }
+            if a.get_item("k").is_none() {
+                a.set_item("k", "1").map_err(|e| e.to_string())?;
+                a.set_item("k2", "2").map_err(|e| e.to_string())?;
+                let b = store
+                    .area(zone, &PartitionKey::None, &b_origin)
+                    .map_err(|e| e.to_string())?;
+                if b.get_item("k").is_some() {
+                    return Err("another origin must not see this origin's item".into());
+                }
+                if a.len() != 2 || a.get_item("k2").as_deref() != Some("2") {
+                    return Err(format!("len/get wrong: len {} k2 {:?}", a.len(), a.get_item("k2")));
+                }
+                a.remove_item("k2").map_err(|e| e.to_string())?;
+                if a.keys() != vec!["k".to_string()] {
+                    return Err(format!("keys after remove: {:?}", a.keys()));
+                }
+                let huge = "v".repeat(gosub_engine::storage::file_store::MAX_VALUE_BYTES + 1);
+                if a.set_item("huge", &huge).is_ok() {
+                    return Err("an oversize value must be refused".into());
+                }
+                if a.get_item("k").as_deref() != Some("1") {
+                    return Err("the service must survive a refused write".into());
+                }
+                println!("set/get/keys/remove/quota through the service ok");
+            } else {
+                if a.get_item("k").as_deref() != Some("1") || a.len() != 1 {
+                    return Err(format!("state did not persist across a restart: {:?}", a.keys()));
+                }
+                a.clear().map_err(|e| e.to_string())?;
+                if !a.is_empty() {
+                    return Err("clear must empty the area".into());
+                }
+                println!("state persisted across a service restart");
+            }
+            store.shutdown();
+            Ok(())
+        };
+        let outcome = run(true).and_then(|()| run(true));
+        let _ = std::fs::remove_dir_all(&dir);
+        match outcome {
+            Ok(()) => 0,
+            Err(e) => {
+                eprintln!("{e}");
+                1
+            }
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the storage service is Linux-only");
+        2
+    }
 }
 
 /// The transport on its own: does a request survive the round trip through a

--- a/crates/gosub_engine/src/child_process.rs
+++ b/crates/gosub_engine/src/child_process.rs
@@ -132,6 +132,17 @@ fn run_role(role: &str, args: &[String]) -> i32 {
             Ok(endpoint) => crate::cookie_vault::child::serve(endpoint, adopt_extra(role, args)),
             Err(code) => code,
         },
+        #[cfg(target_os = "linux")]
+        crate::storage_service::protocol::STORAGE_ROLE => match adopt_link(role, args) {
+            Ok(endpoint) => match args.first().filter(|_| args.len() >= 2) {
+                Some(dir) => crate::storage_service::child::serve(endpoint, std::path::PathBuf::from(dir)),
+                None => {
+                    eprintln!("[gosub] the storage role needs its directory argument");
+                    2
+                }
+            },
+            Err(code) => code,
+        },
         other => {
             eprintln!("[gosub] unknown child role '{other}'");
             2

--- a/crates/gosub_engine/src/engine/engine.rs
+++ b/crates/gosub_engine/src/engine/engine.rs
@@ -95,7 +95,16 @@ pub struct EngineContext {
     /// thread to spawn that process.
     #[cfg(all(feature = "process-isolation", target_os = "linux"))]
     pub net_vault_link: Arc<Mutex<Option<crate::cookie_vault::client::NetVaultLink>>>,
+    /// Storage service processes, one per directory, shared by the zones
+    /// whose local store lives there.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    pub storage_services: Arc<Mutex<StorageServices>>,
 }
+
+/// Storage service per directory, with how many open zones use it.
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+pub type StorageServices =
+    std::collections::HashMap<std::path::PathBuf, (Arc<crate::storage_service::client::ServiceLocalStore>, usize)>;
 
 impl Default for EngineContext {
     fn default() -> Self {
@@ -115,6 +124,8 @@ impl Default for EngineContext {
             cookie_vault: OnceLock::new(),
             #[cfg(all(feature = "process-isolation", target_os = "linux"))]
             net_vault_link: Arc::new(Mutex::new(None)),
+            #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+            storage_services: Arc::new(Mutex::new(std::collections::HashMap::new())),
         }
     }
 }
@@ -163,6 +174,8 @@ impl<C: RenderConfiguration> GosubEngine<C> {
                 cookie_vault: OnceLock::new(),
                 #[cfg(all(feature = "process-isolation", target_os = "linux"))]
                 net_vault_link: Arc::new(Mutex::new(None)),
+                #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+                storage_services: Arc::new(Mutex::new(std::collections::HashMap::new())),
             }),
             render_backend: backend,
             compositor,
@@ -443,11 +456,12 @@ impl<C: RenderConfiguration> GosubEngine<C> {
     /// in CI.
     #[cfg(feature = "process-isolation")]
     fn resolve_isolation_settings(&self) {
-        const PROCESS_SETTINGS: [&str; 4] = [
+        const PROCESS_SETTINGS: [&str; 5] = [
             "security.network_process",
             "security.image_decoder_process",
             "security.renderer_process",
             "security.cookie_vault",
+            "security.storage_service",
         ];
         let store = &self.context.config_store;
 
@@ -555,6 +569,9 @@ impl<C: RenderConfiguration> GosubEngine<C> {
                 log::trace!("signal: shutting down the cookie vault");
                 vault.shutdown();
             }
+            for (store, _) in self.context.storage_services.lock().values() {
+                store.shutdown();
+            }
         }
 
         // Shutdown I/O thread
@@ -614,6 +631,9 @@ impl<C: RenderConfiguration> GosubEngine<C> {
         let config = config.unwrap_or_else(|| self.context.config.default_zone_config.clone());
         let cookie_store = services.cookie_store.clone();
 
+        #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+        self.route_local_storage(&services);
+
         // A zone whose jar the engine provisions keeps it in the vault, behind a
         // jar handle that forwards; an embedder-supplied jar is the embedder's.
         #[cfg(all(feature = "process-isolation", target_os = "linux"))]
@@ -635,6 +655,38 @@ impl<C: RenderConfiguration> GosubEngine<C> {
             _ => services,
         };
         self.create_zone_with_services(config, services, zone_id, cookie_store)
+    }
+
+    /// Route a zone's local storage through the storage service process when
+    /// its store can be served from a directory. One process per directory.
+    #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+    fn route_local_storage(&self, services: &ZoneServices) {
+        use crate::storage_service::client::ServiceLocalStore;
+        if !self.context.config_store.get_bool("security.storage_service") {
+            return;
+        }
+        let Some(dir) = services.storage.local_store().service_directory() else {
+            return;
+        };
+        let mut processes = self.context.storage_services.lock();
+        let store = match processes.get_mut(&dir) {
+            Some((store, zones)) => {
+                *zones += 1;
+                Arc::clone(store)
+            }
+            None => match ServiceLocalStore::new(&dir) {
+                Ok(store) => {
+                    let store = Arc::new(store);
+                    processes.insert(dir, (Arc::clone(&store), 1));
+                    store
+                }
+                Err(e) => {
+                    log::warn!("localStorage stays in-process for {}: {e}", dir.display());
+                    return;
+                }
+            },
+        };
+        services.storage.route_local_through(store);
     }
 
     fn create_zone_with_services(
@@ -687,6 +739,8 @@ impl<C: RenderConfiguration> GosubEngine<C> {
     #[instrument(name = "engine.close_zone", level = "debug", skip(self, zone))]
     pub async fn close_zone(&mut self, zone: Zone<C>) {
         let zone_id = zone.id;
+        #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+        let storage_dir = zone.context.services.storage.local_store().service_directory();
 
         // Stop all tab workers first, so nothing fetches or mutates cookies below.
         zone.close().await;
@@ -710,6 +764,24 @@ impl<C: RenderConfiguration> GosubEngine<C> {
         // Final cookie snapshot + cache eviction; durable data stays on disk.
         if let Some(store) = self.cookie_stores.remove(&zone_id) {
             store.release_zone(zone_id);
+        }
+
+        // The storage service outlives its last zone by nothing.
+        #[cfg(all(feature = "process-isolation", target_os = "linux"))]
+        if let Some(dir) = storage_dir {
+            let mut processes = self.context.storage_services.lock();
+            let last = match processes.get_mut(&dir) {
+                Some((_, zones)) => {
+                    *zones = zones.saturating_sub(1);
+                    *zones == 0
+                }
+                None => false,
+            };
+            if last {
+                if let Some((store, _)) = processes.remove(&dir) {
+                    store.shutdown();
+                }
+            }
         }
 
         self.zones.remove(&zone_id);

--- a/crates/gosub_engine/src/engine/settings.json
+++ b/crates/gosub_engine/src/engine/settings.json
@@ -449,6 +449,12 @@
       "description": "Keep the engine's cookie jars in a separate, sandboxed vault process (Linux). Tabs and the embedder API see an ordinary jar that forwards; the network process, when it runs, gets a direct line to the vault so cookie values attached to requests never pass through the engine process. Persistence stays with the zone's cookie store: the vault sends it a snapshot after every change and never touches a file itself. Takes effect only when the embedder calls gosub_engine::child_process::dispatch() first thing in main(), and falls back to in-process jars with a warning if the vault cannot start."
     },
     {
+      "key": "storage_service",
+      "type": "b",
+      "default": "b:true",
+      "description": "Serve a zone's localStorage from a separate, sandboxed storage process when its local store can be (a FileLocalStore, or a ServiceLocalStore): one process per directory, confined to opening files there. Stores of other kinds stay in-process. Linux; takes effect only when the embedder calls gosub_engine::child_process::dispatch() first thing in main()."
+    },
+    {
       "key": "renderer_process",
       "type": "b",
       "default": "b:true",

--- a/crates/gosub_engine/src/engine/storage.rs
+++ b/crates/gosub_engine/src/engine/storage.rs
@@ -1,39 +1,12 @@
-//! HTML5 **LocalStorage** and **SessionStorage**: in-memory and persistent backends,
-//! a unified service API, and event hooks for reacting to storage changes.
+//! HTML5 LocalStorage and SessionStorage: in-memory and persistent backends, a
+//! unified service API, and event hooks for reacting to storage changes.
 //!
-//! # Concepts
-//!
-//! Gosub separates storage into two main categories:
-//!
-//! - **Local storage** - Persistent key/value data per `(origin, partition)`,
-//!   shared by all tabs in a zone. Backed by a [`LocalStore`].
-//! - **Session storage** - Ephemeral key/value data per `(zone, tab, origin, partition)`,
-//!   valid for the lifetime of a browsing session or until the tab is closed.
-//!   Backed by a [`SessionStore`].
-//!
-//! All stores implement the [`StorageArea`] trait, which provides the
-//! basic API for `get_item`, `set_item`, `remove_item`, and `clear`.
-//!
-//! A [`StorageService`] wraps one local store and one session store into a
-//! single handle that a [`Zone`](crate::zone::Zone) can use to provide both types
-//! of storage to its tabs.
-//!
-//! # Available types
-//!
-//! - [`PartitionKey`] - Identifies a storage partition
-//! - [`StorageArea`] - Trait for any storage backend.
-//! - [`LocalStore`], [`SessionStore`] - Type aliases for specific store traits.
-//! - [`StorageService`] - High-level handle for a zone's local+session storage.
-//! - [`Subscription`] - Used to observe storage change events.
-//! - [`StorageEvent`] - Describes a change in storage (key added, removed, etc.).
-//! - [`SqliteLocalStore`] - SQLite-backed persistent local storage.
-//! - [`InMemorySessionStore`] - In-memory session storage backend.
-//!
-//! # Choosing a backend
-//!
-//! - For persistent **LocalStorage**, use [`SqliteLocalStore`].
-//! - For ephemeral **SessionStorage**, use [`InMemorySessionStore`].
-//! - For testing or incognito modes, you can use in-memory for both.
+//! Local storage ([`LocalStore`], e.g. [`SqliteLocalStore`]) is persistent key/value
+//! data per `(origin, partition)`, shared by all tabs in a zone. Session storage
+//! ([`SessionStore`], e.g. [`InMemorySessionStore`]) is ephemeral data per
+//! `(zone, tab, origin, partition)`, dropped when the tab closes. All areas
+//! implement [`StorageArea`]; a [`StorageService`] bundles one local and one
+//! session store for a [`Zone`](crate::zone::Zone) to hand to its tabs.
 //!
 //! # Example: Attaching storage to a zone
 //!
@@ -72,35 +45,21 @@
 //! let _zone = engine_handle.create_zone(None, services, None)?;
 //! # Ok(()) }
 //! ```
-//!
-//! # See also
-//!
-//! - [`Zone`](crate::zone::Zone) - how storage services are bound to zones.
-//! - [`CookieJar`](crate::cookies::CookieJar) - for cookie storage.
-//!
 
 use std::sync::Arc;
 
-/// Storage area module, defining the key/value storage interface.
 pub mod area;
-/// Event module, providing storage change events.
 pub mod event;
-/// Service module, providing a unified storage service for zones.
 pub mod service;
-/// Storage types
 pub mod types;
 
-/// Local storage module, providing persistent storage areas.
 pub mod local {
-    /// In-memory local storage implementation.
+    pub mod file_store;
     pub mod in_memory;
-    /// SQLite-backed local storage implementation.
     pub mod sqlite_store;
 }
 
-/// Session storage module, providing in-memory session storage.
 pub mod session {
-    /// In-memory session storage implementation.
     pub mod in_memory;
 }
 
@@ -113,8 +72,12 @@ pub struct StorageHandles {
     pub session: Arc<dyn StorageArea>,
 }
 
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+pub use crate::storage_service::client::ServiceLocalStore;
 pub use area::{LocalStore, SessionStore, StorageArea};
 pub use event::StorageEvent;
+pub use local::file_store;
+pub use local::file_store::FileLocalStore;
 pub use local::in_memory::InMemoryLocalStore;
 pub use local::sqlite_store::SqliteLocalStore;
 pub use service::{StorageService, Subscription};

--- a/crates/gosub_engine/src/engine/storage/area.rs
+++ b/crates/gosub_engine/src/engine/storage/area.rs
@@ -34,6 +34,18 @@ pub trait StorageArea: Send + Sync {
 pub trait LocalStore: Send + Sync {
     /// Retrieves a storage area for the given zone, partition, and origin.
     fn area(&self, zone: ZoneId, part: &PartitionKey, origin: &url::Origin) -> Result<Arc<dyn StorageArea>>;
+
+    /// The directory a sandboxed storage service could serve this store's
+    /// files from, for stores whose format allows it (see `FileLocalStore`).
+    /// `None` keeps the store in-process.
+    fn service_directory(&self) -> Option<std::path::PathBuf> {
+        None
+    }
+
+    /// The pid of the process serving the areas, when there is one.
+    fn service_pid(&self) -> Option<u32> {
+        None
+    }
 }
 
 /// Store for sessionStorage-like areas (isolated per (zone, tab, partition, origin)).

--- a/crates/gosub_engine/src/engine/storage/local/file_store.rs
+++ b/crates/gosub_engine/src/engine/storage/local/file_store.rs
@@ -1,0 +1,259 @@
+//! `localStorage` as one JSON file per `(zone, partition, origin)` area.
+//!
+//! Plain files rather than SQLite because the storage service's filter allows
+//! `openat` and not much else (no locks, renames or directory listing).
+//! Filenames are hex-encoded tuples, so page-controlled strings never reach a
+//! path; keys live inside the file. Per-value and per-area size caps.
+
+use crate::storage::{LocalStore, PartitionKey, StorageArea};
+use crate::zone::ZoneId;
+use anyhow::{anyhow, Result};
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+pub const MAX_VALUE_BYTES: usize = 5 * 1024 * 1024;
+/// Per-origin quota, in the range browsers use.
+pub const MAX_AREA_BYTES: usize = 10 * 1024 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct FileLocalStore {
+    dir: PathBuf,
+    /// Loaded areas, so handles to the same area share state.
+    areas: Arc<Mutex<HashMap<PathBuf, Arc<FileArea>>>>,
+}
+
+impl FileLocalStore {
+    /// Creates `dir`. Only the broker can: the service has no `mkdir`.
+    pub fn open(dir: impl Into<PathBuf>) -> Result<Self> {
+        let dir = dir.into();
+        std::fs::create_dir_all(&dir)?;
+        Ok(Self {
+            dir,
+            areas: Arc::new(Mutex::new(HashMap::new())),
+        })
+    }
+
+    /// Uses an existing `dir` without touching it.
+    pub fn attach(dir: impl Into<PathBuf>) -> Self {
+        Self {
+            dir: dir.into(),
+            areas: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    pub fn area_for(&self, zone: &str, partition: &str, origin: &str) -> Arc<FileArea> {
+        let path = self.dir.join(area_file_name(zone, partition, origin));
+        let mut areas = self.areas.lock();
+        Arc::clone(
+            areas
+                .entry(path.clone())
+                .or_insert_with(|| Arc::new(FileArea::load(path))),
+        )
+    }
+}
+
+/// Wire/file form of a `PartitionKey`.
+pub fn partition_name(part: &PartitionKey) -> String {
+    match part {
+        PartitionKey::None => String::new(),
+        PartitionKey::TopLevel(origin) => format!("top:{}", origin.ascii_serialization()),
+        PartitionKey::Custom(s) => s.clone(),
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// `<hex zone>-<hex partition>-<hex origin>.json`; `-` cannot occur inside hex,
+/// so the mapping is injective.
+fn area_file_name(zone: &str, partition: &str, origin: &str) -> String {
+    format!(
+        "{}-{}-{}.json",
+        hex(zone.as_bytes()),
+        hex(partition.as_bytes()),
+        hex(origin.as_bytes())
+    )
+}
+
+impl LocalStore for FileLocalStore {
+    fn area(&self, zone: ZoneId, part: &PartitionKey, origin: &url::Origin) -> Result<Arc<dyn StorageArea>> {
+        Ok(self.area_for(&zone.to_string(), &partition_name(part), &origin.ascii_serialization()))
+    }
+
+    fn service_directory(&self) -> Option<PathBuf> {
+        Some(self.dir.clone())
+    }
+}
+
+/// Items in memory, file rewritten on every change.
+#[derive(Debug)]
+pub struct FileArea {
+    path: PathBuf,
+    items: Mutex<HashMap<String, String>>,
+}
+
+impl FileArea {
+    fn load(path: PathBuf) -> Self {
+        let items = std::fs::read(&path)
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<HashMap<String, String>>(&bytes).ok())
+            .unwrap_or_default();
+        Self {
+            path,
+            items: Mutex::new(items),
+        }
+    }
+
+    /// Written beside the area and renamed over it, so a crash mid-write
+    /// leaves the previous state, never a truncated file.
+    fn persist(&self, items: &HashMap<String, String>) -> Result<()> {
+        let bytes = serde_json::to_vec(items)?;
+        let staged = self.path.with_extension("json.new");
+        std::fs::write(&staged, bytes)?;
+        std::fs::rename(&staged, &self.path)?;
+        Ok(())
+    }
+
+    fn serialized_size(items: &HashMap<String, String>) -> usize {
+        items.iter().map(|(k, v)| k.len() + v.len() + 6).sum()
+    }
+}
+
+impl StorageArea for FileArea {
+    fn get_item(&self, key: &str) -> Option<String> {
+        self.items.lock().get(key).cloned()
+    }
+
+    fn set_item(&self, key: &str, value: &str) -> Result<()> {
+        if value.len() > MAX_VALUE_BYTES {
+            return Err(anyhow!(
+                "value of {} bytes exceeds the {MAX_VALUE_BYTES}-byte limit",
+                value.len()
+            ));
+        }
+        let mut items = self.items.lock();
+        let previous = items.insert(key.to_string(), value.to_string());
+        if Self::serialized_size(&items) > MAX_AREA_BYTES {
+            match previous {
+                Some(old) => items.insert(key.to_string(), old),
+                None => items.remove(key),
+            };
+            return Err(anyhow!("storage quota of {MAX_AREA_BYTES} bytes exceeded"));
+        }
+        self.persist(&items)
+    }
+
+    fn remove_item(&self, key: &str) -> Result<()> {
+        let mut items = self.items.lock();
+        if items.remove(key).is_some() {
+            self.persist(&items)?;
+        }
+        Ok(())
+    }
+
+    fn clear(&self) -> Result<()> {
+        let mut items = self.items.lock();
+        items.clear();
+        self.persist(&items)
+    }
+
+    fn len(&self) -> usize {
+        self.items.lock().len()
+    }
+
+    fn keys(&self) -> Vec<String> {
+        self.items.lock().keys().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn origin(s: &str) -> url::Origin {
+        url::Url::parse(s).expect("url").origin()
+    }
+
+    #[test]
+    fn areas_are_isolated_and_persist_across_reopen() {
+        let dir = std::env::temp_dir().join(format!("gosub-file-store-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let zone = ZoneId::new();
+        {
+            let store = FileLocalStore::open(&dir).expect("open");
+            let a = store
+                .area(zone, &PartitionKey::None, &origin("https://a.test"))
+                .expect("area");
+            let b = store
+                .area(zone, &PartitionKey::None, &origin("https://b.test"))
+                .expect("area");
+            a.set_item("k", "1").expect("set");
+            a.set_item("k2", "2").expect("set");
+            assert_eq!(a.get_item("k").as_deref(), Some("1"));
+            assert!(b.get_item("k").is_none());
+            assert_eq!(a.len(), 2);
+            a.remove_item("k2").expect("remove");
+            assert_eq!(a.keys(), vec!["k".to_string()]);
+            let again = store
+                .area(zone, &PartitionKey::None, &origin("https://a.test"))
+                .expect("area");
+            assert_eq!(again.get_item("k").as_deref(), Some("1"));
+        }
+        let store = FileLocalStore::open(&dir).expect("reopen");
+        let a = store
+            .area(zone, &PartitionKey::None, &origin("https://a.test"))
+            .expect("area");
+        assert_eq!(a.get_item("k").as_deref(), Some("1"));
+        assert_eq!(a.len(), 1);
+        a.clear().expect("clear");
+        assert!(a.is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn quotas_are_enforced_and_leave_state_intact() {
+        let dir = std::env::temp_dir().join(format!("gosub-file-store-quota-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let store = FileLocalStore::open(&dir).expect("open");
+        let a = store
+            .area(ZoneId::new(), &PartitionKey::None, &origin("https://q.test"))
+            .expect("area");
+        a.set_item("small", "x").expect("set");
+        let huge = "v".repeat(MAX_VALUE_BYTES + 1);
+        assert!(a.set_item("huge", &huge).is_err());
+        let big = "v".repeat(MAX_VALUE_BYTES);
+        assert!(a.set_item("b1", &big).is_ok());
+        // Two maximum values exceed the area quota.
+        assert!(
+            a.set_item("b2", &big).is_err(),
+            "second 5 MiB value must exceed the area quota"
+        );
+        assert_eq!(a.len(), 2);
+        assert!(a.get_item("b2").is_none());
+        assert_eq!(a.get_item("small").as_deref(), Some("x"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn file_names_are_injective_and_safe() {
+        let a = area_file_name("z", "ab", "c");
+        let b = area_file_name("z", "a", "bc");
+        assert_ne!(a, b);
+        let name = area_file_name("z", "top:https://x", "https://../../etc");
+        assert!(name.chars().all(|c| c.is_ascii_hexdigit()
+            || c == '-'
+            || c == '.'
+            || c == 'j'
+            || c == 's'
+            || c == 'o'
+            || c == 'n'));
+        assert!(!name.contains("/"));
+    }
+}

--- a/crates/gosub_engine/src/engine/storage/service.rs
+++ b/crates/gosub_engine/src/engine/storage/service.rs
@@ -37,7 +37,9 @@ impl StorageBus {
 
 #[derive(Clone)]
 pub struct StorageService {
-    local: Arc<dyn LocalStore>,
+    /// Behind a lock so the engine can route it through the storage service
+    /// process after the embedder built this; clones share the routing.
+    local: Arc<parking_lot::RwLock<Arc<dyn LocalStore>>>,
     session: Arc<dyn SessionStore>,
     bus: Arc<StorageBus>,
 }
@@ -51,10 +53,20 @@ impl Debug for StorageService {
 impl StorageService {
     pub fn new(local: Arc<dyn LocalStore>, session: Arc<dyn SessionStore>) -> Self {
         Self {
-            local,
+            local: Arc::new(parking_lot::RwLock::new(local)),
             session,
             bus: Arc::new(StorageBus::default()),
         }
+    }
+
+    pub fn local_store(&self) -> Arc<dyn LocalStore> {
+        Arc::clone(&self.local.read())
+    }
+
+    /// Serve local areas from `store` from now on (the engine's storage
+    /// service over the same files). Areas handed out before keep their store.
+    pub fn route_local_through(&self, store: Arc<dyn LocalStore>) {
+        *self.local.write() = store;
     }
 
     pub fn subscribe(&self) -> Subscription {
@@ -62,7 +74,7 @@ impl StorageService {
     }
 
     pub fn local_for(&self, zone: ZoneId, part: &PartitionKey, origin: &url::Origin) -> Result<Arc<dyn StorageArea>> {
-        let inner = self.local.area(zone, part, origin)?;
+        let inner = self.local_store().area(zone, part, origin)?;
         Ok(self.wrap_notifying(inner, zone, None, part.clone(), origin.clone(), StorageScope::Local))
     }
 
@@ -124,7 +136,10 @@ impl StorageArea for NotifyingArea {
         self.inner.get_item(key)
     }
     fn set_item(&self, key: &str, value: &str) -> Result<()> {
-        let old = self.inner.get_item(key);
+        // The old value is only for the event; with a remote store it is a round trip.
+        let old = (self.bus.tx.receiver_count() > 0)
+            .then(|| self.inner.get_item(key))
+            .flatten();
         self.inner.set_item(key, value)?;
         self.bus.publish(StorageEvent {
             zone: self.zone,

--- a/crates/gosub_engine/src/lib.rs
+++ b/crates/gosub_engine/src/lib.rs
@@ -153,6 +153,9 @@ pub mod decoder_process;
 /// The cookie vault: every vaulted zone's jar, in a process of its own.
 #[cfg(all(feature = "process-isolation", target_os = "linux"))]
 pub mod cookie_vault;
+/// `localStorage` served from a sandboxed process confined to one directory.
+#[cfg(all(feature = "process-isolation", target_os = "linux"))]
+pub mod storage_service;
 
 /// The fork server renderers are forked from: warmed fonts, tier-chosen
 /// sandbox. The processes are Linux only - no other platform has a fork to

--- a/crates/gosub_engine/src/storage_service.rs
+++ b/crates/gosub_engine/src/storage_service.rs
@@ -1,0 +1,6 @@
+//! `localStorage` in a sandboxed process; embedders opt in with
+//! [`client::ServiceLocalStore`].
+
+pub mod child;
+pub mod client;
+pub mod protocol;

--- a/crates/gosub_engine/src/storage_service/child.rs
+++ b/crates/gosub_engine/src/storage_service/child.rs
@@ -1,0 +1,71 @@
+//! The storage service process: a `FileLocalStore` behind the filesystem
+//! service filter, Landlock-scoped to its directory. Spawned by the engine,
+//! not the zygote (which denies `openat`).
+
+use crate::storage::file_store::FileLocalStore;
+use crate::storage::StorageArea as _;
+use crate::storage_service::protocol::{FromStorage, ToStorage};
+use gosub_ipc::Endpoint;
+use std::path::PathBuf;
+
+/// `dir` exists: the broker created it.
+pub fn serve(mut link: Endpoint, dir: PathBuf) -> i32 {
+    gosub_sandbox::capture_process_title_region();
+    gosub_sandbox::set_process_title("gosub-storage", "gosub: storage service");
+    gosub_sandbox::lock_down_service(
+        "storage",
+        gosub_sandbox::ServiceCaps {
+            filesystem: true,
+            device: false,
+        },
+        &[(dir.as_path(), true)],
+    );
+
+    let store = FileLocalStore::attach(dir);
+    while let Ok(msg) = link.recv::<ToStorage>() {
+        let reply = match msg {
+            ToStorage::Ping => FromStorage::Pong,
+            ToStorage::Shutdown => break,
+            ToStorage::Get { tag, area, key } => FromStorage::Value {
+                tag,
+                value: store.area_for(&area.zone, &area.partition, &area.origin).get_item(&key),
+            },
+            ToStorage::Set { tag, area, key, value } => FromStorage::Done {
+                tag,
+                error: store
+                    .area_for(&area.zone, &area.partition, &area.origin)
+                    .set_item(&key, &value)
+                    .err()
+                    .map(|e| e.to_string()),
+            },
+            ToStorage::Remove { tag, area, key } => FromStorage::Done {
+                tag,
+                error: store
+                    .area_for(&area.zone, &area.partition, &area.origin)
+                    .remove_item(&key)
+                    .err()
+                    .map(|e| e.to_string()),
+            },
+            ToStorage::Clear { tag, area } => FromStorage::Done {
+                tag,
+                error: store
+                    .area_for(&area.zone, &area.partition, &area.origin)
+                    .clear()
+                    .err()
+                    .map(|e| e.to_string()),
+            },
+            ToStorage::Keys { tag, area } => FromStorage::Keys {
+                tag,
+                keys: store.area_for(&area.zone, &area.partition, &area.origin).keys(),
+            },
+            ToStorage::Len { tag, area } => FromStorage::Len {
+                tag,
+                len: store.area_for(&area.zone, &area.partition, &area.origin).len() as u64,
+            },
+        };
+        if link.send(&reply).is_err() {
+            break;
+        }
+    }
+    0
+}

--- a/crates/gosub_engine/src/storage_service/client.rs
+++ b/crates/gosub_engine/src/storage_service/client.rs
@@ -1,0 +1,348 @@
+//! Broker side: the service process and the [`LocalStore`] that forwards to it.
+
+use crate::storage::file_store::{partition_name, FileLocalStore};
+use crate::storage::{LocalStore, PartitionKey, StorageArea};
+use crate::storage_service::protocol::{AreaKey, FromStorage, Tag, ToStorage, STORAGE_ROLE};
+use crate::zone::ZoneId;
+use anyhow::{anyhow, Result};
+use gosub_ipc::Endpoint;
+use parking_lot::Mutex;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+const REPLY_TIMEOUT: Duration = Duration::from_secs(10);
+const READY_TIMEOUT: Duration = Duration::from_secs(10);
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(2);
+
+/// One link, request/reply, serialized by the mutex. A process that died
+/// (its state is all on disk) is respawned on the next request, which is
+/// then retried once.
+pub struct StorageProcess {
+    link: Mutex<Endpoint>,
+    next_tag: AtomicU64,
+    child: Mutex<Option<gosub_sandbox::spawn::Child>>,
+    dir: PathBuf,
+    last_respawn: Mutex<Option<std::time::Instant>>,
+    closed: std::sync::atomic::AtomicBool,
+}
+
+const RESPAWN_COOLDOWN: Duration = Duration::from_secs(5);
+
+impl std::fmt::Debug for StorageProcess {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StorageProcess").finish_non_exhaustive()
+    }
+}
+
+impl StorageProcess {
+    /// `dir` must exist: the service cannot create it.
+    pub fn spawn(dir: &Path) -> Result<Self> {
+        let dir = std::fs::canonicalize(dir)?;
+        let (link, child) = Self::launch(&dir)?;
+        Ok(Self {
+            link: Mutex::new(link),
+            next_tag: AtomicU64::new(1),
+            child: Mutex::new(Some(child)),
+            dir,
+            last_respawn: Mutex::new(None),
+            closed: std::sync::atomic::AtomicBool::new(false),
+        })
+    }
+
+    /// The service process's pid, while it has one.
+    pub fn pid(&self) -> Option<u32> {
+        self.child.lock().as_ref().map(gosub_sandbox::spawn::Child::id)
+    }
+
+    /// Re-exec this binary as the service on `dir` and confirm it answers.
+    fn launch(dir: &Path) -> Result<(Endpoint, gosub_sandbox::spawn::Child)> {
+        if crate::child_process::is_child_process() {
+            anyhow::bail!(
+                "this process was started as an engine child role but is running embedder startup, \
+                 which means gosub_engine::child_process::dispatch() was not called at the top of \
+                 main(); refusing to spawn further processes"
+            );
+        }
+        let Some(dir_arg) = dir.to_str() else {
+            anyhow::bail!("storage directory is not valid UTF-8: {}", dir.display());
+        };
+        let exe = std::env::current_exe()?;
+        let (ours, theirs) = gosub_ipc::channel::Channel::pair()?;
+        let child = gosub_sandbox::spawn::spawn(
+            &exe,
+            // `spawn` appends the primary link after these.
+            &[crate::child_process::ROLE_FLAG, STORAGE_ROLE, dir_arg],
+            theirs,
+            gosub_sandbox::NamespaceIsolation::Full,
+            gosub_sandbox::spawn::ContainerProfile {
+                name: "gosub-storage",
+                internet: false,
+                fs_grant: Some((dir, true)),
+                data_limit: None,
+                extra_fds: &[],
+                max_tasks: 64,
+                // Whole-file rewrites of areas: a few of them at most.
+                file_size_limit: Some(4 * crate::storage::file_store::MAX_AREA_BYTES as u64),
+            },
+        )?;
+        if let Err(e) = gosub_sandbox::confine_spawned_child(&child) {
+            log::warn!("could not confine the storage service: {e}");
+        }
+        let mut link = Endpoint::from_channel(ours)?;
+        let _ = link.tx.set_write_timeout(Some(REPLY_TIMEOUT));
+        let _ = link.rx.set_read_timeout(Some(READY_TIMEOUT));
+        link.send(&ToStorage::Ping)?;
+        match link.recv::<FromStorage>() {
+            Ok(FromStorage::Pong) => {}
+            other => {
+                let mut child = child;
+                let _ = child.kill();
+                let _ = child.wait();
+                anyhow::bail!("the spawned process did not answer as a storage service: {other:?}");
+            }
+        }
+        let _ = link.rx.set_read_timeout(Some(REPLY_TIMEOUT));
+        Ok((link, child))
+    }
+
+    /// A dead service comes back for the next request, at most once per
+    /// cooldown; `false` when it could not.
+    fn respawn(&self, link: &mut Endpoint) -> bool {
+        if self.closed.load(Ordering::Acquire) {
+            return false;
+        }
+        let mut last = self.last_respawn.lock();
+        if last.is_some_and(|at| at.elapsed() < RESPAWN_COOLDOWN) {
+            return false;
+        }
+        *last = Some(std::time::Instant::now());
+        log::warn!("the storage service died; respawning it");
+        if let Some(mut child) = self.child.lock().take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        match Self::launch(&self.dir) {
+            Ok((fresh, child)) => {
+                *link = fresh;
+                *self.child.lock() = Some(child);
+                log::info!("the storage service is back");
+                true
+            }
+            Err(e) => {
+                log::error!("the storage service could not be respawned ({e}); localStorage requests fail");
+                false
+            }
+        }
+    }
+
+    fn ask(&self, build: impl FnOnce(Tag) -> ToStorage) -> Result<FromStorage> {
+        let tag = self.next_tag.fetch_add(1, Ordering::Relaxed);
+        let msg = build(tag);
+        let mut link = self.link.lock();
+        let exchange = |link: &mut Endpoint| -> Result<FromStorage> {
+            link.send(&msg)
+                .map_err(|e| anyhow!("the storage service is unreachable: {e}"))?;
+            link.recv::<FromStorage>()
+                .map_err(|e| anyhow!("the storage service did not answer: {e}"))
+        };
+        let reply = match exchange(&mut link) {
+            Ok(reply) => reply,
+            // Once more through a fresh process; a timeout of a live one is
+            // not that (the link is intact and the process still there).
+            Err(e) if !link.rx.peer_alive() && self.respawn(&mut link) => exchange(&mut link).map_err(|_| e)?,
+            Err(e) => return Err(e),
+        };
+        // One request in flight at a time: a mismatched tag is a broken child.
+        let echoed = match &reply {
+            FromStorage::Value { tag, .. }
+            | FromStorage::Done { tag, .. }
+            | FromStorage::Keys { tag, .. }
+            | FromStorage::Len { tag, .. } => Some(*tag),
+            FromStorage::Pong => None,
+        };
+        if echoed != Some(tag) {
+            anyhow::bail!("the storage service answered out of order");
+        }
+        Ok(reply)
+    }
+
+    fn done(&self, build: impl FnOnce(Tag) -> ToStorage) -> Result<()> {
+        match self.ask(build)? {
+            FromStorage::Done { error: None, .. } => Ok(()),
+            FromStorage::Done { error: Some(e), .. } => Err(anyhow!(e)),
+            _ => Err(anyhow!("unexpected reply from the storage service")),
+        }
+    }
+
+    pub fn shutdown(&self) {
+        self.closed.store(true, Ordering::Release);
+        let _ = self.link.lock().send(&ToStorage::Shutdown);
+        let Some(mut child) = self.child.lock().take() else {
+            return;
+        };
+        let deadline = std::time::Instant::now() + SHUTDOWN_GRACE;
+        while std::time::Instant::now() < deadline {
+            match child.try_wait() {
+                Ok(true) => return,
+                Ok(false) => std::thread::sleep(Duration::from_millis(20)),
+                Err(_) => break,
+            }
+        }
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+impl Drop for StorageProcess {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// A [`LocalStore`] served by the storage process. Starts it on first use;
+/// falls back to a [`FileLocalStore`] on the same directory (with a warning)
+/// when it cannot start.
+#[derive(Debug)]
+pub struct ServiceLocalStore {
+    dir: PathBuf,
+    backend: OnceLock<Backend>,
+}
+
+#[derive(Debug)]
+enum Backend {
+    Remote(Arc<StorageProcess>),
+    Local(FileLocalStore),
+}
+
+impl ServiceLocalStore {
+    /// Creates `dir` now; the service cannot.
+    pub fn new(dir: impl Into<PathBuf>) -> Result<Self> {
+        let dir = dir.into();
+        std::fs::create_dir_all(&dir)?;
+        Ok(Self {
+            dir,
+            backend: OnceLock::new(),
+        })
+    }
+
+    /// Whether the service process serves the areas (known after first use).
+    pub fn is_remote(&self) -> bool {
+        matches!(self.backend.get(), Some(Backend::Remote(_)))
+    }
+
+    fn backend(&self) -> &Backend {
+        self.backend.get_or_init(|| match StorageProcess::spawn(&self.dir) {
+            Ok(process) => {
+                log::info!("localStorage is served by a separate, sandboxed storage process");
+                Backend::Remote(Arc::new(process))
+            }
+            Err(e) => {
+                log::warn!("the storage service could not start ({e}); localStorage stays in-process");
+                Backend::Local(FileLocalStore::attach(&self.dir))
+            }
+        })
+    }
+
+    /// The service process's pid, when one serves the areas.
+    pub fn pid(&self) -> Option<u32> {
+        match self.backend.get() {
+            Some(Backend::Remote(process)) => process.pid(),
+            _ => None,
+        }
+    }
+
+    /// Areas handed out before fail on their next request.
+    pub fn shutdown(&self) {
+        if let Some(Backend::Remote(process)) = self.backend.get() {
+            process.shutdown();
+        }
+    }
+}
+
+impl LocalStore for ServiceLocalStore {
+    fn service_directory(&self) -> Option<PathBuf> {
+        Some(self.dir.clone())
+    }
+
+    fn service_pid(&self) -> Option<u32> {
+        self.pid()
+    }
+
+    fn area(&self, zone: ZoneId, part: &PartitionKey, origin: &url::Origin) -> Result<Arc<dyn StorageArea>> {
+        match self.backend() {
+            Backend::Local(store) => store.area(zone, part, origin),
+            Backend::Remote(process) => Ok(Arc::new(RemoteArea {
+                process: Arc::clone(process),
+                area: AreaKey {
+                    zone: zone.to_string(),
+                    partition: partition_name(part),
+                    origin: origin.ascii_serialization(),
+                },
+            })),
+        }
+    }
+}
+
+struct RemoteArea {
+    process: Arc<StorageProcess>,
+    area: AreaKey,
+}
+
+impl StorageArea for RemoteArea {
+    fn get_item(&self, key: &str) -> Option<String> {
+        match self.process.ask(|tag| ToStorage::Get {
+            tag,
+            area: self.area.clone(),
+            key: key.to_string(),
+        }) {
+            Ok(FromStorage::Value { value, .. }) => value,
+            _ => None,
+        }
+    }
+
+    fn set_item(&self, key: &str, value: &str) -> Result<()> {
+        self.process.done(|tag| ToStorage::Set {
+            tag,
+            area: self.area.clone(),
+            key: key.to_string(),
+            value: value.to_string(),
+        })
+    }
+
+    fn remove_item(&self, key: &str) -> Result<()> {
+        self.process.done(|tag| ToStorage::Remove {
+            tag,
+            area: self.area.clone(),
+            key: key.to_string(),
+        })
+    }
+
+    fn clear(&self) -> Result<()> {
+        self.process.done(|tag| ToStorage::Clear {
+            tag,
+            area: self.area.clone(),
+        })
+    }
+
+    fn len(&self) -> usize {
+        match self.process.ask(|tag| ToStorage::Len {
+            tag,
+            area: self.area.clone(),
+        }) {
+            Ok(FromStorage::Len { len, .. }) => len as usize,
+            _ => 0,
+        }
+    }
+
+    fn keys(&self) -> Vec<String> {
+        match self.process.ask(|tag| ToStorage::Keys {
+            tag,
+            area: self.area.clone(),
+        }) {
+            Ok(FromStorage::Keys { keys, .. }) => keys,
+            _ => Vec::new(),
+        }
+    }
+}

--- a/crates/gosub_engine/src/storage_service/protocol.rs
+++ b/crates/gosub_engine/src/storage_service/protocol.rs
@@ -1,0 +1,74 @@
+//! Broker ↔ storage service messages. The area on a request is the broker's
+//! word, never a renderer's.
+
+use serde::{Deserialize, Serialize};
+
+/// The argv role name the broker re-execs itself with.
+pub const STORAGE_ROLE: &str = "storage";
+
+pub type Tag = u64;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct AreaKey {
+    pub zone: String,
+    pub partition: String,
+    pub origin: String,
+}
+
+/// Broker → storage service.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ToStorage {
+    Ping,
+    Get {
+        tag: Tag,
+        area: AreaKey,
+        key: String,
+    },
+    Set {
+        tag: Tag,
+        area: AreaKey,
+        key: String,
+        value: String,
+    },
+    Remove {
+        tag: Tag,
+        area: AreaKey,
+        key: String,
+    },
+    Clear {
+        tag: Tag,
+        area: AreaKey,
+    },
+    Keys {
+        tag: Tag,
+        area: AreaKey,
+    },
+    Len {
+        tag: Tag,
+        area: AreaKey,
+    },
+    Shutdown,
+}
+
+/// Storage service → broker.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum FromStorage {
+    Pong,
+    Value {
+        tag: Tag,
+        value: Option<String>,
+    },
+    /// `error` names a refused write (quota, size).
+    Done {
+        tag: Tag,
+        error: Option<String>,
+    },
+    Keys {
+        tag: Tag,
+        keys: Vec<String>,
+    },
+    Len {
+        tag: Tag,
+        len: u64,
+    },
+}

--- a/crates/gosub_engine/tests/process_isolation.rs
+++ b/crates/gosub_engine/tests/process_isolation.rs
@@ -45,6 +45,32 @@ fn a_request_completes_through_the_network_process() {
     );
 }
 
+/// A zone whose local store is a `FileLocalStore` is routed through the
+/// storage process by default.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_zones_file_local_store_is_routed_through_the_storage_service() {
+    let out = run("engine-storage-service");
+    assert!(
+        out.status.success(),
+        "engine storage service scenario failed:\n{}\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn local_storage_is_served_by_the_storage_service() {
+    let out = run("storage");
+    assert!(
+        out.status.success(),
+        "storage scenario failed:\n{}\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 /// The cookie vault on its own: jar that forwards, HttpOnly split, zone
 /// partitioning, persistence brokered through a real SQLite store.
 #[cfg(target_os = "linux")]


### PR DESCRIPTION

Base: `11-cookie-vault` (depends only on the contract PR).

### What is in here

- `FileLocalStore`: `localStorage` as one JSON file per
  `(zone, partition, origin)` area, usable in-process too. Filenames are hex
  tuples so page-controlled strings never reach a path; per-value and per-area
  quotas; writes staged and renamed over.
- `storage_service` (`security.storage_service`): `gosub-storage`, a process
  confined to `openat`/`rename` under one Landlock-scoped directory. A zone
  whose `StorageService` holds a `FileLocalStore` is routed through the process
  at zone creation (one process per directory, refcounted, released with the
  last zone); in-process fallback on the same files; a dead service is
  respawned on the next request.

### Testing

```
cargo test -p gosub_engine --lib storage
./target/debug/isolation-harness storage
./target/debug/isolation-harness engine-storage-service   # kills it once
```