### PR TITLE
gosub-screenshot: add --min-height

### DIFF
--- a/bin/gosub-screenshot/main.rs
+++ b/bin/gosub-screenshot/main.rs
@@ -66,12 +66,21 @@ struct Args {
     /// decode and repaint before the capture
     #[arg(long, default_value = "0")]
     settle: u64,
+    /// Minimum capture height in CSS pixels. The image is normally cut at the page's flow
+    /// height; absolutely-positioned content below it (common in WPT reftest references)
+    /// would be lost, so reftest runners pass the comparison-canvas height here.
+    #[arg(long, default_value = "0")]
+    min_height: u32,
     /// Print the aggregated pipeline timing table (per stage) after the capture
     #[arg(long)]
     timings: bool,
 }
 
 const DEFAULT_ZONE: uuid::Uuid = uuid!("f1234567-abcd-4000-8000-000000000003");
+/// Cap on the composited RGBA buffer (1 GiB): keeps a runaway `--min-height` from
+/// wrapping the size arithmetic or exhausting memory.
+const MAX_CAPTURE_BYTES: usize = 1 << 30;
+
 /// Initial viewport height used for layout, in CSS pixels. Tall enough to trigger
 /// below-the-fold / lazily-loaded content; the captured image uses the page's *true*
 /// height, not this value. CPU rasterization has no GPU texture limit, so there is no
@@ -273,7 +282,7 @@ fn main() {
     };
 
     let page_w = viewport_w;
-    let page_h = (page_height_f.ceil() as u32).max(1);
+    let page_h = (page_height_f.ceil() as u32).max(1).max(args.min_height);
 
     eprintln!(
         "Page size: {}×{} px. Compositing {} tile(s)…",
@@ -282,8 +291,22 @@ fn main() {
         tiles.len()
     );
 
-    // Fill with opaque white, then alpha-blend each tile (premultiplied).
-    let mut pixels = vec![255u8; (page_w * page_h * 4) as usize];
+    // Fill with opaque white, then alpha-blend each tile (premultiplied). The height can now
+    // come from the command line, so the size arithmetic is checked: `page_w * page_h * 4`
+    // silently wraps in release for a large enough --min-height, and the wrapped length would
+    // hand every tile copy below an out-of-bounds slice.
+    let Some(buf_len) = (page_w as usize)
+        .checked_mul(page_h as usize)
+        .and_then(|n| n.checked_mul(4))
+        .filter(|&n| n <= MAX_CAPTURE_BYTES)
+    else {
+        eprintln!(
+            "Capture of {page_w}x{page_h} px exceeds the supported size ({} MiB); lower the width or --min-height.",
+            MAX_CAPTURE_BYTES / (1024 * 1024)
+        );
+        std::process::exit(1);
+    };
+    let mut pixels = vec![255u8; buf_len];
 
     for tile in tiles.iter() {
         let tx = tile.page_x as u32;

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -37,7 +37,7 @@ The tool runs three phases:
 
 1.  **Wait for content** --- spin on the event stream until `NavigationEvent::Finished`, then wait for the first redraw signal after that (the first frame that actually contains the page). Both waits have timeouts (`--nav-timeout`, `--render-timeout`).
 2.  **Obtain the tile cache** --- ask the compositor for the tab's latest frame (`compositor.frame_for(tab_id) -> Option<ExternalHandle>`, with `ExternalHandle` in `gosub_render_pipeline::render::backend`) and expect an `ExternalHandle::TileCache { tiles, page_height, dpr, scroll_x, scroll_y, .. }`, which carries the tiles, the laid-out `page_height`, and the scroll offset the engine rendered at. A 1-px synthetic scroll (`TabCommand::MouseScroll`) nudges the engine into publishing a fresh tile-cache frame if needed.
-3.  **Composite** --- allocate an opaque-white RGBA buffer at `viewport_width × page_height` and blend every tile into it. This is a miniature version of what every host compositor does (see [layering-and-compositing.md](render-pipeline/layering-and-compositing.md)). A windowed UA that only needs the *visible* region can skip writing this itself: `gosub_render_pipeline::render::composite_tiles(&tiles, dpr, (scroll_x, scroll_y), &mut TileTarget { buf, stride, origin_x, origin_y, width, height })` composites the tiles into a `&mut [u32]` 0RGB buffer (the layout softbuffer and most CPU presenters use) --- see `examples/winit-skia/main.rs`. The screenshot tool does the full-page version by hand:
+3.  **Composite** --- allocate an opaque-white RGBA buffer at `viewport_width × page_height` (or `--min-height`, whichever is taller) and blend every tile into it. This is a miniature version of what every host compositor does (see [layering-and-compositing.md](render-pipeline/layering-and-compositing.md)). A windowed UA that only needs the *visible* region can skip writing this itself: `gosub_render_pipeline::render::composite_tiles(&tiles, dpr, (scroll_x, scroll_y), &mut TileTarget { buf, stride, origin_x, origin_y, width, height })` composites the tiles into a `&mut [u32]` 0RGB buffer (the layout softbuffer and most CPU presenters use) --- see `examples/winit-skia/main.rs`. The screenshot tool does the full-page version by hand:
     -   normalize the tile's pixel format to RGBA via `PixelFormat::to_rgba` (tiles are self-describing; Skia produces premultiplied `[B,G,R,A]`);
     -   scale by the tile's layer **group opacity** (a translucent navbar fades as a unit);
     -   **source-over blend** into the buffer rather than overwrite --- a promoted `position: fixed` layer's transparent tile regions must reveal the rows already composited beneath, not erase them.
@@ -50,6 +50,17 @@ Scroll anchors are irrelevant here because the capture is the full page at scrol
 gosub-screenshot <url> [output.png] [width]
     --nav-timeout <s>      wait for navigation (default 30)
     --render-timeout <s>   wait for first render after navigation (default 120)
+    --settle <s>           extra wait after the first render, so async media
+                           decodes and repaints before the capture (default 0)
+    --min-height <px>      capture at least this tall (default 0 - the page's
+                           own flow height)
+    --timings              print the per-stage pipeline timing table
 ```
+
+`--min-height` matters for comparison rendering: the capture is otherwise cut at the
+page's flow height, so absolutely-positioned content below it - which WPT reftest
+references routinely have - is lost, and the comparison fails for the wrong reason. Pass
+the comparison canvas height. The composited buffer is capped at 1 GiB; above that the
+capture is refused rather than truncated.
 
 `https://` is prepended when the URL has no scheme. The build embeds the git SHA and date via `build.rs` (`gosub-screenshot --version`).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--min-height` option to ensure screenshots meet a specified minimum height, including content positioned below the normal page flow.

* **Bug Fixes**
  * Improved screenshot capture safety by rejecting images that exceed the 1 GiB buffer limit instead of risking invalid memory allocation.

* **Documentation**
  * Expanded headless screenshot documentation with details about `--min-height`, `--settle`, `--timings`, and the capture buffer limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->