### PR TITLE
Wpt reftests

### DIFF
--- a/.github/workflows/wpt-reftests.yaml
+++ b/.github/workflows/wpt-reftests.yaml
@@ -1,0 +1,107 @@
+name: WPT reftests
+
+# Manual only. A run is ~7 minutes on top of a cairo gosub-screenshot build the other
+# jobs' caches cannot share (~2 min warm, ~15 cold), and nothing here is gated - the
+# result is a snapshot to look at, not a check to keep green. Not worth paying for on a
+# schedule until reftest results are stable enough to trend.
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Subtree under the wpt root to run (e.g. css/CSS2, css/CSS2/backgrounds)"
+        default: css/CSS2
+        required: true
+      settle:
+        description: "Seconds to wait after first render before capturing"
+        default: "0"
+        required: false
+
+env:
+  CARGO_TERM_COLOR: always
+  TARGET: ${{ inputs.target }}
+
+jobs:
+  wpt-reftests:
+    name: WPT reftests (${{ inputs.target }})
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Checks out third-party content (web-platform-tests); keep the token read-only
+    # and out of .git/config
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Its own key: this builds gosub-screenshot against the cairo backend, which
+          # shares almost no artifacts with the default skia build the other jobs use.
+          shared-key: wpt-reftests
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y \
+            sqlite3 libsqlite3-dev \
+            libglib2.0-dev libcairo2-dev \
+            libgdk-pixbuf-2.0-dev libpango1.0-dev \
+            libgtk-4-dev \
+            python3-pil fontconfig fonts-liberation fonts-dejavu-core
+
+      # css/support and css/reference hold the reference pages the tests are compared
+      # against; fonts/ carries Ahem. Tracks wpt HEAD - nothing here is gated on a
+      # committed baseline, so there is no pinned commit to stay comparable with.
+      - name: Checkout web-platform-tests (sparse, at HEAD)
+        run: |
+          git clone --filter=blob:none --sparse https://github.com/web-platform-tests/wpt.git "$RUNNER_TEMP/wpt"
+          cd "$RUNNER_TEMP/wpt"
+          git sparse-checkout set resources fonts css/support css/reference "$TARGET"
+          echo "WPT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+
+      # Ahem has fixed, integral metrics and most CSS2 reftests lay out against it. Without
+      # it fontconfig substitutes something else and nearly everything fails on sub-pixel
+      # differences. It ships inside the checkout, so no distro package is involved.
+      - name: Install the Ahem font
+        run: |
+          mkdir -p ~/.local/share/fonts
+          cp "$RUNNER_TEMP/wpt/fonts/Ahem.ttf" ~/.local/share/fonts/
+          fc-cache -f
+          test "$(fc-match Ahem | cut -d: -f1)" = "Ahem.ttf" \
+            || { echo "Ahem did not resolve - results would be meaningless"; exit 1; }
+
+      - name: Build gosub-screenshot (cairo backend)
+        run: cargo build --release --locked -p gosub-screenshot --no-default-features --features backend_cairo
+
+      # Ungated: no committed baseline, and a failing reftest must not fail the job.
+      - name: Run the reftests
+        run: |
+          python3 scripts/wpt-reftest.py --wpt-root "$RUNNER_TEMP/wpt" \
+              --out "$RUNNER_TEMP/reftest" --report "$TARGET" \
+              --settle "${{ inputs.settle }}" \
+              2> "$RUNNER_TEMP/reftest.err" | tee "$RUNNER_TEMP/reftest.out" || true
+
+      - name: Summarise
+        if: always()
+        run: |
+          {
+            echo "### WPT reftests, $TARGET - wpt @ $WPT_SHA"
+            echo ""
+            grep -E "^$TARGET: " "$RUNNER_TEMP/reftest.out" || echo "the run produced no summary - see the log"
+            echo ""
+            echo "Side-by-side failures in the \\`wpt-reftest-report\\` artifact."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: wpt-reftest-report
+          path: |
+            ${{ runner.temp }}/reftest/failures.html
+            ${{ runner.temp }}/reftest/results.json
+          retention-days: 30
+          if-no-files-found: warn

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,9 +36,10 @@ descriptions say what they should cover so we can decide what to write next.
   contents by the host engine).
 - [JavaScript stack](javascript.md) — the five scripting crates (`webexecutor` abstraction,
   V8 bindings, proc-macro glue, web APIs, event loop) and their built-but-not-wired status.
