### PR TITLE
Escape audit: an Audit message on every protocol, the harness scenario and suite test

### DIFF
--- a/crates/gosub_engine/src/bin/isolation-harness.rs
+++ b/crates/gosub_engine/src/bin/isolation-harness.rs
@@ -138,6 +138,7 @@ fn main() {
         "engine-renderer-slow-image" => with_font_backend!(engine_renderer_slow_image),
         "renderer-soak" => with_font_backend!(renderer_soak),
         "engine-soak" => with_font_backend!(engine_soak),
+        "escape-audit" => with_font_backend!(escape_audit),
         "storage" => storage(),
         "engine-storage-service" => engine_storage_service(),
         "vault" => vault(),
@@ -3052,6 +3053,187 @@ fn serve_routes(routes: Vec<Route>) -> std::io::Result<u16> {
 
 /// One route of [`serve_routes`]: path → (content type, body, delay before answering).
 type Route = (&'static str, &'static str, Vec<u8>, std::time::Duration);
+
+/// Not a test - a tool: the whole engine with every isolation setting on,
+/// one tab navigating real sites (argv[3..], or a built-in image-heavy set)
+/// in turn, reporting per site what it cost and what it took to render, and
+/// at the end what the renderer processes hold. Exit 1 only if a renderer
+/// crashed or a page could not be rendered out of process.
+/// The escape audit in every process of a running engine: what an attacker
+/// holding each child could still reach, measured from inside it after the
+/// real spawn and lockdown. Exit 1 on any expectation violated or any role
+/// that gave no report.
+fn escape_audit<F: FontSystem + Default>() -> i32 {
+    #[cfg(target_os = "linux")]
+    {
+        use gosub_config::settings::Setting;
+        use gosub_engine::decoder_process::client::ProcessImageDecoder;
+        use gosub_engine::events::{EngineEvent, NavigationEvent, TabCommand};
+        use gosub_engine::storage::{FileLocalStore, InMemorySessionStore, PartitionPolicy, StorageService};
+        use gosub_engine::zone::ZoneServices;
+        use gosub_engine::GosubEngine;
+        use gosub_render_pipeline::render::backends::null::NullBackend;
+        use gosub_render_pipeline::render::DefaultCompositor;
+        use gosub_sandbox::audit::AuditReport;
+        use parking_lot::Mutex;
+
+        let seen: SeenRequests = Arc::new(Mutex::new(Vec::new()));
+        let Ok(port) = serve_cookie_pages(Arc::clone(&seen)) else {
+            eprintln!("could not start the test server");
+            return 1;
+        };
+        let dir = std::env::temp_dir().join(format!("gosub-escape-audit-{}", std::process::id()));
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            eprintln!("no temp dir: {e}");
+            return 1;
+        }
+        let runtime = match tokio::runtime::Builder::new_multi_thread().enable_all().build() {
+            Ok(rt) => rt,
+            Err(e) => {
+                eprintln!("could not build a runtime: {e}");
+                return 1;
+            }
+        };
+        let store_dir = dir.clone();
+        let code = runtime.block_on(async move {
+            let dir = store_dir;
+            let compositor = Arc::new(DefaultCompositor::default());
+            let mut engine: GosubEngine<TileConfig<F>> =
+                GosubEngine::new(None, Arc::new(NullBackend::new()), Arc::clone(&compositor));
+            for key in [
+                "security.network_process",
+                "security.image_decoder_process",
+                "security.renderer_process",
+                "security.cookie_vault",
+                "security.storage_service",
+            ] {
+                if let Err(e) = engine.settings().set(key, Setting::Bool(true)) {
+                    eprintln!("could not enable {key}: {e}");
+                    return 1;
+                }
+            }
+            let mut events = engine.subscribe_events();
+            let Ok(run) = engine.start() else {
+                eprintln!("engine failed to start");
+                return 1;
+            };
+            tokio::spawn(run);
+
+            let storage = Arc::new(StorageService::new(
+                Arc::new(FileLocalStore::attach(&dir)),
+                Arc::new(InMemorySessionStore::new()),
+            ));
+            let services = ZoneServices {
+                storage: Arc::clone(&storage),
+                cookie_store: None,
+                cookie_jar: None,
+                partition_policy: PartitionPolicy::None,
+                places: None,
+            };
+            let Ok(mut zone) = engine.create_zone(None, services, None) else {
+                eprintln!("could not create a zone");
+                return 1;
+            };
+            let Ok(tab) = zone.create_tab(Default::default(), None).await else {
+                eprintln!("could not create a tab");
+                return 1;
+            };
+            let _ = tab
+                .send(TabCommand::SetViewport {
+                    x: 0,
+                    y: 0,
+                    width: 800,
+                    height: 600,
+                })
+                .await;
+            let _ = tab.send(TabCommand::ResumeDrawing { fps: 30 }).await;
+            // A page, so a resident renderer exists and the storage service ran.
+            if tab.navigate(format!("http://127.0.0.1:{port}/")).await.is_err() {
+                eprintln!("navigate failed");
+                return 1;
+            }
+            let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
+            loop {
+                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                match tokio::time::timeout(remaining, events.recv()).await {
+                    Ok(Ok(EngineEvent::Navigation {
+                        event: NavigationEvent::Finished { .. },
+                        ..
+                    })) => break,
+                    Ok(Ok(_)) => continue,
+                    _ => {
+                        eprintln!("the page never finished loading");
+                        return 1;
+                    }
+                }
+            }
+            // Touch storage so its service is spawned (it starts lazily).
+            let origin = url::Url::parse(&format!("http://127.0.0.1:{port}/")).map(|u| u.origin());
+            if let Ok(origin) = origin {
+                if let Ok(area) = storage.local_for(zone.id, &gosub_engine::storage::PartitionKey::None, &origin) {
+                    let _ = area.set_item("audit", "1");
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+            let mut reports: Vec<(String, Option<AuditReport>)> = Vec::new();
+            reports.push(("net".into(), engine.audit_net_process().await));
+            reports.push(("decoder".into(), ProcessImageDecoder.audit().ok().flatten()));
+            reports.push(("vault".into(), engine.cookie_vault().and_then(|v| v.audit())));
+            reports.push(("storage".into(), storage.local_store().escape_audit()));
+            match engine.renderer_pool() {
+                Some(pool) => {
+                    for (label, report) in pool.audit() {
+                        match report {
+                            Ok(report) => reports.push((label, Some(report))),
+                            Err(e) => {
+                                eprintln!("{label}: no report ({e})");
+                                reports.push((label, None));
+                            }
+                        }
+                    }
+                }
+                None => reports.push(("fork-server".into(), None)),
+            }
+
+            let mut failed = false;
+            let mut resident = 0;
+            for (label, report) in &reports {
+                match report {
+                    Some(report) => {
+                        if label.starts_with("renderer ") {
+                            resident += 1;
+                        }
+                        let violations = report.violations().len();
+                        println!("== {label}: {} check(s), {violations} violation(s)", report.items.len());
+                        print!("{}", report.render());
+                        if violations > 0 {
+                            failed = true;
+                        }
+                    }
+                    None => {
+                        println!("== {label}: NO REPORT");
+                        failed = true;
+                    }
+                }
+            }
+            if resident == 0 {
+                println!("no resident renderer was audited");
+                failed = true;
+            }
+            engine.close_zone(zone).await;
+            let _ = engine.shutdown().await;
+            i32::from(failed)
+        });
+        let _ = std::fs::remove_dir_all(&dir);
+        code
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the escape audit is Linux-only");
+        2
+    }
+}
 
 /// The follow-up question to the warm-up finding: a page can introduce a font at
 /// any moment with `@font-face`, long after the sandbox is in place. Does that

--- a/crates/gosub_engine/src/cookie_vault/child.rs
+++ b/crates/gosub_engine/src/cookie_vault/child.rs
@@ -102,6 +102,12 @@ pub fn serve(broker: Endpoint, net_link: Option<Endpoint>) -> i32 {
             ToVault::Revoke { ticket } => {
                 grants.lock().remove(&ticket);
             }
+            ToVault::Audit { tag } => {
+                let report = gosub_sandbox::audit::run(gosub_sandbox::audit::Role::Vault, &[]);
+                if broker_tx.lock().send(&FromVault::Audit { tag, report }).is_err() {
+                    break;
+                }
+            }
             msg => {
                 if let Some(reply) = handle(msg, &jars, &broker_tx) {
                     if broker_tx.lock().send(&reply).is_err() {
@@ -281,7 +287,9 @@ fn handle(msg: ToVault, jars: &Jars, snapshots: &Arc<Mutex<EndpointTx>>) -> Opti
             }
         }),
         ToVault::PurgeExpired { zone } => mutate(jars, snapshots, &zone, |jar| jar.purge_expired()),
-        ToVault::Ping | ToVault::Shutdown | ToVault::Grant { .. } | ToVault::Revoke { .. } => None,
+        ToVault::Ping | ToVault::Shutdown | ToVault::Grant { .. } | ToVault::Revoke { .. } | ToVault::Audit { .. } => {
+            None
+        }
     }
 }
 

--- a/crates/gosub_engine/src/cookie_vault/client.rs
+++ b/crates/gosub_engine/src/cookie_vault/client.rs
@@ -27,6 +27,7 @@ enum Reply {
     Cookies(Option<String>),
     All(Vec<(String, String)>),
     Granted(bool),
+    Audit(gosub_sandbox::audit::AuditReport),
 }
 
 /// Why a zone's snapshot would be expected right now. A snapshot for a zone
@@ -196,6 +197,11 @@ fn start_reader(
                     }
                     // The broker's own stores are fire-and-forget.
                     FromVault::Stored { .. } => {}
+                    FromVault::Audit { tag, report } => {
+                        if let Some(waiter) = waiters.lock().remove(&tag) {
+                            let _ = waiter.send(Reply::Audit(report));
+                        }
+                    }
                     FromVault::Refused { tag } => {
                         if let Some(waiter) = waiters.lock().remove(&tag) {
                             let _ = waiter.send(Reply::Granted(false));
@@ -401,7 +407,7 @@ impl CookieVault {
             visible_only,
         })? {
             Reply::Cookies(header) => header,
-            Reply::All(_) | Reply::Granted(_) => None,
+            Reply::All(_) | Reply::Granted(_) | Reply::Audit(_) => None,
         }
     }
 
@@ -422,6 +428,14 @@ impl CookieVault {
             url: url.to_string(),
             set_cookie,
         });
+    }
+
+    /// The escape audit, run inside the vault process.
+    pub fn audit(&self) -> Option<gosub_sandbox::audit::AuditReport> {
+        match self.ask(|tag| ToVault::Audit { tag })? {
+            Reply::Audit(report) => Some(report),
+            _ => None,
+        }
     }
 
     /// Let the network process act on `scope` for one request. `false` means

