### PR TITLE
Audit hardening

### DIFF
--- a/crates/gosub_engine/src/child_process.rs
+++ b/crates/gosub_engine/src/child_process.rs
@@ -108,6 +108,7 @@ pub fn is_child_process() -> bool {
     std::env::args().any(|a| a == ROLE_FLAG)
 }
 
+#[cfg(feature = "process-isolation")]
 fn run_role(role: &str, args: &[String]) -> i32 {
     use crate::net::process::client::NET_ROLE;
 
@@ -150,8 +151,18 @@ fn run_role(role: &str, args: &[String]) -> i32 {
     }
 }
 
+#[cfg(not(feature = "process-isolation"))]
+fn run_role(role: &str, _args: &[String]) -> i32 {
+    // Reachable only if a broker built *with* isolation spawned a child built
+    // without it, which cannot happen through re-exec of one binary. Refuse
+    // loudly rather than silently continuing into the embedder's `main`.
+    eprintln!("[gosub] child role '{role}' requested, but this build has no process isolation");
+    2
+}
+
 /// The second inherited channel, when the spawner named one before the
 /// primary link. Failing to adopt it is reported and treated as absent.
+#[cfg(feature = "process-isolation")]
 fn adopt_extra(role: &str, args: &[String]) -> Option<gosub_ipc::Endpoint> {
     if args.len() < 2 {
         return None;
@@ -166,6 +177,7 @@ fn adopt_extra(role: &str, args: &[String]) -> Option<gosub_ipc::Endpoint> {
 }
 
 /// Take over the link this child inherited, or report why it could not.
+#[cfg(feature = "process-isolation")]
 fn adopt_link(role: &str, args: &[String]) -> Result<gosub_ipc::Endpoint, i32> {
     // `spawn` appends the primary link last; anything before it is a further
     // inherited channel the role knows what to do with.

--- a/crates/gosub_engine/src/engine/cookies/cookie_jar.rs
+++ b/crates/gosub_engine/src/engine/cookies/cookie_jar.rs
@@ -223,6 +223,11 @@ pub trait CookieJar: Send + Sync {
     fn purge_expired(&mut self);
 }
 
+/// RFC 6265bis limit: a cookie line over this is ignored.
+const MAX_COOKIE_BYTES: usize = 4096;
+/// RFC 6265bis limit: an origin keeps at most this many cookies.
+const MAX_COOKIES_PER_ORIGIN: usize = 180;
+
 /// Default cookie jar which holds cookies for a single zone.
 ///
 /// This implementation is **in-memory only** and performs **no persistence**.
@@ -314,6 +319,10 @@ impl CookieJar for DefaultCookieJar {
             let Ok(header_str) = std::str::from_utf8(header.as_bytes()) else {
                 continue;
             };
+            // RFC 6265bis §5.6: a cookie past 4 KiB is ignored, not truncated.
+            if header_str.len() > MAX_COOKIE_BYTES {
+                continue;
+            }
             let Some((name, rest)) = header_str.split_once('=') else {
                 continue;
             };
@@ -465,6 +474,17 @@ impl CookieJar for DefaultCookieJar {
                 *existing = cookie;
                 existing.created_at = original_created_at;
             } else {
+                // Per-origin cap: the oldest cookie makes room, as browsers do.
+                if bucket.len() >= MAX_COOKIES_PER_ORIGIN {
+                    if let Some(oldest) = bucket
+                        .iter()
+                        .enumerate()
+                        .min_by_key(|(_, c)| c.created_at)
+                        .map(|(i, _)| i)
+                    {
+                        bucket.remove(oldest);
+                    }
+                }
                 cookie.created_at = Utc::now().timestamp_millis();
                 bucket.push(cookie);
             }

--- a/crates/gosub_engine/src/engine/engine.rs
+++ b/crates/gosub_engine/src/engine/engine.rs
@@ -203,9 +203,8 @@ impl<C: RenderConfiguration> GosubEngine<C> {
 
         // Start I/O thread, building the fetcher config from the settings store.
         let io_cfg = fetcher_config_from(&self.context.config_store);
-        // Isolation needs the embedder's cooperation and a platform that has
-        // it; decided before the I/O thread, which spawns the network process.
-        #[cfg(feature = "process-isolation")]
+        // Which `security.*` process settings survive into this run. Decided
+        // before the I/O thread, which is what spawns the network process.
         self.resolve_isolation_settings();
 
         // The vault before the I/O thread: the network process, spawned there,
@@ -220,7 +219,9 @@ impl<C: RenderConfiguration> GosubEngine<C> {
 
         // Start metrics HTTP server (GET http://127.0.0.1:9090/metrics)
         #[cfg(feature = "metrics")]
-        crate::metrics::start(9090, Arc::clone(&self.context));
+        if self.context.config_store.get_bool("telemetry.metrics_enabled") {
+            crate::metrics::start(9090, Arc::clone(&self.context));
+        }
 
         // Spawn the renderer fork server if asked to. Blocks briefly (spawn
         // plus font warm-up, ~200 ms typical) - acceptable at startup, and
@@ -232,6 +233,91 @@ impl<C: RenderConfiguration> GosubEngine<C> {
         // spawning it ourselves. `run()` yields `None` only if the loop was already taken, which
         // cannot happen here since `self.running` was false above.
         self.run().ok_or(EngineError::AlreadyRunning)
+    }
+
+    /// Whether `key` still holds its schema default, i.e. the embedder never
+    /// chose it. A default that cannot apply here is dropped quietly; an
+    /// explicit choice that cannot apply gets a warning.
+    #[cfg_attr(not(feature = "process-isolation"), allow(dead_code))]
+    fn setting_at_default(&self, key: &str) -> bool {
+        let store = &self.context.config_store;
+        match (store.get_info(key), store.get(key)) {
+            (Some(info), Ok(Some(value))) => info.default == value,
+            _ => false,
+        }
+    }
+
+    fn turn_off(&self, key: &str) {
+        let _ = self
+            .context
+            .config_store
+            .set(key, gosub_config::settings::Setting::Bool(false));
+    }
+
+    /// The `security.*` process settings default to on; here the defaults meet
+    /// this process, platform and configuration. Without the embedder's
+    /// `child_process::dispatch()` nothing may spawn (a child is this binary
+    /// re-exec'd, and would run the embedder's own `main()` - for a GUI
+    /// embedder, a phantom window per spawn); the network and decoder
+    /// processes are on by default on Linux only, until the macOS and Windows
+    /// backends have run in CI; the renderer tier has conditions of its own,
+    /// checked in `start_renderer_process`.
+    fn resolve_isolation_settings(&self) {
+        const PROCESS_SETTINGS: [&str; 5] = [
+            "security.network_process",
+            "security.image_decoder_process",
+            "security.renderer_process",
+            "security.cookie_vault",
+            "security.storage_service",
+        ];
+
+        #[cfg(not(feature = "process-isolation"))]
+        {
+            for key in PROCESS_SETTINGS {
+                self.turn_off(key);
+            }
+            return;
+        }
+
+        #[cfg(feature = "process-isolation")]
+        {
+            let store = &self.context.config_store;
+            if !crate::child_process::was_dispatched() {
+                let requested: Vec<&str> = PROCESS_SETTINGS.into_iter().filter(|key| store.get_bool(key)).collect();
+                if requested.is_empty() {
+                    return;
+                }
+                if requested.iter().any(|key| !self.setting_at_default(key)) {
+                    log::warn!(
+                        "{} requested, but gosub_engine::child_process::dispatch() was not called at the \
+                         top of main(); running without process isolation",
+                        requested.join(", ")
+                    );
+                } else {
+                    log::info!(
+                        "process isolation is off: this embedder does not call \
+                         gosub_engine::child_process::dispatch() at the top of main()"
+                    );
+                }
+                for key in requested {
+                    self.turn_off(key);
+                }
+                return;
+            }
+
+            if !cfg!(target_os = "linux") {
+                for key in PROCESS_SETTINGS {
+                    if store.get_bool(key) && self.setting_at_default(key) {
+                        self.turn_off(key);
+                    }
+                }
+                if PROCESS_SETTINGS.iter().any(|key| store.get_bool(key)) {
+                    log::info!(
+                        "process isolation was requested explicitly on a platform where it is not on by default"
+                    );
+                }
+            }
+        }
     }
 
     /// Spawn the cookie vault when `security.cookie_vault` asks for it. With
@@ -427,79 +513,6 @@ impl<C: RenderConfiguration> GosubEngine<C> {
     /// The engine's settings store, for reading or overriding settings (e.g.
     /// `net.user_agent`). Network settings are read once when [`start`](Self::start)
     /// builds the I/O runtime, so overrides must land before then.
-    /// Whether `key` still holds its schema default, i.e. the embedder never
-    /// chose it. A default that cannot apply here is dropped quietly; an
-    /// explicit choice that cannot apply gets a warning.
-    #[cfg(feature = "process-isolation")]
-    fn setting_at_default(&self, key: &str) -> bool {
-        let store = &self.context.config_store;
-        match (store.get_info(key), store.get(key)) {
-            (Some(info), Ok(Some(value))) => info.default == value,
-            _ => false,
-        }
-    }
-
-    #[cfg(feature = "process-isolation")]
-    fn turn_off(&self, key: &str) {
-        let _ = self
-            .context
-            .config_store
-            .set(key, gosub_config::settings::Setting::Bool(false));
-    }
-
-    /// The `security.*` process settings default to on; here the defaults meet
-    /// this process and platform. Without the embedder's
-    /// `child_process::dispatch()` nothing may spawn (a child is this binary
-    /// re-exec'd, and would run the embedder's own `main()` - for a GUI
-    /// embedder, a phantom window per spawn); the network process is on by
-    /// default on Linux only, until the macOS and Windows backends have run
-    /// in CI.
-    #[cfg(feature = "process-isolation")]
-    fn resolve_isolation_settings(&self) {
-        const PROCESS_SETTINGS: [&str; 5] = [
-            "security.network_process",
-            "security.image_decoder_process",
-            "security.renderer_process",
-            "security.cookie_vault",
-            "security.storage_service",
-        ];
-        let store = &self.context.config_store;
-
-        if !crate::child_process::was_dispatched() {
-            let requested: Vec<&str> = PROCESS_SETTINGS.into_iter().filter(|key| store.get_bool(key)).collect();
-            if requested.is_empty() {
-                return;
-            }
-            if requested.iter().any(|key| !self.setting_at_default(key)) {
-                log::warn!(
-                    "{} requested, but gosub_engine::child_process::dispatch() was not called at the \
-                     top of main(); running without process isolation",
-                    requested.join(", ")
-                );
-            } else {
-                log::info!(
-                    "process isolation is off: this embedder does not call \
-                     gosub_engine::child_process::dispatch() at the top of main()"
-                );
-            }
-            for key in requested {
-                self.turn_off(key);
-            }
-            return;
-        }
-
-        if !cfg!(target_os = "linux") {
-            for key in PROCESS_SETTINGS {
-                if store.get_bool(key) && self.setting_at_default(key) {
-                    self.turn_off(key);
-                }
-            }
-            if PROCESS_SETTINGS.iter().any(|key| store.get_bool(key)) {
-                log::info!("process isolation was requested explicitly on a platform where it is not on by default");
-            }
-        }
-    }
-
     pub fn settings(&self) -> &Config {
         &self.context.config_store
     }

--- a/crates/gosub_engine/src/engine/tab/worker.rs
+++ b/crates/gosub_engine/src/engine/tab/worker.rs
@@ -36,6 +36,9 @@ use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 use url::Url;
 
+/// An icon larger than this is not an icon.
+const MAX_FAVICON_BYTES: usize = 512 * 1024;
+
 /// Filename to suggest for downloading `meta`'s resource: the `Content-Disposition`
 /// `filename` parameter when present, else the final URL's last path segment, else
 /// "download". Path separators are stripped so a hostile header cannot escape the
@@ -65,8 +68,15 @@ fn suggested_filename(meta: &FetchResultMeta) -> String {
             })
     });
     let name = name.unwrap_or_default();
-    let name = name.rsplit(['/', '\\']).next().unwrap_or("").trim().to_string();
-    if name.is_empty() {
+    let name: String = name
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or("")
+        .chars()
+        .filter(|c| !c.is_control())
+        .collect();
+    let name = name.trim().to_string();
+    if name.is_empty() || name == "." || name == ".." {
         "download".to_string()
     } else {
         name
@@ -506,6 +516,14 @@ impl<C: RenderConfiguration> TabWorker<C> {
         let Some(base_url) = self.context.document_url().cloned() else {
             return;
         };
+        // The icon URL is the page's (via the renderer): web schemes only,
+        // plus a file page's own files.
+        let allowed = matches!(icon_url.scheme(), "http" | "https")
+            || (icon_url.scheme() == "file" && base_url.scheme() == "file");
+        if !allowed {
+            log::debug!("favicon {icon_url}: scheme not allowed, ignored");
+            return;
+        }
         let req_id = RequestId::new();
         REF_REGISTRY.register_request(req_id, ResourceKind::Image, Initiator::Other);
         let mut headers = HeaderMap::new();
@@ -544,12 +562,23 @@ impl<C: RenderConfiguration> TabWorker<C> {
             let Ok(FetchResult::Buffered { meta, body }) = result else {
                 return;
             };
-            if meta.status != 200 || body.is_empty() {
+            if meta.status != 200 || body.is_empty() || body.len() > MAX_FAVICON_BYTES {
                 log::debug!(
                     "favicon {icon_url}: status {} ({} bytes), ignored",
                     meta.status,
                     body.len()
                 );
+                return;
+            }
+            // The embedder will hand these bytes to an image decoder in its
+            // own process: at least require the response to say it is an image.
+            let is_image = meta
+                .headers
+                .get(http::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .is_none_or(|ct| ct.trim_start().starts_with("image/"));
+            if !is_image {
+                log::debug!("favicon {icon_url}: not an image content type, ignored");
                 return;
             }
             let _ = event_tx.send(EngineEvent::FavIconChanged {
@@ -1109,13 +1138,20 @@ impl<C: RenderConfiguration> TabWorker<C> {
                         self.emit_focus_changed();
                     }
                     if let Some(href) = self.context.hover_link_url.clone() {
-                        let resolved = self
-                            .current_url
-                            .as_ref()
-                            .and_then(|base| base.join(&href).ok())
-                            .map(|u| u.to_string())
-                            .unwrap_or(href);
-                        self.navigate_to(resolved, false, HistoryIntent::Push);
+                        let resolved = self.current_url.as_ref().and_then(|base| base.join(&href).ok());
+                        // A page's link may take the tab to the web, or a file
+                        // page to another file: never to an internal page.
+                        let allowed = resolved.as_ref().is_some_and(|url| {
+                            matches!(url.scheme(), "http" | "https")
+                                || (url.scheme() == "file"
+                                    && self.current_url.as_ref().is_some_and(|cur| cur.scheme() == "file"))
+                        });
+                        match resolved {
+                            Some(url) if allowed => {
+                                self.navigate_to(url.to_string(), false, HistoryIntent::Push);
+                            }
+                            _ => log::debug!("link to {href} not followed: scheme not allowed from a page"),
+                        }
                         return ControlFlow::Continue;
                     }
                 }

--- a/crates/gosub_engine/src/net/ssrf.rs
+++ b/crates/gosub_engine/src/net/ssrf.rs
@@ -217,6 +217,8 @@ pub enum AddressSpace {
     Private,
 }
 
+const MAX_CACHED_HOSTS: usize = 4096;
+
 /// Remembers which address space a host was classified into, so a document's
 /// own host is not resolved again for every subresource it loads.
 #[derive(Debug, Default)]
@@ -250,7 +252,16 @@ impl AddressSpaceCache {
             Ok(addrs) => space_of(addrs.into_iter()),
             Err(_) => AddressSpace::Public,
         };
-        self.hosts.lock().insert(key, (Instant::now(), space));
+        let mut hosts = self.hosts.lock();
+        hosts.insert(key, (Instant::now(), space));
+        // Expired entries are only ever skipped on lookup; sweep them here
+        // when the table grows past what a session plausibly touches.
+        if hosts.len() > MAX_CACHED_HOSTS {
+            hosts.retain(|_, (seen, _)| seen.elapsed() < CLASSIFICATION_TTL);
+            if hosts.len() > MAX_CACHED_HOSTS {
+                hosts.clear();
+            }
+        }
         space
     }
 }


### PR DESCRIPTION

Base: `13-no-broker-dom`. The remaining findings of the four-pass isolation
audit (`isolation-audit.md`) that are not already inside the role PRs. Most of
the audit's larger fixes — forked renderers closing the broker link and anchor
pipe, the net role's namespace and socket-family filter, spawn hygiene,
bounded render exchanges and renderer reports, the media store failing closed,
the bounded `RemoteMediaCache`, timeouts and tagged replies on the net→vault
link — are reviewed inside PRs 1, 3, 7, 8 and 11, where those files live.

### What is in here

- Favicons: web schemes only (a file page may load its own), ≤ 512 KiB, and the
  response must say it is an image before the bytes reach the embedder's decoder.
- Page links cannot target `gosub:`/internal pages; download filenames strip
  control characters and `.`/`..`.
- Cookie jar limits (4 KiB per cookie line, 180 per origin, oldest evicted).
- The address-space classification cache is bounded.
- Builds without `process-isolation` turn every `security.*` process setting
  off at `start()` and refuse child roles loudly; `telemetry.metrics_enabled`
  gates the metrics server.

### Testing

```
cargo test -p gosub_engine --lib
cargo check -p gosub_engine --no-default-features --features sqlite_cookie_store
```