-- [Web-platform-tests](wpt.md) — running WPT `testharness.js` suites against the engine's
-  DOM through the test-only `gosub_domjs` bindings: what is bound, what is not, and why the
-  bindings must stay logic-free.
+- [Web-platform-tests](wpt.md) — the two WPT harnesses: `testharness.js` suites driven
+  through the test-only `gosub_domjs` bindings, and reftests rendered and pixel-compared
+  through `gosub-screenshot`. Which parts of the corpus each can run, where the numbers
+  stand, and what CI does with them.
 - [Fonts](fonts.md) — the two font backend families: *font systems* (measure text for
   layout) vs *text rasterizers* (draw glyphs), and how one shared font collection keeps
   them consistent.

--- a/docs/wpt.md
+++ b/docs/wpt.md
@@ -1,5 +1,84 @@
 # Running web-platform-tests
 
+Two harnesses, because wpt holds two kinds of test that are checked in completely
+different ways. Neither is a browser: both drive the engine directly.
+
+| | testharness.js | reftests |
+|---|---|---|
+| How a test passes | JS assertions report themselves | two renders are pixel-identical |
+| What it needs | a DOM and a JS engine | layout, painting, fonts |
+| Tool | `bin/gosub-wpt` (QuickJS via rquickjs) | `scripts/wpt-reftest.py` -> `gosub-screenshot` |
+| In CI | the `wpt` gate on every PR, plus a nightly | manual only |
+
+## What of wpt we can actually run
+
+Of ~57k `.html` files in the corpus (excluding `-ref`/`-notref`, which are the reference
+halves of reftests rather than tests):
+
+- **~27,300** load `resources/testharness.js` - the testharness harness can run these.
+- **~19,800** are reftests - the reftest runner can run these.
+- The rest are manual tests and conformance-checker fixtures. Neither harness can do
+  anything with them: they parse, report zero subtests, and cost runtime. The nightly
+  filters them out with `grep -lFr 'resources/testharness.js'`.
+
+Nothing here runs `.any.js` / `.window.js` / `.worker.js` wrappers, iframes, workers, or
+anything needing navigation or a network.
+
+## Where the numbers stand
+
+Measured at the pinned commit; regenerate rather than trust these.
+
+| Run | Tests | Passing | Time |
+|---|---:|---:|---:|
+| `wpt` gate - `dom/events`, `html/dom` | 621 files (616 report), 1132 subtests | 101 (8.9%) | 8s |
+| nightly - every testharness suite | 27,301 files | ~2% | 150s |
+| reftests - `css/CSS2` | 5,952 | ~1560 (26%) | 455s |
+
+The reftest rate is the higher one because those exercise layout and painting, which the
+engine does, rather than DOM and Web APIs, which it mostly does not. Within CSS2 the
+spread is the interesting part: `fonts`, `syntax`, `borders` and `normal-flow` sit near
+40-50%, while `floats-clear`, `tables`, `linebox` and `css1` are all under 6%.
+
+**Reftest results are not yet stable run to run.** Two full CSS2 runs on one machine gave
+1558 and 1597, with 133 tests changing status in both directions, concentrated in
+`backgrounds`. A third on another machine gave 1562. The error and skip sets are identical
+across all of them, so discovery is deterministic and only the pixel comparison moves.
+That is why the reftests are manual and ungated: a committed baseline would go red on
+noise. `--settle` was tried against the theory that images had not finished decoding; it
+made things worse, so the cause is still open.
+
+## The CI jobs
+
+- **`wpt`** (`ci.yaml`, every push and PR) - runs the gate against
+  `tests/wpt/expectations.txt` at the commit in `tests/wpt/wpt-commit.txt`, and fails if
+  the results move in either direction. Also uploads a coverage report. Without `WPT_ROOT`
+  the test skips, so an ordinary `cargo test` needs no checkout.
+- **`wpt-full`** (`nightly.yaml`, 02:00 UTC) - every testharness suite at wpt HEAD, no
+  baseline, report as an artifact. A failing subtest cannot turn it red.
+- **`wpt-reftests`** (`wpt-reftests.yaml`, manual) - takes a subtree and a settle value as
+  inputs. Not scheduled: a run needs a cairo `gosub-screenshot` build the other jobs'
+  caches cannot share, and nothing it produces is gated.
+
+## Running the reftests
+
+```bash
+# Ahem ships inside wpt; without it fontconfig substitutes and nearly everything fails
+# on sub-pixel differences.
+mkdir -p ~/.local/share/fonts && cp <wpt>/fonts/Ahem.ttf ~/.local/share/fonts/ && fc-cache -f
+fc-match Ahem      # must say Ahem.ttf
+
+cargo build --release -p gosub-screenshot --no-default-features --features backend_cairo
+python3 scripts/wpt-reftest.py --wpt-root <wpt> --out /tmp/reftest --report css/CSS2
+```
+
+The sparse checkout needs `resources fonts css/support css/reference` plus the subtree -
+`css/support` and `css/reference` hold the reference pages. `--report` writes
+`failures.html` with test, reference and diff side by side; `--chrome` adds a headless
+Chromium render of each failure next to them. `scripts/wpt-fonts.conf` pins the generic
+families so results do not depend on the distro's fontconfig defaults.
+
+## The testharness harness
+
 The engine has no scripting environment yet, so the WPT `testharness.js` suites cannot run
 against it as they stand. `gosub_domjs` is a stopgap: a **test-only** DOM binding over a
 small JavaScript engine (QuickJS, through `rquickjs`), enough to let those tests drive the
