### PR TITLE
Settings and CI: final `security.*` wording, the engine in the cross-compile rows, `engine-stress`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,10 +131,10 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Check (isolation enabled)
         if: matrix.isolation == 'enabled'
-        run: cargo check --locked -p gosub_ipc -p gosub_sandbox --all-targets --target ${{ matrix.target }}
+        run: cargo check --locked -p gosub_ipc -p gosub_sandbox -p gosub_engine --all-targets --target ${{ matrix.target }}
       - name: Check (isolation disabled)
         if: matrix.isolation == 'disabled'
-        run: cargo check --locked -p gosub_ipc -p gosub_sandbox --all-targets --target ${{ matrix.target }} --no-default-features
+        run: cargo check --locked -p gosub_ipc -p gosub_sandbox -p gosub_engine --all-targets --target ${{ matrix.target }} --no-default-features --features gosub_engine/sqlite_cookie_store
 
   # The platforms whose sandbox backend can be *run*, not only type-checked:
   # the Seatbelt (macOS) and mitigation-policy (Windows) probes in
@@ -157,7 +157,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@nextest
       - name: Test
-        run: cargo nextest run --locked -p gosub_ipc -p gosub_sandbox --no-fail-fast
+        run: cargo nextest run --locked -p gosub_ipc -p gosub_sandbox -p gosub_engine --no-fail-fast
 
   fmt:
     runs-on: ubuntu-24.04

--- a/crates/gosub_engine/Cargo.toml
+++ b/crates/gosub_engine/Cargo.toml
@@ -79,20 +79,21 @@ default = ["sqlite_cookie_store", "process-isolation"]
 sqlite_cookie_store = ["r2d2", "r2d2_sqlite"]
 sqlite_places = ["r2d2", "r2d2_sqlite"]
 metrics = []
-# Compiles in the ability to run engine components as separate, sandboxed
-# processes. Off leaves the engine single-process, which is what wasm and any
-# platform without process isolation need. Compiling it in does not enable
-# anything: each process has its own `security.*` setting.
+# Compiles in the ability to run the network stack as a separate, sandboxed
+# process. Off leaves the engine single-process, which is what wasm and any
+# platform without process isolation need; the fetch path is otherwise identical.
+# Compiling it in does not enable it — see the `security.network_process` setting.
 process-isolation = ["dep:gosub_ipc", "dep:gosub_sandbox"]
 # Compile the feature-gated font systems into the isolation harness, so its
-# font scenarios can be pointed at every backend the engine supports - the
+# font scenarios can be pointed at every backend the engine supports — the
 # confinement contract has to hold per font stack, not just for the default.
 # Diagnostic only; nothing in the engine itself selects these.
 pango-fonts = ["gosub_fontmanager/pango"]
 skia-fonts = ["gosub_fontmanager/skia"]
-# Stage-6 rasterization in forked renderers: the Cairo CPU rasterizer, minus
-# its GTK/Pango default features. Diagnostic in the harness; an embedder may
-# also supply its own rasterizer through `RenderConfiguration::forked_tile_rasterizer`.
+# Stage-6 rasterization in the isolation harness's forked renderers: the Cairo
+# CPU rasterizer, minus its GTK/Pango default features. Diagnostic, like the
+# font features — a real embedder supplies its own rasterizer through
+# `RenderConfiguration::forked_tile_rasterizer`.
 cairo-tiles = ["dep:gosub_renderer_cairo"]
 # Same, with Skia's CPU rasterizer (`cairo-tiles` wins when both are on).
 skia-tiles = ["dep:gosub_renderer_skia"]

