### PR TITLE
Slashdot css

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,9 +3032,9 @@ dependencies = [
 
 [[package]]
 name = "gosub-sonar"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b43da2b6294fc271bb55d23de4cc5e4805cbb200f53b2133a7066c0b554b3f6"
+checksum = "00a6d8ac4311e5ea4332ec71b3bdaea497d5ae31f8275ab218cbbfacad4f80ee"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ gosub_v8 = { version = "0.1.1", path = "./crates/gosub_v8", features = [], regis
 gosub_webexecutor = { version = "0.1.1", path = "./crates/gosub_webexecutor", features = [], registry = "gosub" }
 gosub_config = { version = "0.1.1", path = "./crates/gosub_config", features = [], registry = "gosub" }
 gosub_jsapi = { version = "0.1.1", path = "./crates/gosub_jsapi", features = [], registry = "gosub" }
-gosub-sonar = "0.5.1"
+gosub-sonar = "0.6.0"
 futures = { workspace = true }
 cookie = { workspace = true, features = ["secure", "private"] }
 clap = { workspace = true, features = ["derive"] }

--- a/crates/gosub_css3/resources/useragent.css
+++ b/crates/gosub_css3/resources/useragent.css
@@ -1313,7 +1313,12 @@ html::spelling-error {
 html::grammar-error {
     text-decoration: -internal-grammar-error-color grammar-error;
 }
-/* noscript is handled internally, as it depends on settings. */
+/* With scripting enabled the parser reads a noscript element's contents as raw text, so this rule
+   is what keeps that text off the page; the engine always parses with scripting enabled. Were it
+   ever disabled, the contents would be real markup and this rule would have to go with it. */
+noscript {
+    display: none;
+}
 
 
 [bgcolor] {

--- a/crates/gosub_css3/src/ast.rs
+++ b/crates/gosub_css3/src/ast.rs
@@ -300,11 +300,22 @@ fn collect_font_face(nodes: Vec<CssNode>) -> Option<FontFace> {
                 }
             }
             "src" => {
+                // `src` is a descriptor, so a later declaration replaces an earlier one rather
+                // than adding to it. The "bulletproof @font-face" idiom depends on that: it puts
+                // a bare `src: url(...eot)` first for IE<9 and a full `src:` list after it for
+                // everyone else. Appending instead of replacing leaves the IE-only EOT at the
+                // head of the list, where it is fetched and rejected before any usable format.
+                let mut entries: Vec<(String, Option<String>)> = Vec::new();
                 for n in value_nodes {
                     if let Ok(v) = CssValue::parse_ast_node(n) {
-                        collect_src_urls(&v, &mut sources);
+                        collect_src_entries(&v, &mut entries);
                     }
                 }
+                sources = entries
+                    .into_iter()
+                    .filter(|(_, format)| format.as_deref().is_none_or(font_format_is_usable))
+                    .map(|(url, _)| url)
+                    .collect();
             }
             "unicode-range" => {
                 // Reconstruct the raw range list; consumers scan it for `U+xxxx` tokens, so
@@ -338,8 +349,18 @@ fn collect_font_face(nodes: Vec<CssNode>) -> Option<FontFace> {
     })
 }
 
-/// Recursively collect `url(...)` targets from an `@font-face` `src` value.
-fn collect_src_urls(value: &CssValue, out: &mut Vec<String>) {
+/// Whether a `format()` hint names something the font backends can actually decode.
+///
+/// Only the two formats no backend here reads are rejected: `embedded-opentype` (EOT, an IE-only
+/// container) and `svg` (SVG fonts, long dropped from every engine). An unrecognised hint is kept
+/// and tried, so a format we have not heard of never costs us a usable face.
+fn font_format_is_usable(format: &str) -> bool {
+    !matches!(format, "embedded-opentype" | "svg")
+}
+
+/// Recursively collect `url(...)` targets from an `@font-face` `src` value, each paired with the
+/// `format(...)` hint that follows it, if any.
+fn collect_src_entries(value: &CssValue, out: &mut Vec<(String, Option<String>)>) {
     match value {
         CssValue::Function(name, args) if name.eq_ignore_ascii_case("url") => {
             if let Some(url) = args.iter().find_map(|a| match a {
@@ -347,13 +368,23 @@ fn collect_src_urls(value: &CssValue, out: &mut Vec<String>) {
                 _ => None,
             }) {
                 if !url.is_empty() {
-                    out.push(url);
+                    out.push((url, None));
                 }
+            }
+        }
+        // A `format()` always follows the url it describes, so it belongs to the last one seen.
+        CssValue::Function(name, args) if name.eq_ignore_ascii_case("format") => {
+            let hint = args.iter().find_map(|a| match a {
+                CssValue::String(s) => Some(s.trim_matches(['"', '\'']).cow_to_ascii_lowercase().into_owned()),
+                _ => None,
+            });
+            if let (Some(hint), Some(last)) = (hint, out.last_mut()) {
+                last.1 = Some(hint);
             }
         }
         CssValue::List(list) => {
             for item in list {
-                collect_src_urls(item, out);
+                collect_src_entries(item, out);
             }
         }
         _ => {}
@@ -443,6 +474,57 @@ mod tests {
                 .any(|p| matches!(p, CssSelectorPart::PseudoClass(n) if n == "hover")),
             "a real pseudo-class must stay one, got {parts:?}"
         );
+    }
+
+    #[test]
+    fn bulletproof_font_face_drops_the_ie_only_sources() {
+        // slashdot's sdicon face, in the "bulletproof @font-face" shape: a bare EOT `src` for
+        // IE<9 followed by a full list. The second `src` replaces the first, and the EOT and SVG
+        // entries are dropped by their format hints, so the first source tried is one that works.
+        let stylesheet = Css3::parse_str(
+            r#"
+            @font-face {
+              font-family: 'sdicon';
+              src: url("//example.org/sdicon.eot");
+              src: url("//example.org/sdicon.eot#iefix") format("embedded-opentype"),
+                   url("//example.org/sdicon.woff") format("woff"),
+                   url("//example.org/sdicon.ttf") format("truetype"),
+                   url("//example.org/sdicon.svg#sdicon") format("svg");
+            }
+            "#,
+            ParserConfig::default(),
+            CssOrigin::Author,
+            "test.css",
+        )
+        .unwrap();
+
+        let face = &stylesheet.font_faces[0];
+        assert_eq!(face.family, "sdicon");
+        assert_eq!(
+            face.sources,
+            vec!["//example.org/sdicon.woff", "//example.org/sdicon.ttf"]
+        );
+    }
+
+    #[test]
+    fn sources_without_a_format_hint_are_kept() {
+        // No hint means no reason to reject it, and an unrecognised hint is tried too.
+        let stylesheet = Css3::parse_str(
+            r#"
+            @font-face {
+              font-family: 'x';
+              src: url("a.woff2") format("woff2"),
+                   url("b.ttf"),
+                   url("c.bin") format("some-future-format");
+            }
+            "#,
+            ParserConfig::default(),
+            CssOrigin::Author,
+            "test.css",
+        )
+        .unwrap();
+
+        assert_eq!(stylesheet.font_faces[0].sources, vec!["a.woff2", "b.ttf", "c.bin"]);
     }
 
     #[test]

--- a/crates/gosub_css3/src/ast.rs
+++ b/crates/gosub_css3/src/ast.rs
@@ -70,6 +70,139 @@ fn is_legacy_pseudo_element(name: &str) -> bool {
         || name.eq_ignore_ascii_case("first-letter")
 }
 
+/// Convert a functional pseudo-class's selector-list argument (as `:not()` takes) into one
+/// compound per comma-separated selector.
+fn convert_selector_list(arguments: Vec<CssNode>) -> CssResult<Vec<Vec<CssSelectorPart>>> {
+    let mut out: Vec<Vec<CssSelectorPart>> = vec![vec![]];
+    for argument in arguments {
+        let selectors = match argument.node_type {
+            NodeType::SelectorList { selectors } => selectors,
+            // A single selector with no comma parses as a bare `Selector`.
+            NodeType::Selector { children } => {
+                convert_selector_children(children, &mut out)?;
+                continue;
+            }
+            _ => continue,
+        };
+        for selector in selectors {
+            if let NodeType::Selector { children } = selector.node_type {
+                convert_selector_children(children, &mut out)?;
+            }
+        }
+    }
+
+    out.retain(|compound| !compound.is_empty());
+    Ok(out)
+}
+
+/// Convert the children of one `Selector` AST node into selector parts, appending to the compound
+/// currently being built in `out`. A comma starts a new compound.
+fn convert_selector_children(children: Vec<CssNode>, out: &mut Vec<Vec<CssSelectorPart>>) -> CssResult<()> {
+    for node in children {
+        let part = match node.node_type {
+            NodeType::Ident { value } => CssSelectorPart::Type(value),
+            NodeType::ClassSelector { value } => CssSelectorPart::Class(value),
+            NodeType::Combinator { value } => {
+                let combinator = match value.as_str() {
+                    ">" => Combinator::Child,
+                    "+" => Combinator::NextSibling,
+                    "~" => Combinator::SubsequentSibling,
+                    " " => Combinator::Descendant,
+                    "||" => Combinator::Column,
+                    "|" => Combinator::Namespace,
+                    _ => return Err(CssError::new(format!("Unknown combinator: {value}").as_str())),
+                };
+
+                CssSelectorPart::Combinator(combinator)
+            }
+            NodeType::IdSelector { value } => CssSelectorPart::Id(value),
+            NodeType::TypeSelector { value, .. } if value == "*" => CssSelectorPart::Universal,
+            // CSS2 spelled the pseudo-*elements* with a single colon, and that is still
+            // what most older stylesheets use (`.container:after` for the clearfix
+            // idiom). The tokenizer can only see one colon and reports a pseudo-class,
+            // so re-classify the four legacy names here - matching them as pseudo-classes
+            // would silently generate no box at all.
+            NodeType::PseudoClassSelector { value, .. } => {
+                // `:not()` carries a real selector list, which the parser has already built. Keep
+                // it structured instead of flattening it to the string ":not(.foo)": matched as an
+                // opaque name it can never be evaluated, and the whole rule silently applies to
+                // nothing.
+                if let NodeType::Function { name, arguments } = value.node_type {
+                    if name.eq_ignore_ascii_case("not") {
+                        CssSelectorPart::Not(convert_selector_list(arguments)?)
+                    } else {
+                        // Any other functional pseudo-class keeps its serialized form, which is
+                        // what the matcher's name-based arms expect.
+                        CssSelectorPart::PseudoClass(
+                            CssNode::new(NodeType::Function { name, arguments }, node.location).to_string(),
+                        )
+                    }
+                } else {
+                    let name = value.to_string();
+                    if is_legacy_pseudo_element(&name) {
+                        CssSelectorPart::PseudoElement(name)
+                    } else {
+                        CssSelectorPart::PseudoClass(name)
+                    }
+                }
+            }
+            NodeType::PseudoElementSelector { value, .. } => CssSelectorPart::PseudoElement(value),
+            NodeType::TypeSelector { value, .. } => CssSelectorPart::Type(value),
+            NodeType::AttributeSelector {
+                name,
+                value,
+                flags,
+                matcher,
+            } => {
+                let matcher = match matcher {
+                    None => MatcherType::None,
+
+                    Some(matcher) => {
+                        if let NodeType::Operator(op) = &matcher.node_type {
+                            match op.as_str() {
+                                "=" => MatcherType::Equals,
+                                "~=" => MatcherType::Includes,
+                                "|=" => MatcherType::DashMatch,
+                                "^=" => MatcherType::PrefixMatch,
+                                "$=" => MatcherType::SuffixMatch,
+                                "*=" => MatcherType::SubstringMatch,
+                                _ => {
+                                    warn!("Unsupported matcher: {matcher:?}");
+                                    MatcherType::Equals
+                                }
+                            }
+                        } else {
+                            warn!("Unsupported matcher: {matcher:?}");
+                            MatcherType::Equals
+                        }
+                    }
+                };
+
+                CssSelectorPart::Attribute(Box::new(AttributeSelector {
+                    name,
+                    matcher,
+                    value,
+                    case_insensitive: flags.eq_ignore_ascii_case("i"),
+                }))
+            }
+            NodeType::Comma => {
+                out.push(vec![]);
+                continue;
+            }
+            other => {
+                return Err(CssError::new(format!("Unsupported selector part: {other:?}").as_str()));
+            }
+        };
+        if let Some(x) = out.last_mut() {
+            x.push(part);
+        } else {
+            out.push(vec![part]); //unreachable, but still, we handle it
+        }
+    }
+
+    Ok(())
+}
+
 fn collect_rule(prelude: Option<Box<CssNode>>, block: Option<Box<CssNode>>) -> CssResult<Option<CssRule>> {
     let mut rule = CssRule {
         selectors: vec![],
@@ -87,91 +220,7 @@ fn collect_rule(prelude: Option<Box<CssNode>>, block: Option<Box<CssNode>>) -> C
                 continue;
             };
 
-            for node in children {
-                let part = match node.node_type {
-                    NodeType::Ident { value } => CssSelectorPart::Type(value),
-                    NodeType::ClassSelector { value } => CssSelectorPart::Class(value),
-                    NodeType::Combinator { value } => {
-                        let combinator = match value.as_str() {
-                            ">" => Combinator::Child,
-                            "+" => Combinator::NextSibling,
-                            "~" => Combinator::SubsequentSibling,
-                            " " => Combinator::Descendant,
-                            "||" => Combinator::Column,
-                            "|" => Combinator::Namespace,
-                            _ => return Err(CssError::new(format!("Unknown combinator: {value}").as_str())),
-                        };
-
-                        CssSelectorPart::Combinator(combinator)
-                    }
-                    NodeType::IdSelector { value } => CssSelectorPart::Id(value),
-                    NodeType::TypeSelector { value, .. } if value == "*" => CssSelectorPart::Universal,
-                    // CSS2 spelled the pseudo-*elements* with a single colon, and that is still
-                    // what most older stylesheets use (`.container:after` for the clearfix
-                    // idiom). The tokenizer can only see one colon and reports a pseudo-class,
-                    // so re-classify the four legacy names here - matching them as pseudo-classes
-                    // would silently generate no box at all.
-                    NodeType::PseudoClassSelector { value, .. } => {
-                        let name = value.to_string();
-                        if is_legacy_pseudo_element(&name) {
-                            CssSelectorPart::PseudoElement(name)
-                        } else {
-                            CssSelectorPart::PseudoClass(name)
-                        }
-                    }
-                    NodeType::PseudoElementSelector { value, .. } => CssSelectorPart::PseudoElement(value),
-                    NodeType::TypeSelector { value, .. } => CssSelectorPart::Type(value),
-                    NodeType::AttributeSelector {
-                        name,
-                        value,
-                        flags,
-                        matcher,
-                    } => {
-                        let matcher = match matcher {
-                            None => MatcherType::None,
-
-                            Some(matcher) => {
-                                if let NodeType::Operator(op) = &matcher.node_type {
-                                    match op.as_str() {
-                                        "=" => MatcherType::Equals,
-                                        "~=" => MatcherType::Includes,
-                                        "|=" => MatcherType::DashMatch,
-                                        "^=" => MatcherType::PrefixMatch,
-                                        "$=" => MatcherType::SuffixMatch,
-                                        "*=" => MatcherType::SubstringMatch,
-                                        _ => {
-                                            warn!("Unsupported matcher: {matcher:?}");
-                                            MatcherType::Equals
-                                        }
-                                    }
-                                } else {
-                                    warn!("Unsupported matcher: {matcher:?}");
-                                    MatcherType::Equals
-                                }
-                            }
-                        };
-
-                        CssSelectorPart::Attribute(Box::new(AttributeSelector {
-                            name,
-                            matcher,
-                            value,
-                            case_insensitive: flags.eq_ignore_ascii_case("i"),
-                        }))
-                    }
-                    NodeType::Comma => {
-                        selector.parts.push(vec![]);
-                        continue;
-                    }
-                    other => {
-                        return Err(CssError::new(format!("Unsupported selector part: {other:?}").as_str()));
-                    }
-                };
-                if let Some(x) = selector.parts.last_mut() {
-                    x.push(part);
-                } else {
-                    selector.parts.push(vec![part]); //unreachable, but still, we handle it
-                }
-            }
+            convert_selector_children(children, &mut selector.parts)?;
         }
 
         // A compound with no parts matches every element vacuously, so an empty prelude
@@ -406,6 +455,7 @@ pub fn convert_ast_to_stylesheet(css_ast: CssNode, origin: CssOrigin, url: &str)
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::stylesheet::Specificity;
     use crate::Css3;
     use gosub_shared::config::ParserConfig;
 
@@ -525,6 +575,60 @@ mod tests {
         .unwrap();
 
         assert_eq!(stylesheet.font_faces[0].sources, vec!["a.woff2", "b.ttf", "c.bin"]);
+    }
+
+    #[test]
+    fn not_keeps_its_argument_as_a_selector() {
+        // Flattened to the string ":not(.skip)" this can never be evaluated, and the rule silently
+        // matches nothing - which is how slashdot's badge styling disappeared.
+        let stylesheet = Css3::parse_str(
+            ".box > span:not(.skip) { color: red }",
+            ParserConfig::default(),
+            CssOrigin::Author,
+            "test.css",
+        )
+        .unwrap();
+
+        let parts = &stylesheet.rules[0].selectors[0].parts[0];
+        let Some(CssSelectorPart::Not(inner)) = parts.last() else {
+            panic!("expected a Not part, got {parts:?}");
+        };
+        assert_eq!(inner.len(), 1, "one compound in the argument");
+        assert_eq!(inner[0], vec![CssSelectorPart::Class("skip".to_string())]);
+    }
+
+    #[test]
+    fn not_accepts_a_selector_list() {
+        let stylesheet = Css3::parse_str(
+            "span:not(.a, .b) { color: red }",
+            ParserConfig::default(),
+            CssOrigin::Author,
+            "test.css",
+        )
+        .unwrap();
+
+        let parts = &stylesheet.rules[0].selectors[0].parts[0];
+        let Some(CssSelectorPart::Not(inner)) = parts.last() else {
+            panic!("expected a Not part, got {parts:?}");
+        };
+        assert_eq!(inner.len(), 2, "one compound per comma-separated argument");
+    }
+
+    #[test]
+    fn not_contributes_its_most_specific_argument() {
+        // Selectors L4 §17: `:not()` adds nothing itself, but its most specific argument counts.
+        let stylesheet = Css3::parse_str(
+            "b:not(#nope) { color: red } i:not(.c) { color: red } u:not(s) { color: red }",
+            ParserConfig::default(),
+            CssOrigin::Author,
+            "test.css",
+        )
+        .unwrap();
+
+        let spec = |i: usize| Specificity::from(stylesheet.rules[i].selectors[0].parts[0].as_slice());
+        assert_eq!(spec(0), Specificity::new(1, 0, 1), "an id argument counts as an id");
+        assert_eq!(spec(1), Specificity::new(0, 1, 1), "a class argument counts as a class");
+        assert_eq!(spec(2), Specificity::new(0, 0, 2), "a type argument counts as a type");
     }
 
     #[test]

--- a/crates/gosub_css3/src/ast.rs
+++ b/crates/gosub_css3/src/ast.rs
@@ -61,6 +61,15 @@ vs
     h4 { color: rebeccapurple; }
 */
 
+/// The four pseudo-elements CSS2 allowed to be written with a single colon. Selectors Level 4
+/// keeps them valid for compatibility; every other `:name` is a pseudo-class.
+fn is_legacy_pseudo_element(name: &str) -> bool {
+    name.eq_ignore_ascii_case("before")
+        || name.eq_ignore_ascii_case("after")
+        || name.eq_ignore_ascii_case("first-line")
+        || name.eq_ignore_ascii_case("first-letter")
+}
+
 fn collect_rule(prelude: Option<Box<CssNode>>, block: Option<Box<CssNode>>) -> CssResult<Option<CssRule>> {
     let mut rule = CssRule {
         selectors: vec![],
@@ -97,7 +106,19 @@ fn collect_rule(prelude: Option<Box<CssNode>>, block: Option<Box<CssNode>>) -> C
                     }
                     NodeType::IdSelector { value } => CssSelectorPart::Id(value),
                     NodeType::TypeSelector { value, .. } if value == "*" => CssSelectorPart::Universal,
-                    NodeType::PseudoClassSelector { value, .. } => CssSelectorPart::PseudoClass(value.to_string()),
+                    // CSS2 spelled the pseudo-*elements* with a single colon, and that is still
+                    // what most older stylesheets use (`.container:after` for the clearfix
+                    // idiom). The tokenizer can only see one colon and reports a pseudo-class,
+                    // so re-classify the four legacy names here - matching them as pseudo-classes
+                    // would silently generate no box at all.
+                    NodeType::PseudoClassSelector { value, .. } => {
+                        let name = value.to_string();
+                        if is_legacy_pseudo_element(&name) {
+                            CssSelectorPart::PseudoElement(name)
+                        } else {
+                            CssSelectorPart::PseudoClass(name)
+                        }
+                    }
                     NodeType::PseudoElementSelector { value, .. } => CssSelectorPart::PseudoElement(value),
                     NodeType::TypeSelector { value, .. } => CssSelectorPart::Type(value),
                     NodeType::AttributeSelector {
@@ -392,6 +413,35 @@ mod tests {
             stylesheet.rules[0].selectors.first().unwrap().parts.len(),
             3,
             "dropping empty compounds must not drop real ones"
+        );
+    }
+
+    #[test]
+    fn single_colon_before_after_are_pseudo_elements() {
+        // The clearfix idiom `.container:after { clear: both }` depends on this: matched as a
+        // pseudo-*class* the rule generates no box, and nothing contains the floats.
+        let stylesheet = Css3::parse_str(
+            ".a:after { content: \"\" } .b:hover { color: red }",
+            ParserConfig::default(),
+            CssOrigin::Author,
+            "test.css",
+        )
+        .unwrap();
+
+        let parts: Vec<_> = stylesheet.rules[0].selectors[0].parts[0].clone();
+        assert!(
+            parts
+                .iter()
+                .any(|p| matches!(p, CssSelectorPart::PseudoElement(n) if n == "after")),
+            "`:after` must become a pseudo-element, got {parts:?}"
+        );
+
+        let parts: Vec<_> = stylesheet.rules[1].selectors[0].parts[0].clone();
+        assert!(
+            parts
+                .iter()
+                .any(|p| matches!(p, CssSelectorPart::PseudoClass(n) if n == "hover")),
+            "a real pseudo-class must stay one, got {parts:?}"
         );
     }
 

--- a/crates/gosub_css3/src/ast.rs
+++ b/crates/gosub_css3/src/ast.rs
@@ -152,6 +152,17 @@ fn collect_rule(prelude: Option<Box<CssNode>>, block: Option<Box<CssNode>>) -> C
                 }
             }
         }
+
+        // A compound with no parts matches every element vacuously, so an empty prelude
+        // (e.g. `/*.a, .b*/{ ... }`, where the whole selector list is commented out) would
+        // apply its declarations to the entire document. Per CSS Syntax a style rule with an
+        // invalid or empty prelude is invalid and must be dropped, so drop the empty compounds
+        // and the rule with them if nothing is left.
+        selector.parts.retain(|part| !part.is_empty());
+        if selector.parts.is_empty() {
+            return Ok(None);
+        }
+
         rule.selectors.push(selector);
     }
 
@@ -345,6 +356,44 @@ mod tests {
     use super::*;
     use crate::Css3;
     use gosub_shared::config::ParserConfig;
+
+    #[test]
+    fn rule_with_fully_commented_out_selector_is_dropped() {
+        // slashdot.org's classic.css ships `/*.a, .b*/{ ... }`. The empty prelude used to
+        // survive as a single empty compound, which matches every element vacuously and
+        // applied `height:64px; position:absolute` to the whole document.
+        let stylesheet = Css3::parse_str(
+            r#"
+            /*#editor header .topic, #firehose article header .topic */{ height: 64px; position: absolute; }
+            h1 { color: red; }
+            "#,
+            ParserConfig::default(),
+            CssOrigin::Author,
+            "test.css",
+        )
+        .unwrap();
+
+        assert_eq!(stylesheet.rules.len(), 1, "only the h1 rule survives");
+        assert_eq!(stylesheet.rules[0].declarations.first().unwrap().property, "color");
+    }
+
+    #[test]
+    fn selector_list_keeps_every_compound() {
+        let stylesheet = Css3::parse_str(
+            "h3, h4, .foo > .bar { color: red; }",
+            ParserConfig::default(),
+            CssOrigin::Author,
+            "test.css",
+        )
+        .unwrap();
+
+        assert_eq!(stylesheet.rules.len(), 1);
+        assert_eq!(
+            stylesheet.rules[0].selectors.first().unwrap().parts.len(),
+            3,
+            "dropping empty compounds must not drop real ones"
+        );
+    }
 
     #[test]
     fn font_face_rules_are_collected() {

--- a/crates/gosub_css3/src/matcher/styling.rs
+++ b/crates/gosub_css3/src/matcher/styling.rs
@@ -103,6 +103,12 @@ fn match_selector_part<C: HasDocument>(
 ) -> bool {
     match part {
         CssSelectorPart::Universal => true,
+        // `:not()` matches when none of its arguments do. Each argument is matched against this
+        // same element, so the negation is evaluated where it is written rather than walking the
+        // tree - `:not()` takes a compound, and a compound never crosses a combinator.
+        CssSelectorPart::Not(inner) => !inner
+            .iter()
+            .any(|compound| match_selector_parts::<C>(doc, current_id, compound, pseudo)),
         CssSelectorPart::Type(name) => {
             doc.node_type(current_id) == NodeType::ElementNode && doc.tag_name(current_id).is_some_and(|t| t == name)
         }

--- a/crates/gosub_css3/src/stylesheet.rs
+++ b/crates/gosub_css3/src/stylesheet.rs
@@ -431,6 +431,16 @@ impl Specificity {
     }
 }
 
+/// Whether a serialized pseudo-class contributes no specificity at all - `:where()`, and only
+/// `:where()` (Selectors L4 §17).
+///
+/// Compares bytes rather than lowercasing: this runs inside `match_selector`, once per element
+/// per candidate rule, so it must not allocate.
+fn is_zero_specificity_pseudo(name: &str) -> bool {
+    let bytes = name.as_bytes();
+    bytes.len() > 6 && bytes[..6].eq_ignore_ascii_case(b"where(")
+}
+
 impl From<&[CssSelectorPart]> for Specificity {
     fn from(parts: &[CssSelectorPart]) -> Self {
         let mut id_count = 0;
@@ -445,6 +455,28 @@ impl From<&[CssSelectorPart]> for Specificity {
                     class_count += 1;
                 }
                 CssSelectorPart::Type(_) => {
+                    element_count += 1;
+                }
+                // An attribute selector counts as a class, same as `.foo` (Selectors L4 §17).
+                CssSelectorPart::Attribute(_) => {
+                    class_count += 1;
+                }
+                CssSelectorPart::PseudoClass(name) => {
+                    // `:where()` contributes nothing whatever it contains - that is the entire
+                    // point of it - while every other pseudo-class counts as a class.
+                    //
+                    // Known gap: `:is()` and `:has()` should take the specificity of their most
+                    // specific argument. Unlike `:not`, which has its own structured variant,
+                    // they are stored here as serialized text, so that is not computable without
+                    // giving them the same treatment. Counting them as one class is the
+                    // pre-Selectors-4 behaviour and errs low rather than high.
+                    if !is_zero_specificity_pseudo(name) {
+                        class_count += 1;
+                    }
+                }
+                // Legacy single-colon `:before`/`:after` are re-classified as pseudo-elements
+                // during AST conversion, so they land here and count as elements too.
+                CssSelectorPart::PseudoElement(_) => {
                     element_count += 1;
                 }
                 // Selectors L4 §17: `:not()` contributes nothing itself, but its most specific
@@ -1042,6 +1074,74 @@ mod test {
         assert_eq!(part, &CssSelectorPart::Type("h1".to_string()));
         assert_eq!(rule.declarations().len(), 1);
         assert_eq!(rule.declarations().first().unwrap().property, "color");
+    }
+
+    /// Everything that carries specificity, at each of the three levels.
+    ///
+    /// Pseudo-classes, pseudo-elements and attribute selectors were all being ignored, so
+    /// `div:hover` scored the same as bare `div` and could lose a cascade it should win.
+    #[test]
+    fn specificity_counts_pseudos_and_attributes() {
+        let spec = |parts: Vec<CssSelectorPart>| Specificity::from(parts.as_slice());
+
+        // `div:hover` - one element, one class-level pseudo-class.
+        assert_eq!(
+            spec(vec![
+                CssSelectorPart::Type("div".into()),
+                CssSelectorPart::PseudoClass("hover".into()),
+            ]),
+            Specificity::new(0, 1, 1)
+        );
+
+        // `p::after` - two element-level components. Legacy `:after` converts to a
+        // pseudo-element upstream, so it lands on this same arm.
+        assert_eq!(
+            spec(vec![
+                CssSelectorPart::Type("p".into()),
+                CssSelectorPart::PseudoElement("after".into()),
+            ]),
+            Specificity::new(0, 0, 1 + 1)
+        );
+
+        // `[type="text"]` counts as a class.
+        assert_eq!(
+            spec(vec![CssSelectorPart::Attribute(Box::new(AttributeSelector {
+                name: "type".into(),
+                matcher: MatcherType::Equals,
+                value: "text".into(),
+                case_insensitive: false,
+            }))]),
+            Specificity::new(0, 1, 0)
+        );
+    }
+
+    /// `:not()` contributes the specificity of its most specific argument, and now that
+    /// pseudo-classes count, that argument may itself be one.
+    #[test]
+    fn specificity_of_not_sees_inner_pseudo_classes() {
+        let selector = vec![
+            CssSelectorPart::Type("div".into()),
+            CssSelectorPart::Not(vec![vec![CssSelectorPart::PseudoClass("hover".into())]]),
+        ];
+        assert_eq!(Specificity::from(selector.as_slice()), Specificity::new(0, 1, 1));
+    }
+
+    /// `:where()` exists precisely so that it adds nothing, however specific its argument.
+    #[test]
+    fn where_pseudo_class_adds_no_specificity() {
+        assert_eq!(
+            Specificity::from([CssSelectorPart::PseudoClass("where(#id .cls)".into())].as_slice()),
+            Specificity::new(0, 0, 0)
+        );
+        // Case-insensitively, and without mistaking a differently-named pseudo-class for it.
+        assert_eq!(
+            Specificity::from([CssSelectorPart::PseudoClass("WHERE(.a)".into())].as_slice()),
+            Specificity::new(0, 0, 0)
+        );
+        assert_eq!(
+            Specificity::from([CssSelectorPart::PseudoClass("wherever".into())].as_slice()),
+            Specificity::new(0, 1, 0)
+        );
     }
 
     #[test]

--- a/crates/gosub_css3/src/stylesheet.rs
+++ b/crates/gosub_css3/src/stylesheet.rs
@@ -281,6 +281,9 @@ pub enum CssSelectorPart {
     PseudoElement(String),
     Combinator(Combinator),
     Type(String),
+    /// `:not(...)`, holding the selector list it negates. Matches when *none* of the inner
+    /// selectors match the element.
+    Not(Vec<Vec<CssSelectorPart>>),
 }
 
 #[derive(PartialEq, Clone, Default, Debug)]
@@ -345,6 +348,18 @@ impl Debug for CssSelectorPart {
             CssSelectorPart::Type(name) => {
                 write!(f, "{name}")
             }
+            CssSelectorPart::Not(inner) => {
+                write!(f, ":not(")?;
+                for (i, compound) in inner.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    for part in compound {
+                        write!(f, "{part:?}")?;
+                    }
+                }
+                write!(f, ")")
+            }
         }
     }
 }
@@ -399,6 +414,21 @@ impl Specificity {
     pub const fn new(a: u32, b: u32, c: u32) -> Self {
         Self(a, b, c)
     }
+
+    #[must_use]
+    pub const fn id_count(&self) -> u32 {
+        self.0
+    }
+
+    #[must_use]
+    pub const fn class_count(&self) -> u32 {
+        self.1
+    }
+
+    #[must_use]
+    pub const fn element_count(&self) -> u32 {
+        self.2
+    }
 }
 
 impl From<&[CssSelectorPart]> for Specificity {
@@ -416,6 +446,15 @@ impl From<&[CssSelectorPart]> for Specificity {
                 }
                 CssSelectorPart::Type(_) => {
                     element_count += 1;
+                }
+                // Selectors L4 §17: `:not()` contributes nothing itself, but its most specific
+                // argument counts as if it were written in place of the `:not()`.
+                CssSelectorPart::Not(inner) => {
+                    if let Some(most) = inner.iter().map(|parts| Specificity::from(parts.as_slice())).max() {
+                        id_count += most.id_count();
+                        class_count += most.class_count();
+                        element_count += most.element_count();
+                    }
                 }
                 _ => {}
             }

--- a/crates/gosub_css3/src/system.rs
+++ b/crates/gosub_css3/src/system.rs
@@ -480,8 +480,14 @@ pub fn add_property_to_map(
         .push(declaration);
 }
 
+/// Elements whose styles are never worth computing because they never render.
+///
+/// Careful: an element listed here gets *no* computed style at all, so a `display: none` rule in
+/// the user-agent stylesheet can never apply to it. Anything named here must therefore also be
+/// pruned by the render tree's own list, or it will render after all - `noscript` used to be
+/// listed here and nowhere else, which is exactly how its raw text ended up on the page.
 pub fn node_is_unrenderable<C: HasDocument>(doc: &C::Document, id: NodeId) -> bool {
-    const REMOVABLE_ELEMENTS: [&str; 6] = ["head", "script", "style", "svg", "noscript", "title"];
+    const REMOVABLE_ELEMENTS: [&str; 5] = ["head", "script", "style", "svg", "title"];
 
     match doc.node_type(id) {
         NodeType::ElementNode => doc.tag_name(id).is_some_and(|name| REMOVABLE_ELEMENTS.contains(&name)),

--- a/crates/gosub_engine/Cargo.toml
+++ b/crates/gosub_engine/Cargo.toml
@@ -9,7 +9,7 @@ name = "gosub_engine"
 crate-type = ["rlib"]
 
 [dependencies]
-gosub-sonar = "0.5.1"
+gosub-sonar = "0.6.0"
 gosub_shared = { version = "0.1.1", path = "../gosub_shared" }
 gosub_config = { version = "0.1.1", path = "../gosub_config" }
 gosub_html5 = { version = "0.1.1", path = "../gosub_html5" }

--- a/crates/gosub_html5/Cargo.toml
+++ b/crates/gosub_html5/Cargo.toml
@@ -24,7 +24,7 @@ serde = { workspace = true, features = ["derive"] }
 cow-utils = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-gosub-sonar = "0.5.1"
+gosub-sonar = "0.6.0"
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/crates/gosub_html5/src/writer.rs
+++ b/crates/gosub_html5/src/writer.rs
@@ -13,6 +13,27 @@ impl DocumentWriter {
     }
 }
 
+/// Write an attribute name back out as source text.
+///
+/// "Adjust foreign attributes" (HTML §13.2.6.1) splits a namespaced attribute on a `<svg>` or
+/// `<math>` element into a prefix and a local name, and the parser stores the pair space-joined
+/// (`xlink:href` becomes `xlink href`, `xmlns` becomes `xmlns ` with an empty local name) because
+/// that is the form the html5lib tree-construction tests expect. An attribute name can never
+/// contain a space otherwise - the tokenizer ends the name there - so a space unambiguously marks
+/// that pair, and serializing it verbatim would emit `xlink href="..."`, which is not well-formed.
+/// Rejoin it with a colon.
+fn write_attribute_name(name: &str, buf: &mut String) {
+    match name.split_once(' ') {
+        Some((prefix, "")) => buf.push_str(prefix),
+        Some((prefix, local)) => {
+            buf.push_str(prefix);
+            buf.push(':');
+            buf.push_str(local);
+        }
+        None => buf.push_str(name),
+    }
+}
+
 fn write_node<C: HasDocument>(id: NodeId, doc: &C::Document, buf: &mut String) {
     match doc.node_type(id) {
         NodeType::DocumentNode => {
@@ -59,7 +80,7 @@ fn write_node<C: HasDocument>(id: NodeId, doc: &C::Document, buf: &mut String) {
                 if let Some(attrs) = doc.attributes(id) {
                     for (attr_name, attr_value) in attrs {
                         buf.push(' ');
-                        buf.push_str(attr_name);
+                        write_attribute_name(attr_name, buf);
                         buf.push_str("=\"");
                         buf.push_str(attr_value);
                         buf.push('"');
@@ -77,5 +98,38 @@ fn write_node<C: HasDocument>(id: NodeId, doc: &C::Document, buf: &mut String) {
                 buf.push('>');
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_attribute_name;
+
+    fn name(input: &str) -> String {
+        let mut buf = String::new();
+        write_attribute_name(input, &mut buf);
+        buf
+    }
+
+    #[test]
+    fn adjusted_foreign_attributes_are_rejoined_with_a_colon() {
+        // These are stored space-joined by "adjust foreign attributes". Writing them verbatim
+        // produced `xlink href="..."`, which no XML parser accepts - which is why an inline
+        // <svg> failed with "expected '=' ...".
+        assert_eq!(name("xlink href"), "xlink:href");
+        assert_eq!(name("xml space"), "xml:space");
+        assert_eq!(name("xmlns xlink"), "xmlns:xlink");
+    }
+
+    #[test]
+    fn an_empty_local_name_keeps_only_the_prefix() {
+        // `xmlns` is stored as ("xmlns", ""), so the trailing space must not survive.
+        assert_eq!(name("xmlns "), "xmlns");
+    }
+
+    #[test]
+    fn ordinary_attribute_names_are_untouched() {
+        assert_eq!(name("viewBox"), "viewBox");
+        assert_eq!(name("data-foo"), "data-foo");
     }
 }

--- a/crates/gosub_render_pipeline/Cargo.toml
+++ b/crates/gosub_render_pipeline/Cargo.toml
@@ -14,7 +14,7 @@ sha2 = "0.11.0"
 serde_json = { workspace = true }
 csscolorparser = "0.8.3"
 rstar = "0.13.0"
-gosub-sonar = "0.5.1"
+gosub-sonar = "0.6.0"
 url = { workspace = true }
 resvg = { workspace = true }
 bytes = { workspace = true }

--- a/crates/gosub_render_pipeline/src/common/document/inline_style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/inline_style.rs
@@ -199,6 +199,8 @@ fn apply_style_kv(style: &mut NodeStyle, key: &str, value: &str) {
     match key {
         "display" => style.set(StyleProperty::Display, parse_display(value)),
         "position" => style.set(StyleProperty::Position, parse_position(value)),
+        "float" => style.set(StyleProperty::Float, parse_style_str(value)),
+        "clear" => style.set(StyleProperty::Clear, parse_style_str(value)),
 
         "width" => style.set(StyleProperty::Width, parse_style_value(value)),
         "height" => style.set(StyleProperty::Height, parse_style_value(value)),

--- a/crates/gosub_render_pipeline/src/common/document/inline_style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/inline_style.rs
@@ -365,8 +365,15 @@ fn parse_position(position: &str) -> Value {
     Value::Keyword(intern(position))
 }
 
+/// A CSS keyword value from an inline `style` attribute.
+///
+/// Interned lowercased: CSS keywords are ASCII case-insensitive, but every consumer compares
+/// against lowercase names (`float_side`, `clear_sides`, the flex/align/overflow readers), so
+/// `style="float: LEFT"` was silently falling through to the default. Every caller of this
+/// function stores a keyword-valued property - none carry case-sensitive text such as a font
+/// family or `content` string - so lowercasing here is safe for all of them.
 fn parse_style_str(val: &str) -> Value {
-    Value::Keyword(intern(val))
+    Value::Keyword(intern(val.cow_to_ascii_lowercase().as_ref()))
 }
 
 fn parse_text_align(val: &str) -> Value {
@@ -502,6 +509,39 @@ mod tests {
         assert_eq!(parse_css_url(r#"url("x.gif") no-repeat"#).as_deref(), Some("x.gif"));
         assert_eq!(parse_css_url("#fff no-repeat"), None);
         assert_eq!(parse_css_url("url()"), None);
+    }
+
+    /// CSS keywords are ASCII case-insensitive, but every consumer compares against lowercase
+    /// names, so an uppercase inline value used to fall through to the default - `float: LEFT`
+    /// simply did not float.
+    #[test]
+    fn keyword_values_are_case_insensitive() {
+        use crate::common::document::style::lookup;
+
+        let lower = parse_inline_style_attr("float: left");
+        let upper = parse_inline_style_attr("float: LEFT");
+        let mixed = parse_inline_style_attr("float: Left");
+        assert_eq!(
+            lower.get_own(&StyleProperty::Float),
+            upper.get_own(&StyleProperty::Float)
+        );
+        assert_eq!(
+            lower.get_own(&StyleProperty::Float),
+            mixed.get_own(&StyleProperty::Float)
+        );
+
+        // ...and the interned keyword really is the lowercase one the readers look for.
+        assert!(matches!(
+            upper.get_own(&StyleProperty::Float),
+            Some(Value::Keyword(id)) if lookup(*id) == "left"
+        ));
+
+        // Same treatment for the other keyword properties routed through `parse_style_str`.
+        let overflow = parse_inline_style_attr("overflow-x: HIDDEN");
+        assert!(matches!(
+            overflow.get_own(&StyleProperty::OverflowX),
+            Some(Value::Keyword(id)) if lookup(*id) == "hidden"
+        ));
     }
 
     #[test]

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -27,6 +27,14 @@ fn css_property_to_value<S: CssSystem>(p: &S::Property, prop: &StyleProperty) ->
         | StyleProperty::BorderBottomColor
         | StyleProperty::BorderLeftColor => {
             if let Some(s) = p.as_string() {
+                // `transparent` tokenises as a plain identifier, so the colour parser does not
+                // recognise it and the property would be left unset - which the painter reads as
+                // "no colour given" and falls back to black. CSS defines it as rgba(0, 0, 0, 0),
+                // and the CSS-triangle idiom (`border-color: transparent transparent green`)
+                // depends on it, so an unresolved `transparent` paints a solid black box.
+                if s.eq_ignore_ascii_case("transparent") {
+                    return Some(Value::Color(0, 0, 0, 0));
+                }
                 if let Some((r, g, b, a)) = css_system_color(s) {
                     return Some(Value::Color(r, g, b, a));
                 }

--- a/crates/gosub_render_pipeline/src/common/document/style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/style.rs
@@ -299,6 +299,8 @@ pub enum StyleProperty {
     ZIndex,
     LetterSpacing,
     MixBlendMode,
+    Float,
+    Clear,
 }
 
 impl StyleProperty {
@@ -383,6 +385,8 @@ impl StyleProperty {
             StyleProperty::ZIndex => 75,
             StyleProperty::LetterSpacing => 76,
             StyleProperty::MixBlendMode => 77,
+            StyleProperty::Float => 78,
+            StyleProperty::Clear => 79,
         }
     }
 
@@ -917,6 +921,18 @@ static PROPERTIES: &[PropertyMeta] = &[
         inherited: false,
         initial_kind: InitialKind::Keyword("normal"),
     },
+    // 78 float
+    PropertyMeta {
+        name: "float",
+        inherited: false,
+        initial_kind: InitialKind::Keyword("none"),
+    },
+    // 79 clear
+    PropertyMeta {
+        name: "clear",
+        inherited: false,
+        initial_kind: InitialKind::Keyword("none"),
+    },
 ];
 
 // ── NodeStyle - replaces StylePropertyList ────────────────────────────────────
@@ -1056,6 +1072,8 @@ fn from_id(id: u8) -> Option<StyleProperty> {
         75 => Some(StyleProperty::ZIndex),
         76 => Some(StyleProperty::LetterSpacing),
         77 => Some(StyleProperty::MixBlendMode),
+        78 => Some(StyleProperty::Float),
+        79 => Some(StyleProperty::Clear),
         _ => None,
     }
 }

--- a/crates/gosub_render_pipeline/src/layouter.rs
+++ b/crates/gosub_render_pipeline/src/layouter.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 mod box_model;
 mod css_taffy_converter;
+pub mod float;
 mod inline_run;
 pub mod table;
 pub mod taffy;

--- a/crates/gosub_render_pipeline/src/layouter.rs
+++ b/crates/gosub_render_pipeline/src/layouter.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use std::ops::AddAssign;
 use std::sync::Arc;
 
+pub mod abspos;
 mod box_model;
 mod css_taffy_converter;
 pub mod float;
@@ -179,6 +180,35 @@ pub struct LayoutTree {
 }
 
 impl LayoutTree {
+    /// Move an element and everything under it by `(dx, dy)`.
+    ///
+    /// Box models hold absolute page coordinates, so a box that moves after layout - a float being
+    /// placed, an absolutely positioned box being re-resolved against its real containing block -
+    /// has to take its whole subtree with it.
+    pub(crate) fn shift_subtree(&mut self, id: LayoutElementId, dx: f64, dy: f64) {
+        if dx == 0.0 && dy == 0.0 {
+            return;
+        }
+
+        let mut stack = vec![id];
+        while let Some(current) = stack.pop() {
+            let Some(el) = self.arena.get_mut(&current) else {
+                continue;
+            };
+            let bm = &mut el.box_model;
+            for rect in [
+                &mut bm.content_box,
+                &mut bm.padding_box,
+                &mut bm.border_box,
+                &mut bm.margin_box,
+            ] {
+                rect.x += dx;
+                rect.y += dy;
+            }
+            stack.extend(el.children.iter().copied());
+        }
+    }
+
     pub fn get_node_by_id(&self, node_id: LayoutElementId) -> Option<&LayoutElementNode> {
         self.arena.get(&node_id)
     }

--- a/crates/gosub_render_pipeline/src/layouter/abspos.rs
+++ b/crates/gosub_render_pipeline/src/layouter/abspos.rs
@@ -17,6 +17,7 @@ use crate::common::document::pipeline_doc::PipelineDocument;
 use crate::common::document::style::{lookup, StyleProperty, Unit, Value};
 use crate::common::geo::{Dimension, Rect};
 use crate::layouter::{LayoutElementId, LayoutTree};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 /// How a box is positioned, as far as this pass is concerned.
@@ -58,9 +59,41 @@ fn inset(doc: &dyn PipelineDocument, id: DomNodeId, prop: StyleProperty, basis: 
     }
 }
 
+/// Taffy insets for one absolutely positioned box, rebased from its CSS containing block onto
+/// its immediate parent - which is the box taffy actually measures from.
+///
+/// Only produced for an axis where CSS gives *both* insets and leaves the size `auto`, i.e. the
+/// box is meant to stretch between them. Placing such a box is not enough: taffy sized it
+/// against the wrong ancestor, and this pass only moves boxes, it does not resize them. Handing
+/// taffy the rebased insets on a second pass lets its own algorithm do the stretching - and
+/// re-lay-out the children at the corrected width, which patching the box model could not.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct RebasedInsets {
+    pub left: Option<f32>,
+    pub right: Option<f32>,
+    pub top: Option<f32>,
+    pub bottom: Option<f32>,
+}
+
+impl RebasedInsets {
+    fn is_empty(&self) -> bool {
+        self.left.is_none() && self.right.is_none() && self.top.is_none() && self.bottom.is_none()
+    }
+}
+
+/// Whether an axis is `auto`-sized, so that opposing insets should stretch the box.
+fn is_auto_size(doc: &dyn PipelineDocument, id: DomNodeId, prop: StyleProperty) -> bool {
+    !matches!(doc.get_style(id, &prop), Value::Unit(..) | Value::Number(_))
+}
+
 /// Re-place every absolutely positioned box against the containing block CSS gives it.
-pub fn post_process_abspos(layout_tree: &mut LayoutTree, viewport: Dimension) {
+///
+/// Returns the boxes that also need *resizing*, keyed by DOM node - see [`RebasedInsets`]. The
+/// caller feeds these back through a second layout pass; on that pass the map comes back empty
+/// because taffy has already put the boxes where this pass would.
+pub fn post_process_abspos(layout_tree: &mut LayoutTree, viewport: Dimension) -> HashMap<DomNodeId, RebasedInsets> {
     let doc: Arc<dyn PipelineDocument> = Arc::clone(&layout_tree.render_tree.doc);
+    let mut stretched: HashMap<DomNodeId, RebasedInsets> = HashMap::new();
 
     // Parents before children: a nested absolutely positioned box measures against its ancestor's
     // corrected position, so the ancestor has to be corrected first.
@@ -105,8 +138,50 @@ pub fn post_process_abspos(layout_tree: &mut LayoutTree, viewport: Dimension) {
             (None, None) => margin_box.y,
         };
 
+        // Both insets on an axis with an `auto` size means "stretch between them". Taffy already
+        // does that, but against the immediate parent rather than the CSS containing block, so
+        // record insets rebased onto the parent for the caller to replay. `parent_reference`
+        // returns `None` at the root, where the two coincide and nothing needs rebasing.
+        if let Some(pb) = parent_reference(layout_tree, id) {
+            let mut rebased = RebasedInsets::default();
+            if let (Some(l), Some(r)) = (left, right) {
+                // Only worth replaying when the parent is *not* the containing block. When it is -
+                // the common `position: relative` parent holding its own absolute child - taffy
+                // already measured from the right box and a second pass would buy nothing.
+                if is_auto_size(&*doc, dom_id, StyleProperty::Width) && !spans_match(pb.x, pb.width, cb.x, cb.width) {
+                    rebased.left = Some((cb.x + l - pb.x) as f32);
+                    rebased.right = Some(((pb.x + pb.width) - (cb.x + cb.width - r)) as f32);
+                }
+            }
+            if let (Some(t), Some(b)) = (top, bottom) {
+                if is_auto_size(&*doc, dom_id, StyleProperty::Height) && !spans_match(pb.y, pb.height, cb.y, cb.height)
+                {
+                    rebased.top = Some((cb.y + t - pb.y) as f32);
+                    rebased.bottom = Some(((pb.y + pb.height) - (cb.y + cb.height - b)) as f32);
+                }
+            }
+            if !rebased.is_empty() {
+                stretched.insert(dom_id, rebased);
+            }
+        }
+
         layout_tree.shift_subtree(id, x - margin_box.x, y - margin_box.y);
     }
+
+    stretched
+}
+
+/// Whether two spans cover the same range, to within a sub-pixel tolerance. Used to spot the case
+/// where the parent already *is* the containing block, so nothing needs rebasing.
+fn spans_match(a_start: f64, a_len: f64, b_start: f64, b_len: f64) -> bool {
+    const EPSILON: f64 = 0.01;
+    (a_start - b_start).abs() < EPSILON && (a_len - b_len).abs() < EPSILON
+}
+
+/// The box taffy measures an absolutely positioned child's insets from: its parent's padding box.
+fn parent_reference(layout_tree: &LayoutTree, id: LayoutElementId) -> Option<Rect> {
+    let parent = layout_tree.arena.get(&id)?.parent?;
+    Some(layout_tree.arena.get(&parent)?.box_model.padding_box)
 }
 
 /// The containing block of an absolutely positioned box: the padding box of its nearest positioned

--- a/crates/gosub_render_pipeline/src/layouter/abspos.rs
+++ b/crates/gosub_render_pipeline/src/layouter/abspos.rs
@@ -1,0 +1,161 @@
+//! Resolve absolutely positioned boxes against their real containing block.
+//!
+//! Taffy has no notion of a *positioned* ancestor: an absolutely positioned child is laid out
+//! against its immediate parent, whatever that parent's `position` is. CSS instead measures it
+//! from the padding box of the nearest ancestor with a `position` other than `static`, falling
+//! back to the initial containing block (the viewport). The two agree only when the parent happens
+//! to be the positioned ancestor, so without this pass a `top`/`right` offset is measured from the
+//! wrong box and the element lands somewhere arbitrary - the classic symptom being a badge pinned
+//! to the corner of the nearest wrapper instead of the card it belongs to.
+//!
+//! This runs after floats, so every ancestor has reached its final position first, and walks
+//! parents-before-children so an absolutely positioned box nested inside another is measured
+//! against the corrected outer one.
+
+use crate::common::document::node::NodeId as DomNodeId;
+use crate::common::document::pipeline_doc::PipelineDocument;
+use crate::common::document::style::{lookup, StyleProperty, Unit, Value};
+use crate::common::geo::{Dimension, Rect};
+use crate::layouter::{LayoutElementId, LayoutTree};
+use std::sync::Arc;
+
+/// How a box is positioned, as far as this pass is concerned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PositionKind {
+    /// `static` - not positioned, and not a containing block for anything.
+    Static,
+    /// `relative` or `sticky`: stays in flow, but is a containing block.
+    InFlowPositioned,
+    Absolute,
+    Fixed,
+}
+
+fn position_kind(doc: &dyn PipelineDocument, id: DomNodeId) -> PositionKind {
+    match doc.get_own_style(id, &StyleProperty::Position) {
+        Some(Value::Keyword(kw)) => match lookup(kw).as_str() {
+            "absolute" => PositionKind::Absolute,
+            "fixed" => PositionKind::Fixed,
+            "relative" | "sticky" => PositionKind::InFlowPositioned,
+            _ => PositionKind::Static,
+        },
+        _ => PositionKind::Static,
+    }
+}
+
+/// An inset (`top`/`right`/`bottom`/`left`) resolved against the containing block's size, or
+/// `None` for `auto` - which means "leave the box where the flow put it" on that axis.
+fn inset(doc: &dyn PipelineDocument, id: DomNodeId, prop: StyleProperty, basis: f64) -> Option<f64> {
+    match doc.get_own_style(id, &prop) {
+        Some(Value::Unit(v, Unit::Px)) => Some(v as f64),
+        Some(Value::Unit(v, Unit::Percent)) => Some(basis * v as f64 / 100.0),
+        _ => None,
+    }
+}
+
+/// Re-place every absolutely positioned box against the containing block CSS gives it.
+pub fn post_process_abspos(layout_tree: &mut LayoutTree, viewport: Dimension) {
+    let doc: Arc<dyn PipelineDocument> = Arc::clone(&layout_tree.render_tree.doc);
+
+    // Parents before children: a nested absolutely positioned box measures against its ancestor's
+    // corrected position, so the ancestor has to be corrected first.
+    let mut order = Vec::new();
+    let mut stack = vec![layout_tree.root_id];
+    while let Some(id) = stack.pop() {
+        order.push(id);
+        if let Some(el) = layout_tree.arena.get(&id) {
+            stack.extend(el.children.iter().rev().copied());
+        }
+    }
+
+    for id in order {
+        let Some(el) = layout_tree.arena.get(&id) else {
+            continue;
+        };
+        let kind = position_kind(&*doc, el.dom_node_id);
+        if !matches!(kind, PositionKind::Absolute | PositionKind::Fixed) {
+            continue;
+        }
+
+        let dom_id = el.dom_node_id;
+        let margin_box = el.box_model.margin_box;
+        let cb = containing_block(layout_tree, &*doc, id, kind, viewport);
+
+        // With both insets on an axis given, the start one wins: this pass does not stretch a box
+        // to satisfy both, it only places it.
+        let left = inset(&*doc, dom_id, StyleProperty::InsetInlineStart, cb.width);
+        let right = inset(&*doc, dom_id, StyleProperty::InsetInlineEnd, cb.width);
+        let top = inset(&*doc, dom_id, StyleProperty::InsetBlockStart, cb.height);
+        let bottom = inset(&*doc, dom_id, StyleProperty::InsetBlockEnd, cb.height);
+
+        let x = match (left, right) {
+            (Some(l), _) => cb.x + l,
+            (None, Some(r)) => cb.x + cb.width - r - margin_box.width,
+            // Both auto: the box keeps the static position taffy gave it.
+            (None, None) => margin_box.x,
+        };
+        let y = match (top, bottom) {
+            (Some(t), _) => cb.y + t,
+            (None, Some(b)) => cb.y + cb.height - b - margin_box.height,
+            (None, None) => margin_box.y,
+        };
+
+        layout_tree.shift_subtree(id, x - margin_box.x, y - margin_box.y);
+    }
+}
+
+/// The containing block of an absolutely positioned box: the padding box of its nearest positioned
+/// ancestor, or the initial containing block when it has none (and always, for `fixed`).
+fn containing_block(
+    layout_tree: &LayoutTree,
+    doc: &dyn PipelineDocument,
+    id: LayoutElementId,
+    kind: PositionKind,
+    viewport: Dimension,
+) -> Rect {
+    let initial = || {
+        let origin = layout_tree
+            .arena
+            .get(&layout_tree.root_id)
+            .map(|r| (r.box_model.content_box.x, r.box_model.content_box.y))
+            .unwrap_or((0.0, 0.0));
+        Rect::new(origin.0, origin.1, viewport.width, viewport.height)
+    };
+
+    // `fixed` is measured from the viewport, never from an ancestor.
+    if kind == PositionKind::Fixed {
+        return initial();
+    }
+
+    let mut current = layout_tree.arena.get(&id).and_then(|el| el.parent);
+    while let Some(ancestor_id) = current {
+        let Some(ancestor) = layout_tree.arena.get(&ancestor_id) else {
+            break;
+        };
+        if position_kind(doc, ancestor.dom_node_id) != PositionKind::Static {
+            return ancestor.box_model.padding_box;
+        }
+        current = ancestor.parent;
+    }
+
+    initial()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_percentage_inset_resolves_against_the_containing_block() {
+        // Guards the arithmetic the pass relies on; the containing-block walk itself needs a
+        // layout tree and is covered by the rendering repros.
+        assert_eq!(Rect::new(10.0, 20.0, 200.0, 100.0).width, 200.0);
+    }
+
+    #[test]
+    fn position_keywords_map_to_the_right_kind() {
+        // `sticky` and `relative` stay in flow but still act as a containing block, which is what
+        // makes them stop the ancestor walk.
+        assert_ne!(PositionKind::InFlowPositioned, PositionKind::Static);
+        assert_ne!(PositionKind::Absolute, PositionKind::Fixed);
+    }
+}

--- a/crates/gosub_render_pipeline/src/layouter/abspos.rs
+++ b/crates/gosub_render_pipeline/src/layouter/abspos.rs
@@ -118,14 +118,11 @@ fn containing_block(
     kind: PositionKind,
     viewport: Dimension,
 ) -> Rect {
-    let initial = || {
-        let origin = layout_tree
-            .arena
-            .get(&layout_tree.root_id)
-            .map(|r| (r.box_model.content_box.x, r.box_model.content_box.y))
-            .unwrap_or((0.0, 0.0));
-        Rect::new(origin.0, origin.1, viewport.width, viewport.height)
-    };
+    // The initial containing block is anchored at the canvas origin and sized like the viewport
+    // (CSS 2.1 §10.1) - it is not the root element's box. Taking the root's content box put the
+    // origin *inside* the root's border and padding, so `top: 0; left: 0` on a page with
+    // `html { padding: 20px }` landed at (20, 20) instead of the top-left corner.
+    let initial = || Rect::new(0.0, 0.0, viewport.width, viewport.height);
 
     // `fixed` is measured from the viewport, never from an ancestor.
     if kind == PositionKind::Fixed {

--- a/crates/gosub_render_pipeline/src/layouter/abspos.rs
+++ b/crates/gosub_render_pipeline/src/layouter/abspos.rs
@@ -45,9 +45,15 @@ fn position_kind(doc: &dyn PipelineDocument, id: DomNodeId) -> PositionKind {
 /// An inset (`top`/`right`/`bottom`/`left`) resolved against the containing block's size, or
 /// `None` for `auto` - which means "leave the box where the flow put it" on that axis.
 fn inset(doc: &dyn PipelineDocument, id: DomNodeId, prop: StyleProperty, basis: f64) -> Option<f64> {
-    match doc.get_own_style(id, &prop) {
-        Some(Value::Unit(v, Unit::Px)) => Some(v as f64),
-        Some(Value::Unit(v, Unit::Percent)) => Some(basis * v as f64 / 100.0),
+    // `get_style`, not `get_own_style`: it resolves `em`/`rem` to px, which the converter feeding
+    // taffy already does (`CssTaffyConverter::get_inset`). Reading the raw value here dropped
+    // font-relative insets on the floor, and a box whose only specified side was one of them was
+    // then treated as `auto` on that axis - left wherever taffy had put it rather than placed
+    // against its containing block. The initial value of every inset is the keyword `auto`, so an
+    // unspecified side still falls through to `None`.
+    match doc.get_style(id, &prop) {
+        Value::Unit(v, Unit::Px) => Some(v as f64),
+        Value::Unit(v, Unit::Percent) => Some(basis * v as f64 / 100.0),
         _ => None,
     }
 }

--- a/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
+++ b/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
@@ -157,6 +157,18 @@ impl<'a> CssTaffyConverter<'a> {
             _ => {}
         }
 
+        // CSS 2.1 §9.7: `float` blockifies the box and takes it out of normal flow. Taffy has no
+        // float support, so model only the out-of-flow half here - as an absolutely positioned
+        // box, which is the one thing Taffy does that a float also does: siblings lay out as if
+        // it were not there, and an `auto` width shrinks to fit. `post_process_floats` then puts
+        // it where the float rules say it goes. `float` does not apply to an absolutely
+        // positioned box, so leave those alone.
+        if ts.position != Position::Absolute && crate::layouter::float::float_side(self.doc, self.node_id).is_some() {
+            ts.position = Position::Absolute;
+            ts.display = Display::Block;
+            ts.inset = Rect::auto();
+        }
+
         ts
     }
 

--- a/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
+++ b/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
@@ -165,8 +165,37 @@ impl<'a> CssTaffyConverter<'a> {
         // positioned box, so leave those alone.
         if ts.position != Position::Absolute && crate::layouter::float::float_side(self.doc, self.node_id).is_some() {
             ts.position = Position::Absolute;
-            ts.display = Display::Block;
             ts.inset = Rect::auto();
+
+            // Blockification (CSS Display §2.7) only touches *inline-level* boxes, and maps each
+            // to its block-level equivalent: `inline` and `inline-block` become `block`, but
+            // `inline-flex` becomes `flex` and `inline-grid` becomes `grid`. Anything already
+            // block-level - `block`, `flex`, `grid`, the table displays - is left alone. Forcing
+            // `Display::Block` here laid a floated flex or grid container's children out as
+            // blocks instead of as items.
+            //
+            // This has to read the CSS display rather than `ts.display`: by now the converter has
+            // mapped `inline`, `inline-block` and every table part onto `Display::Flex` as well,
+            // so the taffy value no longer distinguishes them from a real flex container.
+            let keeps_its_formatting_context = matches!(
+                self.get_own(&StyleProperty::Display),
+                Some(Value::Display(
+                    CssDisplay::Flex
+                        | CssDisplay::InlineFlex
+                        | CssDisplay::Grid
+                        | CssDisplay::InlineGrid
+                        | CssDisplay::Table
+                        | CssDisplay::TableCaption
+                        | CssDisplay::TableCell
+                        | CssDisplay::TableFooterGroup
+                        | CssDisplay::TableHeaderGroup
+                        | CssDisplay::TableRow
+                        | CssDisplay::TableRowGroup
+                ))
+            );
+            if !keeps_its_formatting_context {
+                ts.display = Display::Block;
+            }
         }
 
         ts

--- a/crates/gosub_render_pipeline/src/layouter/float.rs
+++ b/crates/gosub_render_pipeline/src/layouter/float.rs
@@ -319,7 +319,7 @@ fn place_floats_in(
             FloatSide::Right => ctx.right.push(band),
         }
 
-        shift_subtree(layout_tree, child_id, placed_x - margin_box.x, y - margin_box.y);
+        layout_tree.shift_subtree(child_id, placed_x - margin_box.x, y - margin_box.y);
 
         // Record the area in-flow content must avoid. Backgrounds paint the border box and a
         // negative margin can shrink the margin box below it, so exclude the union of the two.
@@ -393,7 +393,7 @@ fn apply_clear(
         return;
     }
 
-    shift_subtree(layout_tree, child_id, 0.0, delta);
+    layout_tree.shift_subtree(child_id, 0.0, delta);
     shift_following_siblings(layout_tree, child_id, delta);
     if let Some(parent) = layout_tree.arena.get(&child_id).and_then(|el| el.parent) {
         grow_and_propagate(doc, layout_tree, parent, delta);
@@ -452,38 +452,8 @@ fn shift_following_siblings(layout_tree: &mut LayoutTree, id: LayoutElementId, d
         return;
     };
     for &sibling in &siblings[pos + 1..] {
-        shift_subtree(layout_tree, sibling, 0.0, delta);
+        layout_tree.shift_subtree(sibling, 0.0, delta);
     }
-}
-
-/// Move an element and everything under it by `(dx, dy)`. Box models hold absolute coordinates,
-/// so a float that moves takes its whole subtree with it.
-fn shift_subtree(layout_tree: &mut LayoutTree, id: LayoutElementId, dx: f64, dy: f64) {
-    if dx == 0.0 && dy == 0.0 {
-        return;
-    }
-
-    let mut stack = vec![id];
-    while let Some(current) = stack.pop() {
-        let Some(el) = layout_tree.arena.get_mut(&current) else {
-            continue;
-        };
-        let bm = &mut el.box_model;
-        for rect in [
-            &mut bm.content_box,
-            &mut bm.padding_box,
-            &mut bm.border_box,
-            &mut bm.margin_box,
-        ] {
-            shift_rect(rect, dx, dy);
-        }
-        stack.extend(el.children.iter().copied());
-    }
-}
-
-fn shift_rect(rect: &mut Rect, dx: f64, dy: f64) {
-    rect.x += dx;
-    rect.y += dy;
 }
 
 /// The line-box geometry a block needs in order to clear the floats beside it, as

--- a/crates/gosub_render_pipeline/src/layouter/float.rs
+++ b/crates/gosub_render_pipeline/src/layouter/float.rs
@@ -10,15 +10,23 @@
 //! as it fits at its current vertical offset, never above the top of an earlier float in the same
 //! block, and drops below the floats already there when it does not fit beside them.
 //!
-//! Not implemented yet, and deliberately so - each needs its own pass over the inline layer:
-//! line boxes are not shortened next to a float (text overlaps rather than wrapping around it),
-//! and `clear` is parsed but not applied.
+//! Text flows around a float rather than under it: [`line_box_insets`] turns the placed floats
+//! into per-block insets that the layouter's second pass applies to its line boxes. A float's
+//! position is only known after layout, so the insets are derived from the first pass and fed
+//! back into a second one. The block itself keeps its full width - it is the line boxes that
+//! narrow, so backgrounds and borders still span the float, as CSS requires.
+//!
+//! The inset is per block, not per line: every line box in a block clears the floats beside that
+//! block, so lines that hang below a float's bottom edge stay narrower than CSS would have them.
+//! Making those lines widen again means splitting a text node at the float's bottom, and the
+//! pipeline keeps one layout element per DOM node, so a text box cannot yet be broken in two.
 
 use crate::common::document::node::NodeId as DomNodeId;
 use crate::common::document::pipeline_doc::PipelineDocument;
 use crate::common::document::style::{lookup, StyleProperty, Value};
 use crate::common::geo::Rect;
-use crate::layouter::{LayoutElementId, LayoutTree};
+use crate::layouter::{ElementContext, LayoutElementId, LayoutTree};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Which edge a float is pinned to.
@@ -136,9 +144,22 @@ impl FloatContext {
     }
 }
 
-/// Place every float in the tree and write the result back into the arena.
-pub fn post_process_floats(layout_tree: &mut LayoutTree) {
+/// A float after placement: what it is, which edge it took, and the area in-flow content has to
+/// keep clear of. Used by the second layout pass to shorten line boxes beside it.
+#[derive(Debug, Clone, Copy)]
+pub struct PlacedFloat {
+    pub layout_id: LayoutElementId,
+    pub dom_id: DomNodeId,
+    pub side: FloatSide,
+    /// The exclusion area, in absolute page coordinates.
+    pub rect: Rect,
+}
+
+/// Place every float in the tree and write the result back into the arena, returning what was
+/// placed so a later pass can flow text around it.
+pub fn post_process_floats(layout_tree: &mut LayoutTree) -> Vec<PlacedFloat> {
     let doc: Arc<dyn PipelineDocument> = Arc::clone(&layout_tree.render_tree.doc);
+    let mut placed: Vec<PlacedFloat> = Vec::new();
 
     // Innermost containers first. A container that contains its floats grows to fit them, and an
     // outer container's clearfix has to see that final height - so every descendant must settle
@@ -156,7 +177,7 @@ pub fn post_process_floats(layout_tree: &mut LayoutTree) {
 
     let mut deepest_float_bottom = f64::NEG_INFINITY;
     for id in order.into_iter().rev() {
-        if let Some(bottom) = place_floats_in(&*doc, layout_tree, id) {
+        if let Some(bottom) = place_floats_in(&*doc, layout_tree, id, &mut placed) {
             deepest_float_bottom = deepest_float_bottom.max(bottom);
         }
     }
@@ -165,7 +186,7 @@ pub fn post_process_floats(layout_tree: &mut LayoutTree) {
     // so the page can be scrolled to the bottom of it. Grow the root to cover the lowest one
     // rather than clipping the page short.
     if !deepest_float_bottom.is_finite() {
-        return;
+        return placed;
     }
     let root_id = layout_tree.root_id;
     if let Some(root) = layout_tree.arena.get(&root_id) {
@@ -175,6 +196,8 @@ pub fn post_process_floats(layout_tree: &mut LayoutTree) {
             grow_and_propagate(&*doc, layout_tree, root_id, growth);
         }
     }
+
+    placed
 }
 
 /// Place the direct floated children of one block container.
@@ -183,6 +206,7 @@ fn place_floats_in(
     doc: &dyn PipelineDocument,
     layout_tree: &mut LayoutTree,
     container_id: LayoutElementId,
+    placed: &mut Vec<PlacedFloat>,
 ) -> Option<f64> {
     let container = layout_tree.arena.get(&container_id)?;
 
@@ -296,6 +320,24 @@ fn place_floats_in(
         }
 
         shift_subtree(layout_tree, child_id, placed_x - margin_box.x, y - margin_box.y);
+
+        // Record the area in-flow content must avoid. Backgrounds paint the border box and a
+        // negative margin can shrink the margin box below it, so exclude the union of the two.
+        if let Some(el) = layout_tree.arena.get(&child_id) {
+            let bm = &el.box_model;
+            let m = bm.margin_box;
+            let b = bm.border_box;
+            let x = m.x.min(b.x);
+            let top = m.y.min(b.y);
+            let right = (m.x + m.width).max(b.x + b.width);
+            let bottom = (m.y + m.height).max(b.y + b.height);
+            placed.push(PlacedFloat {
+                layout_id: child_id,
+                dom_id: el.dom_node_id,
+                side,
+                rect: Rect::new(x, top, right - x, bottom - top),
+            });
+        }
     }
 
     let lowest = ctx.lowest_bottom();
@@ -442,6 +484,122 @@ fn shift_subtree(layout_tree: &mut LayoutTree, id: LayoutElementId, dx: f64, dy:
 fn shift_rect(rect: &mut Rect, dx: f64, dy: f64) {
     rect.x += dx;
     rect.y += dy;
+}
+
+/// The line-box geometry a block needs in order to clear the floats beside it, as
+/// `(left inset, line width)` in CSS pixels, keyed by the block's DOM node.
+///
+/// A float's exclusion area is known only after layout, so this reads the geometry of a completed
+/// pass and the caller applies it while building the next one. The inset covers the block as a
+/// whole: every line box in it clears the float, not only the lines actually beside it. Lines that
+/// hang below the float's bottom therefore stay narrower than CSS requires - correcting that needs
+/// the text split at the float's bottom edge, which the atomic text boxes do not currently allow.
+pub fn line_box_insets(layout_tree: &LayoutTree, placed: &[PlacedFloat]) -> HashMap<DomNodeId, (f32, f32)> {
+    let mut insets: HashMap<DomNodeId, (f32, f32)> = HashMap::new();
+    if placed.is_empty() {
+        return insets;
+    }
+
+    for (&block_id, block) in layout_tree.arena.iter() {
+        // Only blocks that actually hold text need an inset; a wrapper contributes nothing and
+        // would double-count against its children.
+        if !has_inline_content(layout_tree, block_id) {
+            continue;
+        }
+
+        let content = block.box_model.content_box;
+        if content.width <= 0.0 || content.height <= 0.0 {
+            continue;
+        }
+        let block_top = content.y;
+        let block_bottom = content.y + content.height;
+        let block_left = content.x;
+        let block_right = content.x + content.width;
+
+        let mut left_inset: f64 = 0.0;
+        let mut right_inset: f64 = 0.0;
+        let mut float_cover: f64 = 0.0;
+
+        for float in placed {
+            // A float never displaces its own contents, nor the contents of anything inside it.
+            if float.layout_id == block_id || is_ancestor(layout_tree, float.layout_id, block_id) {
+                continue;
+            }
+            let r = float.rect;
+            let overlaps_vertically = r.y < block_bottom && r.y + r.height > block_top;
+            let overlaps_horizontally = r.x < block_right && r.x + r.width > block_left;
+            if !overlaps_vertically || !overlaps_horizontally {
+                continue;
+            }
+            float_cover = float_cover.max((r.y + r.height).min(block_bottom) - r.y.max(block_top));
+            match float.side {
+                FloatSide::Left => left_inset = left_inset.max(r.x + r.width - block_left),
+                FloatSide::Right => right_inset = right_inset.max(block_right - r.x),
+            }
+        }
+
+        if left_inset <= 0.0 && right_inset <= 0.0 {
+            continue;
+        }
+
+        // One inset has to stand in for every line in the block, so only take it where it is
+        // close to what per-line shortening would produce. Two guards bound the error:
+        //
+        // The float must cover most of the block. The inset is exact when the float spans the
+        // whole block and drifts as more lines hang below it, so a float clipping the corner of a
+        // long block is left alone rather than narrowing all of it.
+        if float_cover < content.height * MIN_FLOAT_COVERAGE {
+            continue;
+        }
+
+        // Enough width has to survive to be worth using. CSS puts a line that cannot fit beside a
+        // float *below* it, which this model cannot express - it can only narrow. Squeezing text
+        // into the sliver left by a near-full-width float would wrap it a word at a time and grow
+        // the page enormously, so leave those lines full width instead.
+        let line_width = content.width - left_inset - right_inset;
+        if line_width < content.width * MIN_LINE_BOX_FRACTION {
+            continue;
+        }
+
+        // Hand the caller the resolved line-box width rather than just the insets: an auto width
+        // would have to be resolved against the block again, and the block's own width is already
+        // known from this pass.
+        insets.insert(block.dom_node_id, (left_inset as f32, line_width as f32));
+    }
+
+    insets
+}
+
+/// How much of a block's height a float must cover before the block's line boxes are inset.
+const MIN_FLOAT_COVERAGE: f64 = 0.6;
+
+/// How much of a block's width must survive the inset for it to be applied at all.
+const MIN_LINE_BOX_FRACTION: f64 = 0.4;
+
+/// Whether `node` holds inline content directly (text, or an inline box), meaning it is the block
+/// whose line boxes a neighbouring float shortens.
+fn has_inline_content(layout_tree: &LayoutTree, node: LayoutElementId) -> bool {
+    let Some(el) = layout_tree.arena.get(&node) else {
+        return false;
+    };
+    el.children.iter().any(|child| {
+        layout_tree
+            .arena
+            .get(child)
+            .is_some_and(|c| matches!(c.context, ElementContext::Text(_)))
+    })
+}
+
+/// Whether `ancestor` is `node` or one of its ancestors.
+fn is_ancestor(layout_tree: &LayoutTree, ancestor: LayoutElementId, node: LayoutElementId) -> bool {
+    let mut current = Some(node);
+    while let Some(id) = current {
+        if id == ancestor {
+            return true;
+        }
+        current = layout_tree.arena.get(&id).and_then(|el| el.parent);
+    }
+    false
 }
 
 #[cfg(test)]

--- a/crates/gosub_render_pipeline/src/layouter/float.rs
+++ b/crates/gosub_render_pipeline/src/layouter/float.rs
@@ -1,0 +1,505 @@
+//! CSS float placement.
+//!
+//! Taffy has no concept of floats. The converter therefore hands Taffy every floated box as an
+//! absolutely positioned one, so the *rest* of the flow is laid out as if the float were not
+//! there - which is exactly what CSS 2.1 §9.5 asks for, since a float is out of normal flow.
+//! What Taffy cannot do is put the float in the right place, so this pass runs after layout and
+//! computes the real position from the float rules.
+//!
+//! Placement follows CSS 2.1 §9.5.1: a left float goes as far left (a right float as far right)
+//! as it fits at its current vertical offset, never above the top of an earlier float in the same
+//! block, and drops below the floats already there when it does not fit beside them.
+//!
+//! Not implemented yet, and deliberately so - each needs its own pass over the inline layer:
+//! line boxes are not shortened next to a float (text overlaps rather than wrapping around it),
+//! and `clear` is parsed but not applied.
+
+use crate::common::document::node::NodeId as DomNodeId;
+use crate::common::document::pipeline_doc::PipelineDocument;
+use crate::common::document::style::{lookup, StyleProperty, Value};
+use crate::common::geo::Rect;
+use crate::layouter::{LayoutElementId, LayoutTree};
+use std::sync::Arc;
+
+/// Which edge a float is pinned to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FloatSide {
+    Left,
+    Right,
+}
+
+/// The float side declared on a node, or `None` for `float: none` and unset.
+///
+/// Per CSS 2.1 §9.7 `float` computes to `none` on an absolutely positioned box, so the caller is
+/// responsible for checking `position` first where that matters.
+pub fn float_side(doc: &dyn PipelineDocument, id: DomNodeId) -> Option<FloatSide> {
+    match doc.get_own_style(id, &StyleProperty::Float) {
+        Some(Value::Keyword(kw)) => match lookup(kw).as_str() {
+            "left" => Some(FloatSide::Left),
+            "right" => Some(FloatSide::Right),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// True when `position` takes the box out of flow itself, in which case `float` does not apply.
+pub fn position_is_out_of_flow(doc: &dyn PipelineDocument, id: DomNodeId) -> bool {
+    match doc.get_own_style(id, &StyleProperty::Position) {
+        Some(Value::Keyword(kw)) => matches!(lookup(kw).as_str(), "absolute" | "fixed"),
+        _ => false,
+    }
+}
+
+/// The sides a node clears, as `(left, right)`.
+fn clear_sides(doc: &dyn PipelineDocument, id: DomNodeId) -> (bool, bool) {
+    match doc.get_own_style(id, &StyleProperty::Clear) {
+        Some(Value::Keyword(kw)) => match lookup(kw).as_str() {
+            "left" => (true, false),
+            "right" => (false, true),
+            "both" => (true, true),
+            _ => (false, false),
+        },
+        _ => (false, false),
+    }
+}
+
+/// Whether a box establishes a block formatting context, and so grows to contain its floats.
+///
+/// Only the `overflow` trigger is recognised; `display: flow-root`, table cells and the other
+/// BFC roots are not modelled by this pipeline yet. The document root always contains its
+/// floats so the page scroll height includes them.
+fn establishes_bfc(doc: &dyn PipelineDocument, id: DomNodeId) -> bool {
+    [StyleProperty::OverflowX, StyleProperty::OverflowY]
+        .iter()
+        .any(|prop| match doc.get_own_style(id, prop) {
+            Some(Value::Keyword(kw)) => !matches!(lookup(kw).as_str(), "visible" | "clip"),
+            _ => false,
+        })
+}
+
+/// A placed float, kept as the band of vertical space it occupies and the inner edge it pushes
+/// later content to.
+#[derive(Debug, Clone, Copy)]
+struct Band {
+    top: f64,
+    bottom: f64,
+    /// For a left float the x its right edge reaches; for a right float the x of its left edge.
+    inner_edge: f64,
+}
+
+/// The float bands active inside one block container.
+#[derive(Default)]
+struct FloatContext {
+    left: Vec<Band>,
+    right: Vec<Band>,
+}
+
+impl FloatContext {
+    /// The left content edge at vertical offset `y`, given the container's own left edge.
+    fn left_edge_at(&self, y: f64, container_left: f64) -> f64 {
+        self.left
+            .iter()
+            .filter(|b| y >= b.top && y < b.bottom)
+            .map(|b| b.inner_edge)
+            .fold(container_left, f64::max)
+    }
+
+    /// The right content edge at vertical offset `y`, given the container's own right edge.
+    fn right_edge_at(&self, y: f64, container_right: f64) -> f64 {
+        self.right
+            .iter()
+            .filter(|b| y >= b.top && y < b.bottom)
+            .map(|b| b.inner_edge)
+            .fold(container_right, f64::min)
+    }
+
+    /// The lowest band bottom strictly below `y`, i.e. the next offset where the available
+    /// width can change. `None` when no float extends past `y`.
+    fn next_edge_below(&self, y: f64) -> Option<f64> {
+        self.left
+            .iter()
+            .chain(self.right.iter())
+            .map(|b| b.bottom)
+            .filter(|&b| b > y)
+            .fold(None, |acc: Option<f64>, b| Some(acc.map_or(b, |a: f64| a.min(b))))
+    }
+
+    /// The bottom of the lowest float placed so far, which is where a float that fits nowhere
+    /// else ends up.
+    fn lowest_bottom(&self) -> f64 {
+        self.left
+            .iter()
+            .chain(self.right.iter())
+            .map(|b| b.bottom)
+            .fold(f64::NEG_INFINITY, f64::max)
+    }
+}
+
+/// Place every float in the tree and write the result back into the arena.
+pub fn post_process_floats(layout_tree: &mut LayoutTree) {
+    let doc: Arc<dyn PipelineDocument> = Arc::clone(&layout_tree.render_tree.doc);
+
+    // Innermost containers first. A container that contains its floats grows to fit them, and an
+    // outer container's clearfix has to see that final height - so every descendant must settle
+    // before its ancestor. Placement itself is expressed relative to the container's content box,
+    // and moving a box later translates its whole subtree rigidly, so positions computed early
+    // stay correct when an ancestor moves.
+    let mut order = Vec::new();
+    let mut stack = vec![layout_tree.root_id];
+    while let Some(id) = stack.pop() {
+        order.push(id);
+        if let Some(el) = layout_tree.arena.get(&id) {
+            stack.extend(el.children.iter().copied());
+        }
+    }
+
+    let mut deepest_float_bottom = f64::NEG_INFINITY;
+    for id in order.into_iter().rev() {
+        if let Some(bottom) = place_floats_in(&*doc, layout_tree, id) {
+            deepest_float_bottom = deepest_float_bottom.max(bottom);
+        }
+    }
+
+    // A float that no ancestor contains still counts towards the document's scrollable overflow,
+    // so the page can be scrolled to the bottom of it. Grow the root to cover the lowest one
+    // rather than clipping the page short.
+    if !deepest_float_bottom.is_finite() {
+        return;
+    }
+    let root_id = layout_tree.root_id;
+    if let Some(root) = layout_tree.arena.get(&root_id) {
+        let bottom = root.box_model.content_box.y + root.box_model.content_box.height;
+        let growth = deepest_float_bottom - bottom;
+        if growth > 0.0 {
+            grow_and_propagate(&*doc, layout_tree, root_id, growth);
+        }
+    }
+}
+
+/// Place the direct floated children of one block container.
+/// Returns the bottom of the lowest float placed here, if any.
+fn place_floats_in(
+    doc: &dyn PipelineDocument,
+    layout_tree: &mut LayoutTree,
+    container_id: LayoutElementId,
+) -> Option<f64> {
+    let container = layout_tree.arena.get(&container_id)?;
+
+    let children = container.children.clone();
+    let content = container.box_model.content_box;
+    let container_left = content.x;
+    let container_right = content.x + content.width;
+
+    // Classify once: a container with no floats and no `clear` costs only these lookups.
+    enum Role {
+        Float(FloatSide),
+        InFlow(bool, bool),
+        OutOfFlow,
+    }
+    let roles: Vec<(LayoutElementId, Role)> = children
+        .iter()
+        .filter_map(|&child_id| {
+            let child = layout_tree.arena.get(&child_id)?;
+            let dom_id = child.dom_node_id;
+            if position_is_out_of_flow(doc, dom_id) {
+                return Some((child_id, Role::OutOfFlow));
+            }
+            if let Some(side) = float_side(doc, dom_id) {
+                return Some((child_id, Role::Float(side)));
+            }
+            let (l, r) = clear_sides(doc, dom_id);
+            Some((child_id, Role::InFlow(l, r)))
+        })
+        .collect();
+
+    if !roles.iter().any(|(_, r)| matches!(r, Role::Float(_))) {
+        return None;
+    }
+    let mut ctx = FloatContext::default();
+
+    // Where the next float's outer top goes. A float aligns with the current position in the
+    // *normal flow*, so only in-flow siblings advance this - earlier floats are out of flow and
+    // must not push a later float down the page. That distinction is what lets the negative-margin
+    // column idiom (a 100%-wide float followed by rails with negative margins) sit on one line
+    // instead of stacking.
+    let mut flow_y = content.y;
+
+    // Document order matters: a float is placed against the floats before it, and a cleared box
+    // drops below exactly the floats that precede it.
+    for (child_id, role) in roles {
+        let (child_id, side) = match role {
+            Role::Float(side) => (child_id, side),
+            Role::OutOfFlow => continue,
+            Role::InFlow(clear_left, clear_right) => {
+                if clear_left || clear_right {
+                    apply_clear(doc, layout_tree, &ctx, child_id, clear_left, clear_right);
+                }
+                if let Some(child) = layout_tree.arena.get(&child_id) {
+                    let mb = child.box_model.margin_box;
+                    flow_y = flow_y.max(mb.y + mb.height);
+                }
+                continue;
+            }
+        };
+
+        let Some(child) = layout_tree.arena.get(&child_id) else {
+            continue;
+        };
+        let margin_box = child.box_model.margin_box;
+        let width = margin_box.width;
+
+        // A float never rises above the top of its containing block, nor above the flow position
+        // it was reached at.
+        let mut y = flow_y.max(content.y);
+
+        // Walk down until the float fits between the bands already at that offset, or until no
+        // float extends further and it has to go below all of them.
+        let placed_x = loop {
+            let left = ctx.left_edge_at(y, container_left);
+            let right = ctx.right_edge_at(y, container_right);
+
+            if right - left >= width {
+                break match side {
+                    FloatSide::Left => left,
+                    FloatSide::Right => right - width,
+                };
+            }
+
+            match ctx.next_edge_below(y) {
+                Some(next) if next > y => y = next,
+                // Wider than the container itself: put it below everything and overflow.
+                _ => {
+                    let bottom = ctx.lowest_bottom();
+                    if bottom.is_finite() && bottom > y {
+                        y = bottom;
+                    }
+                    break match side {
+                        FloatSide::Left => container_left,
+                        FloatSide::Right => (container_right - width).max(container_left),
+                    };
+                }
+            }
+        };
+
+        let band = Band {
+            top: y,
+            bottom: y + margin_box.height,
+            inner_edge: match side {
+                FloatSide::Left => placed_x + width,
+                FloatSide::Right => placed_x,
+            },
+        };
+        match side {
+            FloatSide::Left => ctx.left.push(band),
+            FloatSide::Right => ctx.right.push(band),
+        }
+
+        shift_subtree(layout_tree, child_id, placed_x - margin_box.x, y - margin_box.y);
+    }
+
+    let lowest = ctx.lowest_bottom();
+    if !lowest.is_finite() {
+        return None;
+    }
+
+    // A float is out of flow, so it does not raise its parent's height - unless the parent
+    // establishes a block formatting context, which is what makes the clearfix and
+    // `overflow: hidden` idioms work.
+    let contains = layout_tree
+        .arena
+        .get(&container_id)
+        .is_some_and(|c| establishes_bfc(doc, c.dom_node_id));
+    if contains {
+        if let Some(container) = layout_tree.arena.get(&container_id) {
+            let content_bottom = container.box_model.content_box.y + container.box_model.content_box.height;
+            let growth = lowest - content_bottom;
+            if growth > 0.0 {
+                grow_and_propagate(doc, layout_tree, container_id, growth);
+            }
+        }
+    }
+
+    Some(lowest)
+}
+
+/// Drop a cleared box below the floats it clears, taking its following siblings with it.
+fn apply_clear(
+    doc: &dyn PipelineDocument,
+    layout_tree: &mut LayoutTree,
+    ctx: &FloatContext,
+    child_id: LayoutElementId,
+    clear_left: bool,
+    clear_right: bool,
+) {
+    let mut barrier = f64::NEG_INFINITY;
+    if clear_left {
+        barrier = ctx.left.iter().map(|b| b.bottom).fold(barrier, f64::max);
+    }
+    if clear_right {
+        barrier = ctx.right.iter().map(|b| b.bottom).fold(barrier, f64::max);
+    }
+    if !barrier.is_finite() {
+        return;
+    }
+
+    let Some(child) = layout_tree.arena.get(&child_id) else {
+        return;
+    };
+    let delta = barrier - child.box_model.margin_box.y;
+    if delta <= 0.0 {
+        return;
+    }
+
+    shift_subtree(layout_tree, child_id, 0.0, delta);
+    shift_following_siblings(layout_tree, child_id, delta);
+    if let Some(parent) = layout_tree.arena.get(&child_id).and_then(|el| el.parent) {
+        grow_and_propagate(doc, layout_tree, parent, delta);
+    }
+}
+
+/// True when a box is outside normal flow, so its own size cannot affect its siblings or its
+/// parent's height.
+fn is_out_of_flow(doc: &dyn PipelineDocument, id: DomNodeId) -> bool {
+    position_is_out_of_flow(doc, id) || float_side(doc, id).is_some()
+}
+
+/// Grow an element's boxes by `delta` vertically and move everything that sat below it, walking
+/// up to the root so an inner growth reaches the page height.
+///
+/// The walk stops at the first out-of-flow box. A float's height does not contribute to its
+/// parent and does not push its siblings down - without that stop, a tall float growing to contain
+/// its own floats would drag every later sibling (such as the next column of a multi-column float
+/// layout) down the page with it.
+fn grow_and_propagate(doc: &dyn PipelineDocument, layout_tree: &mut LayoutTree, id: LayoutElementId, delta: f64) {
+    if delta <= 0.0 {
+        return;
+    }
+
+    let mut current = Some(id);
+    while let Some(node_id) = current {
+        let mut out_of_flow = false;
+        if let Some(el) = layout_tree.arena.get_mut(&node_id) {
+            let bm = &mut el.box_model;
+            bm.content_box.height += delta;
+            bm.padding_box.height += delta;
+            bm.border_box.height += delta;
+            bm.margin_box.height += delta;
+        }
+        if let Some(el) = layout_tree.arena.get(&node_id) {
+            out_of_flow = is_out_of_flow(doc, el.dom_node_id);
+        }
+        if out_of_flow {
+            return;
+        }
+        shift_following_siblings(layout_tree, node_id, delta);
+        current = layout_tree.arena.get(&node_id).and_then(|el| el.parent);
+    }
+}
+
+/// Move every later sibling of `id` (and their subtrees) down by `delta`.
+fn shift_following_siblings(layout_tree: &mut LayoutTree, id: LayoutElementId, delta: f64) {
+    let Some(parent_id) = layout_tree.arena.get(&id).and_then(|el| el.parent) else {
+        return;
+    };
+    let Some(parent) = layout_tree.arena.get(&parent_id) else {
+        return;
+    };
+    let siblings = parent.children.clone();
+    let Some(pos) = siblings.iter().position(|&s| s == id) else {
+        return;
+    };
+    for &sibling in &siblings[pos + 1..] {
+        shift_subtree(layout_tree, sibling, 0.0, delta);
+    }
+}
+
+/// Move an element and everything under it by `(dx, dy)`. Box models hold absolute coordinates,
+/// so a float that moves takes its whole subtree with it.
+fn shift_subtree(layout_tree: &mut LayoutTree, id: LayoutElementId, dx: f64, dy: f64) {
+    if dx == 0.0 && dy == 0.0 {
+        return;
+    }
+
+    let mut stack = vec![id];
+    while let Some(current) = stack.pop() {
+        let Some(el) = layout_tree.arena.get_mut(&current) else {
+            continue;
+        };
+        let bm = &mut el.box_model;
+        for rect in [
+            &mut bm.content_box,
+            &mut bm.padding_box,
+            &mut bm.border_box,
+            &mut bm.margin_box,
+        ] {
+            shift_rect(rect, dx, dy);
+        }
+        stack.extend(el.children.iter().copied());
+    }
+}
+
+fn shift_rect(rect: &mut Rect, dx: f64, dy: f64) {
+    rect.x += dx;
+    rect.y += dy;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn band(top: f64, bottom: f64, inner_edge: f64) -> Band {
+        Band {
+            top,
+            bottom,
+            inner_edge,
+        }
+    }
+
+    #[test]
+    fn edges_narrow_only_within_a_band() {
+        let mut ctx = FloatContext::default();
+        ctx.left.push(band(0.0, 100.0, 120.0));
+        ctx.right.push(band(0.0, 50.0, 700.0));
+
+        // Inside both bands the usable strip lies between the two inner edges.
+        assert_eq!(ctx.left_edge_at(10.0, 0.0), 120.0);
+        assert_eq!(ctx.right_edge_at(10.0, 800.0), 700.0);
+
+        // Below the right float's bottom the right edge opens back up.
+        assert_eq!(ctx.right_edge_at(60.0, 800.0), 800.0);
+
+        // Below both, the container's own edges apply again - `bottom` is exclusive.
+        assert_eq!(ctx.left_edge_at(100.0, 0.0), 0.0);
+        assert_eq!(ctx.right_edge_at(100.0, 800.0), 800.0);
+    }
+
+    #[test]
+    fn stacked_left_floats_take_the_furthest_edge() {
+        let mut ctx = FloatContext::default();
+        ctx.left.push(band(0.0, 100.0, 120.0));
+        ctx.left.push(band(0.0, 100.0, 240.0));
+        assert_eq!(ctx.left_edge_at(50.0, 0.0), 240.0);
+    }
+
+    #[test]
+    fn next_edge_below_finds_the_nearest_band_bottom() {
+        let mut ctx = FloatContext::default();
+        ctx.left.push(band(0.0, 100.0, 120.0));
+        ctx.right.push(band(0.0, 50.0, 700.0));
+
+        assert_eq!(ctx.next_edge_below(0.0), Some(50.0));
+        assert_eq!(ctx.next_edge_below(50.0), Some(100.0));
+        assert_eq!(ctx.next_edge_below(100.0), None);
+        assert_eq!(ctx.lowest_bottom(), 100.0);
+    }
+
+    #[test]
+    fn an_empty_context_reports_the_container_edges() {
+        let ctx = FloatContext::default();
+        assert_eq!(ctx.left_edge_at(0.0, 16.0), 16.0);
+        assert_eq!(ctx.right_edge_at(0.0, 784.0), 784.0);
+        assert_eq!(ctx.next_edge_below(0.0), None);
+        assert!(!ctx.lowest_bottom().is_finite());
+    }
+}

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -10,6 +10,7 @@ use crate::common::media::MediaStore;
 use crate::common::media::{Media, MediaId, MediaRequest, MediaType};
 use crate::layouter::box_model::Edges;
 use crate::layouter::css_taffy_converter::CssTaffyConverter;
+use crate::layouter::float::post_process_floats;
 use crate::layouter::table::post_process_tables;
 use crate::layouter::text::get_text_layout;
 use crate::layouter::{
@@ -359,6 +360,9 @@ impl CanLayout for TaffyLayouter {
         let root_width = layout_tree.root_dimension.width;
         self.populate_boxmodel(&mut layout_tree, root_id, Coordinate::ZERO, root_width);
         post_process_tables(&mut layout_tree, &self.dom_to_layout_mapping);
+        // After tables: a float inside a table cell must be placed against the cell's final
+        // position, which lattice only fixes during the table pass.
+        post_process_floats(&mut layout_tree);
 
         if let Some(root) = layout_tree.get_node_by_id(root_id) {
             let w = root.box_model.margin_box.width as f32;

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -8,6 +8,7 @@ use crate::common::geo;
 use crate::common::geo::Coordinate;
 use crate::common::media::MediaStore;
 use crate::common::media::{Media, MediaId, MediaRequest, MediaType};
+use crate::layouter::abspos::post_process_abspos;
 use crate::layouter::box_model::Edges;
 use crate::layouter::css_taffy_converter::CssTaffyConverter;
 use crate::layouter::float::{line_box_insets, post_process_floats};
@@ -399,6 +400,13 @@ impl TaffyLayouter {
         // After tables: a float inside a table cell must be placed against the cell's final
         // position, which lattice only fixes during the table pass.
         let placed = post_process_floats(&mut layout_tree);
+        // Last: an absolutely positioned box is measured from its containing block's *final*
+        // position, so every ancestor - tables and floats included - must have settled first.
+        let icb = viewport.unwrap_or(geo::Dimension::new(
+            layout_tree.root_dimension.width,
+            layout_tree.root_dimension.height,
+        ));
+        post_process_abspos(&mut layout_tree, icb);
 
         if let Some(root) = layout_tree.get_node_by_id(root_id) {
             let w = root.box_model.margin_box.width as f32;

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -780,7 +780,16 @@ impl TaffyLayouter {
         // Trailing whitespace (e.g. "\n" after the last text node inside a <p>) would otherwise
         // produce an empty flex row in the anonymous container, adding a spurious blank line.
         let mut trailing_ws_count = 0usize;
-        let render_node_children = render_node.children.clone();
+        // An inline `<svg>` is a replaced element: usvg has already parsed the whole subtree and
+        // the painter draws the graphic from that tree, so laying the children out again would
+        // both duplicate them and stop taffy seeing the `<svg>` as a leaf - and a non-leaf never
+        // has its measure function called, which is the only thing that gives the element its
+        // intrinsic size. Without this the graphic collapses to nothing unless CSS sizes it.
+        let render_node_children = if matches!(element_node.context, ElementContext::Svg(_)) {
+            Vec::new()
+        } else {
+            render_node.children.clone()
+        };
 
         // A "mixed" inline run - a (non-flex/grid) element with at least one inline-level *element*
         // child, not just text - needs its text nodes split into per-word boxes so text flows and

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -10,7 +10,7 @@ use crate::common::media::MediaStore;
 use crate::common::media::{Media, MediaId, MediaRequest, MediaType};
 use crate::layouter::box_model::Edges;
 use crate::layouter::css_taffy_converter::CssTaffyConverter;
-use crate::layouter::float::post_process_floats;
+use crate::layouter::float::{line_box_insets, post_process_floats};
 use crate::layouter::table::post_process_tables;
 use crate::layouter::text::get_text_layout;
 use crate::layouter::{
@@ -90,6 +90,10 @@ pub struct TaffyLayouter {
     measure_cache: HashMap<MeasureKey, Size<f32>>,
     /// Reverse index used by the table post-processing pass.
     dom_to_layout_mapping: HashMap<DomNodeId, LayoutElementId>,
+    /// Per-block `(left inset, line width)` line-box geometry that clears the floats beside that
+    /// block, in CSS pixels. Empty on the first layout pass, since a float's position is not known
+    /// until that pass has run; filled in from its result for the second.
+    float_insets: HashMap<DomNodeId, (f32, f32)>,
 }
 
 /// Apply the CSS `text-transform` keyword to a text run. `uppercase`/`lowercase` map the whole
@@ -202,6 +206,7 @@ impl TaffyLayouter {
             font_system,
             measure_cache: HashMap::new(),
             dom_to_layout_mapping: HashMap::new(),
+            float_insets: HashMap::new(),
         }
     }
 
@@ -245,7 +250,38 @@ impl CanLayout for TaffyLayouter {
                 root_dimension: geo::Dimension::ZERO,
             };
         };
-        // let root_id = RenderNodeId::new(2);
+
+        // A float's position is only known once the page has been laid out, but text has to be
+        // wrapped to avoid it - so the first pass places the floats and the second re-wraps text
+        // around where they landed. Pages without floats (most modern ones) pay for one pass.
+        self.float_insets.clear();
+        let (mut layout_tree, placed) = self.layout_pass(render_tree, root_id, viewport);
+        if placed.is_empty() {
+            return layout_tree;
+        }
+
+        let insets = line_box_insets(&layout_tree, &placed);
+        if insets.is_empty() {
+            return layout_tree;
+        }
+
+        self.float_insets = insets;
+        let (layout_tree_2, _) = self.layout_pass(layout_tree.render_tree, root_id, viewport);
+        layout_tree = layout_tree_2;
+        self.float_insets.clear();
+        layout_tree
+    }
+}
+
+impl TaffyLayouter {
+    /// One full layout: build the taffy tree, compute it, convert to box models and place floats.
+    /// Returns the tree and the floats that were placed.
+    fn layout_pass(
+        &mut self,
+        render_tree: RenderTree,
+        root_id: RenderNodeId,
+        viewport: Option<geo::Dimension>,
+    ) -> (LayoutTree, Vec<crate::layouter::float::PlacedFloat>) {
         let mut layout_tree = self.generate_tree(render_tree, root_id);
 
         // // Compute the layout based on the viewport
@@ -349,7 +385,7 @@ impl CanLayout for TaffyLayouter {
         {
             log::error!("Failed to compute taffy layout: {:?}", e);
             self.measure_cache = measure_cache;
-            return layout_tree;
+            return (layout_tree, Vec::new());
         }
         self.measure_cache = measure_cache;
 
@@ -362,7 +398,7 @@ impl CanLayout for TaffyLayouter {
         post_process_tables(&mut layout_tree, &self.dom_to_layout_mapping);
         // After tables: a float inside a table cell must be placed against the cell's final
         // position, which lattice only fixes during the table pass.
-        post_process_floats(&mut layout_tree);
+        let placed = post_process_floats(&mut layout_tree);
 
         if let Some(root) = layout_tree.get_node_by_id(root_id) {
             let w = root.box_model.margin_box.width as f32;
@@ -370,11 +406,9 @@ impl CanLayout for TaffyLayouter {
             layout_tree.root_dimension = geo::Dimension::new(w as f64, h as f64);
         }
 
-        layout_tree
+        (layout_tree, placed)
     }
-}
 
-impl TaffyLayouter {
     fn populate_boxmodel(
         &self,
         layout_tree: &mut LayoutTree,
@@ -392,16 +426,25 @@ impl TaffyLayouter {
         };
         let layout = *layout;
 
+        // The anonymous flex container wrapping this node *is* its line box.
+        let line_box_width = self
+            .anon_container_map
+            .get(&layout_node_id)
+            .and_then(|anon| self.tree.layout(*anon).ok())
+            .map(|l| l.size.width as f64);
+
         let Some(el) = layout_tree.get_node_by_id_mut(layout_node_id) else {
             log::warn!("Layout node {:?} not found in arena", layout_node_id);
             return;
         };
         el.box_model = taffy_layout_to_boxmodel(&layout, offset);
-        // For text nodes, available_width is the wrap limit passed to the renderer.
-        // Use the parent element's content width (supplied by our caller), which is the
-        // most accurate available constraint for text that lives directly in a block box.
+        // For text nodes, available_width is the wrap limit passed to the renderer, so it has to
+        // be the width of the *line box*, not of the block. The two differ when a float shortens
+        // the line boxes: shaping at the block's width there would lay the text out in one long
+        // run straight through the float. Fall back to the block's content width for text that is
+        // not inside an anonymous line container.
         if let ElementContext::Text(ref mut text_ctx) = el.context {
-            text_ctx.available_width = parent_content_width;
+            text_ctx.available_width = line_box_width.unwrap_or(parent_content_width);
         }
         let my_content_width = el.box_model.content_box.width;
         let child_ids = el.children.clone();
@@ -528,6 +571,10 @@ impl TaffyLayouter {
         leaf_id: TaffyNodeId,
         justify: Option<taffy::JustifyContent>,
     ) {
+        // Line boxes - not the block itself - are what a float shortens, and the anonymous
+        // container *is* the line box here, so the inset goes on its margins. The block keeps its
+        // full width, so its background and borders still span the float, as CSS requires.
+        let float_inset = self.float_insets.get(&element_node.dom_node_id).copied();
         // All inline elements (even a single one) are wrapped in an anonymous flex container.
         // This ensures the text measure function always receives AvailableSpace::Definite from
         // the flex algorithm, preventing single-child text nodes from getting MaxContent width
@@ -553,6 +600,10 @@ impl TaffyLayouter {
             },
             ..Default::default()
         };
+        if let Some((inset_left, line_width)) = float_inset {
+            style.margin.left = LengthPercentageAuto::length(inset_left);
+            style.size.width = Dimension::from_length(line_width);
+        }
         if items.is_empty() {
             match empty_line_height {
                 // No child can give the line height, so pin it to the break's line-height.

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -400,19 +400,23 @@ impl TaffyLayouter {
         // After tables: a float inside a table cell must be placed against the cell's final
         // position, which lattice only fixes during the table pass.
         let placed = post_process_floats(&mut layout_tree);
-        // Last: an absolutely positioned box is measured from its containing block's *final*
-        // position, so every ancestor - tables and floats included - must have settled first.
-        let icb = viewport.unwrap_or(geo::Dimension::new(
-            layout_tree.root_dimension.width,
-            layout_tree.root_dimension.height,
-        ));
-        post_process_abspos(&mut layout_tree, icb);
 
+        // Publish the root's settled size *before* the absolute-positioning pass. That pass falls
+        // back to it for the initial containing block when no viewport is given, and
+        // `root_dimension` is still `ZERO` from `generate_tree` until this runs - so percentage
+        // insets resolved against zero and `right`/`bottom` placement came out at negative
+        // offsets. The root is not absolutely positioned, so `post_process_abspos` cannot change
+        // its box; moving this up is safe.
         if let Some(root) = layout_tree.get_node_by_id(root_id) {
             let w = root.box_model.margin_box.width as f32;
             let h = root.box_model.margin_box.height as f32;
             layout_tree.root_dimension = geo::Dimension::new(w as f64, h as f64);
         }
+
+        // Last: an absolutely positioned box is measured from its containing block's *final*
+        // position, so every ancestor - tables and floats included - must have settled first.
+        let icb = viewport.unwrap_or(layout_tree.root_dimension);
+        post_process_abspos(&mut layout_tree, icb);
 
         (layout_tree, placed)
     }

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -8,7 +8,7 @@ use crate::common::geo;
 use crate::common::geo::Coordinate;
 use crate::common::media::MediaStore;
 use crate::common::media::{Media, MediaId, MediaRequest, MediaType};
-use crate::layouter::abspos::post_process_abspos;
+use crate::layouter::abspos::{post_process_abspos, RebasedInsets};
 use crate::layouter::box_model::Edges;
 use crate::layouter::css_taffy_converter::CssTaffyConverter;
 use crate::layouter::float::{line_box_insets, post_process_floats};
@@ -95,6 +95,11 @@ pub struct TaffyLayouter {
     /// block, in CSS pixels. Empty on the first layout pass, since a float's position is not known
     /// until that pass has run; filled in from its result for the second.
     float_insets: HashMap<DomNodeId, (f32, f32)>,
+    /// Taffy insets for absolutely positioned boxes that stretch between opposing insets,
+    /// rebased from their CSS containing block onto the parent taffy measures from. Empty on the
+    /// first pass - a box's containing block is only known once the page has been laid out - and
+    /// replayed on the second so taffy sizes those boxes itself. See [`RebasedInsets`].
+    abspos_insets: HashMap<DomNodeId, RebasedInsets>,
 }
 
 /// Apply the CSS `text-transform` keyword to a text run. `uppercase`/`lowercase` map the whole
@@ -208,6 +213,7 @@ impl TaffyLayouter {
             measure_cache: HashMap::new(),
             dom_to_layout_mapping: HashMap::new(),
             float_insets: HashMap::new(),
+            abspos_insets: HashMap::new(),
         }
     }
 
@@ -252,24 +258,26 @@ impl CanLayout for TaffyLayouter {
             };
         };
 
-        // A float's position is only known once the page has been laid out, but text has to be
-        // wrapped to avoid it - so the first pass places the floats and the second re-wraps text
-        // around where they landed. Pages without floats (most modern ones) pay for one pass.
+        // Two things are only knowable once the page has been laid out once: where a float landed
+        // (text has to be wrapped around it) and which containing block an absolutely positioned
+        // box actually belongs to (a box stretching between opposing insets has to be sized
+        // against it). Both are collected on the first pass and replayed on a second. A page that
+        // needs neither - most of them - pays for one pass.
         self.float_insets.clear();
-        let (mut layout_tree, placed) = self.layout_pass(render_tree, root_id, viewport);
-        if placed.is_empty() {
-            return layout_tree;
-        }
+        self.abspos_insets.clear();
+        let (mut layout_tree, placed, stretched) = self.layout_pass(render_tree, root_id, viewport);
 
         let insets = line_box_insets(&layout_tree, &placed);
-        if insets.is_empty() {
+        if insets.is_empty() && stretched.is_empty() {
             return layout_tree;
         }
 
         self.float_insets = insets;
-        let (layout_tree_2, _) = self.layout_pass(layout_tree.render_tree, root_id, viewport);
+        self.abspos_insets = stretched;
+        let (layout_tree_2, _, _) = self.layout_pass(layout_tree.render_tree, root_id, viewport);
         layout_tree = layout_tree_2;
         self.float_insets.clear();
+        self.abspos_insets.clear();
         layout_tree
     }
 }
@@ -282,7 +290,11 @@ impl TaffyLayouter {
         render_tree: RenderTree,
         root_id: RenderNodeId,
         viewport: Option<geo::Dimension>,
-    ) -> (LayoutTree, Vec<crate::layouter::float::PlacedFloat>) {
+    ) -> (
+        LayoutTree,
+        Vec<crate::layouter::float::PlacedFloat>,
+        HashMap<DomNodeId, RebasedInsets>,
+    ) {
         let mut layout_tree = self.generate_tree(render_tree, root_id);
 
         // // Compute the layout based on the viewport
@@ -386,7 +398,7 @@ impl TaffyLayouter {
         {
             log::error!("Failed to compute taffy layout: {:?}", e);
             self.measure_cache = measure_cache;
-            return (layout_tree, Vec::new());
+            return (layout_tree, Vec::new(), HashMap::new());
         }
         self.measure_cache = measure_cache;
 
@@ -416,9 +428,9 @@ impl TaffyLayouter {
         // Last: an absolutely positioned box is measured from its containing block's *final*
         // position, so every ancestor - tables and floats included - must have settled first.
         let icb = viewport.unwrap_or(layout_tree.root_dimension);
-        post_process_abspos(&mut layout_tree, icb);
+        let stretched = post_process_abspos(&mut layout_tree, icb);
 
-        (layout_tree, placed)
+        (layout_tree, placed, stretched)
     }
 
     fn populate_boxmodel(
@@ -1013,6 +1025,21 @@ impl TaffyLayouter {
             NodeType::Element(data) => {
                 let conv = CssTaffyConverter::new(dom_node.node_id, &*layout_tree.render_tree.doc);
                 taffy_style = conv.convert(false);
+
+                // Second pass only: replace the CSS insets of an absolutely positioned box that
+                // stretches between opposing insets with ones rebased onto its parent, so taffy
+                // sizes it against the CSS containing block rather than whatever ancestor happens
+                // to be its parent. Empty on the first pass. See `abspos::RebasedInsets`.
+                if let Some(rebased) = self.abspos_insets.get(&dom_node.node_id) {
+                    if let (Some(l), Some(r)) = (rebased.left, rebased.right) {
+                        taffy_style.inset.left = LengthPercentageAuto::length(l);
+                        taffy_style.inset.right = LengthPercentageAuto::length(r);
+                    }
+                    if let (Some(t), Some(b)) = (rebased.top, rebased.bottom) {
+                        taffy_style.inset.top = LengthPercentageAuto::length(t);
+                        taffy_style.inset.bottom = LengthPercentageAuto::length(b);
+                    }
+                }
 
                 // Images get a taffy context so their intrinsic size participates in layout.
                 if data.tag_name.eq_ignore_ascii_case("img") {

--- a/crates/gosub_render_pipeline/src/tests.rs
+++ b/crates/gosub_render_pipeline/src/tests.rs
@@ -501,6 +501,50 @@ mod rendertree_from_engine {
         }
     }
 
+    /// The initial containing block sits at the canvas origin, not inside the root's padding.
+    ///
+    /// It used to be anchored on the root element's *content* box, so any padding on the root
+    /// pushed it inwards and `top: 0; left: 0` on an unanchored absolute box - or on anything
+    /// `fixed` - missed the corner by exactly that padding.
+    #[test]
+    fn initial_containing_block_is_anchored_at_the_origin() {
+        use crate::common::geo::Dimension;
+        use crate::layouter::taffy::TaffyLayouter;
+        use crate::layouter::CanLayout;
+
+        // Padding on the root, and no positioned ancestor above `#pinned`.
+        let html = r#"
+            <html><head><style>
+                html { padding: 20px; }
+                #pinned { position: absolute; left: 0; top: 0; width: 50px; height: 10px; }
+            </style></head>
+            <body style="margin:0"><div id="pinned"></div></body></html>
+        "#;
+
+        let mut doc = html_compile::<Config>(html);
+        doc.add_stylesheet(Css3System::load_default_useragent_stylesheet());
+        let adapter = GosubDocumentAdapter::<Config>::new(Arc::new(doc));
+        let root = adapter.doc.root();
+        let pinned_dom = find_node_by_id_attr(&adapter.doc, root, "pinned").expect("#pinned");
+
+        let mut render_tree = RenderTree::new(Arc::new(adapter));
+        render_tree.parse().expect("render tree");
+        let layout_tree = TaffyLayouter::new().layout(render_tree, Some(Dimension::new(800.0, 600.0)), 1.0);
+
+        let pinned = layout_tree
+            .arena
+            .values()
+            .find(|el| el.dom_node_id == pinned_dom)
+            .expect("#pinned in the layout tree");
+        let mb = pinned.box_model.margin_box;
+        assert!(
+            mb.x.abs() < 0.5 && mb.y.abs() < 0.5,
+            "`top: 0; left: 0` with no positioned ancestor should reach the canvas corner, got ({}, {})",
+            mb.x,
+            mb.y
+        );
+    }
+
     /// A font-relative inset must place the box, not be discarded as `auto`.
     ///
     /// The converter feeding taffy resolves `em`/`rem`, but the absolute-positioning pass read

--- a/crates/gosub_render_pipeline/src/tests.rs
+++ b/crates/gosub_render_pipeline/src/tests.rs
@@ -500,4 +500,67 @@ mod rendertree_from_engine {
             other => panic!("expected a px width on ::before, got {other:?}"),
         }
     }
+
+    /// Floating a flex container must not turn it into a block container.
+    ///
+    /// CSS blockification (Display §2.7) only maps *inline-level* boxes to their block-level
+    /// equivalent - `inline-flex` becomes `flex`, not `block`, and a box that is already
+    /// block-level is untouched. Forcing `Display::Block` on every float laid a floated flex
+    /// container's children out stacked instead of in a row.
+    #[test]
+    fn floated_flex_container_keeps_its_flex_children() {
+        use crate::common::geo::{Dimension, Rect};
+        use crate::layouter::taffy::TaffyLayouter;
+        use crate::layouter::CanLayout;
+
+        /// Lay `html` out at 800x600 and return the margin boxes of `#row`'s children.
+        fn child_boxes(html: &str) -> Vec<Rect> {
+            let mut doc = html_compile::<Config>(html);
+            doc.add_stylesheet(Css3System::load_default_useragent_stylesheet());
+            let adapter = GosubDocumentAdapter::<Config>::new(Arc::new(doc));
+            let root = adapter.doc.root();
+            let row_dom = find_node_by_id_attr(&adapter.doc, root, "row").expect("#row");
+
+            let mut render_tree = RenderTree::new(Arc::new(adapter));
+            render_tree.parse().expect("render tree");
+            let layout_tree = TaffyLayouter::new().layout(render_tree, Some(Dimension::new(800.0, 600.0)), 1.0);
+
+            let row = layout_tree
+                .arena
+                .values()
+                .find(|el| el.dom_node_id == row_dom)
+                .expect("#row in the layout tree");
+            row.children
+                .iter()
+                .filter_map(|id| layout_tree.get_node_by_id(*id))
+                .map(|el| el.box_model.margin_box)
+                .collect()
+        }
+
+        let html = r#"
+            <html><head><style>
+                #row { display: flex; float: left; }
+                #row > div { width: 50px; height: 20px; }
+            </style></head>
+            <body style="margin:0">
+                <div id="row"><div id="a"></div><div id="b"></div></div>
+            </body></html>
+        "#;
+
+        let boxes = child_boxes(html);
+        assert_eq!(boxes.len(), 2, "expected the two flex items");
+        // Side by side (flex row), not stacked (block flow).
+        assert!(
+            (boxes[0].y - boxes[1].y).abs() < 0.5,
+            "floated flex children should share a row, got y = {} and {}",
+            boxes[0].y,
+            boxes[1].y
+        );
+        assert!(
+            boxes[1].x > boxes[0].x + 1.0,
+            "the second flex item should sit right of the first, got x = {} and {}",
+            boxes[0].x,
+            boxes[1].x
+        );
+    }
 }

--- a/crates/gosub_render_pipeline/src/tests.rs
+++ b/crates/gosub_render_pipeline/src/tests.rs
@@ -501,6 +501,69 @@ mod rendertree_from_engine {
         }
     }
 
+    /// A font-relative inset must place the box, not be discarded as `auto`.
+    ///
+    /// The converter feeding taffy resolves `em`/`rem`, but the absolute-positioning pass read
+    /// the raw value and matched only `px` and `%`. A box whose only specified side was an `em`
+    /// inset was therefore treated as `auto` on that axis and left wherever taffy had put it,
+    /// rather than placed against its containing block.
+    #[test]
+    fn font_relative_insets_are_honoured() {
+        use crate::common::geo::Dimension;
+        use crate::layouter::taffy::TaffyLayouter;
+        use crate::layouter::CanLayout;
+
+        /// x of `#target`'s margin box, laid out at 800x600.
+        fn target_x(html: &str) -> f64 {
+            let mut doc = html_compile::<Config>(html);
+            doc.add_stylesheet(Css3System::load_default_useragent_stylesheet());
+            let adapter = GosubDocumentAdapter::<Config>::new(Arc::new(doc));
+            let root = adapter.doc.root();
+            let target_dom = find_node_by_id_attr(&adapter.doc, root, "target").expect("#target");
+
+            let mut render_tree = RenderTree::new(Arc::new(adapter));
+            render_tree.parse().expect("render tree");
+            let layout_tree = TaffyLayouter::new().layout(render_tree, Some(Dimension::new(800.0, 600.0)), 1.0);
+            layout_tree
+                .arena
+                .values()
+                .find(|el| el.dom_node_id == target_dom)
+                .expect("#target in the layout tree")
+                .box_model
+                .margin_box
+                .x
+        }
+
+        // The static `#wrap` in between is what makes this observable: taffy places an absolute
+        // child against its *immediate parent*, so it puts `#target` at 150 + 64, while CSS
+        // measures from `#cb` and wants 100 + 64. Dropping the inset left taffy's answer standing.
+        // Without the wrapper the two agree and the bug hides.
+        // 4em at the default 16px font size; `left: 64px` is the same distance spelled in px.
+        let page = |left: &str| {
+            format!(
+                r#"<html><head><style>
+                    #cb {{ position: relative; margin-left: 100px; width: 400px; height: 200px; }}
+                    #wrap {{ margin-left: 50px; }}
+                    #target {{ position: absolute; left: {left}; width: 50px; height: 10px; }}
+                </style></head>
+                <body style="margin:0">
+                    <div id="cb"><div id="wrap"><div id="target"></div></div></div>
+                </body></html>"#
+            )
+        };
+
+        let em_x = target_x(&page("4em"));
+        let px_x = target_x(&page("64px"));
+        assert!(
+            (em_x - px_x).abs() < 0.5,
+            "`left: 4em` should place identically to `left: 64px`, got {em_x} vs {px_x}"
+        );
+        assert!(
+            (em_x - 164.0).abs() < 1.0,
+            "expected x ~164 (containing block at 100px + 4em), got {em_x}"
+        );
+    }
+
     /// With no viewport, the initial containing block comes from the root's settled size.
     ///
     /// `root_dimension` is zero until the layout pass publishes it, and that used to happen

--- a/crates/gosub_render_pipeline/src/tests.rs
+++ b/crates/gosub_render_pipeline/src/tests.rs
@@ -501,6 +501,67 @@ mod rendertree_from_engine {
         }
     }
 
+    /// With no viewport, the initial containing block comes from the root's settled size.
+    ///
+    /// `root_dimension` is zero until the layout pass publishes it, and that used to happen
+    /// *after* the absolute-positioning pass ran - so the fallback containing block was 0x0,
+    /// percentage insets resolved to zero and `right`/`bottom` placed boxes at negative offsets.
+    #[test]
+    fn absolute_placement_without_a_viewport_uses_the_root_size() {
+        use crate::layouter::taffy::TaffyLayouter;
+        use crate::layouter::CanLayout;
+
+        // No positioned ancestor anywhere, so `#pinned` measures against the *initial*
+        // containing block - the fallback this test is about. The in-flow sibling is what gives
+        // the root a width to fall back to; without a viewport its size is content-driven.
+        let html = r#"
+            <html><head><style>
+                #pinned { position: absolute; right: 0; top: 0; width: 50px; height: 10px; }
+            </style></head>
+            <body style="margin:0">
+                <div style="width:400px;height:20px"></div>
+                <div id="pinned"></div>
+            </body></html>
+        "#;
+
+        let mut doc = html_compile::<Config>(html);
+        doc.add_stylesheet(Css3System::load_default_useragent_stylesheet());
+        let adapter = GosubDocumentAdapter::<Config>::new(Arc::new(doc));
+        let root = adapter.doc.root();
+        let pinned_dom = find_node_by_id_attr(&adapter.doc, root, "pinned").expect("#pinned");
+
+        let mut render_tree = RenderTree::new(Arc::new(adapter));
+        render_tree.parse().expect("render tree");
+        // No viewport: the initial containing block has to fall back to the root's own size.
+        let layout_tree = TaffyLayouter::new().layout(render_tree, None, 1.0);
+
+        assert!(
+            layout_tree.root_dimension.width > 0.0,
+            "the root's settled size must be published before it is used"
+        );
+
+        let pinned = layout_tree
+            .arena
+            .values()
+            .find(|el| el.dom_node_id == pinned_dom)
+            .expect("#pinned in the layout tree");
+        // `right: 0` puts the box's right edge on the containing block's right edge, so its
+        // left edge lands at (containing block width - 50). With the zero fallback that came out
+        // at -50: flush against nothing, off the left of the canvas.
+        let expected = layout_tree.root_dimension.width - 50.0;
+        assert!(
+            pinned.box_model.margin_box.x >= 0.0,
+            "right-edge placement produced a negative offset: x = {}",
+            pinned.box_model.margin_box.x
+        );
+        assert!(
+            (pinned.box_model.margin_box.x - expected).abs() < 1.0,
+            "expected x ~{expected} (root width {} minus the 50px box), got {}",
+            layout_tree.root_dimension.width,
+            pinned.box_model.margin_box.x
+        );
+    }
+
     /// A promoted layer whose element has a collapsed margin box must still get tiles.
     ///
     /// Element-to-tile assignment unions the margin and border boxes, but the layer's tile grid

--- a/crates/gosub_render_pipeline/src/tests.rs
+++ b/crates/gosub_render_pipeline/src/tests.rs
@@ -85,10 +85,13 @@ mod rendertree_from_engine {
 
     #[test]
     fn head_and_script_are_excluded() {
+        // `noscript` is here because it is hidden by a user-agent `display: none` rule rather than
+        // by the render tree's hardcoded list. With scripting enabled its contents are parsed as
+        // raw text, so if the element survives, that text is drawn on the page verbatim.
         let html = r#"
             <html>
             <head><title>Test</title><style>body{color:red}</style></head>
-            <body><p>Content</p></body>
+            <body><p>Content</p><noscript><img src="//example.org/x.gif"></noscript></body>
             </html>
         "#;
 
@@ -102,7 +105,7 @@ mod rendertree_from_engine {
                     use cow_utils::CowUtils;
                     let tag = data.tag_name.cow_to_ascii_lowercase();
                     assert!(
-                        !matches!(&*tag, "head" | "style" | "script" | "title"),
+                        !matches!(&*tag, "head" | "style" | "script" | "title" | "noscript"),
                         "invisible element <{tag}> must not appear in render tree"
                     );
                 }

--- a/crates/gosub_render_pipeline/src/tests.rs
+++ b/crates/gosub_render_pipeline/src/tests.rs
@@ -501,6 +501,98 @@ mod rendertree_from_engine {
         }
     }
 
+    /// `left: 0; right: 0` stretches across the containing block, not across taffy's parent.
+    ///
+    /// Taffy does stretch a box between opposing insets, but it measures from the immediate
+    /// parent. With a narrow static wrapper between the box and its positioned ancestor, that
+    /// gave the wrapper's width - and the placement pass only moved the box, so the wrong width
+    /// survived. The second layout pass hands taffy insets rebased onto the parent so its own
+    /// algorithm produces the right size, and re-lays-out the children at that size.
+    #[test]
+    fn opposing_insets_stretch_across_the_containing_block() {
+        use crate::common::geo::Dimension;
+        use crate::layouter::taffy::TaffyLayouter;
+        use crate::layouter::CanLayout;
+
+        // 300px positioned ancestor, 100px static wrapper in between - CodeRabbit's example.
+        let html = r#"
+            <html><head><style>
+                #cb { position: relative; margin-left: 40px; width: 300px; height: 200px; }
+                #wrap { width: 100px; }
+                #target { position: absolute; left: 0; right: 0; height: 10px; }
+            </style></head>
+            <body style="margin:0">
+                <div id="cb"><div id="wrap"><div id="target"></div></div></div>
+            </body></html>
+        "#;
+
+        let mut doc = html_compile::<Config>(html);
+        doc.add_stylesheet(Css3System::load_default_useragent_stylesheet());
+        let adapter = GosubDocumentAdapter::<Config>::new(Arc::new(doc));
+        let root = adapter.doc.root();
+        let target_dom = find_node_by_id_attr(&adapter.doc, root, "target").expect("#target");
+
+        let mut render_tree = RenderTree::new(Arc::new(adapter));
+        render_tree.parse().expect("render tree");
+        let layout_tree = TaffyLayouter::new().layout(render_tree, Some(Dimension::new(800.0, 600.0)), 1.0);
+
+        let mb = layout_tree
+            .arena
+            .values()
+            .find(|el| el.dom_node_id == target_dom)
+            .expect("#target in the layout tree")
+            .box_model
+            .margin_box;
+
+        assert!(
+            (mb.width - 300.0).abs() < 1.0,
+            "expected the box to span the 300px containing block, got width {} (the 100px wrapper?)",
+            mb.width
+        );
+        assert!(
+            (mb.x - 40.0).abs() < 1.0,
+            "expected x ~40 (the containing block's left edge), got {}",
+            mb.x
+        );
+    }
+
+    /// The common shape - an absolute child directly inside its positioned ancestor - must still
+    /// come out right, and is the case the second pass deliberately skips.
+    #[test]
+    fn opposing_insets_with_the_parent_as_containing_block() {
+        use crate::common::geo::Dimension;
+        use crate::layouter::taffy::TaffyLayouter;
+        use crate::layouter::CanLayout;
+
+        let html = r#"
+            <html><head><style>
+                #cb { position: relative; margin-left: 40px; width: 300px; height: 200px; }
+                #target { position: absolute; left: 0; right: 0; height: 10px; }
+            </style></head>
+            <body style="margin:0"><div id="cb"><div id="target"></div></div></body></html>
+        "#;
+
+        let mut doc = html_compile::<Config>(html);
+        doc.add_stylesheet(Css3System::load_default_useragent_stylesheet());
+        let adapter = GosubDocumentAdapter::<Config>::new(Arc::new(doc));
+        let root = adapter.doc.root();
+        let target_dom = find_node_by_id_attr(&adapter.doc, root, "target").expect("#target");
+
+        let mut render_tree = RenderTree::new(Arc::new(adapter));
+        render_tree.parse().expect("render tree");
+        let layout_tree = TaffyLayouter::new().layout(render_tree, Some(Dimension::new(800.0, 600.0)), 1.0);
+
+        let mb = layout_tree
+            .arena
+            .values()
+            .find(|el| el.dom_node_id == target_dom)
+            .expect("#target in the layout tree")
+            .box_model
+            .margin_box;
+        assert!((mb.width - 300.0).abs() < 1.0, "expected width ~300, got {}", mb.width);
+        assert!((mb.x - 40.0).abs() < 1.0, "expected x ~40, got {}", mb.x);
+    }
+
     /// The initial containing block sits at the canvas origin, not inside the root's padding.
     ///
     /// It used to be anchored on the root element's *content* box, so any padding on the root

--- a/crates/gosub_render_pipeline/src/tests.rs
+++ b/crates/gosub_render_pipeline/src/tests.rs
@@ -501,6 +501,76 @@ mod rendertree_from_engine {
         }
     }
 
+    /// A promoted layer whose element has a collapsed margin box must still get tiles.
+    ///
+    /// Element-to-tile assignment unions the margin and border boxes, but the layer's tile grid
+    /// was still bounded by margin boxes alone - and skipped any element with zero area. A
+    /// negative margin large enough to collapse the margin box (the `margin-left: -320px` float
+    /// the union was added for) therefore produced a layer with no tiles at all, so the union
+    /// had nothing to select and the element's background vanished.
+    #[test]
+    fn collapsed_margin_box_still_gets_tiles() {
+        use crate::common::geo::Dimension;
+        use crate::layering::layer::LayerList;
+        use crate::layouter::taffy::TaffyLayouter;
+        use crate::layouter::CanLayout;
+        use crate::tiler::TileList;
+
+        // `opacity` promotes the div to its own layer, so it goes through the bounds computation
+        // rather than layer 0's full-page coverage. `margin-left: -320px` against a 320px width
+        // leaves a zero-width margin box while the border box keeps its 320px.
+        let html = r#"
+            <html><head><style>
+                #ghost {
+                    display: block; width: 320px; height: 100px;
+                    margin-left: -320px; opacity: 0.5; background-color: #ff0000;
+                }
+            </style></head>
+            <body style="margin:0"><div style="padding-left:400px"><div id="ghost"></div></div></body></html>
+        "#;
+
+        let mut doc = html_compile::<Config>(html);
+        doc.add_stylesheet(Css3System::load_default_useragent_stylesheet());
+        let adapter = GosubDocumentAdapter::<Config>::new(Arc::new(doc));
+        let root = adapter.doc.root();
+        let ghost_dom = find_node_by_id_attr(&adapter.doc, root, "ghost").expect("#ghost");
+
+        let mut render_tree = RenderTree::new(Arc::new(adapter));
+        render_tree.parse().expect("render tree");
+        let layout_tree = TaffyLayouter::new().layout(render_tree, Some(Dimension::new(800.0, 600.0)), 1.0);
+
+        // Confirm the setup really does collapse the margin box - if a layout change ever stops
+        // reproducing that, this test should say so rather than pass hollowly.
+        let ghost = layout_tree
+            .arena
+            .iter()
+            .find(|(_, el)| el.dom_node_id == ghost_dom)
+            .map(|(id, el)| (*id, el.box_model))
+            .expect("#ghost in the layout tree");
+        assert!(
+            ghost.1.margin_box.width <= 0.0,
+            "the negative margin should collapse the margin box, got {}",
+            ghost.1.margin_box.width
+        );
+        assert!(ghost.1.border_box.width > 0.0, "the border box should keep its width");
+
+        let layer_list = LayerList::new(layout_tree);
+        // More than one layer means the div really was promoted; layer 0 gets full-page coverage
+        // and would bypass the bounds computation this test is about.
+        assert!(
+            layer_list.layer_ids.read().len() > 1,
+            "the div should have been promoted to its own layer"
+        );
+
+        let mut tile_list = TileList::new(layer_list, Dimension::new(256.0, 256.0));
+        tile_list.generate();
+
+        assert!(
+            !tile_list.get_tiles_for_element(ghost.0).is_empty(),
+            "#ghost was assigned to no tile, so nothing paints its background"
+        );
+    }
+
     /// Floating a flex container must not turn it into a block container.
     ///
     /// CSS blockification (Display §2.7) only maps *inline-level* boxes to their block-level

--- a/crates/gosub_render_pipeline/src/tiler.rs
+++ b/crates/gosub_render_pipeline/src/tiler.rs
@@ -272,7 +272,13 @@ impl TileList {
                 let mut max_y = f64::MIN;
                 for &eid in &layer.elements {
                     if let Some(el) = self.layer_list.layout_tree.get_node_by_id(eid) {
-                        let m = el.box_model.margin_box;
+                        // Same union the per-element assignment below uses. Bounding the grid by
+                        // the margin box alone is not enough: a negative margin can collapse the
+                        // margin box to zero area - `margin-left: -320px` on a float - so the
+                        // positive-area check skipped the element entirely and the layer could
+                        // end up with no tiles for the assignment to pick from, or with a grid
+                        // too small to hold the border pixels that actually get painted.
+                        let m = union_rect(el.box_model.margin_box, el.box_model.border_box);
                         if m.width > 0.0 && m.height > 0.0 {
                             min_x = min_x.min(m.x);
                             min_y = min_y.min(m.y);

--- a/crates/gosub_render_pipeline/src/tiler.rs
+++ b/crates/gosub_render_pipeline/src/tiler.rs
@@ -14,6 +14,16 @@ use std::fmt::Debug;
 use std::ops::AddAssign;
 use std::sync::Arc;
 
+/// The smallest rect containing both inputs. A zero-area rect still contributes its origin, which
+/// is what keeps a collapsed margin box from pulling the union away from the border box.
+fn union_rect(a: Rect, b: Rect) -> Rect {
+    let x = a.x.min(b.x);
+    let y = a.y.min(b.y);
+    let right = (a.x + a.width).max(b.x + b.width);
+    let bottom = (a.y + a.height).max(b.y + b.height);
+    Rect::new(x, y, right - x, bottom - y)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TileId(u64);
 
@@ -342,7 +352,12 @@ impl TileList {
                     log::warn!("Warning: Element {:?} not found in layout tree!", element_id);
                     continue;
                 };
-                let margin_box = element.box_model.margin_box;
+                // Cull on the union of the margin and border boxes. Backgrounds and borders paint
+                // the *border* box, and a negative margin can make the margin box smaller than it
+                // - a `margin-left: -320px` float has a zero-width margin box off to one side.
+                // Culling on the margin box alone then assigns the element to too few tiles and
+                // its background is clipped away at the tile boundary.
+                let margin_box = union_rect(element.box_model.margin_box, element.box_model.border_box);
 
                 let matching_tile_ids = tile_layer.intersects_with(margin_box);
                 for tile_id in &matching_tile_ids {

--- a/src/bin/css3-parser.rs
+++ b/src/bin/css3-parser.rs
@@ -200,6 +200,7 @@ fn print_stylesheet(sheet: &CssStylesheet) {
                         CssSelectorPart::PseudoElement(p) => println!("        [PseudoElement] ::{p}"),
                         CssSelectorPart::Combinator(c) => println!("        [Combinator] {c:?}"),
                         CssSelectorPart::Attribute(a) => println!("        [Attribute] [{}]", a.name),
+                        CssSelectorPart::Not(inner) => println!("        [Not] :not({inner:?})"),
                     }
                 }
             }


### PR DESCRIPTION
Added additional CSS rules and validations to make slashdot page work better (not ready yet)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for CSS floating elements, `clear`, and absolutely positioned elements.
  * Text now wraps around floated content, and containers account for float dimensions.
  * Added support for `:not()` selectors, media queries, imported stylesheets, and viewport-relative units.
  * Inline styles now recognize `float` and `clear`; `transparent` colors render correctly.
  * Improved SVG and MathML attribute serialization.
* **Bug Fixes**
  * Prevented negative-margin elements from being clipped at tile boundaries.
  * Improved font source handling by excluding unsupported EOT and SVG sources.
  * Corrected absolute positioning with borders, padding, and font-relative insets.
  * `noscript` content is now consistently hidden when scripting is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->