@@ -12,7 +91,7 @@ modules (`edit`, `form`, `focus`) that are not on main yet.
 
 It exists to find bugs, not to run websites.
 
-## Setup
+### Setup
 
 The checkout is pinned: `tests/wpt/wpt-commit.txt` holds the commit CI uses, and results are
 only comparable against that one.
@@ -31,7 +110,7 @@ cargo run -p gosub-wpt -- <wpt-root> <test.html>... [-v]
 Paths are taken relative to the wpt root when they are not found as given. The exit code is
 non-zero if any subtest failed.
 
-## The expectations file
+### The expectations file
 
 `tests/wpt/expectations.txt` is the committed baseline: which suites are covered, and
 which subtests are known to fail. Four record types - `FILE`, `FAIL <path> :: <name>`,
@@ -49,7 +128,7 @@ That is what `cargo test -p gosub-wpt --test wpt_conformance` runs when `WPT_ROO
 and what the `wpt` CI job runs at the pinned commit. Without `WPT_ROOT` the test skips,
 so an ordinary `cargo test` needs no checkout.
 
-## Running a list of tests
+### Running a list of tests
 
 `--tests-from <file>` takes the paths from a file, one per line (`-` reads stdin); blank
 lines and `#` comments are skipped. It is the only way to run a corpus of any size: the
@@ -67,7 +146,7 @@ Two thirds of those files are not testharness suites at all - reftests, the
 `conformance-checkers/` fixtures, manual tests - and report zero subtests. Filtering them
 out first is worth it for both the runtime and the readability of the page.
 
-## The overview page
+### The overview page
 
 `--report page.html` writes a coverage-report view of the whole run: the headline rate, then
 every directory with its pass/fail split and a bar, expandable to the suites underneath.
@@ -94,14 +173,14 @@ cargo run --release -p gosub-wpt -- "$WPT_ROOT" --write-expectations $(paths...)
 Diagnostics (console output, listener and timer exceptions, scripts that threw) go to
 stderr; only results go to stdout, so regenerating never picks up stray lines.
 
-## The one rule
+### The one rule
 
 **The bindings hold no DOM logic.** Every property reads or writes the real document, so a
 passing test says something about the engine rather than about the binding layer. When a
 test needs behaviour the engine does not have, the fix belongs in engine code — never in a
 shim that makes the test go green.
 
