### PR TITLE
Data urls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3203,6 +3203,7 @@ dependencies = [
  "allsorts",
  "anyhow",
  "async-trait",
+ "base64 0.23.1",
  "bitflags 2.13.1",
  "bytes",
  "chrono",

--- a/crates/gosub_engine/Cargo.toml
+++ b/crates/gosub_engine/Cargo.toml
@@ -30,6 +30,7 @@ thiserror = { workspace = true }
 rand = { workspace = true }
 futures = { workspace = true, features = ["executor"] }
 anyhow = { workspace = true }
+base64 = { workspace = true }
 http = { workspace = true }
 url = { workspace = true }
 percent-encoding = { workspace = true }

--- a/crates/gosub_engine/src/engine/media_source.rs
+++ b/crates/gosub_engine/src/engine/media_source.rs
@@ -63,6 +63,22 @@ impl EngineMediaSource {
             return;
         };
 
+        // A data: URL is already the bytes. There is nothing to request, so it is answered
+        // here rather than submitted: decoding is the whole of the work, and a consumer
+        // waiting on the hand-off gets its answer without a round trip through the fetcher.
+        if parsed.scheme() == "data" {
+            match crate::net::decode_data_url(&parsed) {
+                Some((content_type, bytes)) => {
+                    gosub_shared::subresource::complete(scope, url, Some(content_type), bytes);
+                }
+                None => {
+                    log::warn!("could not decode data: URL for media");
+                    gosub_shared::subresource::abandon(scope, url);
+                }
+            }
+            return;
+        }
+
         // The same refusal the document scan applies, and the reason this belongs on this
         // side of the boundary: a page from the network does not get to read the disk because
         // it named the file somewhere the scan could not see.

--- a/crates/gosub_engine/src/engine/resource_pipeline/html.rs
+++ b/crates/gosub_engine/src/engine/resource_pipeline/html.rs
@@ -167,6 +167,14 @@ impl<C: RenderConfiguration> HtmlPipelineImpl<C> {
 
         let doc_url = meta.final_url.clone();
         let mut on_discover = |hint: ResourceHint| {
+            // A data: URL carries its own bytes, so preloading one hides no latency: there is
+            // no connection to open and no round trip to get ahead of. Skipping it here is an
+            // optimisation only - a consumer that asks for it still gets it, through the same
+            // fetch path as anything else, because the I/O thread serves the scheme itself
+            // (see `crate::net::data_url`).
+            if hint.url.scheme() == "data" {
+                return;
+            }
             // A remote document must never pull file:// subresources; don't even submit
             // them (the file loader refuses them again as defense in depth).
             if hint.url.scheme() == "file" && doc_url.scheme() != "file" {

--- a/crates/gosub_engine/src/net.rs
+++ b/crates/gosub_engine/src/net.rs
@@ -50,9 +50,11 @@
 //! The submodules below are internal implementation details unless re-exported. Public
 //! items are documented via the re-exports that follow.
 //!
+mod data_url;
 mod decision;
 mod decision_hub;
 pub(crate) mod emitter;
+pub use data_url::decode as decode_data_url;
 pub mod events;
 mod fetcher;
 mod file_loader;

--- a/crates/gosub_engine/src/net/data_url.rs
+++ b/crates/gosub_engine/src/net/data_url.rs
@@ -1,0 +1,265 @@
+//! `data:` URLs, decoded where they are asked for rather than fetched.
+//!
+//! A `data:` URL carries its own bytes, so there is nothing to request: no connection, no
+//! cache, no referrer, no policy to apply. That makes it the odd one out in a network stack
+//! built around submitting a request and waiting, and the reason it is handled here instead
+//! of in the fetcher: a consumer that hits one decodes it and is done.
+//!
+//! The syntax is RFC 2397: `data:[<mediatype>][;base64],<data>`. An absent media type means
+//! `text/plain;charset=US-ASCII`, and without `;base64` the payload is percent-encoded.
+
+use crate::net::types::{FetchRequest, FetchResult, FetchResultMeta, NetError};
+use base64::Engine as _;
+use bytes::Bytes;
+use gosub_sonar::net::events::NetEvent;
+use gosub_sonar::net::observer::NetObserver;
+use http::HeaderMap;
+use std::sync::Arc;
+use url::Url;
+
+/// The default per RFC 2397, for a URL that names no media type.
+const DEFAULT_MEDIA_TYPE: &str = "text/plain;charset=US-ASCII";
+
+/// Whether this request is for the engine-served `data:` scheme.
+///
+/// gosub-sonar only speaks http(s), so the I/O thread answers these itself, the same way it
+/// answers `file://`. Without this a `data:` stylesheet, script or font reaches the zone
+/// fetcher and fails as an unsupported scheme - only images worked, because the media source
+/// decodes them before ever submitting a request.
+pub fn handles(req: &FetchRequest) -> bool {
+    req.url.scheme() == "data"
+}
+
+/// Answer a `data:` request from the URL itself.
+///
+/// No policy gate, unlike `file://`: the bytes travel inside the URL, so serving one reads
+/// neither the disk nor the network and crosses no privilege boundary. The worst a malformed
+/// one can do is fail to decode.
+pub async fn serve(req: &FetchRequest, observer: Arc<dyn NetObserver + Send + Sync>) -> FetchResult {
+    let url = req.url.clone();
+    observer.on_event(NetEvent::Started { url: url.clone() });
+    let started = std::time::Instant::now();
+
+    let Some((content_type, body)) = decode(&url) else {
+        let err = NetError::Io(Arc::new(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "malformed data: URL",
+        )));
+        observer.on_event(NetEvent::Failed {
+            url,
+            error: anyhow::anyhow!(err.clone()),
+        });
+        return FetchResult::Error(err);
+    };
+
+    let body = Bytes::from(body);
+    let len = body.len() as u64;
+    let mut headers = HeaderMap::new();
+    if let Ok(v) = content_type.parse() {
+        headers.insert(http::header::CONTENT_TYPE, v);
+    }
+    if let Ok(v) = len.to_string().parse() {
+        headers.insert(http::header::CONTENT_LENGTH, v);
+    }
+    observer.on_event(NetEvent::ResponseHeaders {
+        url: url.clone(),
+        status: 200,
+        headers: headers.clone(),
+    });
+    observer.on_event(NetEvent::Progress {
+        received_bytes: len,
+        expected_length: Some(len),
+        elapsed: started.elapsed(),
+    });
+    observer.on_event(NetEvent::Finished {
+        received_bytes: len,
+        elapsed: started.elapsed(),
+        url: url.clone(),
+    });
+
+    FetchResult::Buffered {
+        meta: {
+            let mut meta = FetchResultMeta::synthetic(url);
+            meta.headers = headers;
+            meta.content_length = Some(len);
+            meta.content_type = Some(content_type);
+            meta.has_body = len > 0;
+            meta
+        },
+        body,
+    }
+}
+
+/// Decode a `data:` URL into its media type and bytes.
+///
+/// `None` when this is not a `data:` URL, when the comma separating metadata from payload is
+/// missing, or when the payload does not decode. A caller should treat that exactly as it
+/// treats a failed fetch: the resource is not coming.
+pub fn decode(url: &Url) -> Option<(String, Vec<u8>)> {
+    if url.scheme() != "data" {
+        return None;
+    }
+
+    // `Url` keeps everything after `data:` in the path, except that a payload containing a
+    // `#` (legal in base64? no, but legal in percent-encoded text) would land in the
+    // fragment. Rebuilding from the pieces keeps such a payload whole.
+    let mut rest = url.path().to_string();
+    if let Some(query) = url.query() {
+        rest.push('?');
+        rest.push_str(query);
+    }
+    if let Some(fragment) = url.fragment() {
+        rest.push('#');
+        rest.push_str(fragment);
+    }
+
+    let (meta, payload) = rest.split_once(',')?;
+    let (media_type, is_base64) = match meta.strip_suffix(";base64") {
+        Some(head) => (head, true),
+        None => (meta, false),
+    };
+    let media_type = if media_type.is_empty() {
+        DEFAULT_MEDIA_TYPE.to_string()
+    } else {
+        media_type.to_string()
+    };
+
+    let bytes = if is_base64 {
+        // The URL parser has already removed any tabs and newlines an author wrapped a long
+        // payload with, so this is belt and braces for a `Url` built by other means.
+        let cleaned: String = payload.chars().filter(|c| !c.is_ascii_whitespace()).collect();
+        base64::engine::general_purpose::STANDARD
+            .decode(cleaned.as_bytes())
+            .ok()?
+    } else {
+        percent_decode(payload)?
+    };
+
+    Some((media_type, bytes))
+}
+
+/// Percent-decoding for a non-base64 payload. Bytes are taken as they come: a `data:` URL
+/// may name any charset, so this does not assume UTF-8.
+fn percent_decode(input: &str) -> Option<Vec<u8>> {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'%' => {
+                let hex = bytes.get(i + 1..i + 3)?;
+                let text = std::str::from_utf8(hex).ok()?;
+                out.push(u8::from_str_radix(text, 16).ok()?);
+                i += 3;
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gosub_sonar::net::null_emitter::NullEmitter;
+    use gosub_sonar::types::RequestId;
+    use http::Method;
+
+    fn url(s: &str) -> Url {
+        Url::parse(s).expect("valid url")
+    }
+
+    fn request(url: &Url) -> FetchRequest {
+        FetchRequest::builder(Method::GET, url.clone())
+            .with_req_id(RequestId::new())
+            .build()
+    }
+
+    #[test]
+    fn the_scheme_is_claimed_and_only_this_scheme() {
+        assert!(handles(&request(&url("data:text/plain,x"))));
+        assert!(!handles(&request(&url("https://example.test/a.css"))));
+        assert!(!handles(&request(&url("file:///tmp/a.css"))));
+    }
+
+    #[tokio::test]
+    async fn a_request_is_answered_from_the_url_itself() {
+        // The path every non-image subresource takes: a stylesheet reaching the I/O thread as
+        // an ordinary fetch. Before the scheme was served here it fell through to the zone
+        // fetcher, which speaks only http(s), and failed.
+        let result = serve(
+            &request(&url("data:text/css,body%7Bcolor%3Ared%7D")),
+            Arc::new(NullEmitter),
+        )
+        .await;
+        match result {
+            FetchResult::Buffered { meta, body } => {
+                assert_eq!(meta.status, 200);
+                assert_eq!(meta.content_type.as_deref(), Some("text/css"));
+                assert_eq!(meta.content_length, Some(body.len() as u64));
+                assert!(meta.has_body);
+                assert_eq!(std::str::from_utf8(&body).unwrap(), "body{color:red}");
+            }
+            other => panic!("expected buffered response, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_malformed_url_fails_rather_than_serving_empty_bytes() {
+        let result = serve(&request(&url("data:text/css;base64,!!!!")), Arc::new(NullEmitter)).await;
+        assert!(
+            matches!(result, FetchResult::Error(_)),
+            "a payload that will not decode must not read as an empty stylesheet"
+        );
+    }
+
+    #[test]
+    fn base64_payloads_decode_with_their_media_type() {
+        let (media, bytes) = decode(&url("data:image/png;base64,aGVsbG8=")).expect("decodes");
+        assert_eq!(media, "image/png");
+        assert_eq!(bytes, b"hello");
+    }
+
+    #[test]
+    fn a_payload_wrapped_across_lines_still_decodes() {
+        // What an author does to a long data URL in an HTML attribute. The URL parser strips
+        // the newline before we ever see it, which is worth pinning: it is the reason this
+        // decoder does not have to care.
+        let (_, bytes) = decode(&url("data:image/png;base64,aGVs\nbG8=")).expect("decodes");
+        assert_eq!(bytes, b"hello");
+    }
+
+    #[test]
+    fn a_missing_media_type_gets_the_spec_default() {
+        let (media, bytes) = decode(&url("data:,plain")).expect("decodes");
+        assert_eq!(media, DEFAULT_MEDIA_TYPE);
+        assert_eq!(bytes, b"plain");
+    }
+
+    #[test]
+    fn percent_encoded_payloads_decode() {
+        let (media, bytes) = decode(&url("data:text/plain,a%20b%2Fc")).expect("decodes");
+        assert_eq!(media, "text/plain");
+        assert_eq!(bytes, b"a b/c");
+    }
+
+    #[test]
+    fn other_schemes_and_malformed_payloads_are_refused() {
+        assert!(decode(&url("https://example.test/a.png")).is_none());
+        // No comma: nothing separates the metadata from the payload.
+        assert!(decode(&url("data:image/png;base64")).is_none());
+        // Not base64.
+        assert!(decode(&url("data:image/png;base64,!!!!")).is_none());
+    }
+
+    #[test]
+    fn a_payload_containing_a_hash_survives_url_parsing() {
+        // `Url` files everything after `#` as the fragment; a decoder reading only the path
+        // would silently truncate the payload rather than fail, which is the worst outcome.
+        let (_, bytes) = decode(&url("data:text/plain,before%20#after")).expect("decodes");
+        assert_eq!(bytes, b"before #after");
+    }
+}

--- a/crates/gosub_engine/src/net/data_url.rs
+++ b/crates/gosub_engine/src/net/data_url.rs
@@ -20,6 +20,22 @@ use url::Url;
 /// The default per RFC 2397, for a URL that names no media type.
 const DEFAULT_MEDIA_TYPE: &str = "text/plain;charset=US-ASCII";
 
+/// What a media type of bare parameters is understood to be a parameter *of*, so that
+/// `data:;charset=utf-8,x` names `text/plain;charset=utf-8` rather than the nonsense type
+/// `;charset=utf-8`. RFC 2397 spells the shorthand out explicitly.
+const IMPLIED_MEDIA_TYPE: &str = "text/plain";
+
+/// Base64 as a `data:` URL is allowed to write it: padding optional rather than required, and
+/// the leftover bits of an unpadded final chunk dropped rather than rejected. This is the
+/// forgiving-base64 decode of the Infra standard, which is what the data URL processor calls
+/// for - a stricter engine turns URLs every other browser accepts into failed resources.
+const BASE64: base64::engine::general_purpose::GeneralPurpose = base64::engine::general_purpose::GeneralPurpose::new(
+    &base64::alphabet::STANDARD,
+    base64::engine::GeneralPurposeConfig::new()
+        .with_decode_padding_mode(base64::engine::DecodePaddingMode::Indifferent)
+        .with_decode_allow_trailing_bits(true),
+);
+
 /// Whether this request is for the engine-served `data:` scheme.
 ///
 /// gosub-sonar only speaks http(s), so the I/O thread answers these itself, the same way it
@@ -93,72 +109,80 @@ pub async fn serve(req: &FetchRequest, observer: Arc<dyn NetObserver + Send + Sy
 /// Decode a `data:` URL into its media type and bytes.
 ///
 /// `None` when this is not a `data:` URL, when the comma separating metadata from payload is
-/// missing, or when the payload does not decode. A caller should treat that exactly as it
+/// missing, or when a base64 payload does not decode. A caller should treat that exactly as it
 /// treats a failed fetch: the resource is not coming.
 pub fn decode(url: &Url) -> Option<(String, Vec<u8>)> {
     if url.scheme() != "data" {
         return None;
     }
 
-    // `Url` keeps everything after `data:` in the path, except that a payload containing a
-    // `#` (legal in base64? no, but legal in percent-encoded text) would land in the
-    // fragment. Rebuilding from the pieces keeps such a payload whole.
+    // The payload is the URL serialized with its *fragment excluded*, so a `#` ends the data:
+    // `data:text/plain,a#b` carries `a`. `Url` has already filed the fragment separately, so
+    // excluding it is a matter of not putting it back. The query does serialize, and so is put
+    // back: `data:text/plain,a?b` carries `a?b`.
     let mut rest = url.path().to_string();
     if let Some(query) = url.query() {
         rest.push('?');
         rest.push_str(query);
     }
-    if let Some(fragment) = url.fragment() {
-        rest.push('#');
-        rest.push_str(fragment);
-    }
 
     let (meta, payload) = rest.split_once(',')?;
-    let (media_type, is_base64) = match meta.strip_suffix(";base64") {
-        Some(head) => (head, true),
-        None => (meta, false),
-    };
-    let media_type = if media_type.is_empty() {
-        DEFAULT_MEDIA_TYPE.to_string()
-    } else {
-        media_type.to_string()
+    let meta = meta.trim();
+
+    // Percent-decoding comes first and applies to the whole payload, base64 or not. That is
+    // what makes `data:text/plain;base64,SGVsbG8%3D` - an author or a serializer escaping the
+    // padding - decode rather than fail.
+    let body = percent_decode(payload);
+
+    // `;base64` is a parameter name, and parameter names are case-insensitive: `;BASE64` marks
+    // the payload just as well.
+    let (media_type, bytes) = match meta.rsplit_once(';') {
+        Some((head, param)) if param.trim().eq_ignore_ascii_case("base64") => {
+            let cleaned: Vec<u8> = body.into_iter().filter(|b| !b.is_ascii_whitespace()).collect();
+            (head.trim_end(), BASE64.decode(cleaned).ok()?)
+        }
+        _ => (meta, body),
     };
 
-    let bytes = if is_base64 {
-        // The URL parser has already removed any tabs and newlines an author wrapped a long
-        // payload with, so this is belt and braces for a `Url` built by other means.
-        let cleaned: String = payload.chars().filter(|c| !c.is_ascii_whitespace()).collect();
-        base64::engine::general_purpose::STANDARD
-            .decode(cleaned.as_bytes())
-            .ok()?
+    let media_type = if media_type.is_empty() {
+        DEFAULT_MEDIA_TYPE.to_string()
+    } else if media_type.starts_with(';') {
+        format!("{IMPLIED_MEDIA_TYPE}{media_type}")
     } else {
-        percent_decode(payload)?
+        media_type.to_string()
     };
 
     Some((media_type, bytes))
 }
 
-/// Percent-decoding for a non-base64 payload. Bytes are taken as they come: a `data:` URL
-/// may name any charset, so this does not assume UTF-8.
-fn percent_decode(input: &str) -> Option<Vec<u8>> {
+/// Percent-decoding for the payload. Bytes are taken as they come: a `data:` URL may name any
+/// charset, so this does not assume UTF-8.
+///
+/// A `%` that does not introduce two hex digits stands for itself instead of failing the
+/// decode, per the URL standard - `data:text/plain,100%` is a readable resource, not a
+/// malformed one.
+fn percent_decode(input: &str) -> Vec<u8> {
     let bytes = input.as_bytes();
     let mut out = Vec::with_capacity(bytes.len());
     let mut i = 0;
     while i < bytes.len() {
-        match bytes[i] {
-            b'%' => {
-                let hex = bytes.get(i + 1..i + 3)?;
-                let text = std::str::from_utf8(hex).ok()?;
-                out.push(u8::from_str_radix(text, 16).ok()?);
+        let escape = (bytes[i] == b'%')
+            .then(|| bytes.get(i + 1..i + 3))
+            .flatten()
+            .filter(|hex| hex.iter().all(u8::is_ascii_hexdigit))
+            .and_then(|hex| u8::from_str_radix(std::str::from_utf8(hex).ok()?, 16).ok());
+        match escape {
+            Some(b) => {
+                out.push(b);
                 i += 3;
             }
-            b => {
-                out.push(b);
+            None => {
+                out.push(bytes[i]);
                 i += 1;
             }
         }
     }
-    Some(out)
+    out
 }
 
 #[cfg(test)]
@@ -256,10 +280,57 @@ mod tests {
     }
 
     #[test]
-    fn a_payload_containing_a_hash_survives_url_parsing() {
-        // `Url` files everything after `#` as the fragment; a decoder reading only the path
-        // would silently truncate the payload rather than fail, which is the worst outcome.
+    fn a_fragment_ends_the_payload() {
+        // The data URL processor serializes the URL with the fragment excluded, so `#` ends
+        // the data rather than being part of it - the same as it would be in any other URL.
         let (_, bytes) = decode(&url("data:text/plain,before%20#after")).expect("decodes");
-        assert_eq!(bytes, b"before #after");
+        assert_eq!(bytes, b"before ");
+    }
+
+    #[test]
+    fn a_query_is_part_of_the_payload() {
+        // The other half of the fragment rule: `?` does serialize, so it is data.
+        let (_, bytes) = decode(&url("data:text/plain,a?b=c")).expect("decodes");
+        assert_eq!(bytes, b"a?b=c");
+    }
+
+    #[test]
+    fn a_percent_encoded_base64_payload_decodes() {
+        // Percent-decoding runs over the payload first, base64 or not, so an escaped `=` is
+        // still padding by the time the base64 decoder sees it.
+        let (_, bytes) = decode(&url("data:text/plain;base64,SGVsbG8%3D")).expect("decodes");
+        assert_eq!(bytes, b"Hello");
+    }
+
+    #[test]
+    fn the_base64_marker_is_case_insensitive() {
+        let (media, bytes) = decode(&url("data:text/plain;BASE64,aGVsbG8=")).expect("decodes");
+        assert_eq!(media, "text/plain");
+        assert_eq!(bytes, b"hello");
+    }
+
+    #[test]
+    fn unpadded_base64_decodes() {
+        // Forgiving-base64: padding is optional, and the bits left over from the final chunk
+        // are dropped rather than rejected.
+        let (_, bytes) = decode(&url("data:text/plain;base64,SGVsbG8")).expect("decodes");
+        assert_eq!(bytes, b"Hello");
+    }
+
+    #[test]
+    fn a_media_type_of_bare_parameters_gets_the_implied_type() {
+        // RFC 2397 shorthand: the charset alone stands for a parameter on `text/plain`, and a
+        // consumer parsing `;charset=utf-8` as a media type would get nothing usable.
+        let (media, bytes) = decode(&url("data:;charset=utf-8,hello")).expect("decodes");
+        assert_eq!(media, "text/plain;charset=utf-8");
+        assert_eq!(bytes, b"hello");
+    }
+
+    #[test]
+    fn a_stray_percent_stands_for_itself() {
+        // Percent-decoding does not fail on an escape that is not one; treating this URL as
+        // malformed would drop a perfectly readable resource.
+        let (_, bytes) = decode(&url("data:text/plain,100%")).expect("decodes");
+        assert_eq!(bytes, b"100%");
     }
 }

--- a/crates/gosub_engine/src/net/io_runtime.rs
+++ b/crates/gosub_engine/src/net/io_runtime.rs
@@ -127,6 +127,20 @@ impl IoRouter {
         });
     }
 
+    /// Serve a `data:` request from the URL itself, for the same reason as
+    /// [`Self::serve_file_request`]: gosub-sonar only speaks http(s). Policy lives in
+    /// [`crate::net::data_url`] - which is to say there is none, the bytes being in the URL.
+    fn serve_data_url_request(&self, req: FetchRequest, reply_tx: oneshot::Sender<crate::net::types::FetchResult>) {
+        use gosub_sonar::net::fetcher_context::FetcherContext;
+        let observer = self
+            .local_ctx
+            .observer_for(req.reference, req.req_id, req.kind, req.initiator);
+        spawn_named("data-url", async move {
+            let result = crate::net::data_url::serve(&req, observer).await;
+            let _ = reply_tx.send(result);
+        });
+    }
+
     pub fn get_or_spawn_zone_fetcher(&self, zone_id: ZoneId) -> Result<Arc<Fetcher>, EngineError> {
         if let Some(f) = self.zones.get(&zone_id) {
             return Ok(f.fetcher.clone());
@@ -254,10 +268,14 @@ pub fn spawn_io_thread(cfg: FetcherConfig, engine_ctx: Arc<EngineContext>) -> Io
                 maybe_req = rx_submit.recv() => {
                     match maybe_req {
                         Some(IoCommand::Fetch { zone_id, req, handle, reply_tx }) => {
-                            // The engine serves file:// itself; everything else goes to the
-                            // zone's gosub-sonar fetcher.
+                            // The engine serves file:// and data: itself; everything else goes
+                            // to the zone's gosub-sonar fetcher, which only speaks http(s).
                             if crate::net::file_loader::handles(&req) {
                                 router.serve_file_request(req, reply_tx);
+                                continue;
+                            }
+                            if crate::net::data_url::handles(&req) {
+                                router.serve_data_url_request(req, reply_tx);
                                 continue;
                             }
                             // The I/O thread must keep running; drop the request on fetcher failure.

--- a/crates/gosub_engine/src/net/io_runtime.rs
+++ b/crates/gosub_engine/src/net/io_runtime.rs
@@ -130,12 +130,24 @@ impl IoRouter {
     /// Serve a `data:` request from the URL itself, for the same reason as
     /// [`Self::serve_file_request`]: gosub-sonar only speaks http(s). Policy lives in
     /// [`crate::net::data_url`] - which is to say there is none, the bytes being in the URL.
-    fn serve_data_url_request(&self, req: FetchRequest, reply_tx: oneshot::Sender<crate::net::types::FetchResult>) {
+    fn serve_data_url_request(
+        &self,
+        req: FetchRequest,
+        cancel: CancellationToken,
+        reply_tx: oneshot::Sender<crate::net::types::FetchResult>,
+    ) {
         use gosub_sonar::net::fetcher_context::FetcherContext;
         let observer = self
             .local_ctx
             .observer_for(req.reference, req.req_id, req.kind, req.initiator);
         spawn_named("data-url", async move {
+            // A navigation cancelled while its request sat in the I/O queue must not go on to
+            // emit network events for it. Decoding never awaits, so there is no point inside
+            // `serve` to cancel at: the check belongs here, ahead of the first event. Dropping
+            // `reply_tx` is how the zone fetcher reports a cancelled fetch too.
+            if cancel.is_cancelled() {
+                return;
+            }
             let result = crate::net::data_url::serve(&req, observer).await;
             let _ = reply_tx.send(result);
         });
@@ -275,7 +287,7 @@ pub fn spawn_io_thread(cfg: FetcherConfig, engine_ctx: Arc<EngineContext>) -> Io
                                 continue;
                             }
                             if crate::net::data_url::handles(&req) {
-                                router.serve_data_url_request(req, reply_tx);
+                                router.serve_data_url_request(req, handle.cancel.clone(), reply_tx);
                                 continue;
                             }
                             // The I/O thread must keep running; drop the request on fetcher failure.


### PR DESCRIPTION
Implementing data-urls (data:....) inline data. The issue is that we do not need to fetch the resource as the data is already present, but we catch these urls (same as with file://). The handler will just respond by creating a fabricated FetchResult.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added direct loading of `data:` URLs, including percent-encoded and Base64-encoded content.
  - Supports case-insensitive Base64 markers, unpadded Base64, escaped padding, and inferred `text/plain` media types.
  - Preserves decoded media types and content for inline resources.

- **Bug Fixes**
  - URL fragments are excluded from inline payloads.
  - Malformed or cancelled inline requests are handled safely.
  - Inline resources no longer trigger unnecessary network fetches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->