### PR TITLE
DPR fixes for vello

### DIFF
--- a/crates/gosub_engine/src/engine/tab/worker.rs
+++ b/crates/gosub_engine/src/engine/tab/worker.rs
@@ -1923,8 +1923,8 @@ impl<C: RenderConfiguration> TabWorker<C> {
         // through to the display-list path below so the backend draws those tiles into a GPU
         // texture and the host presents a `WgpuTextureId` instead of compositing CPU tiles.
         //
-        // DPR comes from the backend: Cairo rasterizes at physical pixels (DPR > 1 on HiDPI);
-        // Skia and Vello rasterize at CSS pixels (DPR = 1).
+        // DPR comes from the backend: every backend that honours it rasterizes at physical
+        // pixels on a HiDPI host. Only the null backend stays at 1.
         if render_backend.raster_strategy() != RasterStrategy::None && !render_backend.renders_to_gpu_texture() {
             let dpr = render_backend.device_pixel_ratio();
 
@@ -1954,8 +1954,23 @@ impl<C: RenderConfiguration> TabWorker<C> {
         // The host then presents the resulting `WgpuTextureId`. Scroll re-renders with a new
         // translate (no rebuild); only content/hover/size changes rebuild the command list.
         if render_backend.renders_to_gpu_texture() {
-            let surface_recreated =
-                self.ensure_surface_tracked(render_backend.clone(), self.desired_viewport.as_size())?;
+            // The viewport is CSS pixels, the texture is physical ones. Sizing the texture in
+            // CSS pixels leaves the host to upscale it, which reads as blurry text rather than
+            // as the scaling bug it is. The backend scales its scene to match, so the page is
+            // re-rendered at this resolution instead of stretched.
+            //
+            // The GPU tile path is excluded: `composite_tiles` takes the CSS viewport and
+            // places CSS-sized tiles, so it stays at 1 until it learns about DPR too.
+            let dpr = if render_backend.gpu_tile_compositing() {
+                1
+            } else {
+                render_backend.device_pixel_ratio().max(1)
+            };
+            let mut surface_size = self.desired_viewport.as_size();
+            surface_size.width *= dpr;
+            surface_size.height *= dpr;
+
+            let surface_recreated = self.ensure_surface_tracked(render_backend.clone(), surface_size)?;
             self.context.set_viewport(self.desired_viewport);
 
             // Consolidated tile path (opt-in): rather than the one-shot whole-viewport scene, run

--- a/crates/gosub_interface/src/render/backend.rs
+++ b/crates/gosub_interface/src/render/backend.rs
@@ -472,8 +472,10 @@ pub trait RenderBackend: Send {
         RasterStrategy::None
     }
 
-    /// The device-pixel ratio this backend rasterizes at. Backends that rasterize at physical
-    /// pixels (Cairo) override this; CSS-pixel backends (Skia, Vello) and the null backend use 1.
+    /// The device-pixel ratio this backend rasterizes at. Cairo, Skia and Vello all override
+    /// this to follow the host's [`DEVICE_PIXEL_RATIO`]; only the null backend keeps 1.
+    ///
+    /// [`DEVICE_PIXEL_RATIO`]: crate::render::DEVICE_PIXEL_RATIO
     fn device_pixel_ratio(&self) -> u32 {
         1
     }

--- a/crates/gosub_renderer_vello/src/backend.rs
+++ b/crates/gosub_renderer_vello/src/backend.rs
@@ -286,6 +286,15 @@ impl<C: WgpuContextProvider + Send + Sync> RenderBackend for VelloBackend<C> {
         "vello"
     }
 
+    /// Honour the host's DPR. Vello draws vectors, so a HiDPI display is served by rendering
+    /// the same scene into a larger texture rather than by upscaling a CSS-sized one -- glyph
+    /// outlines are re-tessellated at the physical resolution and come out sharp.
+    fn device_pixel_ratio(&self) -> u32 {
+        gosub_render_pipeline::render::DEVICE_PIXEL_RATIO
+            .load(std::sync::atomic::Ordering::Relaxed)
+            .max(1)
+    }
+
     fn create_surface(&self, size: SurfaceSize, _present: PresentMode) -> Result<Box<dyn ErasedSurface + Send>> {
         let texture_store_id = self
             .context
@@ -310,6 +319,19 @@ impl<C: WgpuContextProvider + Send + Sync> RenderBackend for VelloBackend<C> {
             let mut fs = self.font_system.lock();
             let font_cx = fs.font_cx_mut();
             self.build_scene(&mut tr, &mut fm, &mut fc, font_cx, ctx)?
+        };
+
+        // The scene is built in CSS pixels; the surface is physical. Appending under a scale
+        // is what turns one into the other, and it happens here rather than inside the scene
+        // builders so both of them -- paint commands and the display-list fallback -- are
+        // covered by the same transform.
+        let dpr = self.device_pixel_ratio();
+        let scene = if dpr > 1 {
+            let mut scaled = Scene::new();
+            scaled.append(&scene, Some(Affine::scale(dpr as f64)));
+            scaled
+        } else {
+            scene
         };
 
         let s = surface


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering clarity on high-DPI displays by matching page rendering and display scaling to the device’s pixel ratio.
  * Reduced browser-side upscaling and resulting visual blur in supported rendering paths.
  * Preserved consistent behavior for rendering modes that do not use device-pixel scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->