-## How a test runs
+### How a test runs
 
 1. The file is parsed into a `DocumentImpl` by `gosub_html5`.
 2. A fresh QuickJS context gets `self`, then wpt's own `testharness.js`.
@@ -119,7 +198,7 @@ shim that makes the test go green.
    would otherwise hang the run forever; this turns it into a TIMEOUT result instead.
 7. Results come out of an `add_completion_callback` hook.
 
-## Timers
+### Timers
 
 There is no clock. `setTimeout`, `setInterval`, `requestAnimationFrame` and their cancel
 functions all feed one queue ordered by due time and then insertion order, and firing a
@@ -133,7 +212,7 @@ rAF purely to wait a turn.
 testharness passes `null` where a delay or a timer id is expected, which is not the same as
 omitting the argument, so both are taken as raw values and coerced.
 
-## Events
+### Events
 
 `addEventListener`/`removeEventListener`/`dispatchEvent` are on nodes, on `document` and on
 the global object; `Event` is constructible with `bubbles`/`cancelable`/`composed`. Dispatch
@@ -149,7 +228,7 @@ report TIMEOUT rather than hanging.
 Removed listeners are tombstoned rather than deleted, because dispatch holds indices into
 the listener list and has to observe removals made by listeners that run before them.
 
-## What is bound
+### What is bound
 
 `document`: `getElementById`, `createElement`, `createTextNode`, `querySelector`,
 `getElementsByTagName`, `body`, `head`, `documentElement`.
@@ -164,7 +243,7 @@ the option/textarea reflections `value`, `label`, `text`, `type`.
 
 Node wrappers are cached per node, so `a.parentNode === b` holds.
 
-## What is not
+### What is not
 
 - **No activation behaviour** behind `click()`, and no `focus()`/`blur()`/`activeElement`
   (288 uses in the forms corpus) — both need engine code that is not public yet.

--- a/scripts/wpt-fonts.conf
+++ b/scripts/wpt-fonts.conf
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<!--
+  Deterministic generic-family mapping for WPT reftests (used via FONTCONFIG_FILE by
+  scripts/wpt-reftest.py). Pins the generics to the same fonts snap Chromium resolves
+  (Liberation Serif/Sans, DejaVu Sans Mono) so gosub and the report's Chrome column
+  shape identical glyphs - and so `serif` has Times-class metrics (ascent+descent
+  ~1.11em): many CSS2 tests put 20px text in a 24px line box and assume the descender
+  fits, which Noto Serif's 1.36em metrics cannot satisfy.
+-->
+<fontconfig>
+  <include ignore_missing="yes">/etc/fonts/fonts.conf</include>
+
+  <match target="pattern">
+    <test qual="any" name="family"><string>serif</string></test>
+    <edit name="family" mode="prepend" binding="strong"><string>Liberation Serif</string></edit>
+  </match>
+  <match target="pattern">
+    <test qual="any" name="family"><string>sans-serif</string></test>
+    <edit name="family" mode="prepend" binding="strong"><string>Liberation Sans</string></edit>
+  </match>
+  <match target="pattern">
+    <test qual="any" name="family"><string>monospace</string></test>
+    <edit name="family" mode="prepend" binding="strong"><string>DejaVu Sans Mono</string></edit>
+  </match>
+</fontconfig>