--- a/crates/gosub_engine/src/bin/isolation-harness.rs
+++ b/crates/gosub_engine/src/bin/isolation-harness.rs
@@ -139,6 +139,7 @@ fn main() {
         "renderer-soak" => with_font_backend!(renderer_soak),
         "engine-soak" => with_font_backend!(engine_soak),
         "escape-audit" => with_font_backend!(escape_audit),
+        "engine-stress" => with_font_backend!(engine_stress),
         "storage" => storage(),
         "engine-storage-service" => engine_storage_service(),
         "vault" => vault(),
@@ -3231,6 +3232,330 @@ fn escape_audit<F: FontSystem + Default>() -> i32 {
     #[cfg(not(target_os = "linux"))]
     {
         eprintln!("the escape audit is Linux-only");
+        2
+    }
+}
+
+/// Not a test - a tool: several tabs at once over real sites (the same site in
+/// more than one tab on purpose), continuously navigating, scrolling, hovering,
+/// closing and reopening for `argv[3]` seconds (default 120), logging every
+/// action and every engine event as it happens, with a status line every few
+/// seconds. `argv[4..]` replaces the built-in site list. Exit 1 on crashes.
+fn engine_stress<F: FontSystem + Default>() -> i32 {
+    println!("font backend: {}", std::any::type_name::<F>());
+    #[cfg(target_os = "linux")]
+    {
+        use gosub_config::settings::Setting;
+        use gosub_engine::events::{EngineEvent, NavigationEvent, TabCommand};
+        use gosub_engine::storage::{InMemoryLocalStore, InMemorySessionStore, PartitionPolicy, StorageService};
+        use gosub_engine::tab::{TabHandle, TabId};
+        use gosub_engine::zone::ZoneServices;
+        use gosub_engine::GosubEngine;
+        use gosub_render_pipeline::render::backends::null::NullBackend;
+        use gosub_render_pipeline::render::DefaultCompositor;
+        use std::collections::HashMap;
+
+        let seconds: u64 = std::env::args().nth(3).and_then(|a| a.parse().ok()).unwrap_or(120);
+        let mut sites: Vec<String> = std::env::args().skip(4).collect();
+        if sites.is_empty() {
+            sites = [
+                "https://en.wikipedia.org/wiki/Main_Page",
+                "https://www.bbc.com/news",
+                "https://www.theverge.com",
+                "https://www.nasa.gov",
+                "https://commons.wikimedia.org/wiki/Main_Page",
+                "https://news.ycombinator.com",
+                "https://en.wikipedia.org/wiki/Cat",
+                "https://www.bbc.com/sport",
+                "https://en.wikipedia.org/wiki/Rust_(programming_language)",
+                "https://www.rust-lang.org",
+                "https://developer.mozilla.org/en-US/",
+                "https://archive.org",
+                "https://www.openstreetmap.org/about",
+                "https://www.gnu.org",
+                "https://lwn.net",
+                "https://www.kernel.org",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        }
+        // Knobs beyond the positional args: how many tabs at once, and how
+        // fast actions fire (the base of the 1x-3.4x random pause).
+        let tabs_wanted: usize = std::env::var("GOSUB_STRESS_TABS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(6)
+            .max(1);
+        let pace_ms: u64 = std::env::var("GOSUB_STRESS_PACE_MS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(250)
+            .max(10);
+
+        // Deterministic per run, seedable; no need for a crate.
+        let mut rng_state: u64 = std::env::var("GOSUB_STRESS_SEED")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0x9E37_79B9_7F4A_7C15);
+        let mut rng = move || {
+            rng_state ^= rng_state << 13;
+            rng_state ^= rng_state >> 7;
+            rng_state ^= rng_state << 17;
+            rng_state
+        };
+
+        let runtime = match tokio::runtime::Builder::new_multi_thread().enable_all().build() {
+            Ok(rt) => rt,
+            Err(e) => {
+                eprintln!("could not build a runtime: {e}");
+                return 1;
+            }
+        };
+        runtime.block_on(async move {
+            let started = tokio::time::Instant::now();
+            let stamp = move || format!("[{:>7.2}s]", started.elapsed().as_secs_f64());
+
+            let compositor = Arc::new(DefaultCompositor::default());
+            let mut engine: GosubEngine<TileConfig<F>> =
+                GosubEngine::new(None, Arc::new(NullBackend::new()), Arc::clone(&compositor));
+            for key in ["security.network_process", "security.image_decoder_process", "security.renderer_process"] {
+                if let Err(e) = engine.settings().set(key, Setting::Bool(true)) {
+                    eprintln!("could not enable {key}: {e}");
+                    return 1;
+                }
+            }
+            let Ok(run) = engine.start() else {
+                eprintln!("engine failed to start");
+                return 1;
+            };
+            tokio::spawn(run);
+            let Some(pool) = engine.renderer_pool().cloned() else {
+                eprintln!("renderer isolation did not start");
+                return 1;
+            };
+            let mut firehose = gosub_engine::telemetry::subscribe();
+            let mut events = engine.subscribe_events();
+            println!(
+                "{} engine up: {tabs_wanted} tabs over {} sites for {seconds}s (pace {pace_ms} ms; GOSUB_STRESS_TABS / GOSUB_STRESS_PACE_MS / GOSUB_STRESS_SEED to change); viewer: http://127.0.0.1:9090",
+                stamp(),
+                sites.len()
+            );
+
+            let services = ZoneServices {
+                storage: Arc::new(StorageService::new(
+                    Arc::new(InMemoryLocalStore::new()),
+                    Arc::new(InMemorySessionStore::new()),
+                )),
+                cookie_store: None,
+                cookie_jar: None,
+                partition_policy: PartitionPolicy::None,
+                places: None,
+            };
+            let Ok(mut zone) = engine.create_zone(None, services, None) else {
+                eprintln!("could not create a zone");
+                return 1;
+            };
+
+            // Tabs by slot number, so the log can say "tab 3" rather than a uuid.
+            let mut tabs: Vec<(usize, TabHandle)> = Vec::new();
+            let mut names: HashMap<TabId, usize> = HashMap::new();
+            let mut next_slot = 1usize;
+            for _ in 0..tabs_wanted {
+                let Ok(handle) = zone.create_tab(Default::default(), None).await else {
+                    eprintln!("could not create a tab");
+                    return 1;
+                };
+                let slot = next_slot;
+                next_slot += 1;
+                let _ = handle
+                    .send(TabCommand::SetViewport {
+                        x: 0,
+                        y: 0,
+                        width: 1280,
+                        height: 720,
+                    })
+                    .await;
+                let _ = handle.send(TabCommand::ResumeDrawing { fps: 30 }).await;
+                let site = sites[(rng() as usize) % sites.len()].clone();
+                println!("{} tab {slot}: navigate {site}", stamp());
+                let _ = handle.navigate(site).await;
+                names.insert(handle.tab_id, slot);
+                tabs.push((slot, handle));
+            }
+
+            let mut crashes = 0usize;
+            let mut nav_ok = 0usize;
+            let mut nav_failed = 0usize;
+            let (mut loads, mut bytes, mut passes) = (0usize, 0usize, 0usize);
+            let mut last_status = tokio::time::Instant::now();
+            let deadline = started + std::time::Duration::from_secs(seconds);
+
+            while tokio::time::Instant::now() < deadline {
+                // One action on a random tab.
+                let pick = (rng() as usize) % tabs.len();
+                let (slot, handle) = (tabs[pick].0, tabs[pick].1.clone());
+                let action = rng() % 100;
+                match action {
+                    0..=49 => {
+                        let dy = ((rng() % 1200) as f32) - 300.0;
+                        println!("{} tab {slot}: scroll {dy:+.0}", stamp());
+                        let _ = handle.send(TabCommand::MouseScroll { delta_x: 0.0, delta_y: dy }).await;
+                    }
+                    50..=74 => {
+                        let (x, y) = ((rng() % 1280) as f32, (rng() % 720) as f32);
+                        println!("{} tab {slot}: hover ({x:.0},{y:.0})", stamp());
+                        let _ = handle.send(TabCommand::MouseMove { x, y }).await;
+                    }
+                    75..=89 => {
+                        let site = sites[(rng() as usize) % sites.len()].clone();
+                        println!("{} tab {slot}: navigate {site}", stamp());
+                        let _ = handle.navigate(site).await;
+                    }
+                    90..=94 => {
+                        println!("{} tab {slot}: reload", stamp());
+                        let _ = handle.send(TabCommand::Reload { ignore_cache: false }).await;
+                    }
+                    _ => {
+                        println!("{} tab {slot}: close", stamp());
+                        let id = handle.tab_id;
+                        zone.close_tab(id).await;
+                        names.remove(&id);
+                        tabs.remove(pick);
+                        if let Ok(handle) = zone.create_tab(Default::default(), None).await {
+                            let slot = next_slot;
+                            next_slot += 1;
+                            let _ = handle
+                                .send(TabCommand::SetViewport {
+                                    x: 0,
+                                    y: 0,
+                                    width: 1280,
+                                    height: 720,
+                                })
+                                .await;
+                            let _ = handle.send(TabCommand::ResumeDrawing { fps: 30 }).await;
+                            let site = sites[(rng() as usize) % sites.len()].clone();
+                            println!("{} tab {slot}: open + navigate {site}", stamp());
+                            let _ = handle.navigate(site).await;
+                            names.insert(handle.tab_id, slot);
+                            tabs.push((slot, handle));
+                        }
+                    }
+                }
+
+                // Let things happen, draining what the engine and the firehose say.
+                let pause = std::time::Duration::from_millis(pace_ms + rng() % (pace_ms.saturating_mul(12) / 5).max(1));
+                let until = tokio::time::Instant::now() + pause;
+                loop {
+                    let remaining = until.saturating_duration_since(tokio::time::Instant::now());
+                    if remaining.is_zero() {
+                        break;
+                    }
+                    tokio::select! {
+                        event = events.recv() => match event {
+                            Ok(EngineEvent::Navigation { tab_id, event: NavigationEvent::Finished { .. } }) => {
+                                nav_ok += 1;
+                                println!("{} tab {}: navigation finished", stamp(), names.get(&tab_id).copied().unwrap_or(0));
+                            }
+                            Ok(EngineEvent::Navigation { tab_id, event: NavigationEvent::Failed { error, .. } }) => {
+                                nav_failed += 1;
+                                println!("{} tab {}: navigation FAILED: {error}", stamp(), names.get(&tab_id).copied().unwrap_or(0));
+                            }
+                            Ok(EngineEvent::RendererCrashed { site, tabs: affected, error, .. }) => {
+                                crashes += 1;
+                                let slots: Vec<usize> = affected.iter().filter_map(|t| names.get(t).copied()).collect();
+                                println!("{} !!! RENDERER CRASHED for {site} (tabs {slots:?}): {error}", stamp());
+                            }
+                            Ok(_) => {}
+                            Err(_) => {}
+                        },
+                        event = firehose.recv() => if let Ok(event) = event {
+                            match event.kind.as_str() {
+                                "net.load" => {
+                                    loads += 1;
+                                    bytes += event.data["bytes"].as_u64().unwrap_or(0) as usize;
+                                    let outcome = event.data["outcome"].as_str().unwrap_or("");
+                                    let ms = event.data["duration_us"].as_u64().unwrap_or(0) / 1000;
+                                    if outcome != "ok" || ms > 2000 {
+                                        println!(
+                                            "{}   load {} ms {}: {} {}",
+                                            stamp(),
+                                            ms,
+                                            event.data["url"].as_str().unwrap_or(""),
+                                            outcome,
+                                            event.data["error"].as_str().unwrap_or("")
+                                        );
+                                    }
+                                }
+                                "remote.navigate" | "remote.scroll" | "remote.hover" => {
+                                    passes += 1;
+                                    let ms = event.data["exchange_us"].as_u64().unwrap_or(0) / 1000;
+                                    if ms > 1000 {
+                                        let stages = event.data["renderer_us"]
+                                            .as_object()
+                                            .map(|m| {
+                                                let mut parts: Vec<String> = m
+                                                    .iter()
+                                                    .map(|(k, v)| format!("{k} {}", v.as_u64().unwrap_or(0) / 1000))
+                                                    .collect();
+                                                parts.sort();
+                                                parts.join(", ")
+                                            })
+                                            .unwrap_or_default();
+                                        println!(
+                                            "{}   slow {}: {ms} ms total ({stages}) ms, {} fresh tiles - {}",
+                                            stamp(),
+                                            event.kind,
+                                            event.data["tiles_fresh"],
+                                            event.data["url"].as_str().unwrap_or("")
+                                        );
+                                    }
+                                }
+                                _ => {}
+                            }
+                        },
+                        _ = tokio::time::sleep(remaining) => break,
+                    }
+                }
+
+                if last_status.elapsed() >= std::time::Duration::from_secs(5) {
+                    last_status = tokio::time::Instant::now();
+                    let renderers = pool.snapshot();
+                    let rss_max = renderers.iter().filter_map(|r| r.rss_kb).max().unwrap_or(0) / 1024;
+                    let rss_sum: u64 = renderers.iter().filter_map(|r| r.rss_kb).sum::<u64>() / 1024;
+                    println!(
+                        "{} === tabs {} | renderers {} (rss max {rss_max} MiB, total {rss_sum} MiB) | navs ok {nav_ok} failed {nav_failed} | loads {loads} ({} MiB) | passes {passes} | crashes {crashes}",
+                        stamp(),
+                        tabs.len(),
+                        renderers.len(),
+                        bytes / (1024 * 1024)
+                    );
+                    for r in &renderers {
+                        println!(
+                            "{}     pid {:>7} {:<38} {} tab(s) rss {} MiB",
+                            stamp(),
+                            r.pid,
+                            r.key.site,
+                            r.tabs,
+                            r.rss_kb.map_or(0, |kb| kb / 1024)
+                        );
+                    }
+                }
+            }
+
+            println!(
+                "{} done: navs ok {nav_ok} failed {nav_failed} | loads {loads} ({} MiB) | passes {passes} | crashes {crashes}",
+                stamp(),
+                bytes / (1024 * 1024)
+            );
+            engine.close_zone(zone).await;
+            let _ = engine.shutdown().await;
+            i32::from(crashes > 0)
+        })
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("the renderer process exists only on Linux");
         2
     }
 }

--- a/crates/gosub_engine/src/engine/settings.json
+++ b/crates/gosub_engine/src/engine/settings.json
@@ -424,29 +424,28 @@
   ],
   "security": [
     {
-      "key": "sandbox_mode",
-      "type": "s",
-      "values": "off,balanced,strict",
-      "default": "s:balanced",
-      "description": "Sandboxing level applied to zones."
-    },
-    {
       "key": "network_process",
       "type": "b",
       "default": "b:true",
-      "description": "Run the network stack in a sandboxed child process. Needs the embedder to dispatch child roles; turned off at start when it cannot apply. Streamed bodies cross the process boundary through a shared-memory ring on Linux, and are buffered on other platforms."
+      "description": "Run the network stack in a separate, sandboxed process. On by default on Linux; elsewhere the default is off until those platforms are verified (set it explicitly to try). Takes effect only when the embedder calls gosub_engine::child_process::dispatch() first thing in main() - without that the engine turns it off at start with a log line; if the child cannot be started the engine falls back to in-process networking (with a warning). Streamed bodies cross the process boundary through a shared-memory ring on Linux, and are buffered on other platforms."
     },
     {
       "key": "image_decoder_process",
       "type": "b",
       "default": "b:true",
-      "description": "Decode raster images in a throwaway, sandboxed process, one per image. Needs the embedder to dispatch child roles. SVG is rasterized in that process at its intrinsic size (without system fonts), since a parsed vector tree cannot cross a process boundary; a decode the process refuses or cannot start is a failed image, never decoded in-process instead."
+      "description": "Decode raster images in a throwaway, sandboxed process, one per image. On by default on Linux (off elsewhere until verified). Takes effect only when the embedder calls gosub_engine::child_process::dispatch() first thing in main(). Costs a process spawn per image. SVG is rasterized in that process at its intrinsic size (without system fonts), since a parsed vector tree cannot cross a process boundary; a decode the process refuses or cannot start is a failed image, never decoded in-process instead."
+    },
+    {
+      "key": "renderer_process",
+      "type": "b",
+      "default": "b:true",
+      "description": "Spawn the renderer fork server at engine start: a warmed, sandboxed process that resident renderers are forked from - one long-lived renderer per (zone, site), hosting that site's tabs, confined to the tier the configured font system answers. On by default on Linux when the embedder calls gosub_engine::child_process::dispatch_with::<AppConfig>() first thing in main() (plain dispatch() cannot run this role), the configured font system can run fully confined (Parley, cosmic-text) and the configuration has a forked rasterizer (the engine's cairo-tiles/skia-tiles feature, or a custom RenderConfiguration); a font system that reads font files while operating (Skia, Pango) renders in a throwaway process per render instead and must be opted into explicitly. If the fork server cannot start, pages render in-process (with a warning at startup); once it runs, page content is never rendered in-process - a failed render leaves the tab blank and emits EngineEvent::RendererCrashed. See docs/process-isolation.md. Linux only."
     },
     {
       "key": "cookie_vault",
       "type": "b",
       "default": "b:true",
-      "description": "Keep the engine's cookie jars in a separate, sandboxed vault process (Linux). Tabs and the embedder API see an ordinary jar that forwards; the network process, when it runs, gets a direct line to the vault so cookie values attached to requests never pass through the engine process. Persistence stays with the zone's cookie store: the vault sends it a snapshot after every change and never touches a file itself. Takes effect only when the embedder calls gosub_engine::child_process::dispatch() first thing in main(), and falls back to in-process jars with a warning if the vault cannot start."
+      "description": "Keep the engine's cookie jars in a separate, sandboxed vault process (Linux). Tabs and the embedder API see an ordinary jar that forwards; the network process, when it runs, gets a direct line to the vault so cookie values attached to requests never pass through the engine process. Persistence stays with the zone's cookie store: the vault sends it a snapshot after every change and never touches a file itself. On by default on Linux (off elsewhere); takes effect only when the embedder calls gosub_engine::child_process::dispatch() first thing in main(), and falls back to in-process jars with a warning if the vault cannot start."
     },
     {
       "key": "storage_service",
@@ -455,10 +454,11 @@
       "description": "Serve a zone's localStorage from a separate, sandboxed storage process when its local store can be (a FileLocalStore, or a ServiceLocalStore): one process per directory, confined to opening files there. Stores of other kinds stay in-process. Linux; takes effect only when the embedder calls gosub_engine::child_process::dispatch() first thing in main()."
     },
     {
-      "key": "renderer_process",
-      "type": "b",
-      "default": "b:true",
-      "description": "Spawn the renderer fork server at engine start: a warmed, sandboxed process that renderers are forked from, one throwaway renderer per render, confined to the tier the configured font system answers. On by default on Linux when the embedder calls gosub_engine::child_process::dispatch_with::<AppConfig>() first thing in main() (plain dispatch() cannot run this role), the configured font system can run fully confined (Parley, cosmic-text) and the configuration has a forked rasterizer (the engine's cairo-tiles/skia-tiles feature, or a custom RenderConfiguration); a font system that reads font files while operating (Skia, Pango) renders in a throwaway exec'd process per render instead and must be opted into explicitly. If the fork server cannot start, pages render in-process (with a warning at startup); once it runs, page content is never rendered in-process - a failed render leaves the tab blank and emits EngineEvent::RendererCrashed. Linux only."
+      "key": "sandbox_mode",
+      "type": "s",
+      "values": "off,balanced,strict",
+      "default": "s:balanced",
+      "description": "Sandboxing level applied to zones."
     }
   ],
   "telemetry": [


### PR DESCRIPTION

Base: `15-escape-audit`.

### What is in here

- `settings.json`: the final descriptions of the five `security.*` settings
  (what is and is not isolated, on which platforms, what `dispatch()` and the
  font tier decide); `sandbox_mode` moved after them.
- CI: the cross-compile (darwin, windows-msvc) and native-test jobs now cover
  `gosub_engine` as well as the two isolation crates.
- `engine-stress`: the tab-storm tool that found the pool↔renderer lock-order
  deadlock and the crash storm (`GOSUB_STRESS_TABS=12 GOSUB_STRESS_PACE_MS=60
  isolation-harness engine-stress parley 120`).

Note on defaults: each `security.*` setting has defaulted to **on** since the
PR that introduced it (Linux, dispatching embedders only; `start()` drops what
cannot apply). Nothing flips here.