--- a/crates/gosub_engine/src/cookie_vault/protocol.rs
+++ b/crates/gosub_engine/src/cookie_vault/protocol.rs
@@ -86,6 +86,10 @@ pub enum ToVault {
     PurgeExpired {
         zone: String,
     },
+    /// Broker only: run the escape audit in the vault and report it.
+    Audit {
+        tag: Tag,
+    },
     Shutdown,
 }
 
@@ -102,6 +106,10 @@ pub enum FromVault {
     },
     Stored {
         tag: Tag,
+    },
+    Audit {
+        tag: Tag,
+        report: gosub_sandbox::audit::AuditReport,
     },
     Cookies {
         tag: Tag,

--- a/crates/gosub_engine/src/decoder_process/child.rs
+++ b/crates/gosub_engine/src/decoder_process/child.rs
@@ -30,6 +30,17 @@ pub fn serve(mut link: Endpoint) -> i32 {
 
     let (mime, bytes) = match link.recv::<ToDecoder>() {
         Ok(ToDecoder::Decode { mime, bytes }) => (mime, bytes),
+        Ok(ToDecoder::Audit) => {
+            #[cfg(target_os = "linux")]
+            let report = Some(gosub_sandbox::audit::run(gosub_sandbox::audit::Role::Decoder, &[]));
+            #[cfg(not(target_os = "linux"))]
+            let report = None;
+            return if link.send(&FromDecoder::Audit(report)).is_ok() {
+                0
+            } else {
+                1
+            };
+        }
         Ok(ToDecoder::Dimensions { mime, bytes }) => {
             let reply = match registry.dimensions(mime.as_deref(), &bytes) {
                 Some((width, height)) => FromDecoder::Dimensions { width, height },

--- a/crates/gosub_engine/src/decoder_process/client.rs
+++ b/crates/gosub_engine/src/decoder_process/client.rs
@@ -51,6 +51,17 @@ impl ImageDecoder for ProcessImageDecoder {
 enum Answer {
     Raster(RasterImage),
     Dimensions(u32, u32),
+    Audit(Option<gosub_sandbox::audit::AuditReport>),
+}
+
+impl ProcessImageDecoder {
+    /// The escape audit, run in a throwaway decoder process under its lockdown.
+    pub fn audit(&self) -> Result<Option<gosub_sandbox::audit::AuditReport>, DecodeError> {
+        match ask_child(ToDecoder::Audit)? {
+            Answer::Audit(report) => Ok(report),
+            _ => Err(DecodeError::Failed("the decoder answered the wrong question".into())),
+        }
+    }
 }
 
 fn ask_child(request: ToDecoder) -> Result<Answer, DecodeError> {
@@ -126,6 +137,7 @@ fn exchange(channel: gosub_ipc::channel::Channel, request: ToDecoder) -> Result<
 
         match msg {
             FromDecoder::Failed(why) => return Err(DecodeError::Unsupported(why)),
+            FromDecoder::Audit(report) => return Ok(Answer::Audit(report)),
             FromDecoder::Dimensions { width, height } => {
                 if width == 0 || height == 0 || width > MAX_DIMENSION || height > MAX_DIMENSION {
                     return Err(DecodeError::Failed(format!(

--- a/crates/gosub_engine/src/decoder_process/protocol.rs
+++ b/crates/gosub_engine/src/decoder_process/protocol.rs
@@ -28,6 +28,8 @@ pub enum ToDecoder {
     },
     /// The intrinsic size only, from the header.
     Dimensions { mime: Option<String>, bytes: Vec<u8> },
+    /// Run the escape audit under the decoder's lockdown and report it.
+    Audit,
 }
 
 /// Decoder → broker.
@@ -50,4 +52,6 @@ pub enum FromDecoder {
         height: u32,
     },
     Failed(String),
+    /// Answer to [`ToDecoder::Audit`]; `None` where the audit cannot run.
+    Audit(Option<gosub_sandbox::audit::AuditReport>),
 }

--- a/crates/gosub_engine/src/engine/engine.rs
+++ b/crates/gosub_engine/src/engine/engine.rs
@@ -475,6 +475,13 @@ impl<C: RenderConfiguration> GosubEngine<C> {
         self.context.renderer_process.get()
     }
 
+    /// The escape audit in the network process; `None` when networking is
+    /// in-process (tools and tests).
+    #[cfg(feature = "process-isolation")]
+    pub async fn audit_net_process(&self) -> Option<gosub_sandbox::audit::AuditReport> {
+        self.io_handle.as_ref()?.audit_net().await
+    }
+
     /// The cookie vault, when one runs (tools and tests).
     #[cfg(all(feature = "process-isolation", target_os = "linux"))]
     pub fn cookie_vault(&self) -> Option<&Arc<crate::cookie_vault::client::CookieVault>> {

--- a/crates/gosub_engine/src/engine/events.rs
+++ b/crates/gosub_engine/src/engine/events.rs
@@ -133,6 +133,11 @@ pub enum IoCommand {
         zone_id: ZoneId,
         reply_tx: oneshot::Sender<()>,
     },
+    /// Run the escape audit in the network process, when there is one.
+    #[cfg(feature = "process-isolation")]
+    AuditNet {
+        reply_tx: oneshot::Sender<Option<gosub_sandbox::audit::AuditReport>>,
+    },
 }
 
 /// Commands that can be sent to a specific tab

--- a/crates/gosub_engine/src/engine/resource_pipeline/html.rs
+++ b/crates/gosub_engine/src/engine/resource_pipeline/html.rs
@@ -263,6 +263,10 @@ mod tests {
                     IoCommand::ShutdownZone { reply_tx, .. } => {
                         let _ = reply_tx.send(());
                     }
+                    #[cfg(feature = "process-isolation")]
+                    IoCommand::AuditNet { reply_tx } => {
+                        let _ = reply_tx.send(None);
+                    }
                 }
             }
         });

--- a/crates/gosub_engine/src/engine/storage/area.rs
+++ b/crates/gosub_engine/src/engine/storage/area.rs
@@ -46,6 +46,12 @@ pub trait LocalStore: Send + Sync {
     fn service_pid(&self) -> Option<u32> {
         None
     }
+
+    /// The escape audit run inside the serving process, when there is one.
+    #[cfg(feature = "process-isolation")]
+    fn escape_audit(&self) -> Option<gosub_sandbox::audit::AuditReport> {
+        None
+    }
 }
 
 /// Store for sessionStorage-like areas (isolated per (zone, tab, partition, origin)).

--- a/crates/gosub_engine/src/fork_server/child.rs
+++ b/crates/gosub_engine/src/fork_server/child.rs
@@ -147,6 +147,15 @@ fn serve_warmed<C: RenderConfiguration>(mut link: Endpoint) -> i32 {
                 let _ = gosub_sandbox::reap_exited_children();
                 FromForkServer::Pong
             }
+            ToForkServer::Audit => {
+                FromForkServer::Audit(gosub_sandbox::audit::run(gosub_sandbox::audit::Role::ForkServer, &[]))
+            }
+            ToForkServer::AuditRenderer => match fork_confined_task(font_access, &parent_only, || {
+                Some(gosub_sandbox::audit::run(gosub_sandbox::audit::Role::Renderer, &[]))
+            }) {
+                Ok(report) => FromForkServer::Audit(report),
+                Err(e) => FromForkServer::Refused(e),
+            },
             ToForkServer::RenderPage {
                 html,
                 url,
@@ -274,6 +283,8 @@ fn decline(mut link: Endpoint, answer: &Confinement) -> i32 {
             ToForkServer::ForkProof
             | ToForkServer::RenderPage { .. }
             | ToForkServer::SpawnRenderer { .. }
+            | ToForkServer::Audit
+            | ToForkServer::AuditRenderer
             | ToForkServer::Resource(_) => FromForkServer::Refused(refusal.clone()),
         };
         if link.send(&reply).is_err() {
@@ -488,6 +499,9 @@ fn fork_and_render<C: RenderConfiguration>(
                         // lets go of anything.
                         FromRenderer::Evict { .. } => {
                             return Err(std::io::Error::other("a one-shot renderer sent an eviction"));
+                        }
+                        FromRenderer::Audit(_) => {
+                            return Err(std::io::Error::other("a one-shot renderer sent an audit report"));
                         }
                     }
                 }

--- a/crates/gosub_engine/src/fork_server/client.rs
+++ b/crates/gosub_engine/src/fork_server/client.rs
@@ -246,6 +246,7 @@ impl RenderStream for FromRenderer {
             FromRenderer::TileUnchanged(header) => RenderEvent::TileUnchanged(header),
             FromRenderer::Rendered { summary, hit_regions } => RenderEvent::Rendered { summary, hit_regions },
             FromRenderer::Evict { hashes } => RenderEvent::Evict(hashes),
+            FromRenderer::Audit(_) => anyhow::bail!("an audit report in the middle of a render"),
         })
     }
 
@@ -676,6 +677,26 @@ impl ForkServer {
         }
     }
 
+    /// The escape audit, run in the fork server itself.
+    pub fn audit(&mut self) -> anyhow::Result<gosub_sandbox::audit::AuditReport> {
+        self.link.send(&ToForkServer::Audit)?;
+        match self.link.recv::<FromForkServer>()? {
+            FromForkServer::Audit(report) => Ok(report),
+            FromForkServer::Refused(reason) => anyhow::bail!("{reason}"),
+            other => anyhow::bail!("unexpected reply to Audit: {other:?}"),
+        }
+    }
+
+    /// The escape audit, run in a renderer forked for it.
+    pub fn audit_forked_renderer(&mut self) -> anyhow::Result<gosub_sandbox::audit::AuditReport> {
+        self.link.send(&ToForkServer::AuditRenderer)?;
+        match self.link.recv::<FromForkServer>()? {
+            FromForkServer::Audit(report) => Ok(report),
+            FromForkServer::Refused(reason) => anyhow::bail!("{reason}"),
+            other => anyhow::bail!("unexpected reply to AuditRenderer: {other:?}"),
+        }
+    }
+
     /// Fork a renderer and run the pipeline over `html` in it - parse, style,
     /// layout, layering, tiling, paint, and (when the configuration has a
     /// forked rasterizer) rasterize - under its tier sandbox, with the
@@ -877,6 +898,19 @@ impl ResidentRenderer {
             self.mark_dead();
         }
         result
+    }
+
+    /// The escape audit, run inside this resident renderer.
+    pub fn audit(&mut self) -> anyhow::Result<gosub_sandbox::audit::AuditReport> {
+        self.send(&ToRenderer::Audit)?;
+        match self.link.recv::<FromRenderer>() {
+            Ok(FromRenderer::Audit(report)) => Ok(report),
+            Ok(other) => anyhow::bail!("unexpected reply to Audit: {other:?}"),
+            Err(e) => {
+                self.mark_dead();
+                anyhow::bail!("renderer link failed: {e}")
+            }
+        }
     }
 
     /// Whether the process is still there, without sending anything: a closed

--- a/crates/gosub_engine/src/fork_server/pool.rs
+++ b/crates/gosub_engine/src/fork_server/pool.rs
@@ -274,6 +274,28 @@ impl RendererPool {
         count
     }
 
+    /// The escape audit in the fork server, a renderer forked for it, and
+    /// every resident renderer, labelled.
+    pub fn audit(&self) -> Vec<(String, anyhow::Result<gosub_sandbox::audit::AuditReport>)> {
+        let mut out = Vec::new();
+        {
+            let mut server = self.fork_server.lock();
+            out.push(("fork-server".to_string(), server.audit()));
+            out.push(("forked renderer".to_string(), server.audit_forked_renderer()));
+        }
+        let renderers: Vec<(RendererKey, Arc<Mutex<ResidentRenderer>>)> = self
+            .state
+            .lock()
+            .renderers
+            .iter()
+            .map(|(k, r)| (k.clone(), Arc::clone(r)))
+            .collect();
+        for (key, renderer) in renderers {
+            out.push((format!("renderer {}", key.site), renderer.lock().audit()));
+        }
+        out
+    }
+
     /// Every running renderer and how many tabs it hosts.
     pub fn snapshot(&self) -> Vec<RendererStatus> {
         // The `/proc` reads happen after the lock is released.

--- a/crates/gosub_engine/src/fork_server/protocol.rs
+++ b/crates/gosub_engine/src/fork_server/protocol.rs
@@ -78,6 +78,10 @@ pub enum ToForkServer {
     /// process's children, so only it can reap them). The broker sends this
     /// after it observed a renderer's link close.
     ReapExited,
+    /// Run the escape audit in the fork server itself.
+    Audit,
+    /// Fork a renderer that runs the escape audit and reports it.
+    AuditRenderer,
     /// Exit cleanly.
     Shutdown,
     /// The broker's answer to [`FromForkServer::NeedResource`], relayed on to
@@ -127,6 +131,8 @@ pub enum ToRenderer {
     /// of the broker's recovery; a renderer that obeys it was going to be
     /// trusted with nothing anyway.
     CrashForTest,
+    /// Run the escape audit in this process and report it.
+    Audit,
     /// Exit cleanly. The broker sends this when the renderer's last tab
     /// closes; a closed link means the same.
     Shutdown,
@@ -166,6 +172,8 @@ pub enum FromForkServer {
     /// immediately as a file descriptor. `pid` is the number the fork
     /// server's own namespace - and so the broker's - sees.
     RendererSpawned { pid: i32 },
+    /// Answer to [`ToForkServer::Audit`] and [`ToForkServer::AuditRenderer`].
+    Audit(gosub_sandbox::audit::AuditReport),
     /// The request could not be served; the string says why (e.g. forking is
     /// refused under `Unsupported`, or the forked child died).
     Refused(String),
@@ -397,6 +405,8 @@ pub enum FromRenderer {
     /// drops them; scrolling back there ships them afresh. Only a resident
     /// renderer sends this.
     Evict { hashes: Vec<u64> },
+    /// Answer to [`ToRenderer::Audit`].
+    Audit(gosub_sandbox::audit::AuditReport),
     /// The final message: the render is complete, with the page's hit-test
     /// geometry.
     Rendered {

--- a/crates/gosub_engine/src/fork_server/resident.rs
+++ b/crates/gosub_engine/src/fork_server/resident.rs
@@ -88,6 +88,12 @@ pub fn serve<C: RenderConfiguration>(
             }
             ToRenderer::Shutdown => gosub_sandbox::exit_now(0),
             ToRenderer::CrashForTest => gosub_sandbox::exit_now(139),
+            ToRenderer::Audit => {
+                let report = gosub_sandbox::audit::run(gosub_sandbox::audit::Role::Renderer, &[]);
+                if link.lock().send(&FromRenderer::Audit(report)).is_err() {
+                    gosub_sandbox::exit_now(1);
+                }
+            }
             ToRenderer::Navigate {
                 tab,
                 html,

--- a/crates/gosub_engine/src/net/io_runtime.rs
+++ b/crates/gosub_engine/src/net/io_runtime.rs
@@ -77,6 +77,14 @@ impl IoHandle {
     pub fn subscribe(&self) -> IoChannel {
         self.tx_submit.clone()
     }
+
+    /// The escape audit in the network process; `None` without one.
+    #[cfg(feature = "process-isolation")]
+    pub async fn audit_net(&self) -> Option<gosub_sandbox::audit::AuditReport> {
+        let (tx, rx) = oneshot::channel();
+        self.tx_submit.send(IoCommand::AuditNet { reply_tx: tx }).ok()?;
+        rx.await.ok().flatten()
+    }
 }
 
 pub struct ZoneEntry {
@@ -714,6 +722,20 @@ pub fn spawn_io_thread(cfg: FetcherConfig, engine_ctx: Arc<EngineContext>) -> Io
                                     }
                                     (None, None) => {}
                                 }
+                            });
+                        }
+                        #[cfg(feature = "process-isolation")]
+                        Some(IoCommand::AuditNet { reply_tx }) => {
+                            let net = router.net_process();
+                            spawn_named("io-audit-net", async move {
+                                let report = match net {
+                                    Some(net) => tokio::task::spawn_blocking(move || net.audit().ok().flatten())
+                                        .await
+                                        .ok()
+                                        .flatten(),
+                                    None => None,
+                                };
+                                let _ = reply_tx.send(report);
                             });
                         }
                         Some(IoCommand::Decision { token, action }) => {

--- a/crates/gosub_engine/src/net/process/child.rs
+++ b/crates/gosub_engine/src/net/process/child.rs
@@ -126,6 +126,11 @@ pub fn serve(link: Endpoint, vault: Option<Endpoint>) -> i32 {
                     token.cancel();
                 }
             }
+            ToNet::Audit => {
+                if link_tx.lock().send(&FromNet::Audit(platform::escape_audit())).is_err() {
+                    break;
+                }
+            }
             // The vault was respawned: its new line follows on the link.
             ToNet::VaultLine => match platform::adopt_vault_line(&mut link_rx) {
                 Ok(line) => *vault.lock() = Some(line),

--- a/crates/gosub_engine/src/net/process/child/linux.rs
+++ b/crates/gosub_engine/src/net/process/child/linux.rs
@@ -14,6 +14,10 @@ use std::time::Duration;
 /// Bodies may stream: the link carries the ring's fd.
 pub(super) const STREAMING: bool = true;
 
+pub(super) fn escape_audit() -> Option<gosub_sandbox::audit::AuditReport> {
+    Some(gosub_sandbox::audit::run(gosub_sandbox::audit::Role::Net, &[]))
+}
+
 /// Ring window for streamed bodies. Small on purpose: a large body wraps
 /// through it many times, and neither side ever holds more than this (plus one
 /// chunk) for the transport.

--- a/crates/gosub_engine/src/net/process/child/portable.rs
+++ b/crates/gosub_engine/src/net/process/child/portable.rs
@@ -12,6 +12,10 @@ use std::sync::Arc;
 /// Bodies never stream: the broker asks for them buffered.
 pub(super) const STREAMING: bool = false;
 
+pub(super) fn escape_audit() -> Option<gosub_sandbox::audit::AuditReport> {
+    None
+}
+
 /// Never constructed here; the type exists so the caller has no branch.
 pub(super) enum Streamed {}
 

--- a/crates/gosub_engine/src/net/process/client.rs
+++ b/crates/gosub_engine/src/net/process/client.rs
@@ -113,7 +113,11 @@ pub struct NetProcess {
     /// The child holds a direct line to the cookie vault: requests may carry a
     /// cookie scope instead of a header.
     vault_linked: bool,
+    /// Who is waiting for an audit report, if anyone.
+    audit_waiter: AuditWaiter,
 }
+
+type AuditWaiter = Arc<Mutex<Option<std::sync::mpsc::SyncSender<Option<gosub_sandbox::audit::AuditReport>>>>>;
 
 impl std::fmt::Debug for NetProcess {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -188,6 +192,8 @@ impl NetProcess {
         // A plain thread, not a task: it blocks on the link, and must keep
         // draining even when every runtime worker is busy waiting on a reply.
         let waiters = pending.clone();
+        let audit_waiter: AuditWaiter = Arc::new(Mutex::new(None));
+        let audit_reply = Arc::clone(&audit_waiter);
         std::thread::Builder::new()
             .name("net-process-reader".into())
             .spawn(move || {
@@ -195,6 +201,11 @@ impl NetProcess {
                     match msg {
                         FromNet::Pong => {
                             let _ = ready_tx.send(());
+                        }
+                        FromNet::Audit(report) => {
+                            if let Some(waiter) = audit_reply.lock().take() {
+                                let _ = waiter.send(report);
+                            }
                         }
                         FromNet::Reply { tag, outcome } => {
                             // A streamed head is followed by its ring fd; take it
@@ -228,6 +239,7 @@ impl NetProcess {
             child: Mutex::new(Some(child)),
             inflight: Arc::new(tokio::sync::Semaphore::new(MAX_INFLIGHT)),
             vault_linked: !extra_fds.is_empty(),
+            audit_waiter,
         };
 
         // Confirm the child really is a network process before returning it as
@@ -258,6 +270,15 @@ impl NetProcess {
     /// Whether the child resolves cookies against the vault itself.
     pub fn vault_linked(&self) -> bool {
         self.vault_linked
+    }
+
+    /// The escape audit, run inside the network process. Blocking.
+    pub fn audit(&self) -> anyhow::Result<Option<gosub_sandbox::audit::AuditReport>> {
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        *self.audit_waiter.lock() = Some(tx);
+        self.tx.lock().send(&ToNet::Audit)?;
+        rx.recv_timeout(Duration::from_secs(30))
+            .map_err(|_| anyhow::anyhow!("the network process did not answer the audit"))
     }
 
     /// Hand the child a new line to a respawned vault, over its own link. The

--- a/crates/gosub_engine/src/net/process/protocol.rs
+++ b/crates/gosub_engine/src/net/process/protocol.rs
@@ -22,6 +22,8 @@ pub enum ToNet {
     /// A new line to the cookie vault follows as a file descriptor (the vault
     /// was respawned); it replaces the one inherited at spawn.
     VaultLine,
+    /// Run the escape audit under the net lockdown and report it.
+    Audit,
 }
 
 /// One request, flattened to what actually has to travel.
@@ -110,6 +112,8 @@ pub enum FromNet {
         tag: RequestTag,
         outcome: FetchOutcome,
     },
+    /// Answer to [`ToNet::Audit`]; `None` where the audit cannot run.
+    Audit(Option<gosub_sandbox::audit::AuditReport>),
 }
 
 /// What became of a request.

--- a/crates/gosub_engine/src/storage_service/child.rs
+++ b/crates/gosub_engine/src/storage_service/child.rs
@@ -21,6 +21,7 @@ pub fn serve(mut link: Endpoint, dir: PathBuf) -> i32 {
         &[(dir.as_path(), true)],
     );
 
+    let own = vec![dir.clone()];
     let store = FileLocalStore::attach(dir);
     while let Ok(msg) = link.recv::<ToStorage>() {
         let reply = match msg {
@@ -61,6 +62,10 @@ pub fn serve(mut link: Endpoint, dir: PathBuf) -> i32 {
             ToStorage::Len { tag, area } => FromStorage::Len {
                 tag,
                 len: store.area_for(&area.zone, &area.partition, &area.origin).len() as u64,
+            },
+            ToStorage::Audit { tag } => FromStorage::Audit {
+                tag,
+                report: gosub_sandbox::audit::run(gosub_sandbox::audit::Role::Storage, &own),
             },
         };
         if link.send(&reply).is_err() {

--- a/crates/gosub_engine/src/storage_service/client.rs
+++ b/crates/gosub_engine/src/storage_service/client.rs
@@ -159,7 +159,8 @@ impl StorageProcess {
             FromStorage::Value { tag, .. }
             | FromStorage::Done { tag, .. }
             | FromStorage::Keys { tag, .. }
-            | FromStorage::Len { tag, .. } => Some(*tag),
+            | FromStorage::Len { tag, .. }
+            | FromStorage::Audit { tag, .. } => Some(*tag),
             FromStorage::Pong => None,
         };
         if echoed != Some(tag) {
@@ -173,6 +174,14 @@ impl StorageProcess {
             FromStorage::Done { error: None, .. } => Ok(()),
             FromStorage::Done { error: Some(e), .. } => Err(anyhow!(e)),
             _ => Err(anyhow!("unexpected reply from the storage service")),
+        }
+    }
+
+    /// The escape audit, run inside the service process.
+    pub fn audit(&self) -> Result<gosub_sandbox::audit::AuditReport> {
+        match self.ask(|tag| ToStorage::Audit { tag })? {
+            FromStorage::Audit { report, .. } => Ok(report),
+            _ => Err(anyhow!("unexpected reply to the audit")),
         }
     }
 
@@ -268,6 +277,13 @@ impl LocalStore for ServiceLocalStore {
 
     fn service_pid(&self) -> Option<u32> {
         self.pid()
+    }
+
+    fn escape_audit(&self) -> Option<gosub_sandbox::audit::AuditReport> {
+        match self.backend.get() {
+            Some(Backend::Remote(process)) => process.audit().ok(),
+            _ => None,
+        }
     }
 
     fn area(&self, zone: ZoneId, part: &PartitionKey, origin: &url::Origin) -> Result<Arc<dyn StorageArea>> {

--- a/crates/gosub_engine/src/storage_service/protocol.rs
+++ b/crates/gosub_engine/src/storage_service/protocol.rs
@@ -47,6 +47,10 @@ pub enum ToStorage {
         tag: Tag,
         area: AreaKey,
     },
+    /// Run the escape audit in the service and report it.
+    Audit {
+        tag: Tag,
+    },
     Shutdown,
 }
 
@@ -70,5 +74,9 @@ pub enum FromStorage {
     Len {
         tag: Tag,
         len: u64,
+    },
+    Audit {
+        tag: Tag,
+        report: gosub_sandbox::audit::AuditReport,
     },
 }

--- a/crates/gosub_engine/tests/process_isolation.rs
+++ b/crates/gosub_engine/tests/process_isolation.rs
@@ -545,6 +545,35 @@ fn an_exec_fresh_renderer_renders_one_page_confined() {
     );
 }
 
+/// The escape audit inside every process of a running engine: nothing a
+/// compromised child would try - files, sockets, fork, exec, signals, the
+/// broker's memory - comes out other than the role's design says.
+#[cfg(target_os = "linux")]
+#[test]
+fn no_process_finds_a_way_out_of_its_sandbox() {
+    let out = run_with_backend("escape-audit", "parley");
+    assert!(
+        out.status.success(),
+        "escape audit failed:\n{}\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A *spawned* child must run under the restricted token, not fall back to
+/// the inherited one: `gosub_sandbox::spawn` reports the fallback on stderr,
+/// which the harness (spawning the network process) inherits.
+#[cfg(target_os = "windows")]
+#[test]
+fn spawned_children_get_a_restricted_token() {
+    let out = run("direct");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("using inherited token"),
+        "a child fell back to the inherited token - restricted_token() failed:\n{stderr}"
+    );
+}
+
 /// The wiring: an ordinary navigation with `security.network_process` on resolves
 /// through the child rather than an in-process fetcher.
 #[test]


### PR DESCRIPTION

Base: `14-audit-hardening`. The "hostile child" test: does anything a
compromised role would try actually get out?

### What is in here

- Every protocol gains an `Audit` request (net, decoder, fork server, forked
  and resident renderers, vault, storage) that runs `gosub_sandbox::audit`
  *inside the live, confined process* and reports back. The broker's
  `IoCommand::AuditNet`, `RendererPool::audit`, `LocalStore::escape_audit`
  and `GosubEngine::audit_net_process` collect them.
- Harness scenario `escape-audit`: starts an engine with everything on, opens a
  tab, and audits all seven processes against their role expectations (a net
  role may resolve and connect, nothing else; a renderer may not open a file,
  socket, fork, exec, signal another process, or ptrace). Suite test
  `no_process_finds_a_way_out_of_its_sandbox`.

### Testing

```
cargo test -p gosub_engine --test process_isolation --features cairo-tiles   # 33
./target/debug/isolation-harness escape-audit parley                         # 0 violations across 7 processes
```