--- a/scripts/wpt-reftest.py
+++ b/scripts/wpt-reftest.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""WPT reftest runner for the gosub engine.
+
+Discovers reftests (<link rel="match"/"mismatch">) under a WPT subtree,
+renders test and reference pages with gosub-screenshot (Cairo backend), and
+pixel-compares them on a WPT-style 800x600 canvas.
+
+Usage:
+  scripts/wpt-reftest.py --wpt-root ~/code/gosub/wpt css/CSS2/tables
+  scripts/wpt-reftest.py --wpt-root ~/code/gosub/wpt css/CSS2/tables/table-anonymous-objects-001.xht
+
+Outputs a summary, a JSON results file, and (with --report) an HTML report of
+failures with test/ref/diff images side by side.
+
+Requirements: the Ahem font must be installed (fc-match Ahem), and
+target/release/gosub-screenshot must be built with the Cairo backend:
+  cargo build --release -p gosub-screenshot --no-default-features --features backend_cairo
+"""
+
+import argparse
+import base64
+import concurrent.futures
+import functools
+import html
+import http.server
+import io
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+from PIL import Image, ImageChops
+
+VIEWPORT_W = 800
+VIEWPORT_H = 600
+
+LINK_RE = re.compile(
+    r'<link[^>]+rel=["\']?(match|mismatch)["\']?[^>]*>', re.I)
+HREF_RE = re.compile(r'href=["\']?([^"\'\s>]+)', re.I)
+FUZZY_RE = re.compile(
+    r'<meta[^>]+name=["\']?fuzzy["\']?[^>]+content=["\']([^"\']+)["\']', re.I)
+WAIT_RE = re.compile(r'class=["\'][^"\']*reftest-wait', re.I)
+SCRIPT_RE = re.compile(r'<script\b', re.I)
+
+
+def parse_fuzzy(content):
+    """Parse one WPT fuzzy annotation into (max_channel_diff, max_pixel_count).
+
+    Content looks like "maxDifference=0-2;totalPixels=0-300"; ranges keep their
+    upper bound. Explicit zeros stay zero: they demand an exact match.
+    """
+    max_diff = pixels = 0
+    for part in content.split(";"):
+        m = re.match(r'(maxDifference|totalPixels)\s*=\s*(?:\d+-)?(\d+)', part.strip())
+        if not m:
+            continue
+        if m.group(1) == "maxDifference":
+            max_diff = int(m.group(2))
+        else:
+            pixels = int(m.group(2))
+    return max_diff, pixels
+
+
+def parse_fuzzy_meta(text):
+    """Collect every fuzzy annotation in a test: {ref_name_or_None: (max_diff, pixels)}.
+
+    A "ref.html:maxDifference=..." annotation applies only to that reference; an
+    unprefixed one is the default for the rest. Absent metadata means exact match.
+    """
+    out = {}
+    for fm in FUZZY_RE.finditer(text):
+        content = fm.group(1)
+        head, sep, tail = content.partition(":")
+        if sep and "=" in tail and "=" not in head:
+            out[Path(head.strip()).name] = parse_fuzzy(tail)
+        else:
+            out[None] = parse_fuzzy(content)
+    return out
+
+
+def fuzzy_for(fuzzy_meta, ref):
+    """Tolerance for `ref`: its own annotation, else the unprefixed default, else exact."""
+    return fuzzy_meta.get(ref.name, fuzzy_meta.get(None, (0, 0)))
+
+
+def discover(root, target):
+    """Yield (test_path, [(rel, ref_path)], fuzzy, skip_reason) tuples."""
+    target_path = root / target
+    files = [target_path] if target_path.is_file() else sorted(
+        p for p in target_path.rglob("*")
+        if p.suffix in (".html", ".htm", ".xht", ".xhtml")
+    )
+    for f in files:
+        try:
+            text = f.read_text(errors="replace")
+        except OSError:
+            continue
+        refs = []
+        for link in LINK_RE.finditer(text):
+            href = HREF_RE.search(link.group(0))
+            if href:
+                rel = link.group(1).lower()
+                h = href.group(1)
+                # WPT-root-absolute hrefs ("/css/reference/...") resolve against the
+                # checkout root, not the test's directory.
+                base = root if h.startswith("/") else f.parent
+                ref = (base / h.lstrip("/")).resolve()
+                refs.append((rel, ref))
+        if not refs:
+            continue
+        skip = None
+        if WAIT_RE.search(text):
+            skip = "reftest-wait (needs script support)"
+        elif SCRIPT_RE.search(text):
+            skip = "uses <script>"
+        yield f, refs, parse_fuzzy_meta(text), skip
+
+
+class WptHandler(http.server.SimpleHTTPRequestHandler):
+    """Serves the WPT tree; XHTML goes out as text/html for the engine.
+
+    The engine has no XML parser, so XHTML gets the HTML treatment. That
+    breaks `<![CDATA[ ... ]]>`-wrapped stylesheets (the markers become
+    stylesheet text and poison rule parsing), so those markers are stripped
+    on the way out.
+    """
+    extensions_map = {
+        **http.server.SimpleHTTPRequestHandler.extensions_map,
+        ".xht": "text/html",
+        ".xhtml": "text/html",
+        ".htm": "text/html",
+    }
+
+    def do_GET(self):
+        path = Path(self.translate_path(self.path))
+        if path.suffix not in (".xht", ".xhtml", ".html", ".htm") or not path.is_file():
+            return super().do_GET()
+        data = path.read_bytes().replace(b"<![CDATA[", b"").replace(b"]]>", b"")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, *args):
+        pass
+
+
+class QuietServer(http.server.ThreadingHTTPServer):
+    """A ThreadingHTTPServer that does not report client disconnects.
+
+    A render only reads as much of a response as it needs and then closes, which reaches
+    the handler thread as BrokenPipe or ConnectionReset. There are hundreds per run - a
+    full CSS2 pass produced 280 - and socketserver prints a traceback for each, which
+    would bury a real failure in the log. Every other error still reports.
+    """
+
+    def handle_error(self, request, client_address):
+        if not isinstance(sys.exc_info()[1], (BrokenPipeError, ConnectionResetError, ConnectionAbortedError)):
+            super().handle_error(request, client_address)
+
+
+def start_server(root):
+    handler = functools.partial(WptHandler, directory=str(root))
+    server = QuietServer(("127.0.0.1", 0), handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, server.server_address[1]
+
+
+def to_canvas(png_bytes):
+    """Place a full-page render on a white WPT viewport canvas (800x600)."""
+    img = Image.open(io.BytesIO(png_bytes)).convert("RGB")
+    canvas = Image.new("RGB", (VIEWPORT_W, VIEWPORT_H), "white")
+    canvas.paste(img.crop((0, 0, min(img.width, VIEWPORT_W),
+                           min(img.height, VIEWPORT_H))), (0, 0))
+    return canvas
+
+
+def images_match(a, b, fuzzy):
+    diff = ImageChops.difference(a, b)
+    bbox = diff.getbbox()
+    if bbox is None:
+        return True, 0, 0
+    hist_max = max(ch.getextrema()[1] for ch in diff.split())
+    differing = sum(1 for px in diff.getdata() if px != (0, 0, 0))
+    if fuzzy is None:
+        # No metadata at all. The old CSS2 tests predate WPT fuzzy annotations and say
+        # "except for antialiasing issues" in prose, so channel differences of 1
+        # (sub-antialiasing rounding noise between two float layout paths) pass.
+        return hist_max <= 1, hist_max, differing
+    # Explicit metadata is taken literally: maxDifference=0;totalPixels=0 is exact.
+    max_diff, pixel_budget = fuzzy
+    ok = hist_max <= max_diff and differing <= pixel_budget
+    return ok, hist_max, differing
+
+
+class Renderer:
+    def __init__(self, shot_bin, root, port, out_dir, jobs, settle=0):
+        self.settle = settle
+        self.shot_bin, self.root, self.port = shot_bin, root, port
+        self.out_dir = out_dir
+        self.cache = {}
+        self.lock = threading.Lock()
+        self.sem = threading.Semaphore(jobs)
+
+    def render(self, page: Path):
+        """Render one page, cached by path. Returns PNG bytes or raises."""
+        key = str(page)
+        with self.lock:
+            fut = self.cache.get(key)
+            if fut is None:
+                fut = self.cache[key] = concurrent.futures.Future()
+                owner = True
+            else:
+                owner = False
+        if not owner:
+            return fut.result()
+        try:
+            rel = page.relative_to(self.root).as_posix()
+            out = self.out_dir / (rel.replace("/", "__") + ".png")
+            url = f"http://127.0.0.1:{self.port}/{rel}"
+            # Pin the generic font families (see wpt-fonts.conf) so results don't depend on
+            # the distro's fontconfig defaults.
+            env = dict(os.environ,
+                       FONTCONFIG_FILE=str(Path(__file__).resolve().parent / "wpt-fonts.conf"))
+            with self.sem:
+                proc = subprocess.run(
+                    [self.shot_bin, url, str(out), str(VIEWPORT_W),
+                     # Min capture height = comparison canvas: abs-positioned reference
+                     # content below the page's flow height must not be cut off.
+                     "--min-height", str(VIEWPORT_H),
+                     "--nav-timeout", "20", "--render-timeout", "30",
+                     "--settle", str(self.settle)],
+                    capture_output=True, timeout=90, env=env)
+            if proc.returncode != 0 or not out.exists():
+                raise RuntimeError(
+                    f"render failed: {proc.stderr.decode(errors='replace')[-200:]}")
+            data = out.read_bytes()
+            fut.set_result(data)
+            return data
+        except BaseException as e:
+            fut.set_exception(e)
+            raise
+
+
+def run_test(renderer, test, refs, fuzzy_meta):
+    try:
+        test_img = to_canvas(renderer.render(test))
+    except Exception as e:
+        return "ERROR", f"test render: {e}", None
+
+    match_results, detail = [], []
+    for rel, ref in refs:
+        if not ref.exists():
+            return "ERROR", f"missing ref {ref.name}", None
+        try:
+            ref_img = to_canvas(renderer.render(ref))
+        except Exception as e:
+            return "ERROR", f"ref render: {e}", None
+        fuzzy = fuzzy_for(fuzzy_meta, ref) if fuzzy_meta else None
+        equal, max_d, n_px = images_match(test_img, ref_img, fuzzy)
+        detail.append(f"{rel} {ref.name}: maxdiff={max_d} pixels={n_px}")
+        if rel == "match":
+            match_results.append(equal)
+        elif equal:  # mismatch ref that matched
+            return "FAIL", "; ".join(detail), refs[0][1]
+    # Multiple match refs are alternates: any one passing suffices.
+    if match_results and not any(match_results):
+        return "FAIL", "; ".join(detail), refs[0][1]
+    return "PASS", "; ".join(detail), None
+
+
+def chrome_shot(url, chrome_bin="chromium"):
+    """Render `url` with headless Chromium (writes inside $HOME: snap)."""
+    tmp = Path.home() / f"gosub-wpt-chrome-{os.getpid()}.png"
+    try:
+        subprocess.run(
+            [chrome_bin, "--headless", "--disable-gpu", "--hide-scrollbars",
+             "--force-device-scale-factor=1",
+             f"--window-size={VIEWPORT_W},{VIEWPORT_H}",
+             f"--screenshot={tmp}", url],
+            capture_output=True, timeout=60)
+        return tmp.read_bytes()
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def write_report(path, failures, renderer, with_chrome=False):
+    rows = []
+    for test, refs, note in failures:
+        try:
+            t64 = base64.b64encode(renderer.render(test)).decode()
+            r64 = base64.b64encode(renderer.render(refs[0][1])).decode()
+        except Exception:
+            continue
+        chrome_fig = ""
+        if with_chrome:
+            try:
+                rel = test.relative_to(renderer.root).as_posix()
+                c64 = base64.b64encode(
+                    chrome_shot(f"http://127.0.0.1:{renderer.port}/{rel}")).decode()
+                chrome_fig = (f'<figure><figcaption>chrome (test)</figcaption>'
+                              f'<img src="data:image/png;base64,{c64}"></figure>')
+            except Exception:
+                pass
+        rows.append(f"""
+<section><h2>{html.escape(str(test.relative_to(renderer.root)))}</h2>
+<p>{html.escape(note)}</p>
+<div class="pair">
+<figure><figcaption>gosub (test)</figcaption><img src="data:image/png;base64,{t64}"></figure>
+<figure><figcaption>gosub (ref, {html.escape(refs[0][0])})</figcaption><img src="data:image/png;base64,{r64}"></figure>
+{chrome_fig}
+</div></section>""")
+    path.write_text(f"""<!doctype html><meta charset="utf-8">
+<title>gosub WPT reftest failures</title>
+<style>body{{font:14px sans-serif;margin:1rem;background:#f4f4f4;color:#222}}
+.pair{{display:flex;gap:8px}} figure{{flex:1;margin:0;min-width:0}}
+img{{width:100%;border:1px solid #ccc;background:#fff}}
+figcaption{{font-size:.75rem;color:#555}}
+h2{{font-size:1rem;margin:1.5rem 0 .3rem;font-family:monospace}}
+p{{font-size:.8rem;color:#666;margin:.2rem 0}}</style>
+<h1 style="font-size:1.2rem">{len(rows)} failures shown</h1>{''.join(rows)}""")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("target", help="path under the WPT root, dir or file")
+    ap.add_argument("--wpt-root", default=os.path.expanduser("~/code/gosub/wpt"))
+    ap.add_argument("--shot-bin", default="target/release/gosub-screenshot")
+    ap.add_argument("--jobs", type=int, default=max(2, (os.cpu_count() or 4) // 2))
+    ap.add_argument("--out", default="target/wpt-reftest")
+    ap.add_argument("--report", action="store_true",
+                    help="write failures.html with side-by-side images")
+    ap.add_argument("--max-report", type=int, default=80)
+    ap.add_argument("--chrome", action="store_true",
+                    help="add a headless-Chromium render of each failing test to the report")
+    ap.add_argument("--settle", type=int, default=0,
+                    help="seconds gosub-screenshot waits after the first render, so async "
+                         "media decodes before the capture")
+    ap.add_argument("--filter", default="",
+                    help="only run tests whose filename contains this substring")
+    args = ap.parse_args()
+
+    root = Path(args.wpt_root).resolve()
+    out_dir = Path(args.out)
+    (out_dir / "shots").mkdir(parents=True, exist_ok=True)
+
+    if subprocess.run(["fc-match", "Ahem"], capture_output=True,
+                      text=True).stdout.split(":")[0] != "Ahem.ttf":
+        print("warning: Ahem font not resolved - expect bogus failures", file=sys.stderr)
+
+    tests = [t for t in discover(root, args.target) if args.filter in t[0].name]
+    if not tests:
+        sys.exit(f"no reftests found under {args.target}")
+
+    server, port = start_server(root)
+    renderer = Renderer(args.shot_bin, root, port, out_dir / "shots", args.jobs, args.settle)
+
+    results, failures = {}, []
+    done = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:
+        futs = {}
+        for test, refs, fuzzy, skip in tests:
+            name = str(test.relative_to(root))
+            if skip:
+                results[name] = {"status": "SKIP", "note": skip}
+                continue
+            futs[pool.submit(run_test, renderer, test, refs, fuzzy)] = (test, refs, name)
+        for fut in concurrent.futures.as_completed(futs):
+            test, refs, name = futs[fut]
+            status, note, _ = fut.result()
+            results[name] = {"status": status, "note": note}
+            if status == "FAIL":
+                failures.append((test, refs, note))
+            done += 1
+            if done % 25 == 0:
+                print(f"  ...{done}/{len(futs)}", file=sys.stderr)
+
+    counts = {}
+    for r in results.values():
+        counts[r["status"]] = counts.get(r["status"], 0) + 1
+    (out_dir / "results.json").write_text(json.dumps(results, indent=1, sort_keys=True))
+
+    total_run = counts.get("PASS", 0) + counts.get("FAIL", 0) + counts.get("ERROR", 0)
+    print(f"\n{args.target}: {counts.get('PASS', 0)}/{total_run} pass "
+          f"({counts.get('FAIL', 0)} fail, {counts.get('ERROR', 0)} error, "
+          f"{counts.get('SKIP', 0)} skipped)")
+    print(f"results: {out_dir}/results.json")
+
+    if args.report and failures:
+        failures.sort(key=lambda f: str(f[0]))
+        write_report(out_dir / "failures.html", failures[:args.max_report],
+                     renderer, with_chrome=args.chrome)
+        print(f"report:  {out_dir}/failures.html")
+
+    server.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for running Web Platform Tests reftests with screenshot-based pixel comparisons.
  - Added configurable reftest targets and rendering wait times, with HTML and JSON result reports.
  - Added deterministic font configuration for more consistent test rendering.
  - Added a manual CI workflow that runs reftests and preserves failure reports as downloadable artifacts.

- **Documentation**
  - Expanded WPT documentation to cover both testharness and reftest workflows, supported coverage, results, and available CI jobs.
  - Improved the organization of existing testharness documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->