### PR TITLE
css3: parse quoted operators as literals, not property references

### DIFF
--- a/crates/gosub_css3/src/matcher/shorthands.rs
+++ b/crates/gosub_css3/src/matcher/shorthands.rs
@@ -27,7 +27,6 @@ impl CssSyntaxTree {
 impl SyntaxComponent {
     pub fn has_property_syntax(&self, prop: &str, path: &mut Vec<usize>) -> bool {
         match self {
-            SyntaxComponent::Property { property, .. } => prop == property,
             SyntaxComponent::Definition { datatype, quoted, .. } if *quoted => prop == datatype,
             SyntaxComponent::Group { components, .. } => {
                 for (i, component) in components.iter().enumerate() {
@@ -47,7 +46,6 @@ impl SyntaxComponent {
     pub fn multipliers(&self) -> &[SyntaxComponentMultiplier] {
         match self {
             SyntaxComponent::GenericKeyword { multipliers, .. } => multipliers,
-            SyntaxComponent::Property { multipliers, .. } => multipliers,
             SyntaxComponent::Function { multipliers, .. } => multipliers,
             SyntaxComponent::Definition { multipliers, .. } => multipliers,
             SyntaxComponent::Inherit { multipliers, .. } => multipliers,
@@ -649,38 +647,23 @@ impl CssDefinitions {
             }
         }
 
-        if let [component] = syntax.components.as_slice() {
-            match component {
-                SyntaxComponent::Definition { datatype, .. } => {
-                    if let Some(d) = self.syntax.get(datatype) {
-                        if let Some(mut shorthands) = self.resolve_shorthands(computed, &d.syntax, name) {
-                            shorthands.multiplier = Multiplier::None;
+        // A property reference is written `<'name'>`, which compiles to a quoted `Definition` -
+        // so both a value type and a property reference arrive here as one.
+        if let [SyntaxComponent::Definition { datatype, .. }] = syntax.components.as_slice() {
+            if let Some(d) = self.syntax.get(datatype) {
+                if let Some(mut shorthands) = self.resolve_shorthands(computed, &d.syntax, name) {
+                    shorthands.multiplier = Multiplier::None;
 
-                            return Some(shorthands);
-                        }
-                    }
-
-                    if let Some(p) = self.properties.get(datatype) {
-                        //currently properties get parsed as definitions
-                        if let Some(mut shorthands) = self.resolve_shorthands(computed, &p.syntax, name) {
-                            shorthands.multiplier = Multiplier::None;
-
-                            return Some(shorthands);
-                        }
-                    }
+                    return Some(shorthands);
                 }
+            }
 
-                SyntaxComponent::Property { property, .. } => {
-                    if let Some(d) = self.properties.get(property) {
-                        if let Some(mut shorthands) = self.resolve_shorthands(computed, &d.syntax, name) {
-                            shorthands.multiplier = Multiplier::None;
+            if let Some(p) = self.properties.get(datatype) {
+                if let Some(mut shorthands) = self.resolve_shorthands(computed, &p.syntax, name) {
+                    shorthands.multiplier = Multiplier::None;
 
-                            return Some(shorthands);
-                        }
-                    }
+                    return Some(shorthands);
                 }
-
-                _ => {}
             }
         }
 

--- a/crates/gosub_css3/src/matcher/syntax.rs
+++ b/crates/gosub_css3/src/matcher/syntax.rs
@@ -138,11 +138,6 @@ pub enum SyntaxComponent {
         keyword: String,
         multipliers: Vec<SyntaxComponentMultiplier>,
     },
-    /// Quoted string that indicates css property
-    Property {
-        property: String,
-        multipliers: Vec<SyntaxComponentMultiplier>,
-    },
     /// Functions like `color()`, `length()` etc
     Function {
         name: String,
@@ -210,7 +205,6 @@ impl SyntaxComponent {
         match self {
             SyntaxComponent::Group { multipliers, .. } => multipliers.clone(),
             SyntaxComponent::Function { multipliers, .. } => multipliers.clone(),
-            SyntaxComponent::Property { multipliers, .. } => multipliers.clone(),
             SyntaxComponent::GenericKeyword { multipliers, .. } => multipliers.clone(),
             SyntaxComponent::Definition { multipliers, .. } => multipliers.clone(),
             SyntaxComponent::Unit { multipliers, .. } => multipliers.clone(),
@@ -229,9 +223,6 @@ impl SyntaxComponent {
                 *multipliers = new_multipliers;
             }
             SyntaxComponent::Function { multipliers, .. } => {
-                *multipliers = new_multipliers;
-            }
-            SyntaxComponent::Property { multipliers, .. } => {
                 *multipliers = new_multipliers;
             }
             SyntaxComponent::GenericKeyword { multipliers, .. } => {
@@ -650,22 +641,6 @@ fn parse_function(input: &str) -> IResult<&str, SyntaxComponent> {
     }
 }
 
-fn parse_property(input: &str) -> IResult<&str, SyntaxComponent> {
-    debug_print!("Parsing property: {}", input);
-
-    let (input, property) = delimited(
-        tag("'"),
-        map(parse_keyword, |s: &str| SyntaxComponent::Property {
-            property: s.to_string(),
-            multipliers: vec![SyntaxComponentMultiplier::Once],
-        }),
-        tag("'"),
-    )
-    .parse(input)?;
-
-    Ok((input, property))
-}
-
 fn parse_generic_keyword(input: &str) -> IResult<&str, SyntaxComponent> {
     debug_print!("Parsing generic keyword: '{}'", input);
 
@@ -855,8 +830,11 @@ fn parse_component(input: &str) -> IResult<&str, SyntaxComponent> {
         parse_unit_function,
         parse_at_keyword,
         parse_function,
-        parse_property,
         parse_specific_keyword,
+        // Before any rule that would claim a quoted token. In the value definition syntax a
+        // bare `'x'` is a literal - a property reference is the *angle-bracketed* `<'name'>`,
+        // which `parse_datatype` handles with `quoted: true`. Every bare quoted token in the
+        // compiled-in definitions is punctuation: `'+'`, `'-'`, `'('`, `','` and friends.
         parse_literal,
         parse_group,
         parse_paren_group,
@@ -898,6 +876,44 @@ mod tests {
     #[test]
     fn test_compile_empty() {
         assert!(CssSyntax::new("").compile().is_ok());
+    }
+
+    #[test]
+    fn a_bare_quoted_token_is_a_literal_not_a_property_reference() {
+        // `<calc-sum>` is written `<calc-product> [ [ '+' | '-' ] <calc-product> ]*`. Those
+        // quoted operators are literal tokens: a property reference is the angle-bracketed
+        // `<'name'>`. Parsing `'-'` as a property produced a component the matcher had no arm
+        // for, so `width: calc-size(auto, size)` panicked the engine - three WPT suites
+        // reported CRASH for it, and any page using the syntax would have taken the process
+        // down. `'+'` and `'*'` escaped only because a keyword cannot start with them.
+        let parts = CssSyntax::new("'-' | '+' | '*'").compile().expect("compiles");
+        for component in &parts.components {
+            assert!(
+                matches!(
+                    component,
+                    SyntaxComponent::Group { .. } | SyntaxComponent::Literal { .. }
+                ),
+                "quoted operators must compile to literals, got {component:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn calc_grammars_match_without_panicking() {
+        // The regression these guard: every sizing property resolves `calc-size()`, whose
+        // grammar reaches `<calc-sum>` and its quoted operators.
+        let defs = get_css_definitions();
+        for (property, value) in [
+            ("width", "calc-size(auto, size)"),
+            ("height", "calc-size(auto, size)"),
+            ("max-width", "calc(1px + 2px)"),
+            ("min-height", "calc(100% - 10px)"),
+        ] {
+            let def = defs.find_property(property).expect("property is defined");
+            let parsed = crate::stylesheet::CssValue::parse_str(value).expect("value parses");
+            // The assertion is that this returns at all: before the fix it panicked.
+            let _ = def.matches(parsed.to_slice());
+        }
     }
 
     #[test]

--- a/crates/gosub_css3/src/matcher/syntax.rs
+++ b/crates/gosub_css3/src/matcher/syntax.rs
@@ -887,15 +887,25 @@ mod tests {
         // reported CRASH for it, and any page using the syntax would have taken the process
         // down. `'+'` and `'*'` escaped only because a keyword cannot start with them.
         let parts = CssSyntax::new("'-' | '+' | '*'").compile().expect("compiles");
-        for component in &parts.components {
-            assert!(
-                matches!(
-                    component,
-                    SyntaxComponent::Group { .. } | SyntaxComponent::Literal { .. }
-                ),
-                "quoted operators must compile to literals, got {component:?}"
+
+        // An alternation compiles to one root group, so the assertion has to descend into it:
+        // testing the root alone passes whatever the alternatives turn out to be, which is
+        // exactly the bug this guards against.
+        let [SyntaxComponent::Group { components, .. }] = parts.components.as_slice() else {
+            panic!(
+                "an alternation must compile to a single group, got {:?}",
+                parts.components
             );
-        }
+        };
+
+        let literals: Vec<&str> = components
+            .iter()
+            .map(|component| match component {
+                SyntaxComponent::Literal { literal, .. } => literal.as_str(),
+                other => panic!("quoted operators must compile to literals, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(literals, ["-", "+", "*"], "each operator keeps its own token");
     }
 
     #[test]

--- a/docs/wpt-quickstart.md
+++ b/docs/wpt-quickstart.md
@@ -40,12 +40,11 @@ The run ends like this:
 
 ```
   css/css-values                 █░░░░░░░░░  192/4516    4.3%
-  css/css-values/calc-size       ███████░░░     5/7     71.4%
+  css/css-values/calc-size       ███░░░░░░░    38/120   31.7%
   css/css-values/urls            ███░░░░░░░    39/126   31.0%
 
-  270 files: 15 fully passing, 247 with failures, 5 could not run
-  4903 subtests: 292 passed, 4611 failed
-  3 files crashed the engine (grep the run for CRASH)
+  270 files: 15 fully passing, 250 with failures, 5 could not run
+  5030 subtests: 328 passed, 4702 failed
 ```
 
 Low numbers are expected and are not the interesting part. What matters is which suites are
@@ -64,10 +63,6 @@ cargo run --release -p gosub-wpt -- "$WPT_ROOT" css/css-values --shortlist
 ```
 
 ```
-  Crashes - engine code panicking on input a real page could carry. Take these first.
-    css/css-values/calc-size/calc-size-parsing.html
-      Unknown syntax component: Property { property: "-", multipliers: [Once] } (at crates/gosub_css3/src/matcher/syntax_matcher.rs:541)
-
   Partly passing, nearest to working first:
      94.3%  css/css-values/progress-invalid.html            33/35, 2 left
      71.4%  css/css-values/random-item-invalid.html         10/14, 4 left
@@ -78,6 +73,10 @@ Take one off the top. A partly-passing suite means the engine already understand
 the thing and is wrong about a detail — that is an afternoon. Suites that fully fail are left
 out, because those are usually missing a whole feature and are a project rather than a first
 task.
+
+If the listing opens with a **Crashes** section, start there instead: those are suites that
+panicked the engine, which is a bug a real page could reach rather than a feature it lacks.
+There are none at the time of writing, but they come back.
 
 If nothing there appeals, the two big structural gaps are always open, and either is worth
 hundreds of subtests: **CSSOM serialization** (the engine hands back the author's text rather

--- a/docs/wpt.md
+++ b/docs/wpt.md
@@ -37,13 +37,14 @@ run ends with a rollup per directory and the totals:
 
 ```
   css/css-values                 █░░░░░░░░░  192/4516    4.3%
-  css/css-values/calc-size       ███████░░░     5/7     71.4%
+  css/css-values/calc-size       ███░░░░░░░    38/120   31.7%
   css/css-values/urls            ███░░░░░░░    39/126   31.0%
 
-  270 files: 15 fully passing, 247 with failures, 5 could not run
-  4903 subtests: 292 passed, 4611 failed
-  3 files crashed the engine (grep the run for CRASH)
+  270 files: 15 fully passing, 250 with failures, 5 could not run
+  5030 subtests: 328 passed, 4702 failed
 ```
+
+A run with panics also ends with `N files crashed the engine (grep the run for CRASH)`.
 
 That is the whole setup. The next section is how to turn one of those failures into a fix.
 
@@ -85,7 +86,7 @@ halves, the `conformance-checkers/` fixtures and the manual tests are left out �
 `css/css-values` is 270 suites, not the 518 `.html` files it contains.
 
 Grouping in the rollup is by each suite's own directory, not by a fixed prefix depth, because
-that is the granularity work gets picked at: `calc-size` at 71% and `calc-size/animation` at 0%
+that is the granularity work gets picked at: `calc-size` at 32% and `calc-size/animation` at 0%
 is the useful shape, and one averaged line is not.
 
 ## Picking something to fix
@@ -202,7 +203,7 @@ Measured at the pinned commit; regenerate rather than trust these.
 | Run | Tests | Passing | Time |
 |---|---:|---:|---:|
 | `wpt` gate - `dom/events`, `html/dom` | 621 files, 50,310 subtests | 2,348 (4.7%) | 30s |
-| CSS parser component - `css/css-syntax`, `css/css-values` | 309 files, 5,317 subtests | 310 (5.8%) | 30s |
+| CSS parser component - `css/css-syntax`, `css/css-values` | 309 files, 5,441 subtests | 343 (6.3%) | 30s |
 | nightly - every testharness suite | 27,301 files | ~2% | 150s |
 | reftests - `css/CSS2` | 5,952 | ~1560 (26%) | 455s |
 
@@ -214,7 +215,7 @@ of suites that happened to survive, not the corpus.
 The CSS component's 5.8% is close to a floor rather than a measurement of the parser: 156 of
 its 309 suites need `getComputedStyle`, which does not exist, and most of the rest assert a
 canonical serialization the engine does not produce. Where the parser is actually reached the
-numbers are much higher - `calc-size` at 71%, `urls` at 31%, `position` at 25%.
+numbers are much higher - `calc-size` at 32%, `urls` at 31%, `position` at 25%.
 
 The reftest rate is the higher one because those exercise layout and painting, which the
 engine does, rather than DOM and Web APIs, which it mostly does not. Within CSS2 the

--- a/tests/wpt/expectations-css.txt
+++ b/tests/wpt/expectations-css.txt
@@ -200,7 +200,6 @@ FILE css/css-values/calc-serialization.html
 FILE css/css-values/calc-size/animation/calc-size-height-interpolation.html
 HARNESS css/css-values/calc-size/animation/calc-size-height-interpolation.html
 FILE css/css-values/calc-size/animation/calc-size-interpolation-expansion.html
-CRASH css/css-values/calc-size/animation/calc-size-interpolation-expansion.html
 FILE css/css-values/calc-size/animation/calc-size-width-interpolation.html
 HARNESS css/css-values/calc-size/animation/calc-size-width-interpolation.html
 FILE css/css-values/calc-size/animation/interpolate-size-height-composition.html
@@ -241,9 +240,40 @@ HARNESS css/css-values/calc-size/calc-size-height-box-sizing.html
 FILE css/css-values/calc-size/calc-size-height.html
 HARNESS css/css-values/calc-size/calc-size-height.html
 FILE css/css-values/calc-size/calc-size-parsing.html
-CRASH css/css-values/calc-size/calc-size-parsing.html
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['width'] = "calc-size(auto, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['min-width'] = "calc-size(auto, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['height'] = "calc-size(auto, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['min-height'] = "calc-size(auto, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['width'] = "calc-size(max-content, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['height'] = "calc-size(max-content, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['max-width'] = "calc-size(max-content, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['max-height'] = "calc-size(max-content, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['min-width'] = "calc-size(max-content, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['min-height'] = "calc-size(max-content, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['block-size'] = "calc-size(max-content, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['inline-size'] = "calc-size(max-content, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['max-block-size'] = "calc-size(max-content, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['max-inline-size'] = "calc-size(max-content, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['min-block-size'] = "calc-size(max-content, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['min-inline-size'] = "calc-size(max-content, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['width'] = "calc-size(fit-content, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['width'] = "calc-size(any, 25em)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['width'] = "calc-size(any, 40%)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['width'] = "calc-size(calc-size(any, 30px), size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['width'] = "calc-size(10px, sign(size) * size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['width'] = "size" should not set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['width'] = "calc-size(30px, 25em)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['width'] = "calc-size(calc-size(any, 30px), 25em)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['width'] = "calc-size(calc-size(min-content, 30px), 25em)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['width'] = "calc-size(calc-size(min-content, size), size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['flex-basis'] = "calc-size(any, 50px)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['flex-basis'] = "calc-size(auto, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['flex-basis'] = "calc-size(min-content, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['flex-basis'] = "calc-size(max-content, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['flex-basis'] = "calc-size(fit-content, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['flex-basis'] = "calc-size(content, size)" should set the property value
+PASS css/css-values/calc-size/calc-size-parsing.html :: e.style['width'] = "calc-size(0px, 0px)" should set the property value
 FILE css/css-values/calc-size/calc-size-typed-om.html
-CRASH css/css-values/calc-size/calc-size-typed-om.html
 FILE css/css-values/calc-size/calc-size-width-box-sizing.html
 HARNESS css/css-values/calc-size/calc-size-width-box-sizing.html
 FILE css/css-values/calc-size/calc-size-width.html


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CSS grammar handling for quoted operators and property definitions.
  - Fixed several `calc-size()` parsing scenarios that could previously crash the engine.
  - Expanded successful `calc-size()` parsing coverage across width, height, block/inline size, and flex-basis properties.

- **Documentation**
  - Updated Web Platform Test guidance and sample results to reflect current outcomes.
  - Added guidance to prioritize investigating crashes when reviewing test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->