### PR TITLE
CSS updates to make wikipedia pages somewhat renderable

### DIFF
--- a/crates/gosub_css3/src/colors.rs
+++ b/crates/gosub_css3/src/colors.rs
@@ -45,61 +45,81 @@ impl Default for RgbColor {
 }
 
 impl From<&str> for RgbColor {
+    /// Lossy conversion: anything that is not a colour becomes opaque black. Prefer
+    /// [`RgbColor::try_from_str`], which reports that case instead of inventing a colour.
     fn from(value: &str) -> Self {
+        RgbColor::try_from_str(value).unwrap_or_default()
+    }
+}
+
+impl RgbColor {
+    /// Parses a CSS `<color>` from its textual form, or `None` when the string is not a colour.
+    ///
+    /// Reporting the failure matters: a declaration whose value is invalid at computed-value
+    /// time must be dropped, so the property keeps its inherited or initial value. Answering
+    /// with a colour instead turns every keyword that reaches a colour slot into an opaque
+    /// black paint - `background: none` and `background: no-repeat` (the shorthand's non-colour
+    /// components) both filled their box with black.
+    #[must_use]
+    pub fn try_from_str(value: &str) -> Option<Self> {
         if value.is_empty() {
-            return RgbColor::default();
+            return None;
         }
-        if value == "currentcolor" {
-            // @todo: implement currentcolor
-            return RgbColor::default();
+        // CSS defines it as rgba(0, 0, 0, 0), and the named-colour table does not carry it.
+        if value.eq_ignore_ascii_case("transparent") {
+            return Some(RgbColor::new(0.0, 0.0, 0.0, 0.0));
+        }
+        if value.eq_ignore_ascii_case("currentcolor") {
+            // @todo: implement currentcolor - it resolves to the element's own `color`, which
+            // is not reachable from here. Black keeps the pre-existing behaviour; returning
+            // `None` instead would silently drop every `currentcolor` declaration.
+            return Some(RgbColor::default());
         }
 
         if value.starts_with('#') {
-            return parse_hex(value);
+            return try_parse_hex(value);
         }
         if value.starts_with("rgb(") {
             // Rgb function
-            let Ok(rgb) = Rgb::from_str(value) else {
-                return RgbColor::default();
-            };
-            return RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), 255.0);
+            let rgb = Rgb::from_str(value).ok()?;
+            return Some(RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), 255.0));
         }
         if value.starts_with("rgba(") {
             // Rgba function - alpha from colors_transform is in 0..1 range; scale to 0..255
-            let Ok(rgb) = Rgb::from_str(value) else {
-                return RgbColor::default();
-            };
-            return RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), rgb.get_alpha() * 255.0);
+            let rgb = Rgb::from_str(value).ok()?;
+            return Some(RgbColor::new(
+                rgb.get_red(),
+                rgb.get_green(),
+                rgb.get_blue(),
+                rgb.get_alpha() * 255.0,
+            ));
         }
         if value.starts_with("hsl(") {
-            let Ok(hsl) = Hsl::from_str(value) else {
-                return RgbColor::default();
-            };
+            let hsl = Hsl::from_str(value).ok()?;
             let rgb: Rgb = hsl.to_rgb();
-            return RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), 255.0);
+            return Some(RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), 255.0));
         }
         if value.starts_with("hsla(") {
             // hsla() - alpha from colors_transform is in 0..1 range; scale to 0..255
-            let Ok(hsl) = Hsl::from_str(value) else {
-                return RgbColor::default();
-            };
+            let hsl = Hsl::from_str(value).ok()?;
             let rgb: Rgb = hsl.to_rgb();
-            return RgbColor::new(rgb.get_red(), rgb.get_green(), rgb.get_blue(), rgb.get_alpha() * 255.0);
+            return Some(RgbColor::new(
+                rgb.get_red(),
+                rgb.get_green(),
+                rgb.get_blue(),
+                rgb.get_alpha() * 255.0,
+            ));
         }
 
         // Modern CSS Color Level 4 functions stored as unparsed strings.
         if value.starts_with("oklch(") {
-            if let Some(c) = parse_oklch_str(value) {
-                return c;
-            }
+            return parse_oklch_str(value);
         }
         if value.starts_with("oklab(") {
-            if let Some(c) = parse_oklab_str(value) {
-                return c;
-            }
+            return parse_oklab_str(value);
         }
 
-        named_color_hex(value).map_or(RgbColor::default(), parse_hex)
+        named_color_hex(value).and_then(try_parse_hex)
     }
 }
 
@@ -214,7 +234,9 @@ fn is_hex(value: &str) -> bool {
     value.chars().skip(1).all(|c| c.is_ascii_hexdigit())
 }
 
-fn parse_hex(value: &str) -> RgbColor {
+/// Parses `#rgb`, `#rgba`, `#rrggbb` and `#rrggbbaa`, or `None` when the string is not one of
+/// those - a malformed hex value is an invalid declaration, not black.
+fn try_parse_hex(value: &str) -> Option<RgbColor> {
     const R: usize = 0;
     const G: usize = 1;
     const B: usize = 2;
@@ -222,7 +244,7 @@ fn parse_hex(value: &str) -> RgbColor {
     const DEFAULT_A_VALUE: f32 = 255.0;
 
     if !is_hex(value) {
-        return RgbColor::default();
+        return None;
     }
 
     // 3 hex digits (RGB)
@@ -233,12 +255,12 @@ fn parse_hex(value: &str) -> RgbColor {
         let r = number_array[R];
         let g = number_array[G];
         let b = number_array[B];
-        return RgbColor::new(
+        return Some(RgbColor::new(
             (r * 16 + r) as f32,
             (g * 16 + g) as f32,
             (b * 16 + b) as f32,
             DEFAULT_A_VALUE,
-        );
+        ));
     }
 
     // 4 hex digits (RGBA)
@@ -251,12 +273,12 @@ fn parse_hex(value: &str) -> RgbColor {
         let b = number_array[B];
         let a = number_array[A];
 
-        return RgbColor::new(
+        return Some(RgbColor::new(
             (r * 16 + r) as f32,
             (g * 16 + g) as f32,
             (b * 16 + b) as f32,
             (a * 16 + a) as f32,
-        );
+        ));
     }
 
     // 6 hex digits (RRGGBB)
@@ -267,7 +289,7 @@ fn parse_hex(value: &str) -> RgbColor {
         let g = number_array[G];
         let b = number_array[B];
 
-        return RgbColor::new(r as f32, g as f32, b as f32, DEFAULT_A_VALUE);
+        return Some(RgbColor::new(r as f32, g as f32, b as f32, DEFAULT_A_VALUE));
     }
 
     // 8 hex digits (RRGGBBAA)
@@ -280,10 +302,10 @@ fn parse_hex(value: &str) -> RgbColor {
         let b = number_array[B];
         let a = number_array[A];
 
-        return RgbColor::new(r as f32, g as f32, b as f32, a as f32);
+        return Some(RgbColor::new(r as f32, g as f32, b as f32, a as f32));
     }
 
-    RgbColor::default()
+    None
 }
 
 fn convert_from_hex_str_to_vec_of_ints(hex_value: &str, hex_size: usize) -> Vec<i32> {
@@ -546,5 +568,55 @@ mod tests {
         assert_eq!(color.g, 0.0);
         assert_eq!(color.b, 0.0);
         assert_eq!(color.a, 255.0);
+    }
+
+    #[test]
+    fn non_colours_are_reported_rather_than_blackened() {
+        // These reach a colour slot through the `background` shorthand, whose non-colour
+        // components used to parse as opaque black and fill the element's box.
+        for keyword in ["none", "no-repeat", "center", "inherit", "", "notacolour"] {
+            assert_eq!(
+                super::RgbColor::try_from_str(keyword),
+                None,
+                "{keyword} is not a colour"
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_values_are_reported() {
+        for value in ["#incorrect", "ff0000", "abcd", "#12345", "rgb(bogus)", "hsl(nope)"] {
+            assert_eq!(super::RgbColor::try_from_str(value), None, "{value} is not a colour");
+        }
+    }
+
+    #[test]
+    fn transparent_is_a_colour_with_zero_alpha() {
+        let color = super::RgbColor::try_from_str("transparent").expect("transparent is a colour");
+        assert_eq!((color.r, color.g, color.b, color.a), (0.0, 0.0, 0.0, 0.0));
+        // CSS keywords are ASCII case-insensitive.
+        assert_eq!(super::RgbColor::try_from_str("TRANSPARENT"), Some(color));
+    }
+
+    #[test]
+    fn colours_still_parse() {
+        assert_eq!(
+            super::RgbColor::try_from_str("#ff0000"),
+            Some(super::RgbColor::new(255.0, 0.0, 0.0, 255.0))
+        );
+        assert_eq!(
+            super::RgbColor::try_from_str("red"),
+            Some(super::RgbColor::new(255.0, 0.0, 0.0, 255.0))
+        );
+        assert_eq!(
+            super::RgbColor::try_from_str("rgb(255, 0, 0)"),
+            Some(super::RgbColor::new(255.0, 0.0, 0.0, 255.0))
+        );
+    }
+
+    #[test]
+    fn the_lossy_conversion_keeps_its_black_default() {
+        // `From<&str>` is unchanged for callers that have nowhere to report a failure.
+        assert_eq!(super::RgbColor::from("none"), super::RgbColor::default());
     }
 }

--- a/crates/gosub_css3/src/functions/var.rs
+++ b/crates/gosub_css3/src/functions/var.rs
@@ -53,6 +53,13 @@ fn resolve_var_inner(
         return resolve_fallback(seen);
     };
 
+    // `--x: initial` sets the property to its initial value, and css-variables-1 defines a custom
+    // property's initial value as the guaranteed-invalid value. Substituting it would splice the
+    // literal token `initial` into the declaration instead of taking the fallback.
+    if matches!(value, CssValue::Initial) {
+        return resolve_fallback(seen);
+    }
+
     // Custom properties are stored with their `var()` references intact (they are substituted
     // lazily, at use), so the substituted value has to be resolved in turn.
     seen.push(name);
@@ -87,6 +94,16 @@ fn substitute(values: &[CssValue], custom_props: &HashMap<String, CssValue>, see
                     return vec![];
                 }
                 out.extend(resolved);
+            }
+            // Any other function may hold a `var()` among its arguments -
+            // `linear-gradient(var(--from), white)` - so it is rebuilt around its substituted
+            // arguments rather than cloned whole.
+            CssValue::Function(name, args) => {
+                let resolved = substitute(args, custom_props, seen);
+                if resolved.is_empty() && !args.is_empty() {
+                    return vec![];
+                }
+                out.push(CssValue::Function(name.clone(), resolved));
             }
             other => out.push(other.clone()),
         }
@@ -220,6 +237,58 @@ mod tests {
         let props = HashMap::new();
         let args = vec![s("--missing")];
         assert_eq!(resolve_var(&args, &props), vec![]);
+    }
+
+    #[test]
+    fn initial_is_the_guaranteed_invalid_value() {
+        // css-variables-1: a custom property's initial value *is* the guaranteed-invalid value,
+        // so `--x: initial` is not a value the reference can use.
+        let props = props(&[("--x", CssValue::Initial)]);
+
+        assert_eq!(
+            resolve_var(&[s("--x"), CssValue::Comma, s("blue")], &props),
+            vec![s("blue")]
+        );
+        assert_eq!(resolve_var(&[s("--x")], &props), vec![]);
+    }
+
+    #[test]
+    fn var_inside_another_function_is_substituted() {
+        // A custom property holding `linear-gradient(var(--from), white)` used to come back with
+        // the inner `var()` untouched, because only a bare `var()` and a list were descended into.
+        let gradient = CssValue::Function(
+            "linear-gradient".to_string(),
+            vec![
+                CssValue::Function("var".to_string(), vec![s("--from")]),
+                CssValue::Comma,
+                s("white"),
+            ],
+        );
+        let props = props(&[("--from", s("red")), ("--g", gradient)]);
+
+        assert_eq!(
+            resolve_var(&[s("--g")], &props),
+            vec![CssValue::Function(
+                "linear-gradient".to_string(),
+                vec![s("red"), CssValue::Comma, s("white")]
+            )]
+        );
+    }
+
+    #[test]
+    fn an_unresolvable_var_invalidates_the_function_around_it() {
+        let props = props(&[(
+            "--g",
+            CssValue::Function(
+                "linear-gradient".to_string(),
+                vec![CssValue::Function("var".to_string(), vec![s("--nope")])],
+            ),
+        )]);
+
+        assert_eq!(
+            resolve_var(&[s("--g"), CssValue::Comma, s("red")], &props),
+            vec![s("red")]
+        );
     }
 
     #[test]

--- a/crates/gosub_css3/src/functions/var.rs
+++ b/crates/gosub_css3/src/functions/var.rs
@@ -1,50 +1,231 @@
 use crate::stylesheet::CssValue;
 use std::collections::HashMap;
 
+/// How deep a chain of custom properties referencing other custom properties is followed
+/// (`--a: var(--b); --b: var(--c); …`). Cyclic references are already caught by the
+/// visited-name stack; this only bounds pathological but acyclic chains.
+const MAX_VAR_DEPTH: usize = 32;
+
+/// Resolves a single `var(--name[, <fallback>])` against the custom properties in scope.
+///
+/// Returns the substitution tokens, which the caller splices into the surrounding value.
+/// An empty vector means the reference is invalid at computed-value time (the property is
+/// undefined and no fallback was given, or the fallback itself is unresolvable) - the caller
+/// drops the declaration, which is what CSS requires.
 pub fn resolve_var(values: &[CssValue], custom_props: &HashMap<String, CssValue>) -> Vec<CssValue> {
-    let Some(name) = values.first().map(|v| v.to_string()) else {
+    resolve_var_inner(values, custom_props, &mut Vec::new())
+}
+
+fn resolve_var_inner(
+    values: &[CssValue],
+    custom_props: &HashMap<String, CssValue>,
+    seen: &mut Vec<String>,
+) -> Vec<CssValue> {
+    let Some(name) = values.first().map(ToString::to_string) else {
         return vec![];
     };
 
-    if let Some(value) = custom_props.get(&name) {
-        return vec![value.clone()];
+    // `var(--a, <fallback>)`: the arguments arrive as a flat token list with the separator kept
+    // as its own `Comma`, so the fallback is everything after the *first* comma. It can be more
+    // than one token (`var(--rule, 1px solid red)`) and may contain commas of its own
+    // (`var(--font, "A", sans-serif)`), which stay part of the fallback.
+    let fallback = values
+        .iter()
+        .position(|v| matches!(v, CssValue::Comma))
+        .map(|comma| &values[comma + 1..]);
+
+    // A `var()` inside the fallback (or inside the substituted value below) is resolved with the
+    // same scope, so `var(--a, var(--b, red))` keeps working.
+    let resolve_fallback = |seen: &mut Vec<String>| match fallback {
+        Some(tokens) if !tokens.is_empty() => substitute(tokens, custom_props, seen),
+        _ => vec![],
+    };
+
+    // A cycle (`--a: var(--b); --b: var(--a)`) makes every property in it invalid at
+    // computed-value time. Note this deliberately does not fall through to the fallback:
+    // the reference itself is what is cyclic.
+    if seen.iter().any(|n| n == &name) || seen.len() >= MAX_VAR_DEPTH {
+        return vec![];
     }
 
-    // Variable not found - use the fallback if provided
-    if let Some(fallback) = values.get(1).cloned() {
-        return vec![fallback];
-    }
+    let Some(value) = custom_props.get(&name) else {
+        // Variable not defined - use the fallback if provided.
+        return resolve_fallback(seen);
+    };
 
-    vec![]
+    // Custom properties are stored with their `var()` references intact (they are substituted
+    // lazily, at use), so the substituted value has to be resolved in turn.
+    seen.push(name);
+    let resolved = substitute(std::slice::from_ref(value), custom_props, seen);
+    seen.pop();
+
+    if resolved.is_empty() {
+        // The custom property is defined but computes to the guaranteed-invalid value, which
+        // css-variables-1 treats the same as undefined: use the fallback.
+        return resolve_fallback(seen);
+    }
+    resolved
+}
+
+/// Replaces every `var()` in `values` with its substitution, splicing multi-token results into
+/// the surrounding list. Returns an empty vector when any `var()` is unresolvable, so the
+/// invalidity propagates to the declaration.
+fn substitute(values: &[CssValue], custom_props: &HashMap<String, CssValue>, seen: &mut Vec<String>) -> Vec<CssValue> {
+    let mut out = Vec::with_capacity(values.len());
+    for value in values {
+        match value {
+            CssValue::Function(name, args) if name.eq_ignore_ascii_case("var") => {
+                let resolved = resolve_var_inner(args, custom_props, seen);
+                if resolved.is_empty() {
+                    return vec![];
+                }
+                out.extend(resolved);
+            }
+            CssValue::List(list) => {
+                let resolved = substitute(list, custom_props, seen);
+                if resolved.is_empty() && !list.is_empty() {
+                    return vec![];
+                }
+                out.extend(resolved);
+            }
+            other => out.push(other.clone()),
+        }
+    }
+    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn props(pairs: &[(&str, CssValue)]) -> HashMap<String, CssValue> {
+        pairs.iter().map(|(k, v)| ((*k).to_string(), v.clone())).collect()
+    }
+
+    fn s(v: &str) -> CssValue {
+        CssValue::String(v.to_string())
+    }
+
     #[test]
     fn resolves_defined_variable() {
-        let mut props = HashMap::new();
-        props.insert("--color".to_string(), CssValue::String("red".to_string()));
+        let props = props(&[("--color", s("red"))]);
 
-        let args = vec![CssValue::String("--color".to_string())];
-        assert_eq!(resolve_var(&args, &props), vec![CssValue::String("red".to_string())]);
+        let args = vec![s("--color")];
+        assert_eq!(resolve_var(&args, &props), vec![s("red")]);
     }
 
     #[test]
     fn falls_back_when_undefined() {
         let props = HashMap::new();
+        let args = vec![s("--missing"), CssValue::Comma, s("blue")];
+        assert_eq!(resolve_var(&args, &props), vec![s("blue")]);
+    }
+
+    #[test]
+    fn fallback_keeps_all_its_tokens() {
+        let props = HashMap::new();
         let args = vec![
-            CssValue::String("--missing".to_string()),
-            CssValue::String("blue".to_string()),
+            s("--rule"),
+            CssValue::Comma,
+            CssValue::Unit(1.0, "px".to_string()),
+            s("solid"),
+            s("red"),
         ];
-        assert_eq!(resolve_var(&args, &props), vec![CssValue::String("blue".to_string())]);
+        assert_eq!(
+            resolve_var(&args, &props),
+            vec![CssValue::Unit(1.0, "px".to_string()), s("solid"), s("red")]
+        );
+    }
+
+    #[test]
+    fn fallback_may_contain_commas() {
+        let props = HashMap::new();
+        let args = vec![
+            s("--font"),
+            CssValue::Comma,
+            s("Helvetica"),
+            CssValue::Comma,
+            s("serif"),
+        ];
+        assert_eq!(
+            resolve_var(&args, &props),
+            vec![s("Helvetica"), CssValue::Comma, s("serif")]
+        );
+    }
+
+    #[test]
+    fn nested_fallback_resolves() {
+        let props = props(&[("--b", s("green"))]);
+        let args = vec![
+            s("--a"),
+            CssValue::Comma,
+            CssValue::Function("var".to_string(), vec![s("--b")]),
+        ];
+        assert_eq!(resolve_var(&args, &props), vec![s("green")]);
+    }
+
+    #[test]
+    fn resolves_variable_referencing_another_variable() {
+        let props = props(&[
+            ("--base", s("red")),
+            ("--accent", CssValue::Function("var".to_string(), vec![s("--base")])),
+        ]);
+
+        let args = vec![s("--accent")];
+        assert_eq!(resolve_var(&args, &props), vec![s("red")]);
+    }
+
+    #[test]
+    fn variable_referencing_undefined_variable_uses_outer_fallback() {
+        let props = props(&[("--accent", CssValue::Function("var".to_string(), vec![s("--nope")]))]);
+
+        let args = vec![s("--accent"), CssValue::Comma, s("blue")];
+        assert_eq!(resolve_var(&args, &props), vec![s("blue")]);
+    }
+
+    #[test]
+    fn cyclic_references_resolve_to_nothing() {
+        let props = props(&[
+            ("--a", CssValue::Function("var".to_string(), vec![s("--b")])),
+            ("--b", CssValue::Function("var".to_string(), vec![s("--a")])),
+        ]);
+
+        assert_eq!(resolve_var(&[s("--a")], &props), vec![]);
+    }
+
+    #[test]
+    fn substitutes_into_a_multi_token_value() {
+        let props = props(&[(
+            "--rule",
+            CssValue::List(vec![
+                CssValue::Unit(1.0, "px".to_string()),
+                s("solid"),
+                CssValue::Function("var".to_string(), vec![s("--c")]),
+            ]),
+        )]);
+        let props = {
+            let mut p = props;
+            p.insert("--c".to_string(), s("red"));
+            p
+        };
+
+        assert_eq!(
+            resolve_var(&[s("--rule")], &props),
+            vec![CssValue::Unit(1.0, "px".to_string()), s("solid"), s("red")]
+        );
     }
 
     #[test]
     fn returns_empty_when_undefined_and_no_fallback() {
         let props = HashMap::new();
-        let args = vec![CssValue::String("--missing".to_string())];
+        let args = vec![s("--missing")];
+        assert_eq!(resolve_var(&args, &props), vec![]);
+    }
+
+    #[test]
+    fn empty_fallback_is_not_a_value() {
+        let props = HashMap::new();
+        let args = vec![s("--missing"), CssValue::Comma];
         assert_eq!(resolve_var(&args, &props), vec![]);
     }
 }

--- a/crates/gosub_css3/src/matcher/shorthands.rs
+++ b/crates/gosub_css3/src/matcher/shorthands.rs
@@ -449,6 +449,20 @@ impl FixList {
 
             had_shorthands = true;
 
+            // The longhands a *nested* shorthand expands to are still the author's declaration and
+            // must carry its cascade metadata. Without this they fell through to the synthesized
+            // default below - author origin, zero specificity, order 0, depth `u16::MAX` - so for
+            // `border-left-width: 4px; border: 1px solid` the `border-left-width` produced by the
+            // second declaration lost to the first, and the earlier longhand won.
+            fix_list.set_info(FixListInfo::new(
+                decl.origin,
+                decl.important,
+                decl.location.clone(),
+                decl.specificity,
+                decl.shadow_depth,
+                decl.order,
+            ));
+
             prop.matches_and_shorthands(decl.value.to_slice(), &mut fix_list);
         }
 

--- a/crates/gosub_css3/src/matcher/shorthands.rs
+++ b/crates/gosub_css3/src/matcher/shorthands.rs
@@ -122,6 +122,10 @@ pub struct FixListInfo {
     /// Shadow depth of the declaring sheet, carried through shorthand expansion so the
     /// longhands it produces keep the cross-tree half of the cascade.
     shadow_depth: u16,
+    /// Document-order position of the shorthand being expanded. The longhands inherit it, so a
+    /// longhand declared *after* the shorthand still wins the cascade even though every
+    /// expansion is applied after all the direct declarations.
+    order: u32,
 }
 
 impl FixListInfo {
@@ -132,6 +136,7 @@ impl FixListInfo {
         location: String,
         specificity: Specificity,
         shadow_depth: u16,
+        order: u32,
     ) -> Self {
         Self {
             origin,
@@ -139,6 +144,7 @@ impl FixListInfo {
             location,
             specificity,
             shadow_depth,
+            order,
         }
     }
 }
@@ -380,6 +386,7 @@ impl FixList {
                 specificity: info.specificity,
                 location: info.location.clone(),
                 shadow_depth: info.shadow_depth,
+                order: info.order,
             }
         } else {
             DeclarationProperty {
@@ -398,6 +405,7 @@ impl FixList {
                 // fall back to losing on specificity, exactly as they did before there was
                 // a cross-tree comparison at all.
                 shadow_depth: u16::MAX,
+                order: 0,
             }
         }
     }

--- a/crates/gosub_css3/src/matcher/styling.rs
+++ b/crates/gosub_css3/src/matcher/styling.rs
@@ -552,6 +552,15 @@ pub struct DeclarationProperty {
     /// 1 for a sheet in a shadow tree hosted by a document element, and so on. Feeds the
     /// cross-tree half of the cascade; see [`DeclarationProperty::tree_rank`].
     pub shadow_depth: u16,
+    /// Position of the declaration in document order, counted across every matched rule.
+    /// The last step of the cascade: when origin, tree and specificity all tie, the
+    /// declaration that comes later in the stylesheets wins.
+    ///
+    /// A longhand produced by expanding a shorthand inherits the *shorthand's* position, so
+    /// `margin: 4px` followed by `margin-left: 80px` resolves the way it reads. Without this,
+    /// expansion order decided instead - and every expanded longhand is added after all the
+    /// directly declared ones, so a shorthand silently beat every longhand it overlapped.
+    pub order: u32,
 }
 
 /// Cascade rank of a declaration from its origin and importance, as defined in
@@ -609,6 +618,7 @@ impl Ord for DeclarationProperty {
             .cmp(&other.priority())
             .then_with(|| self.tree_rank().cmp(&other.tree_rank()))
             .then_with(|| self.specificity.cmp(&other.specificity))
+            .then_with(|| self.order.cmp(&other.order))
     }
 }
 
@@ -763,6 +773,7 @@ impl From<CssValue> for CssProperty {
             origin: CssOrigin::Author,
             specificity: Specificity::new(0, 0, 0),
             shadow_depth: 0,
+            order: 0,
         }];
 
         this.calculate_value();
@@ -780,6 +791,7 @@ impl From<CssValue> for DeclarationProperty {
             origin: CssOrigin::Author,
             specificity: Specificity::new(0, 0, 0),
             shadow_depth: 0,
+            order: 0,
         }
     }
 }
@@ -975,6 +987,7 @@ mod tests {
             location: String::new(),
             specificity: Specificity::new(1, 0, 0),
             shadow_depth: 0,
+            order: 0,
         });
 
         assert_eq!(
@@ -1002,6 +1015,7 @@ mod tests {
             location: String::new(),
             specificity: Specificity::new(1, 0, 0),
             shadow_depth: 0,
+            order: 0,
         });
 
         assert_eq!(prop.compute_value(), &CssValue::String("red".into()));
@@ -1020,6 +1034,7 @@ mod tests {
             location: String::new(),
             specificity: Specificity::new(1, 0, 0),
             shadow_depth: 0,
+            order: 0,
         };
         let b = DeclarationProperty {
             value: CssValue::String("blue".into()),
@@ -1028,6 +1043,7 @@ mod tests {
             location: String::new(),
             specificity: Specificity::new(1, 0, 0),
             shadow_depth: 0,
+            order: 0,
         };
         let c = DeclarationProperty {
             value: CssValue::String("green".into()),
@@ -1036,6 +1052,7 @@ mod tests {
             location: String::new(),
             specificity: Specificity::new(1, 0, 0),
             shadow_depth: 0,
+            order: 0,
         };
         let d = DeclarationProperty {
             value: CssValue::String("yellow".into()),
@@ -1044,6 +1061,7 @@ mod tests {
             location: String::new(),
             specificity: Specificity::new(1, 0, 0),
             shadow_depth: 0,
+            order: 0,
         };
         let e = DeclarationProperty {
             value: CssValue::String("orange".into()),
@@ -1052,6 +1070,7 @@ mod tests {
             location: String::new(),
             specificity: Specificity::new(1, 0, 0),
             shadow_depth: 0,
+            order: 0,
         };
         let f = DeclarationProperty {
             value: CssValue::String("purple".into()),
@@ -1060,6 +1079,7 @@ mod tests {
             location: String::new(),
             specificity: Specificity::new(1, 0, 0),
             shadow_depth: 0,
+            order: 0,
         };
 
         assert_eq!(3, a.priority());

--- a/crates/gosub_css3/src/media_query.rs
+++ b/crates/gosub_css3/src/media_query.rs
@@ -277,10 +277,23 @@ impl MediaCondition {
     /// Convert a single non-operator node (a feature or a range) into a condition.
     fn term_from_ast(node: &Node) -> Option<Self> {
         match &node.node_type {
-            NodeType::Feature { name, value, .. } => Some(MediaCondition::Feature(MediaFeature {
-                name: name.cow_to_lowercase().into_owned(),
-                value: value.as_deref().and_then(FeatureValue::from_ast),
-            })),
+            NodeType::Feature { name, value, .. } => {
+                // A feature written *with* a value that we cannot understand is false, per
+                // mediaqueries-4 - it must not collapse into the boolean form `(hover)`, which
+                // asks a different question and answers true for anything with a non-zero value.
+                // `(max-width: <unparseable>)` used to match every viewport that way.
+                let value = match value.as_deref() {
+                    Some(node) => match FeatureValue::from_ast(node) {
+                        Some(value) => Some(value),
+                        None => return Some(MediaCondition::Unknown),
+                    },
+                    None => None,
+                };
+                Some(MediaCondition::Feature(MediaFeature {
+                    name: name.cow_to_lowercase().into_owned(),
+                    value,
+                }))
+            }
             NodeType::Range {
                 left,
                 left_comparison,
@@ -329,6 +342,15 @@ impl FeatureValue {
             NodeType::Number { value } => Some(FeatureValue::Number(*value)),
             NodeType::Ident { value } => Some(FeatureValue::Ident(value.cow_to_lowercase().into_owned())),
             NodeType::Dimension { value, unit } => Self::from_dimension(*value, unit),
+            // `(max-width: calc(1120px - 1px))`. The media prelude parser reads a function token
+            // with `parse_function`, so `calc()` arrives as a `Function` node whose arguments are
+            // the expression's tokens; `Calc` covers the value-parser's shape for the same thing.
+            NodeType::Function { name, arguments } if name.eq_ignore_ascii_case("calc") => {
+                eval_calc(arguments).map(FeatureValue::Length)
+            }
+            NodeType::Calc { .. } => eval_calc_node(node)
+                .and_then(|term| term.is_length.then_some(term.value))
+                .map(FeatureValue::Length),
             // A ratio arrives as `<number> / <number>`.
             NodeType::Value { children } => match children.as_slice() {
                 [num, op, den] if matches!(&op.node_type, NodeType::Operator(o) if o == "/") => {
@@ -343,15 +365,10 @@ impl FeatureValue {
     }
 
     fn from_dimension(value: f32, unit: &str) -> Option<Self> {
+        if let Some(px) = length_to_px(value, unit) {
+            return Some(FeatureValue::Length(px));
+        }
         Some(match unit.cow_to_lowercase().as_ref() {
-            "px" => FeatureValue::Length(value),
-            "em" | "rem" => FeatureValue::Length(value * MEDIA_QUERY_FONT_SIZE),
-            "pt" => FeatureValue::Length(value * PX_PER_IN / 72.0),
-            "pc" => FeatureValue::Length(value * PX_PER_IN / 6.0),
-            "in" => FeatureValue::Length(value * PX_PER_IN),
-            "cm" => FeatureValue::Length(value * PX_PER_CM),
-            "mm" => FeatureValue::Length(value * PX_PER_CM / 10.0),
-            "q" => FeatureValue::Length(value * PX_PER_CM / 40.0),
             "dppx" | "x" => FeatureValue::Resolution(value),
             "dpi" => FeatureValue::Resolution(value / PX_PER_IN),
             "dpcm" => FeatureValue::Resolution(value / PX_PER_CM),
@@ -377,6 +394,215 @@ impl FeatureValue {
             _ => None,
         }
     }
+}
+
+/// A length in its CSS unit, converted to px. `None` when the unit is not a length - a
+/// resolution (`dppx`) or an angle has no px value, and neither do the relative units that need
+/// a layout to resolve.
+fn length_to_px(value: f32, unit: &str) -> Option<f32> {
+    Some(match unit.cow_to_lowercase().as_ref() {
+        "px" => value,
+        // Media queries evaluate against the initial font size: the query decides which rules
+        // apply, so it cannot depend on a font size those rules might set.
+        "em" | "rem" => value * MEDIA_QUERY_FONT_SIZE,
+        "pt" => value * PX_PER_IN / 72.0,
+        "pc" => value * PX_PER_IN / 6.0,
+        "in" => value * PX_PER_IN,
+        "cm" => value * PX_PER_CM,
+        "mm" => value * PX_PER_CM / 10.0,
+        "q" => value * PX_PER_CM / 40.0,
+        _ => return None,
+    })
+}
+
+/// One term of a `calc()` expression: a resolved value plus whether it carried a unit.
+///
+/// The distinction matters because css-values-3 only allows a `<length>` to be scaled by a
+/// unitless `<number>` - `calc(100px * 2)` is a length, `calc(100px * 2px)` is invalid - and
+/// because a media feature wants a length out, not a bare number.
+#[derive(Clone, Copy)]
+struct CalcTerm {
+    value: f32,
+    is_length: bool,
+}
+
+/// Evaluates a `calc()` expression given as the function's argument nodes, returning a length
+/// in CSS px. `None` when the expression is not a plain arithmetic length - a percentage, a
+/// viewport unit, an unsupported nested function - which makes the whole media feature false
+/// rather than silently guessing.
+fn eval_calc(arguments: &[Node]) -> Option<f32> {
+    let term = eval_calc_terms(arguments)?;
+    term.is_length.then_some(term.value)
+}
+
+/// Evaluates one node that may hold a `calc()` in either shape the parsers produce: argument
+/// nodes (the media prelude reads `calc(` with `parse_function`) or the raw expression text
+/// (`parse_calc`, used by the value parser and so by any *nested* `calc()`).
+fn eval_calc_node(node: &Node) -> Option<CalcTerm> {
+    match &node.node_type {
+        NodeType::Calc { expr } => eval_calc_node(expr),
+        NodeType::Raw { value } => {
+            let mut rest = value.as_str();
+            let term = eval_calc_sum(&mut rest)?;
+            rest.trim().is_empty().then_some(term)
+        }
+        NodeType::Function { name, arguments } if name.is_empty() || name.eq_ignore_ascii_case("calc") => {
+            eval_calc_terms(arguments)
+        }
+        _ => eval_calc_terms(std::slice::from_ref(node)),
+    }
+}
+
+/// `<product> ( ('+' | '-') <product> )*` over the raw expression text.
+fn eval_calc_sum(rest: &mut &str) -> Option<CalcTerm> {
+    let mut acc = eval_calc_product(rest)?;
+    loop {
+        *rest = rest.trim_start();
+        let Some(op) = rest.chars().next().filter(|c| *c == '+' || *c == '-') else {
+            return Some(acc);
+        };
+        *rest = &rest[1..];
+        let rhs = eval_calc_product(rest)?;
+        acc = combine_add(acc, rhs, if op == '+' { 1.0 } else { -1.0 })?;
+    }
+}
+
+/// `<value> ( ('*' | '/') <value> )*`, binding tighter than `+`/`-`.
+fn eval_calc_product(rest: &mut &str) -> Option<CalcTerm> {
+    let mut acc = eval_calc_value(rest)?;
+    loop {
+        *rest = rest.trim_start();
+        let Some(op) = rest.chars().next().filter(|c| *c == '*' || *c == '/') else {
+            return Some(acc);
+        };
+        *rest = &rest[1..];
+        let rhs = eval_calc_value(rest)?;
+        acc = if op == '*' {
+            combine_mul(acc, rhs)?
+        } else {
+            combine_div(acc, rhs)?
+        };
+    }
+}
+
+/// A parenthesised group, a nested `calc(...)`, or a number with an optional unit.
+fn eval_calc_value(rest: &mut &str) -> Option<CalcTerm> {
+    *rest = rest.trim_start();
+    for prefix in ["calc(", "("] {
+        if let Some(inner) = rest.strip_prefix(prefix) {
+            *rest = inner;
+            let term = eval_calc_sum(rest)?;
+            *rest = rest.trim_start().strip_prefix(')')?;
+            return Some(term);
+        }
+    }
+
+    // A number, then the run of letters after it as the unit.
+    let digits = rest
+        .find(|c: char| !(c.is_ascii_digit() || c == '.' || c == '-' || c == '+'))
+        .unwrap_or(rest.len());
+    let value: f32 = rest[..digits].parse().ok()?;
+    *rest = &rest[digits..];
+    let unit_len = rest.find(|c: char| !c.is_ascii_alphabetic()).unwrap_or(rest.len());
+    let unit = &rest[..unit_len];
+    *rest = &rest[unit_len..];
+
+    if unit.is_empty() {
+        return Some(CalcTerm {
+            value,
+            is_length: false,
+        });
+    }
+    Some(CalcTerm {
+        value: length_to_px(value, unit)?,
+        is_length: true,
+    })
+}
+
+fn eval_calc_terms(nodes: &[Node]) -> Option<CalcTerm> {
+    // Sum of products: collect `* / ` chains into single terms, then add and subtract them.
+    let mut sum: Option<CalcTerm> = None;
+    let mut pending_add: Option<char> = None;
+    let mut current: Option<CalcTerm> = None;
+    let mut pending_mul: Option<char> = None;
+
+    for node in nodes {
+        if let NodeType::Operator(op) = &node.node_type {
+            match op.as_str() {
+                "+" | "-" => {
+                    // A `+`/`-` closes the product being built; fold it into the sum.
+                    let term = current.take()?;
+                    sum = Some(match (sum, pending_add) {
+                        (None, None) => term,
+                        (Some(acc), Some('+')) => combine_add(acc, term, 1.0)?,
+                        (Some(acc), Some('-')) => combine_add(acc, term, -1.0)?,
+                        _ => return None,
+                    });
+                    pending_add = op.chars().next();
+                }
+                "*" | "/" => pending_mul = op.chars().next(),
+                _ => return None,
+            }
+            continue;
+        }
+
+        let term = match &node.node_type {
+            NodeType::Number { value } => CalcTerm {
+                value: *value,
+                is_length: false,
+            },
+            NodeType::Dimension { value, unit } => CalcTerm {
+                value: length_to_px(*value, unit)?,
+                is_length: true,
+            },
+            // A nested `calc()` or a bare parenthesised group.
+            NodeType::Function { name, arguments } if name.is_empty() || name.eq_ignore_ascii_case("calc") => {
+                eval_calc_terms(arguments)?
+            }
+            NodeType::Calc { .. } | NodeType::Raw { .. } => eval_calc_node(node)?,
+            // Percentages need a layout to resolve, and anything else is not arithmetic.
+            _ => return None,
+        };
+
+        current = Some(match (current, pending_mul.take()) {
+            (None, None) => term,
+            (Some(acc), Some('*')) => combine_mul(acc, term)?,
+            (Some(acc), Some('/')) => combine_div(acc, term)?,
+            _ => return None,
+        });
+    }
+
+    let term = current?;
+    match (sum, pending_add) {
+        (None, None) => Some(term),
+        (Some(acc), Some('+')) => combine_add(acc, term, 1.0),
+        (Some(acc), Some('-')) => combine_add(acc, term, -1.0),
+        _ => None,
+    }
+}
+
+/// `a ± b`. css-values-3 forbids mixing a length with a bare number in an addition.
+fn combine_add(a: CalcTerm, b: CalcTerm, sign: f32) -> Option<CalcTerm> {
+    (a.is_length == b.is_length).then_some(CalcTerm {
+        value: a.value + sign * b.value,
+        is_length: a.is_length,
+    })
+}
+
+/// `a * b`. At most one side may carry a unit.
+fn combine_mul(a: CalcTerm, b: CalcTerm) -> Option<CalcTerm> {
+    (!(a.is_length && b.is_length)).then_some(CalcTerm {
+        value: a.value * b.value,
+        is_length: a.is_length || b.is_length,
+    })
+}
+
+/// `a / b`. The divisor must be a unitless number, and not zero.
+fn combine_div(a: CalcTerm, b: CalcTerm) -> Option<CalcTerm> {
+    (!b.is_length && b.value != 0.0).then_some(CalcTerm {
+        value: a.value / b.value,
+        is_length: a.is_length,
+    })
 }
 
 /// The `min-`/`max-` prefix on a feature name, which the spec defines as `>=` / `<=`.
@@ -822,5 +1048,46 @@ mod tests {
         let default = MediaEnvironment::default();
         assert!(!matches("aural", &default));
         assert!(matches("not aural", &default));
+    }
+
+    #[test]
+    fn calc_in_a_length_feature_is_evaluated() {
+        let narrow = env(1119.0, 800.0);
+        let wide = env(1280.0, 800.0);
+
+        // Wikipedia's Vector-2022 shell is gated on exactly this query. Before calc() was
+        // evaluated it degraded to the boolean form `(max-width)` and matched every viewport,
+        // so a 1280px window got the narrow layout.
+        assert!(matches("screen and (max-width: calc(1120px - 1px))", &narrow));
+        assert!(!matches("screen and (max-width: calc(1120px - 1px))", &wide));
+
+        assert!(matches("(min-width: calc(640px + 10px))", &wide));
+        assert!(!matches("(min-width: calc(640px + 10px))", &env(600.0, 800.0)));
+    }
+
+    #[test]
+    fn calc_handles_precedence_and_nesting() {
+        let env = env(1000.0, 800.0);
+        // 100px * 2 + 100px = 300px, not 100px * (2 + 100px)
+        assert!(matches("(min-width: calc(100px * 2 + 100px))", &env));
+        assert!(!matches("(min-width: calc(100px * 2 + 900px))", &env));
+        assert!(matches("(max-width: calc(2000px / 2 + 1px))", &env));
+        assert!(matches("(min-width: calc(calc(500px + 100px) + 100px))", &env));
+        // `em` in a media query resolves against the initial font size, in calc too.
+        assert!(matches("(min-width: calc(40em + 8px))", &env));
+        assert!(!matches("(min-width: calc(70em + 8px))", &env));
+    }
+
+    #[test]
+    fn an_unparseable_feature_value_is_false_not_boolean() {
+        let env = env(1280.0, 800.0);
+        // Invalid arithmetic (a length added to a bare number) makes the feature false. The
+        // danger is the opposite answer: treating it as the valueless form `(max-width)`, which
+        // is true for any non-zero width.
+        assert!(!matches("(max-width: calc(100px + 5))", &env));
+        assert!(!matches("(max-width: calc(50% - 1px))", &env));
+        assert!(!matches("(min-width: nonsense)", &env));
+        // The genuine boolean form still works.
+        assert!(matches("(width)", &env));
     }
 }

--- a/crates/gosub_css3/src/media_query.rs
+++ b/crates/gosub_css3/src/media_query.rs
@@ -188,7 +188,12 @@ impl MediaQuery {
             negated,
             media_type,
             unknown_type,
-            condition: condition.as_deref().and_then(MediaCondition::from_ast),
+            // A condition that is present but unparseable is *unknown*, not absent: dropping it
+            // to `None` left the query matching on its media type alone, so `@media screen and
+            // (width > junk)` applied everywhere on screen.
+            condition: condition
+                .as_deref()
+                .map(|c| MediaCondition::from_ast(c).unwrap_or(MediaCondition::Unknown)),
         })
     }
 
@@ -889,6 +894,19 @@ mod tests {
 
     fn matches(query: &str, env: &MediaEnvironment) -> bool {
         query_list(query).matches(env)
+    }
+
+    /// A condition the engine cannot read must not simply vanish: dropping it left the query
+    /// matching on its media type alone, which turns "screen and something-we-do-not-understand"
+    /// into plain "screen" and applies the rules everywhere.
+    #[test]
+    fn an_unreadable_condition_does_not_match_on_media_type_alone() {
+        let screen = env(1200.0, 800.0);
+
+        assert!(!matches("screen and (width > junk)", &screen));
+        assert!(!matches("(width > junk)", &screen));
+        // The type on its own still matches, so the test is about the condition, not the type.
+        assert!(matches("screen", &screen));
     }
 
     #[test]

--- a/crates/gosub_css3/src/parser/at_rule.rs
+++ b/crates/gosub_css3/src/parser/at_rule.rs
@@ -17,23 +17,30 @@ use cow_utils::CowUtils;
 use gosub_shared::errors::{CssError, CssResult};
 
 impl Css3<'_> {
+    /// Decide how to read the body of an at-rule the parser has no specific handler for, by
+    /// looking ahead for whichever comes first: a `{` or an `@` means the body holds nested rules
+    /// (`@keyframes`), and the block's own `}` means it holds declarations (`@counter-style`,
+    /// `@property`).
+    ///
+    /// Every arm used to answer `RegularBlock`, so a descriptor body was always parsed as if it
+    /// were rules: `@counter-style x{system:numeric;…}` read `system:numeric` as a selector and
+    /// then failed on the `;`, and the same for `@property`. The caller has already consumed the
+    /// opening `{`, so the scan starts at the first token inside the block.
     fn declaration_block_at_rule(&mut self) -> BlockParseMode {
-        let mut offset = 1;
+        let mut offset = 0;
         loop {
             let t = self.tokenizer.lookahead(offset);
             offset += 1;
 
             match t.token_type {
+                // The block closed without a nested rule starting: it was all declarations.
                 TokenType::RCurly => {
-                    return BlockParseMode::RegularBlock;
+                    return BlockParseMode::StyleBlock;
                 }
-                TokenType::LCurly => {
+                TokenType::LCurly | TokenType::AtKeyword(_) => {
                     return BlockParseMode::RegularBlock;
                 }
                 TokenType::Eof => {
-                    return BlockParseMode::RegularBlock;
-                }
-                TokenType::AtKeyword(_) => {
                     return BlockParseMode::RegularBlock;
                 }
                 _ => {
@@ -206,5 +213,62 @@ impl Css3<'_> {
             },
             t.location,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Css3, CssOrigin};
+    use gosub_shared::config::ParserConfig;
+
+    /// Parse with errors *not* ignored, so a rule the parser trips over is visible as a failure
+    /// rather than a log line. A page is parsed with `ignore_errors: true`, where the same trip
+    /// only costs the offending rule - which is why this went unnoticed as five warnings a load.
+    fn parse_strict(css: &str) -> Result<crate::stylesheet::CssStylesheet, String> {
+        Css3::parse_str(css, ParserConfig::default(), CssOrigin::Author, "test.css").map_err(|e| format!("{e:?}"))
+    }
+
+    fn selector_text(sheet: &crate::stylesheet::CssStylesheet) -> Vec<String> {
+        sheet
+            .rules
+            .iter()
+            .flat_map(|rule| rule.selectors().iter().map(|sel| format!("{sel:?}")))
+            .collect()
+    }
+
+    #[test]
+    fn an_unknown_at_rule_body_of_descriptors_parses() {
+        // Wikipedia ships three of these. Every arm of the block-mode scan answered "nested
+        // rules", so `system:numeric` was read as a selector and the `;` after it was a parse
+        // error - one per descriptor list, on every page load.
+        let sheet = parse_strict("@counter-style meetei{system:numeric;symbols:'0' '1';suffix:') '}")
+            .expect("a descriptor body should parse");
+        assert!(
+            selector_text(&sheet).is_empty(),
+            "the at-rule contributes no style rules"
+        );
+    }
+
+    #[test]
+    fn an_unknown_at_rule_of_descriptors_leaves_its_neighbours_alone() {
+        let sheet = parse_strict("a{color:red}@property --x{syntax:'<color>';inherits:false}b{color:blue}")
+            .expect("a descriptor body should parse");
+        let selectors = selector_text(&sheet);
+        assert_eq!(selectors.len(), 2, "{selectors:?}");
+    }
+
+    #[test]
+    fn an_unknown_at_rule_of_nested_rules_still_reads_as_rules() {
+        // `@keyframes` is the other shape: its body holds qualified rules, not descriptors, and
+        // the `{` of the first one is what says so.
+        let sheet = parse_strict("@keyframes spin{from{opacity:0}to{opacity:1}}a{color:red}")
+            .expect("a nested-rule body should parse");
+        assert_eq!(selector_text(&sheet).len(), 1);
+    }
+
+    #[test]
+    fn an_empty_unknown_at_rule_block_is_harmless() {
+        let sheet = parse_strict("@counter-style empty{}a{color:red}").expect("an empty body should parse");
+        assert_eq!(selector_text(&sheet).len(), 1);
     }
 }

--- a/crates/gosub_css3/src/stylesheet.rs
+++ b/crates/gosub_css3/src/stylesheet.rs
@@ -779,7 +779,10 @@ impl CssValue {
     pub fn to_color(&self) -> Option<RgbColor> {
         match self {
             CssValue::Color(col) => Some(*col),
-            CssValue::String(s) => Some(RgbColor::from(s.as_str())),
+            // Fallible on purpose: a string that is not a colour (`none`, `no-repeat`, any
+            // keyword that lands in a colour slot) must leave the property unset rather than
+            // resolve to `RgbColor`'s opaque-black default and paint over the element.
+            CssValue::String(s) => RgbColor::try_from_str(s.as_str()),
             CssValue::Function(name, args) => parse_css_color_function(name, args),
             _ => None,
         }

--- a/crates/gosub_css3/src/system.rs
+++ b/crates/gosub_css3/src/system.rs
@@ -669,7 +669,14 @@ pub fn node_is_unrenderable<C: HasDocument>(doc: &C::Document, id: NodeId) -> bo
 
     match doc.node_type(id) {
         NodeType::ElementNode => doc.tag_name(id).is_some_and(|name| REMOVABLE_ELEMENTS.contains(&name)),
-        NodeType::TextNode => doc.text_value(id).is_some_and(|v| v.chars().all(char::is_whitespace)),
+        // Only *collapsible* whitespace makes a text node unrenderable. `char::is_whitespace` is
+        // the Unicode set, which includes U+00A0 NO-BREAK SPACE and the other fixed-width spaces -
+        // characters CSS renders like any other, and which exist precisely to be kept. Parsoid
+        // wraps every entity in its own element, so `Designed<span>&nbsp;</span>by` had the whole
+        // span dropped and Wikipedia's infoboxes read "Designedby", "Firstappeared", "May1, 1964".
+        NodeType::TextNode => doc
+            .text_value(id)
+            .is_some_and(|v| v.chars().all(|c: char| c.is_ascii_whitespace())),
         _ => false,
     }
 }

--- a/crates/gosub_css3/src/system.rs
+++ b/crates/gosub_css3/src/system.rs
@@ -301,9 +301,15 @@ fn compute_properties<C: HasDocument<CssSystem = Css3System>>(
 
     let mut fix_list = FixList::new();
 
+    // Document-order position of each declaration, the cascade's last tiebreak. `matched` is in
+    // stylesheet order and `declarations()` in source order, so a simple running counter is
+    // exactly the order the author wrote.
+    let mut order: u32 = 0;
+
     for (sheet, rule, specificity, depth) in matched {
         // Selector matched, so we add all declared values to the map
         for declaration in rule.declarations() {
+            order += 1;
             // Custom property declarations were consumed above; keep them out of
             // the regular cascade.
             if declaration.property.starts_with("--") {
@@ -329,6 +335,7 @@ fn compute_properties<C: HasDocument<CssSystem = Css3System>>(
                         important: declaration.important,
                     },
                     depth,
+                    order,
                 );
                 continue;
             }
@@ -353,6 +360,7 @@ fn compute_properties<C: HasDocument<CssSystem = Css3System>>(
                         sheet.url.clone(),
                         specificity,
                         depth,
+                        order,
                     ));
 
                     // Each CSS declaration starts with a fresh TRBL multiplier
@@ -387,6 +395,7 @@ fn compute_properties<C: HasDocument<CssSystem = Css3System>>(
                                         important: declaration.important,
                                     },
                                     depth,
+                                    order,
                                 );
                                 recovered = true;
                             }
@@ -401,6 +410,7 @@ fn compute_properties<C: HasDocument<CssSystem = Css3System>>(
                                         important: declaration.important,
                                     },
                                     depth,
+                                    order,
                                 );
                                 recovered = true;
                             }
@@ -435,6 +445,7 @@ fn compute_properties<C: HasDocument<CssSystem = Css3System>>(
                             important: declaration.important,
                         },
                         depth,
+                        order,
                     );
                 }
                 None => {
@@ -464,6 +475,7 @@ fn compute_properties<C: HasDocument<CssSystem = Css3System>>(
                             important: declaration.important,
                         },
                         depth,
+                        order,
                     );
                 }
             }
@@ -545,6 +557,7 @@ pub fn add_property_to_map(
     specificity: Specificity,
     declaration: &CssDeclaration,
     shadow_depth: u16,
+    order: u32,
 ) {
     let property_name = declaration.property.clone();
 
@@ -556,6 +569,7 @@ pub fn add_property_to_map(
         location: sheet.url.clone(),
         specificity,
         shadow_depth,
+        order,
     };
 
     css_map_entry

--- a/crates/gosub_fontmanager/src/lib.rs
+++ b/crates/gosub_fontmanager/src/lib.rs
@@ -1,3 +1,29 @@
+#[cfg(any(feature = "pango", feature = "skia"))]
+pub(crate) mod fontconfig_lock {
+    use parking_lot::{Mutex, MutexGuard};
+
+    /// Serialises this crate's use of the process-global fontconfig configuration.
+    ///
+    /// fontconfig's documented thread safety does not cover mutating the current config while
+    /// another thread reads it, and "reads it" includes everything that goes through it
+    /// indirectly: Pango's ft2 font map walks the config's font set, and Skia's
+    /// `FontMgr::new()` calls `FcInitLoadConfigAndFonts()`, which builds a config and mmaps its
+    /// caches. Registering a web font (`FcConfigBuildFonts`) underneath either one segfaults.
+    ///
+    /// The lock lives at the crate root rather than in one font system because the two ends of
+    /// the race are in *different* ones - a Pango `list_families()` crashing while Skia builds a
+    /// config on another thread - and neither module can see the other's lock.
+    static FONTCONFIG: Mutex<()> = Mutex::new(());
+
+    /// Hold the fontconfig lock for the current scope.
+    ///
+    /// Not reentrant: no path that takes it may call another that does. Today the direct FFI
+    /// (`fontconfig_match`, font registration) and the Pango font-map walks are disjoint.
+    pub(crate) fn hold() -> MutexGuard<'static, ()> {
+        FONTCONFIG.lock()
+    }
+}
+
 pub mod cosmic_system;
 pub mod parley_system;
 

--- a/crates/gosub_fontmanager/src/pango_system.rs
+++ b/crates/gosub_fontmanager/src/pango_system.rs
@@ -690,10 +690,18 @@ mod tests {
         let fs = Arc::new(PangoFontSystem::new());
         let style = TextStyle::new("sans-serif", 16.0);
 
-        let threads: Vec<_> = (0..8)
+        // Each worker reports when it finishes. `join()` on its own cannot tell a deadlock from
+        // slow work - it waits forever, so the test would hang rather than report, and only the
+        // harness timeout would ever notice. Collecting the reports with a deadline turns a
+        // deadlock into a failure with a message.
+        const WORKERS: usize = 8;
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+
+        let threads: Vec<_> = (0..WORKERS)
             .map(|i| {
                 let fs = Arc::clone(&fs);
                 let style = style.clone();
+                let done_tx = done_tx.clone();
                 std::thread::spawn(move || {
                     for _ in 0..20 {
                         if i % 2 == 0 {
@@ -707,12 +715,23 @@ mod tests {
                             assert!(!family.is_empty(), "a family must always be chosen");
                         }
                     }
+                    let _ = done_tx.send(i);
                 })
             })
             .collect();
+        drop(done_tx);
+
+        // Generous against the work itself - 160 layouts take milliseconds - and decisive against
+        // a deadlock, which never finishes at all.
+        let deadline = std::time::Duration::from_secs(30);
+        for _ in 0..WORKERS {
+            done_rx
+                .recv_timeout(deadline)
+                .expect("a worker never finished: fontconfig_lock is being taken twice on one thread");
+        }
 
         for t in threads {
-            t.join().expect("no thread may panic or hang");
+            t.join().expect("no thread may panic");
         }
     }
 

--- a/crates/gosub_fontmanager/src/pango_system.rs
+++ b/crates/gosub_fontmanager/src/pango_system.rs
@@ -276,7 +276,18 @@ impl PangoFontSystem {
 
     /// Walk `families` (comma-separated CSS `font-family` value) and return the
     /// first family name that Pango knows about, falling back to `"sans"`.
+    ///
+    /// Listing the context's families reads the fontconfig-backed font map, which
+    /// `register_font_via_fontconfig` mutates under `fontconfig_lock`, so the read is taken under
+    /// the same lock. The lock is a plain mutex and does not re-enter: a caller that already holds
+    /// it - `build_layout` does - must use [`Self::find_available_font_locked`] instead.
     pub fn find_available_font(&self, families: &str, ctx: &pango::Context) -> String {
+        let _guard = crate::fontconfig_lock::hold();
+        self.find_available_font_locked(families, ctx)
+    }
+
+    /// [`Self::find_available_font`] for a caller that is already holding `fontconfig_lock`.
+    fn find_available_font_locked(&self, families: &str, ctx: &pango::Context) -> String {
         let available_fonts: Vec<String> = ctx
             .list_families()
             .iter()
@@ -370,7 +381,8 @@ impl PangoFontSystem {
         // 96 DPI matches the browser/CSS convention, same as the rasterizer.
         context_set_resolution(&layout.context(), 96.0);
 
-        let family = self.find_available_font(&style.family, &layout.context());
+        // The lock is held above and does not re-enter, so this takes the unlocked helper.
+        let family = self.find_available_font_locked(&style.family, &layout.context());
         let mut font_desc = pango::FontDescription::new();
         font_desc.set_family(&family);
         // CSS px → pt (× 72/96), then to Pango units (× SCALE).
@@ -664,6 +676,44 @@ mod tests {
     fn registers_font_via_fontconfig() {
         let res = register_font_via_fontconfig(gosub_shared::ROBOTO_FONT, Some("Gosub Roboto Test"));
         assert!(res.is_ok(), "fontconfig registration failed: {res:?}");
+    }
+
+    /// `find_available_font` takes `fontconfig_lock`, and `build_layout` holds it for the whole
+    /// of its work - including its own family lookup. A plain mutex does not re-enter, so if
+    /// `build_layout` ever went through the public entry point instead of the unlocked helper,
+    /// this deadlocks rather than failing an assertion. Running both concurrently is what makes
+    /// that visible.
+    #[test]
+    fn measuring_and_resolving_a_family_do_not_deadlock() {
+        use std::sync::Arc;
+
+        let fs = Arc::new(PangoFontSystem::new());
+        let style = TextStyle::new("sans-serif", 16.0);
+
+        let threads: Vec<_> = (0..8)
+            .map(|i| {
+                let fs = Arc::clone(&fs);
+                let style = style.clone();
+                std::thread::spawn(move || {
+                    for _ in 0..20 {
+                        if i % 2 == 0 {
+                            let layout = fs.build_layout("hello", &style).expect("layout");
+                            assert!(layout.pixel_size().0 > 0);
+                        } else {
+                            let surface = cairo::ImageSurface::create(cairo::Format::ARgb32, 1, 1).expect("surface");
+                            let cr = cairo::Context::new(&surface).expect("cairo");
+                            let layout = pangocairo::functions::create_layout(&cr);
+                            let family = fs.find_available_font("sans-serif", &layout.context());
+                            assert!(!family.is_empty(), "a family must always be chosen");
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        for t in threads {
+            t.join().expect("no thread may panic or hang");
+        }
     }
 
     /// `families()` reads the default Pango font map (fontconfig): non-empty on any machine

--- a/crates/gosub_fontmanager/src/pango_system.rs
+++ b/crates/gosub_fontmanager/src/pango_system.rs
@@ -19,12 +19,6 @@ use std::sync::{Arc, OnceLock};
 
 const DEFAULT_FONT_FAMILY: &str = "sans";
 
-/// Serialises every direct fontconfig call in this module. Mutating the process-global config
-/// (`FcConfigAppFontAddFile`/`FcConfigBuildFonts`) while another thread matches against it
-/// (`FcFontMatch`) segfaults - fontconfig's documented thread safety does not cover concurrent
-/// mutation of the current config.
-static FONTCONFIG_LOCK: Mutex<()> = Mutex::new(());
-
 /// Register an in-memory `@font-face` font so Pango (via fontconfig) can discover it.
 ///
 /// The bytes are written to a uniquely-named file in the temp dir - intentionally left on
@@ -64,7 +58,7 @@ fn register_font_via_fontconfig(data: &[u8], family_override: Option<&str>) -> R
         .ok_or_else(|| FontError::InvalidFont("non-UTF-8 font path".to_string()))?;
     let c_path = std::ffi::CString::new(path_str).map_err(|e| FontError::InvalidFont(format!("font path: {e}")))?;
 
-    let _guard = FONTCONFIG_LOCK.lock();
+    let _guard = crate::fontconfig_lock::hold();
 
     #[allow(unsafe_code)] // fontconfig has no safe Rust binding for app-font registration
     // SAFETY: `FcConfigGetCurrent` returns the process-global config (auto-initialised, not
@@ -158,7 +152,7 @@ fn fontconfig_match(
         .filter_map(|f| std::ffi::CString::new(*f).ok())
         .collect();
 
-    let _guard = FONTCONFIG_LOCK.lock();
+    let _guard = crate::fontconfig_lock::hold();
 
     #[allow(unsafe_code)] // fontconfig has no safe Rust binding for font matching
     // SAFETY: `FcConfigGetCurrent` returns the process-global config (checked for null). The
@@ -367,6 +361,9 @@ impl PangoFontSystem {
     fn build_layout(&self, text: &str, style: &TextStyle) -> Option<pango::Layout> {
         use pangocairo::functions::{context_set_resolution, create_layout};
 
+        // Same global config as `families()`: `create_layout` and `find_available_font` both
+        // read the fontconfig-backed font map.
+        let _guard = crate::fontconfig_lock::hold();
         let surface = cairo::ImageSurface::create(cairo::Format::ARgb32, 1, 1).ok()?;
         let cr = cairo::Context::new(&surface).ok()?;
         let layout = create_layout(&cr);
@@ -538,6 +535,9 @@ impl FontSystem for PangoFontSystem {
         // default font map - the fontconfig database, including web fonts registered before
         // the font map was first built.
         use pangocairo::functions::create_layout;
+        // Walking the font map reads the global fontconfig config, so it must not overlap a
+        // thread registering a web font into it or building a fresh one.
+        let _guard = crate::fontconfig_lock::hold();
         let Ok(surface) = cairo::ImageSurface::create(cairo::Format::ARgb32, 1, 1) else {
             return Vec::new();
         };

--- a/crates/gosub_fontmanager/src/skia_system.rs
+++ b/crates/gosub_fontmanager/src/skia_system.rs
@@ -18,6 +18,38 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 
+/// The system font manager for this thread, built once and reused.
+///
+/// Two reasons it is not simply `FontMgr::new()` at each use site.
+///
+/// **It must not be built concurrently.** On Linux `FontMgr::new()` reaches
+/// `SkFontMgr_New_FontConfig` → `FcInitLoadConfigAndFonts()`, which builds a fontconfig
+/// configuration and mmaps its caches. Two threads doing that at once - or one doing it while
+/// Pango walks the same global config on another thread - had one unmapping cache files under
+/// the other, segfaulting inside libfontconfig. It showed up as an occasional SIGSEGV in this
+/// crate's tests, but only under `cargo test --workspace`: the `pango` and `skia` features are
+/// off by default, so a standalone run never compiled the two systems into the same binary.
+///
+/// **It is expensive.** Each call scanned the system's fonts from scratch, and eight call sites
+/// did so on every query.
+///
+/// The handle itself stays per-thread because skia-safe puts no `Send`/`Sync` on `RCHandle`, so a
+/// `FontMgr` cannot be shared between threads; only its construction is serialised.
+fn system_font_mgr() -> FontMgr {
+    thread_local! {
+        static SYSTEM_FONT_MGR: RefCell<Option<FontMgr>> = const { RefCell::new(None) };
+    }
+
+    SYSTEM_FONT_MGR.with(|cell| {
+        let mut cell = cell.borrow_mut();
+        cell.get_or_insert_with(|| {
+            let _guard = crate::fontconfig_lock::hold();
+            FontMgr::new()
+        })
+        .clone()
+    })
+}
+
 // ── Registered web fonts ──────────────────────────────────────────────────────
 //
 // `@font-face` fonts are registered as raw bytes in a process-global registry (bytes are
@@ -60,7 +92,7 @@ fn build_web_font_mgr() -> Option<FontMgr> {
     if reg.fonts.is_empty() {
         return None;
     }
-    let fm = FontMgr::new();
+    let fm = system_font_mgr();
     let mut provider = TypefaceFontProvider::new();
     let mut any = false;
     for (family, bytes) in reg.fonts.iter() {
@@ -137,7 +169,7 @@ thread_local! {
 
 fn base_font_collection() -> FontCollection {
     let mut fc = FontCollection::new();
-    fc.set_default_font_manager(FontMgr::new(), None);
+    fc.set_default_font_manager(system_font_mgr(), None);
     fc
 }
 
@@ -225,7 +257,7 @@ pub(crate) fn resolve_family_list(families: &str) -> Vec<String> {
             return v.clone();
         }
 
-        let fm = FontMgr::new();
+        let fm = system_font_mgr();
         let web = web_font_mgr();
         let normal = FontStyle::normal();
 
@@ -378,12 +410,12 @@ impl FontSystem for SkiaFontSystem {
         // Validate the bytes and derive the family name if none was supplied.
         let family = match family_override {
             Some(f) => f.to_string(),
-            None => match FontMgr::new().new_from_data(&data, None) {
+            None => match system_font_mgr().new_from_data(&data, None) {
                 Some(tf) => tf.family_name(),
                 None => return Err(FontError::InvalidFont("could not decode font data".into())),
             },
         };
-        if FontMgr::new().new_from_data(&data, None).is_none() {
+        if system_font_mgr().new_from_data(&data, None).is_none() {
             return Err(FontError::InvalidFont(format!("unsupported font data for '{family}'")));
         }
         let mut reg = registry().lock();
@@ -408,7 +440,7 @@ impl FontSystem for SkiaFontSystem {
         }
 
         let web = web_font_mgr();
-        let fm = FontMgr::new();
+        let fm = system_font_mgr();
         for name in &names {
             let typeface = web
                 .as_ref()
@@ -432,7 +464,7 @@ impl FontSystem for SkiaFontSystem {
     fn families(&mut self) -> Vec<String> {
         // System fonts plus the registered web fonts, which live in a separate provider
         // (`web_font_mgr`) rather than the platform font manager.
-        let mut out: Vec<String> = FontMgr::new().family_names().collect();
+        let mut out: Vec<String> = system_font_mgr().family_names().collect();
         if let Some(web) = web_font_mgr() {
             out.extend(web.family_names());
         }
@@ -627,7 +659,7 @@ mod tests {
             let name = &resolved[0];
             // If the system has any monospace font, the generic must have been replaced by
             // the same concrete family `matchFamilyStyle` (fc-match) picks.
-            if let Some(tf) = FontMgr::new().match_family_style("monospace", FontStyle::normal()) {
+            if let Some(tf) = system_font_mgr().match_family_style("monospace", FontStyle::normal()) {
                 assert_eq!(name, &tf.family_name(), "stack '{stack}'");
             } else {
                 assert_eq!(name, "monospace");

--- a/crates/gosub_lattice/src/compute.rs
+++ b/crates/gosub_lattice/src/compute.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 
 use crate::grid::{build_section_grid, PlacedCell, SectionGrid};
 use crate::model::{build_model, RowGroup};
-use crate::sizing::columns::compute_column_widths;
+use crate::sizing::columns::{compute_column_widths, max_content_width};
 use crate::sizing::rows::{compute_row_heights, read_border, read_padding};
 use crate::types::{CellLayout, CssLength, CssProp};
 use crate::TableTree;
@@ -55,10 +55,20 @@ pub fn compute_table_layout<T: TableTree>(
         return Ok((0.0, 0.0));
     }
 
-    // Resolve table width
+    // Resolve table width. An auto width normally takes everything on offer; a table that
+    // sizes to its contents instead takes `min(available, max-content)` - CSS 2.1 §17.5.2.2's
+    // `max(MIN, min(MAX, available))`, with the cells' natural widths standing in for MAX.
     let table_width = match tree.css_length(model.node, CssProp::Width) {
         CssLength::Px(w) => w,
         CssLength::Percent(p) => p / 100.0 * available_width,
+        _ if tree.table_shrink_to_fit(model.node) => {
+            let grids: Vec<&SectionGrid<T::NodeId>> = header_grids
+                .iter()
+                .chain(body_grids.iter())
+                .chain(footer_grids.iter())
+                .collect();
+            max_content_width(tree, n_cols, spacing_x, &grids).min(available_width)
+        }
         _ => available_width,
     };
 
@@ -104,11 +114,27 @@ pub fn compute_table_layout<T: TableTree>(
     //    Each cell is positioned relative to its row.
     let inner_width = col_widths.iter().sum::<f32>() + (n_cols as f32 + 1.0) * spacing_x;
 
+    // The caption spans the finished table and sits outside the row stack (CSS 2.1 §17.4).
+    // It takes no part in the column algorithm, so it is measured only now, once the width it
+    // will be laid out at is known, and everything below it starts under it.
+    let caption = model.caption.map(|node| {
+        (
+            node,
+            tree.caption_height(node, table_width),
+            tree.caption_at_bottom(node),
+        )
+    });
+    // A top caption pushes the rows down; a bottom one is placed once their height is known.
+    let caption_offset = match caption {
+        Some((_, height, false)) => height,
+        _ => 0.0,
+    };
+
     // Y offset of the next group, relative to the table. Vertically the table is one
     // flat stack of rows: one gutter above the first row, one between any two adjacent
     // rows (also across group boundaries), one below the last. Groups therefore carry
     // only the (n_rows - 1) *internal* gutters; the shared boundary gutters live here.
-    let mut group_y = spacing_y;
+    let mut group_y = caption_offset + spacing_y;
 
     #[allow(clippy::type_complexity)]
     let section_data: &[(&[RowGroup<T::NodeId>], &[SectionGrid<T::NodeId>], &[Vec<f32>])] = &[
@@ -148,7 +174,23 @@ pub fn compute_table_layout<T: TableTree>(
         }
     }
 
-    let total_height = group_y;
+    let mut total_height = group_y;
+
+    if let Some((node, height, at_bottom)) = caption {
+        let y = if at_bottom { total_height } else { 0.0 };
+        tree.set_layout(
+            node,
+            CellLayout {
+                position: Point::new(0.0, y),
+                size: Size::new(table_width, height),
+                border: BOX_EDGES_ZERO,
+                padding: BOX_EDGES_ZERO,
+            },
+        );
+        if at_bottom {
+            total_height += height;
+        }
+    }
 
     Ok((table_width, total_height))
 }

--- a/crates/gosub_lattice/src/lib.rs
+++ b/crates/gosub_lattice/src/lib.rs
@@ -76,4 +76,15 @@ pub trait TableTree {
     fn cell_content_width(&self, _id: Self::NodeId) -> f32 {
         0.0
     }
+
+    /// Returns the min-content border-box width of cell `id`: the width of its widest unbreakable
+    /// content - its longest word, or a replaced element's full width.
+    ///
+    /// A column is never given less than this. Below it the shaper has to break inside a word,
+    /// which browsers do not do under `overflow-wrap: normal`; the content overflows the cell
+    /// instead, which is worse. Implementors that cannot measure it may return `0.0`, which
+    /// restores the unfloored proportional split.
+    fn cell_min_content_width(&mut self, _id: Self::NodeId) -> f32 {
+        0.0
+    }
 }

--- a/crates/gosub_lattice/src/lib.rs
+++ b/crates/gosub_lattice/src/lib.rs
@@ -47,6 +47,28 @@ pub trait TableTree {
     /// by the row-height algorithm.
     fn layout_cell(&mut self, id: Self::NodeId, available_width: f32) -> f32;
 
+    /// Whether this table box sizes to its contents rather than filling the space offered.
+    ///
+    /// CSS auto table width is `max(MIN, min(MAX, available))`; a table that is floated or
+    /// `inline-table` is always shrink-to-fit. Implementors that do not model floats can leave
+    /// this `false`, which keeps the "fill the available width" behaviour.
+    fn table_shrink_to_fit(&self, _id: Self::NodeId) -> bool {
+        false
+    }
+
+    /// Whether the caption goes below the table rather than above (`caption-side: bottom`).
+    fn caption_at_bottom(&self, _id: Self::NodeId) -> bool {
+        false
+    }
+
+    /// Height of the table's caption when laid out at `width`.
+    ///
+    /// A caption does not take part in the column algorithm - it is placed across the finished
+    /// table (CSS 2.1 §17.4) - so it is measured separately, after the width is known.
+    fn caption_height(&mut self, _id: Self::NodeId, _width: f32) -> f32 {
+        0.0
+    }
+
     /// Returns the natural (pre-pass) border-box width of cell `id` as
     /// measured by the layout engine in a prior pass (e.g. Taffy).  Used to
     /// distribute auto column widths proportionally to content width rather

--- a/crates/gosub_lattice/src/mock.rs
+++ b/crates/gosub_lattice/src/mock.rs
@@ -29,6 +29,8 @@ pub struct MockCell {
     pub padding: f32,
     /// Natural (pre-pass) border-box width reported via `cell_content_width`.
     pub content_width: f32,
+    /// Min-content border-box width reported via `cell_min_content_width`.
+    pub min_content_width: f32,
     /// Content height reported by `layout_cell` (as if children were laid out).
     pub content_height: f32,
 }
@@ -44,6 +46,7 @@ impl MockCell {
             border: 0.0,
             padding: 1.0,
             content_width: 0.0,
+            min_content_width: 0.0,
             content_height: 0.0,
         }
     }
@@ -74,6 +77,10 @@ impl MockCell {
     }
     pub fn content_width(mut self, w: f32) -> Self {
         self.content_width = w;
+        self
+    }
+    pub fn min_content_width(mut self, w: f32) -> Self {
+        self.min_content_width = w;
         self
     }
     pub fn content_height(mut self, h: f32) -> Self {
@@ -200,6 +207,7 @@ struct MockNode {
     border: f32,
     padding: f32,
     content_width: f32,
+    min_content_width: f32,
     content_height: f32,
 }
 
@@ -248,6 +256,7 @@ impl MockTree {
                 border,
                 padding,
                 content_width: 0.0,
+                min_content_width: 0.0,
                 content_height: 0.0,
             },
         );
@@ -268,6 +277,7 @@ impl MockTree {
         );
         if let Some(node) = self.nodes.get_mut(&id) {
             node.content_width = mc.content_width;
+            node.min_content_width = mc.min_content_width;
             node.content_height = mc.content_height;
         }
         id
@@ -356,6 +366,10 @@ impl TableTree for MockTree {
 
     fn cell_content_width(&self, id: u32) -> f32 {
         self.nodes.get(&id).map(|n| n.content_width).unwrap_or(0.0)
+    }
+
+    fn cell_min_content_width(&mut self, id: u32) -> f32 {
+        self.nodes.get(&id).map(|n| n.min_content_width).unwrap_or(0.0)
     }
 }
 

--- a/crates/gosub_lattice/src/mock.rs
+++ b/crates/gosub_lattice/src/mock.rs
@@ -31,6 +31,8 @@ pub struct MockCell {
     pub content_width: f32,
     /// Min-content border-box width reported via `cell_min_content_width`.
     pub min_content_width: f32,
+    /// For a `TableRole::Caption` node: whether it sits below the table (`caption-side: bottom`).
+    pub caption_at_bottom: bool,
     /// Content height reported by `layout_cell` (as if children were laid out).
     pub content_height: f32,
 }
@@ -47,6 +49,7 @@ impl MockCell {
             padding: 1.0,
             content_width: 0.0,
             min_content_width: 0.0,
+            caption_at_bottom: false,
             content_height: 0.0,
         }
     }
@@ -81,6 +84,11 @@ impl MockCell {
     }
     pub fn min_content_width(mut self, w: f32) -> Self {
         self.min_content_width = w;
+        self
+    }
+    /// Place a caption below the table rather than above it.
+    pub fn caption_at_bottom(mut self) -> Self {
+        self.caption_at_bottom = true;
         self
     }
     pub fn content_height(mut self, h: f32) -> Self {
@@ -208,6 +216,7 @@ struct MockNode {
     padding: f32,
     content_width: f32,
     min_content_width: f32,
+    caption_at_bottom: bool,
     content_height: f32,
 }
 
@@ -257,6 +266,7 @@ impl MockTree {
                 padding,
                 content_width: 0.0,
                 min_content_width: 0.0,
+                caption_at_bottom: false,
                 content_height: 0.0,
             },
         );
@@ -278,7 +288,19 @@ impl MockTree {
         if let Some(node) = self.nodes.get_mut(&id) {
             node.content_width = mc.content_width;
             node.min_content_width = mc.min_content_width;
+            node.caption_at_bottom = mc.caption_at_bottom;
             node.content_height = mc.content_height;
+        }
+        id
+    }
+
+    /// Allocate a `TableRole::Caption` node from a [`MockCell`] spec. The spec's `height` is what
+    /// `caption_height` reports, standing in for a measured caption, and `caption_at_bottom`
+    /// chooses the side.
+    pub fn alloc_caption(&mut self, mc: MockCell) -> u32 {
+        let id = self.alloc_cell(mc);
+        if let Some(node) = self.nodes.get_mut(&id) {
+            node.role = TableRole::Caption;
         }
         id
     }
@@ -370,6 +392,16 @@ impl TableTree for MockTree {
 
     fn cell_min_content_width(&mut self, id: u32) -> f32 {
         self.nodes.get(&id).map(|n| n.min_content_width).unwrap_or(0.0)
+    }
+
+    fn caption_at_bottom(&self, id: u32) -> bool {
+        self.nodes.get(&id).is_some_and(|n| n.caption_at_bottom)
+    }
+
+    /// A mock caption carries no content, so its explicit CSS `height` stands in for the height
+    /// the layout engine would have measured.
+    fn caption_height(&mut self, id: u32, _width: f32) -> f32 {
+        self.nodes.get(&id).and_then(|n| n.height).unwrap_or(0.0)
     }
 }
 

--- a/crates/gosub_lattice/src/model.rs
+++ b/crates/gosub_lattice/src/model.rs
@@ -105,6 +105,11 @@ pub fn build_model<T: TableTree>(tree: &T, table_node: T::NodeId) -> TableModel<
             // An anonymous cell has no node of its own, and the layout tree is addressed by
             // node, so the run's first child stands in for it. That is exact for a run of one,
             // which is the shape that occurs in practice.
+            //
+            // KNOWN LIMIT: for a longer run only that first child is measured and positioned by
+            // the table - the rest keep whatever the layout engine gave them inside the table's
+            // box. Representing the whole run needs either a synthetic node id, which the
+            // `TableTree` contract has no way to mint, or a cell that carries several nodes.
             TableRole::Other => {
                 let group = anon_body_group(&mut model.row_groups);
                 let row = anon_row(&mut group.rows);

--- a/crates/gosub_lattice/src/model.rs
+++ b/crates/gosub_lattice/src/model.rs
@@ -62,6 +62,10 @@ pub fn build_model<T: TableTree>(tree: &T, table_node: T::NodeId) -> TableModel<
         border_spacing: parse_border_spacing(tree, table_node),
     };
 
+    // Consecutive non-table children share one anonymous cell, so only the first of a run
+    // opens one; the rest are already inside it.
+    let mut in_anonymous_run = false;
+
     for child in tree.children(table_node) {
         match tree.table_role(child) {
             TableRole::Caption => {
@@ -92,9 +96,32 @@ pub fn build_model<T: TableTree>(tree: &T, table_node: T::NodeId) -> TableModel<
                 let row = anon_row(&mut group.rows);
                 row.cells.push(build_source_cell(tree, child));
             }
-            // Column, Other - not direct children of the table box
-            TableRole::Table | TableRole::Column | TableRole::Other => {}
+            // Content that is not part of the table structure: CSS 2.1 §17.2.1 wraps each
+            // consecutive run of it in one anonymous cell, inside an anonymous row and body
+            // group. That is what makes `display: table` usable as a plain shrink-to-fit box -
+            // Wikipedia thumbnails are `figure { display: table }` around a link and a caption,
+            // and without the fixup such a table has no columns at all and computes to 0x0.
+            //
+            // An anonymous cell has no node of its own, and the layout tree is addressed by
+            // node, so the run's first child stands in for it. That is exact for a run of one,
+            // which is the shape that occurs in practice.
+            TableRole::Other => {
+                let group = anon_body_group(&mut model.row_groups);
+                let row = anon_row(&mut group.rows);
+                if in_anonymous_run {
+                    continue;
+                }
+                row.cells.push(SourceCell {
+                    node: child,
+                    colspan: 1,
+                    rowspan: 1,
+                });
+                in_anonymous_run = true;
+                continue;
+            }
+            TableRole::Table | TableRole::Column => {}
         }
+        in_anonymous_run = false;
     }
 
     model

--- a/crates/gosub_lattice/src/sizing/columns.rs
+++ b/crates/gosub_lattice/src/sizing/columns.rs
@@ -33,13 +33,20 @@ pub fn compute_column_widths<T: TableTree>(
     let mut explicit: Vec<Option<f32>> = vec![None; n_cols];
     let mut natural: Vec<f32> = vec![0.0; n_cols];
 
-    // Scan the first non-empty row for explicit widths and natural content widths.
+    // Scan for explicit widths and natural content widths, taking the first row that actually
+    // says something about individual columns.
+    //
+    // A row made only of spanning cells says nothing: it covers several columns at once and cannot
+    // tell them apart. Stopping at the first *non-empty* row therefore learned nothing at all from
+    // a table whose first row is a `colspan` title - Wikipedia's infobox, whose heading spans both
+    // columns - and every column fell through to equal widths. That gave the label column half the
+    // box and left the values overflowing it.
     'outer: for grid in grids {
         for row_idx in 0..grid.n_rows {
-            let mut found_any = false;
+            let mut found_single = false;
             for cell in grid.cells_in_row(row_idx) {
-                found_any = true;
                 if cell.colspan == 1 {
+                    found_single = true;
                     let cw = tree.cell_content_width(cell.node);
                     if explicit[cell.col].is_none() {
                         // A specified width cannot shrink a cell below its content's min-width
@@ -56,7 +63,7 @@ pub fn compute_column_widths<T: TableTree>(
                     }
                 }
             }
-            if found_any {
+            if found_single {
                 break 'outer;
             }
         }

--- a/crates/gosub_lattice/src/sizing/columns.rs
+++ b/crates/gosub_lattice/src/sizing/columns.rs
@@ -211,6 +211,11 @@ pub fn max_content_width<T: TableTree>(
     if n_cols == 0 {
         return 0.0;
     }
+    let width_of = |cell: &crate::grid::PlacedCell<T::NodeId>| match tree.css_length(cell.node, CssProp::Width) {
+        CssLength::Px(px) => px.max(tree.cell_content_width(cell.node)),
+        _ => tree.cell_content_width(cell.node),
+    };
+
     let mut natural = vec![0.0_f32; n_cols];
     for grid in grids {
         for row_idx in 0..grid.n_rows {
@@ -218,13 +223,40 @@ pub fn max_content_width<T: TableTree>(
                 if cell.colspan != 1 || cell.col >= n_cols {
                     continue;
                 }
-                let width = match tree.css_length(cell.node, CssProp::Width) {
-                    CssLength::Px(px) => px.max(tree.cell_content_width(cell.node)),
-                    _ => tree.cell_content_width(cell.node),
-                };
+                let width = width_of(cell);
                 natural[cell.col] = natural[cell.col].max(width);
             }
         }
     }
+
+    // A spanning cell has to fit too. Here the answer *is* the table's width - a floated table is
+    // sized from it - so leaving spanning cells out is not the harmless approximation it is when
+    // distributing a width that is already known: a table whose content lives entirely in spanning
+    // cells measured nothing but its gutters and every column was then sized from near zero.
+    //
+    // Only the shortfall is added, spread evenly over the columns the cell covers, so a spanning
+    // cell that already fits changes nothing.
+    for grid in grids {
+        for row_idx in 0..grid.n_rows {
+            for cell in grid.cells_in_row(row_idx) {
+                let last = cell.col + cell.colspan;
+                if cell.colspan <= 1 || last > n_cols {
+                    continue;
+                }
+                let covered = &mut natural[cell.col..last];
+                let spanned_gutters = (cell.colspan as f32 - 1.0) * border_spacing_x;
+                let width = width_of(cell);
+                let shortfall = width - spanned_gutters - covered.iter().sum::<f32>();
+                if shortfall <= 0.0 {
+                    continue;
+                }
+                let share = shortfall / cell.colspan as f32;
+                for col in covered {
+                    *col += share;
+                }
+            }
+        }
+    }
+
     natural.iter().sum::<f32>() + (n_cols as f32 + 1.0) * border_spacing_x
 }

--- a/crates/gosub_lattice/src/sizing/columns.rs
+++ b/crates/gosub_lattice/src/sizing/columns.rs
@@ -1,6 +1,7 @@
 use crate::grid::SectionGrid;
 use crate::types::{CssLength, CssProp};
 use crate::TableTree;
+use std::collections::HashMap;
 
 /// Compute column widths for a table with `n_cols` columns.
 ///
@@ -17,7 +18,7 @@ use crate::TableTree;
 ///    natural content width. Falls back to equal distribution if no content
 ///    width information is available.
 pub fn compute_column_widths<T: TableTree>(
-    tree: &T,
+    tree: &mut T,
     n_cols: usize,
     table_width: f32,
     border_spacing_x: f32,
@@ -33,6 +34,7 @@ pub fn compute_column_widths<T: TableTree>(
 
     let mut explicit: Vec<Option<f32>> = vec![None; n_cols];
     let mut natural: Vec<f32> = vec![0.0; n_cols];
+    let mut min_content: Vec<f32> = vec![0.0; n_cols];
 
     // Scan every row for explicit widths and natural content widths.
     //
@@ -50,6 +52,10 @@ pub fn compute_column_widths<T: TableTree>(
                     continue;
                 }
                 let cw = tree.cell_content_width(cell.node);
+                let mcw = tree.cell_min_content_width(cell.node);
+                if mcw > min_content[cell.col] {
+                    min_content[cell.col] = mcw;
+                }
                 if explicit[cell.col].is_none() {
                     // A specified width cannot shrink a cell below its content's min-width
                     // (CSS: used width = max(specified, min-content)). Without this, e.g. a
@@ -99,17 +105,29 @@ pub fn compute_column_widths<T: TableTree>(
 
             if content_natural_total > 0.0 {
                 let content_remaining = (remaining - narrow_total).max(0.0);
+                let content_cols: Vec<usize> = auto_cols
+                    .iter()
+                    .copied()
+                    .filter(|&c| natural[c] >= NARROW_THRESHOLD)
+                    .collect();
+                let shares = distribute_with_floor(
+                    content_remaining,
+                    &content_cols,
+                    &natural,
+                    &min_content,
+                    content_natural_total,
+                );
                 for &col in &auto_cols {
                     if natural[col] < NARROW_THRESHOLD {
-                        explicit[col] = Some(natural[col].max(NARROW_FLOOR));
+                        explicit[col] = Some(natural[col].max(NARROW_FLOOR).max(min_content[col]));
                     } else {
-                        explicit[col] = Some(content_remaining * natural[col] / content_natural_total);
+                        explicit[col] = Some(shares[&col]);
                     }
                 }
             } else {
                 // All auto columns are narrow - distribute remaining proportionally.
                 for &col in &auto_cols {
-                    explicit[col] = Some(remaining * natural[col] / total_natural);
+                    explicit[col] = Some((remaining * natural[col] / total_natural).max(min_content[col]));
                 }
             }
         } else {
@@ -122,6 +140,57 @@ pub fn compute_column_widths<T: TableTree>(
     }
 
     explicit.iter().map(|w| w.unwrap_or(0.0)).collect()
+}
+
+/// Share `space` among `cols` proportionally to their natural width, but never below a column's
+/// min-content width.
+///
+/// A plain proportional split can hand a column less than its content can ever occupy, and the
+/// content then spills out of the cell - Wikipedia's dialect table gave the "Windows" column 73px
+/// for a word that is 87px wide including its padding. This follows the shape of CSS 2.1
+/// §17.5.2.2: every column takes its min-content first, and what is left over is shared out in
+/// proportion to how much *more* than that each column wants. When even the min-contents do not
+/// fit, each column takes its min-content and the table overflows, which is what browsers do.
+fn distribute_with_floor(
+    space: f32,
+    cols: &[usize],
+    natural: &[f32],
+    min_content: &[f32],
+    natural_total: f32,
+) -> HashMap<usize, f32> {
+    // A column can want less than its min-content (a long word inside a cell whose other content
+    // is narrower), so the ceiling is the larger of the two.
+    let want = |c: usize| natural[c].max(min_content[c]);
+    let floor_total: f32 = cols.iter().map(|&c| min_content[c]).sum();
+
+    if floor_total <= 0.0 {
+        // Nothing to floor against - the plain proportional split, unchanged.
+        return cols.iter().map(|&c| (c, space * natural[c] / natural_total)).collect();
+    }
+    if space <= floor_total {
+        return cols.iter().map(|&c| (c, min_content[c])).collect();
+    }
+
+    let want_total: f32 = cols.iter().map(|&c| want(c)).sum();
+    let slack_total = want_total - floor_total;
+    let surplus = space - floor_total;
+    if slack_total <= 0.0 {
+        // Every column is at its floor; share what is left equally rather than by a zero ratio.
+        let each = surplus / cols.len() as f32;
+        return cols.iter().map(|&c| (c, min_content[c] + each)).collect();
+    }
+    // Every column reaches its floor first, then takes a share of what is left in proportion to
+    // how much *more* than that it asked for.
+    let ratio = (surplus / slack_total).min(1.0);
+    // Space beyond what the columns asked for altogether. It is shared in proportion to `want`,
+    // which is what the unfloored split did with all of it.
+    let extra = (surplus - slack_total).max(0.0);
+    cols.iter()
+        .map(|&c| {
+            let share = min_content[c] + (want(c) - min_content[c]) * ratio + extra * want(c) / want_total;
+            (c, share)
+        })
+        .collect()
 }
 
 /// The table's max-content width.

--- a/crates/gosub_lattice/src/sizing/columns.rs
+++ b/crates/gosub_lattice/src/sizing/columns.rs
@@ -60,9 +60,16 @@ pub fn compute_column_widths<T: TableTree>(
                     // A specified width cannot shrink a cell below its content's min-width
                     // (CSS: used width = max(specified, min-content)). Without this, e.g. a
                     // `width:18px` cell holding a 20px image clips it and eats the padding.
+                    //
+                    // Both measurements are needed for that floor. `cell_content_width` reports
+                    // the width the cell *has* - in the pipeline, the width pinned by the previous
+                    // pass - which can be less than the widest word it holds, so clamping to it
+                    // alone let an explicit-width column keep the overflow the auto path below now
+                    // prevents.
+                    let floor = cw.max(mcw);
                     match tree.css_length(cell.node, CssProp::Width) {
-                        CssLength::Px(px) => explicit[cell.col] = Some(px.max(cw)),
-                        CssLength::Percent(p) => explicit[cell.col] = Some((p / 100.0 * table_width).max(cw)),
+                        CssLength::Px(px) => explicit[cell.col] = Some(px.max(floor)),
+                        CssLength::Percent(p) => explicit[cell.col] = Some((p / 100.0 * table_width).max(floor)),
                         _ => {}
                     }
                 }

--- a/crates/gosub_lattice/src/sizing/columns.rs
+++ b/crates/gosub_lattice/src/sizing/columns.rs
@@ -118,3 +118,39 @@ pub fn compute_column_widths<T: TableTree>(
 
     explicit.iter().map(|w| w.unwrap_or(0.0)).collect()
 }
+
+/// The table's max-content width.
+///
+/// Every column at its cells' natural width, plus the gutters.
+///
+/// Used for a shrink-to-fit table, where the used width is `min(available, max-content)` rather
+/// than all the space on offer. A cell's natural width comes from the layout engine's earlier
+/// pass, so this is only as good as that measurement - which is exactly what the auto column
+/// distribution below already relies on.
+#[must_use]
+pub fn max_content_width<T: TableTree>(
+    tree: &T,
+    n_cols: usize,
+    border_spacing_x: f32,
+    grids: &[&SectionGrid<T::NodeId>],
+) -> f32 {
+    if n_cols == 0 {
+        return 0.0;
+    }
+    let mut natural = vec![0.0_f32; n_cols];
+    for grid in grids {
+        for row_idx in 0..grid.n_rows {
+            for cell in grid.cells_in_row(row_idx) {
+                if cell.colspan != 1 || cell.col >= n_cols {
+                    continue;
+                }
+                let width = match tree.css_length(cell.node, CssProp::Width) {
+                    CssLength::Px(px) => px.max(tree.cell_content_width(cell.node)),
+                    _ => tree.cell_content_width(cell.node),
+                };
+                natural[cell.col] = natural[cell.col].max(width);
+            }
+        }
+    }
+    natural.iter().sum::<f32>() + (n_cols as f32 + 1.0) * border_spacing_x
+}

--- a/crates/gosub_lattice/src/sizing/columns.rs
+++ b/crates/gosub_lattice/src/sizing/columns.rs
@@ -7,11 +7,12 @@ use crate::TableTree;
 /// Algorithm:
 /// 1. The available space is `table_width` minus the horizontal border-spacing
 ///    gutters (one between each pair of columns plus the outer two).
-/// 2. Scan the first non-empty row across all provided grids (header first,
-///    then body, then footer).  For each single-column cell in that row:
-///    - If it has an explicit CSS `width` in px or %, assign that to its column.
-///    - Record its pre-pass natural width (from `cell_content_width`) for use
-///      in step 3.
+/// 2. Scan every row of every provided grid (header first, then body, then
+///    footer).  For each single-column cell:
+///    - If it has an explicit CSS `width` in px or % and its column has no
+///      width yet, assign that to the column.
+///    - Keep the widest pre-pass natural width (from `cell_content_width`)
+///      seen in the column, for use in step 3.
 /// 3. Remaining space is distributed to auto columns proportionally to their
 ///    natural content width. Falls back to equal distribution if no content
 ///    width information is available.
@@ -33,38 +34,35 @@ pub fn compute_column_widths<T: TableTree>(
     let mut explicit: Vec<Option<f32>> = vec![None; n_cols];
     let mut natural: Vec<f32> = vec![0.0; n_cols];
 
-    // Scan for explicit widths and natural content widths, taking the first row that actually
-    // says something about individual columns.
+    // Scan every row for explicit widths and natural content widths.
     //
-    // A row made only of spanning cells says nothing: it covers several columns at once and cannot
-    // tell them apart. Stopping at the first *non-empty* row therefore learned nothing at all from
-    // a table whose first row is a `colspan` title - Wikipedia's infobox, whose heading spans both
-    // columns - and every column fell through to equal widths. That gave the label column half the
-    // box and left the values overflowing it.
-    'outer: for grid in grids {
+    // A column's natural width is the widest of its cells, so all of them have to be looked at.
+    // Reading a single row instead cannot describe a table whose columns are not all introduced at
+    // once: Wikipedia's dialect table heads columns 0-6 in its first row and puts columns 7 and 8
+    // in a *second* header row, under a `colspan=2` title. The first row says nothing about those
+    // two, so they measured 0 and collapsed to the narrow floor - 14 px each - while their content
+    // spilled out to the right. Only cells spanning one column are counted: a spanning cell covers
+    // several at once and cannot tell them apart.
+    for grid in grids {
         for row_idx in 0..grid.n_rows {
-            let mut found_single = false;
             for cell in grid.cells_in_row(row_idx) {
-                if cell.colspan == 1 {
-                    found_single = true;
-                    let cw = tree.cell_content_width(cell.node);
-                    if explicit[cell.col].is_none() {
-                        // A specified width cannot shrink a cell below its content's min-width
-                        // (CSS: used width = max(specified, min-content)). Without this, e.g. a
-                        // `width:18px` cell holding a 20px image clips it and eats the padding.
-                        match tree.css_length(cell.node, CssProp::Width) {
-                            CssLength::Px(px) => explicit[cell.col] = Some(px.max(cw)),
-                            CssLength::Percent(p) => explicit[cell.col] = Some((p / 100.0 * table_width).max(cw)),
-                            _ => {}
-                        }
-                    }
-                    if cw > natural[cell.col] {
-                        natural[cell.col] = cw;
+                if cell.colspan != 1 || cell.col >= n_cols {
+                    continue;
+                }
+                let cw = tree.cell_content_width(cell.node);
+                if explicit[cell.col].is_none() {
+                    // A specified width cannot shrink a cell below its content's min-width
+                    // (CSS: used width = max(specified, min-content)). Without this, e.g. a
+                    // `width:18px` cell holding a 20px image clips it and eats the padding.
+                    match tree.css_length(cell.node, CssProp::Width) {
+                        CssLength::Px(px) => explicit[cell.col] = Some(px.max(cw)),
+                        CssLength::Percent(p) => explicit[cell.col] = Some((p / 100.0 * table_width).max(cw)),
+                        _ => {}
                     }
                 }
-            }
-            if found_single {
-                break 'outer;
+                if cw > natural[cell.col] {
+                    natural[cell.col] = cw;
+                }
             }
         }
     }

--- a/crates/gosub_lattice/src/sizing/columns.rs
+++ b/crates/gosub_lattice/src/sizing/columns.rs
@@ -98,10 +98,14 @@ pub fn compute_column_widths<T: TableTree>(
             const NARROW_THRESHOLD: f32 = 50.0;
             const NARROW_FLOOR: f32 = 14.0;
 
+            // The same floor the assignment below uses. Reserving only `max(natural, FLOOR)` here
+            // while handing out `max(natural, FLOOR, min_content)` there leaves the difference
+            // counted twice - once in a narrow column and once in the content columns' share - so
+            // the columns together came out wider than the table.
             let narrow_total: f32 = auto_cols
                 .iter()
                 .filter(|&&c| natural[c] < NARROW_THRESHOLD)
-                .map(|&c| natural[c].max(NARROW_FLOOR))
+                .map(|&c| narrow_width(natural[c], min_content[c], NARROW_FLOOR))
                 .sum();
 
             let content_natural_total: f32 = auto_cols
@@ -126,7 +130,7 @@ pub fn compute_column_widths<T: TableTree>(
                 );
                 for &col in &auto_cols {
                     if natural[col] < NARROW_THRESHOLD {
-                        explicit[col] = Some(natural[col].max(NARROW_FLOOR).max(min_content[col]));
+                        explicit[col] = Some(narrow_width(natural[col], min_content[col], NARROW_FLOOR));
                     } else {
                         explicit[col] = Some(shares[&col]);
                     }
@@ -147,6 +151,13 @@ pub fn compute_column_widths<T: TableTree>(
     }
 
     explicit.iter().map(|w| w.unwrap_or(0.0)).collect()
+}
+
+/// The width a narrow structural column takes: its content, never under the visibility floor and
+/// never under its longest unbreakable word. One place, so the budget and the assignment cannot
+/// drift apart.
+fn narrow_width(natural: f32, min_content: f32, floor: f32) -> f32 {
+    natural.max(floor).max(min_content)
 }
 
 /// Share `space` among `cols` proportionally to their natural width, but never below a column's

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -414,6 +414,42 @@ mod layout_tests {
         assert_approx!(l.size.width, 100.0, "single column takes full width");
     }
 
+    // A first row made only of spanning cells says nothing about individual columns, so the
+    // column scan must look past it. Wikipedia's infobox opens with a `colspan=2` title; stopping
+    // there learned no content widths at all and every column fell back to an equal share, which
+    // gave the narrow label column half the box and left the values overflowing it.
+    #[test]
+    fn a_spanning_first_row_does_not_hide_the_column_widths() {
+        use crate::mock::MockTree;
+
+        let mut tree = MockTree::new(0.0, 0.0);
+        let root = tree.alloc(TableRole::Table, None, 1, 1, None, None, 0.0, 0.0);
+        let group = tree.alloc(TableRole::RowGroup, None, 1, 1, None, None, 0.0, 0.0);
+        tree.add_child(root, group);
+
+        let title_row = tree.alloc(TableRole::Row, None, 1, 1, None, None, 0.0, 0.0);
+        tree.add_child(group, title_row);
+        let title = tree.alloc_cell(cell("title").colspan(2).height(10.0).padding(0.0));
+        tree.add_child(title_row, title);
+
+        let data_row = tree.alloc(TableRole::Row, None, 1, 1, None, None, 0.0, 0.0);
+        tree.add_child(group, data_row);
+        let label = tree.alloc_cell(cell("label").content_width(60.0).height(10.0).padding(0.0));
+        tree.add_child(data_row, label);
+        let value = tree.alloc_cell(cell("value").content_width(240.0).height(10.0).padding(0.0));
+        tree.add_child(data_row, value);
+
+        compute_table_layout(&mut tree, root, 300.0, None).expect("layout");
+
+        let label_w = tree.layout(label).expect("label laid out").size.width;
+        let value_w = tree.layout(value).expect("value laid out").size.width;
+        assert!(
+            value_w > label_w * 2.0,
+            "the second row's content widths must decide the split, not an equal share: {label_w} vs {value_w}"
+        );
+        assert_approx!(label_w + value_w, 300.0, "the columns still fill the table");
+    }
+
     // 16. Rowspan never escapes its section: a rowspan=3 in a 1-row header is
     //     clamped and does not reach into the body rows.
     #[test]

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -601,6 +601,33 @@ mod layout_tests {
         assert_approx!(wide + word, 200.0, "the columns still fill the table");
     }
 
+    // A narrow structural column is handed its min-content floor like any other, so the budget the
+    // content columns share has to reserve that floor too. Reserving only the visibility floor
+    // counted the difference twice and the columns together came out wider than the table.
+    #[test]
+    fn a_narrow_columns_floor_comes_out_of_the_budget() {
+        let (mut tree, root) = MockTable::new(200.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![
+                // Narrow by content, but holding a word far wider than the 14px floor.
+                cell("rank")
+                    .content_width(10.0)
+                    .min_content_width(100.0)
+                    .height(10.0)
+                    .padding(0.0),
+                cell("body").content_width(200.0).height(10.0).padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 200.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        let rank = tree.layout(cells[0]).expect("rank laid out").size.width;
+        let body = tree.layout(cells[1]).expect("body laid out").size.width;
+        assert_approx!(rank, 100.0, "the narrow column keeps its longest word");
+        assert_approx!(rank + body, 200.0, "and the columns still add up to the table");
+    }
+
     // When the floors alone do not fit, every column takes its min-content and the table overflows
     // - the same thing a browser does, and better than breaking words to fit.
     #[test]

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -450,6 +450,50 @@ mod layout_tests {
         assert_approx!(label_w + value_w, 300.0, "the columns still fill the table");
     }
 
+    // A column is only described by the rows it appears in, so every row has to be scanned.
+    // Wikipedia's dialect table heads seven columns in its first row and introduces the last two
+    // in a *second* header row, under a `colspan=2` title; reading only the first row left those
+    // two measuring nothing and they collapsed to the 14px narrow floor with their content
+    // hanging out to the right.
+    #[test]
+    fn columns_introduced_in_a_later_row_are_measured() {
+        let (mut tree, root) = MockTable::new(300.0)
+            .spacing(0.0, 0.0)
+            .header_row(vec![
+                cell("plain").rowspan(2).content_width(80.0).height(10.0).padding(0.0),
+                cell("group").colspan(2).height(10.0).padding(0.0),
+            ])
+            .header_row(vec![
+                cell("sub-a").content_width(110.0).height(10.0).padding(0.0),
+                cell("sub-b").content_width(90.0).height(10.0).padding(0.0),
+            ])
+            .body_row(vec![
+                cell("x").height(10.0).padding(0.0),
+                cell("y").height(10.0).padding(0.0),
+                cell("z").height(10.0).padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 300.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        let sub_a = tree.layout(cells[2]).expect("sub-a laid out").size.width;
+        let sub_b = tree.layout(cells[3]).expect("sub-b laid out").size.width;
+        assert!(
+            sub_a > 50.0 && sub_b > 50.0,
+            "the second header row's columns must take their content widths, not the narrow floor: {sub_a} and {sub_b}"
+        );
+        assert!(
+            sub_a > sub_b,
+            "and they share space proportionally to that content: {sub_a} vs {sub_b}"
+        );
+        assert_approx!(
+            tree.layout(cells[0]).expect("plain laid out").size.width + sub_a + sub_b,
+            300.0,
+            "the columns still fill the table"
+        );
+    }
+
     // 16. Rowspan never escapes its section: a rowspan=3 in a 1-row header is
     //     clamped and does not reach into the body rows.
     #[test]

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -450,6 +450,55 @@ mod layout_tests {
         assert_approx!(label_w + value_w, 300.0, "the columns still fill the table");
     }
 
+    // A shrink-to-fit table is sized *from* its max-content width, so a spanning cell has to be
+    // counted there. Skipping them - harmless when distributing a width that is already known -
+    // measured a table whose content is all in spanning cells as nothing but its gutters.
+    #[test]
+    fn max_content_counts_spanning_cells() {
+        use crate::grid::build_section_grid;
+        use crate::model::build_model;
+        use crate::sizing::columns::max_content_width;
+
+        let (tree, root) = MockTable::new(500.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![cell("title")
+                .colspan(2)
+                .content_width(300.0)
+                .height(10.0)
+                .padding(0.0)])
+            .body_row(vec![
+                cell("a").content_width(40.0).height(10.0).padding(0.0),
+                cell("b").content_width(40.0).height(10.0).padding(0.0),
+            ])
+            .into_tree();
+
+        let model = build_model(&tree, root);
+        let grids: Vec<_> = model.row_groups.iter().map(|g| build_section_grid(&g.rows)).collect();
+        let refs: Vec<_> = grids.iter().collect();
+
+        // The single-column cells ask for 80 between them; the title needs 300, so the table is
+        // as wide as the title rather than as wide as the row below it.
+        assert_approx!(max_content_width(&tree, 2, 0.0, &refs), 300.0, "table max-content");
+
+        // A spanning cell that already fits adds nothing.
+        let (narrow, narrow_root) = MockTable::new(500.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![cell("title")
+                .colspan(2)
+                .content_width(50.0)
+                .height(10.0)
+                .padding(0.0)])
+            .body_row(vec![
+                cell("a").content_width(40.0).height(10.0).padding(0.0),
+                cell("b").content_width(40.0).height(10.0).padding(0.0),
+            ])
+            .into_tree();
+        let model = build_model(&narrow, narrow_root);
+        let grids: Vec<_> = model.row_groups.iter().map(|g| build_section_grid(&g.rows)).collect();
+        let refs: Vec<_> = grids.iter().collect();
+        assert_approx!(max_content_width(&narrow, 2, 0.0, &refs), 80.0, "the row below decides");
+    }
+
     // A column may not be shrunk below the width of its widest unbreakable word: below that the
     // shaper has to break *inside* a word, which browsers do not do, so the content spills out of
     // the cell instead. Wikipedia's dialect table gave the "Windows" column 73px for an 87px word.

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -450,6 +450,75 @@ mod layout_tests {
         assert_approx!(label_w + value_w, 300.0, "the columns still fill the table");
     }
 
+    // A caption is laid out across the finished table and outside the row stack (CSS 2.1 §17.4),
+    // so it moves every row and changes the table's height - in opposite ways for the two
+    // `caption-side` values. Both branches are worth pinning down.
+    #[test]
+    fn a_caption_shifts_the_rows_or_extends_the_table() {
+        use crate::mock::MockTree;
+
+        // `side` picks `caption-side`; the table is otherwise identical.
+        let build = |at_bottom: bool| {
+            let mut tree = MockTree::new(0.0, 0.0);
+            let root = tree.alloc(TableRole::Table, None, 1, 1, None, None, 0.0, 0.0);
+
+            let mut spec = cell("caption").height(25.0).padding(0.0);
+            if at_bottom {
+                spec = spec.caption_at_bottom();
+            }
+            let caption = tree.alloc_caption(spec);
+            tree.add_child(root, caption);
+
+            let group = tree.alloc(TableRole::RowGroup, None, 1, 1, None, None, 0.0, 0.0);
+            tree.add_child(root, group);
+            let row = tree.alloc(TableRole::Row, None, 1, 1, None, None, 0.0, 0.0);
+            tree.add_child(group, row);
+            let c = tree.alloc_cell(cell("body").content_width(100.0).height(40.0).padding(0.0));
+            tree.add_child(row, c);
+
+            let (_, height) = compute_table_layout(&mut tree, root, 200.0, None).expect("layout");
+            let caption_layout = tree.layout(caption).expect("caption laid out");
+            let group_y = tree.layout(group).expect("group laid out").position.y;
+            (height, caption_layout.position.y, caption_layout.size.width, group_y)
+        };
+
+        let (height, caption_y, caption_w, group_y) = build(false);
+        assert_approx!(caption_y, 0.0, "a top caption starts at the table's top");
+        assert_approx!(group_y, 25.0, "and pushes the rows down by its height");
+        assert_approx!(caption_w, 200.0, "a caption spans the finished table");
+        assert_approx!(height, 65.0, "25 caption + 40 row");
+
+        let (height, caption_y, _, group_y) = build(true);
+        assert_approx!(group_y, 0.0, "a bottom caption leaves the rows where they are");
+        assert_approx!(caption_y, 40.0, "and sits below them");
+        assert_approx!(height, 65.0, "the table is as tall either way");
+    }
+
+    // An explicit `width` is a floor of its own, but it cannot pull a column below the widest word
+    // in it - `used width = max(specified, min-content)`. Clamping only to the width the cell
+    // already has misses that, since in the pipeline that is the width pinned by the last pass.
+    #[test]
+    fn an_explicit_width_still_respects_min_content() {
+        let (mut tree, root) = MockTable::new(400.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![
+                cell("narrow")
+                    .width(30.0)
+                    .content_width(30.0)
+                    .min_content_width(90.0)
+                    .height(10.0)
+                    .padding(0.0),
+                cell("rest").content_width(200.0).height(10.0).padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 400.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        let narrow = tree.layout(cells[0]).expect("narrow laid out").size.width;
+        assert_approx!(narrow, 90.0, "the explicit 30px cannot cut off a 90px word");
+    }
+
     // A shrink-to-fit table is sized *from* its max-content width, so a spanning cell has to be
     // counted there. Skipping them - harmless when distributing a width that is already known -
     // measured a table whose content is all in spanning cells as nothing but its gutters.

--- a/crates/gosub_lattice/src/tests.rs
+++ b/crates/gosub_lattice/src/tests.rs
@@ -450,6 +450,97 @@ mod layout_tests {
         assert_approx!(label_w + value_w, 300.0, "the columns still fill the table");
     }
 
+    // A column may not be shrunk below the width of its widest unbreakable word: below that the
+    // shaper has to break *inside* a word, which browsers do not do, so the content spills out of
+    // the cell instead. Wikipedia's dialect table gave the "Windows" column 73px for an 87px word.
+    #[test]
+    fn a_column_is_never_narrower_than_its_min_content() {
+        // Two content columns wanting 300px between them in a 200px table. The plain proportional
+        // split gives the narrow one 50px, which is less than the 80px word it holds.
+        let (mut tree, root) = MockTable::new(200.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![
+                cell("wide")
+                    .content_width(300.0)
+                    .min_content_width(60.0)
+                    .height(10.0)
+                    .padding(0.0),
+                cell("word")
+                    .content_width(100.0)
+                    .min_content_width(80.0)
+                    .height(10.0)
+                    .padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 200.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        let wide = tree.layout(cells[0]).expect("wide laid out").size.width;
+        let word = tree.layout(cells[1]).expect("word laid out").size.width;
+        assert!(word >= 80.0, "the column keeps its longest word: {word}");
+        assert!(wide >= 60.0, "and so does the other one: {wide}");
+        assert_approx!(wide + word, 200.0, "the columns still fill the table");
+    }
+
+    // When the floors alone do not fit, every column takes its min-content and the table overflows
+    // - the same thing a browser does, and better than breaking words to fit.
+    #[test]
+    fn columns_take_their_floor_when_it_does_not_fit() {
+        let (mut tree, root) = MockTable::new(100.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![
+                cell("a")
+                    .content_width(200.0)
+                    .min_content_width(90.0)
+                    .height(10.0)
+                    .padding(0.0),
+                cell("b")
+                    .content_width(200.0)
+                    .min_content_width(90.0)
+                    .height(10.0)
+                    .padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 100.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        for c in &cells {
+            let w = tree.layout(*c).expect("cell laid out").size.width;
+            assert_approx!(w, 90.0, "each column takes its min-content");
+        }
+    }
+
+    // A table with room to spare still shares the surplus proportionally, exactly as before the
+    // floor existed - the floor must not flatten a split that already fits.
+    #[test]
+    fn the_floor_does_not_disturb_a_table_with_room_to_spare() {
+        let (mut tree, root) = MockTable::new(400.0)
+            .spacing(0.0, 0.0)
+            .body_row(vec![
+                cell("a")
+                    .content_width(100.0)
+                    .min_content_width(50.0)
+                    .height(10.0)
+                    .padding(0.0),
+                cell("b")
+                    .content_width(300.0)
+                    .min_content_width(50.0)
+                    .height(10.0)
+                    .padding(0.0),
+            ])
+            .into_tree();
+
+        compute_table_layout(&mut tree, root, 400.0, None).expect("layout");
+
+        let cells = tree.nodes_with_role(TableRole::Cell);
+        let a = tree.layout(cells[0]).expect("a laid out").size.width;
+        let b = tree.layout(cells[1]).expect("b laid out").size.width;
+        assert_approx!(a, 100.0, "column a takes what it asked for");
+        assert_approx!(b, 300.0, "column b takes what it asked for");
+    }
+
     // A column is only described by the rows it appears in, so every row has to be scanned.
     // Wikipedia's dialect table heads seven columns in its first row and introduces the last two
     // in a *second* header row, under a `colspan=2` title; reading only the first row left those

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -208,6 +208,40 @@ fn css_property_to_value<S: CssSystem>(p: &S::Property, prop: &StyleProperty) ->
             Some(Value::Keyword(intern(&s)))
         }
 
+        // ── `grid-template-areas`: one quoted string per row ───────────────
+        // `'siteNotice siteNotice' 'columnStart pageContent'` is a *list* of strings, and the
+        // row boundaries carry the meaning - joining on a space would merge every row into one.
+        // Rows are joined with '\n' (which cannot occur inside an area name) and re-split by
+        // the layouter's `parse_grid_areas`.
+        StyleProperty::GridTemplateAreas => {
+            let rows: Vec<&str> = match p.as_list() {
+                Some(list) => list.iter().filter_map(|v| v.as_string()).collect(),
+                None => vec![p.as_string()?],
+            };
+            let joined = rows
+                .iter()
+                .map(|row| row.trim_matches(['"', '\'']))
+                .collect::<Vec<_>>()
+                .join("\n");
+            Some(Value::Keyword(intern(&joined)))
+        }
+
+        // ── Grid placements: a name, a line number, or `<start> / <end>` ──
+        // The slash form arrives as a list (`[1, "/", 3]`) which `as_string()` does not return,
+        // so without this `grid-column: 1 / 3` was dropped and the item never spanned.
+        StyleProperty::GridArea | StyleProperty::GridRow | StyleProperty::GridColumn => {
+            let s = match p.as_string() {
+                Some(str) => str.to_string(),
+                None => p
+                    .as_list()?
+                    .iter()
+                    .map(grid_value_to_string::<S>)
+                    .collect::<Vec<_>>()
+                    .join(" "),
+            };
+            Some(Value::Keyword(intern(&s)))
+        }
+
         // ── Default: unit-based or keyword ────────────────────────────────
         _ => {
             if let Some((v, unit)) = p.as_unit() {

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -774,6 +774,42 @@ pub trait PipelineDocument: Send + Sync {
         // element's font-size (16px default). `em` is relative to the *parent's* computed
         // font-size for `font-size` itself, and to the element's *own* computed font-size
         // for every other property (e.g. `max-width: 17ch` lands here as `em`).
+        // `font-size` written as a percentage or a keyword. Neither could be turned into pixels,
+        // so `font_size_px` fell back to its 16px default and the element rendered at full body
+        // size - every `<sup>` on Wikipedia, whose rule is `font-size: 80%`, and anything using
+        // the UA's `sup { font-size: smaller }` or `<small>`.
+        //
+        // A percentage is against the *parent's* computed size, as are `smaller`/`larger`, which
+        // step by the spec's suggested 1.2 factor. The absolute keywords are the CSS scale with
+        // `medium` at 16px.
+        if matches!(prop, StyleProperty::FontSize) {
+            let parent_size = || match self.parent(id) {
+                Some(parent) => self.font_size_px(parent),
+                None => 16.0,
+            };
+            if let Value::Unit(pct, Unit::Percent) = &raw {
+                return Value::Unit(parent_size() * pct / 100.0, Unit::Px);
+            }
+            if let Value::Keyword(kw) = &raw {
+                let px = match crate::common::document::style::lookup(*kw).as_str() {
+                    "xx-small" => Some(9.0),
+                    "x-small" => Some(10.0),
+                    "small" => Some(13.0),
+                    "medium" => Some(16.0),
+                    "large" => Some(18.0),
+                    "x-large" => Some(24.0),
+                    "xx-large" => Some(32.0),
+                    "xxx-large" => Some(48.0),
+                    "smaller" => Some(parent_size() / 1.2),
+                    "larger" => Some(parent_size() * 1.2),
+                    _ => None,
+                };
+                if let Some(px) = px {
+                    return Value::Unit(px, Unit::Px);
+                }
+            }
+        }
+
         match &raw {
             Value::Unit(v, Unit::Rem) => Value::Unit(v * 16.0, Unit::Px),
             Value::Unit(v, Unit::Em) => {

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -635,17 +635,6 @@ pub enum BgAnchor {
 }
 
 impl BgAnchor {
-    /// The px offset this anchor carries on its own, for callers with no box to resolve against.
-    /// `Start` is exact; an edge or percentage anchor has no meaning without the box, and falls
-    /// back to the origin.
-    #[must_use]
-    pub fn as_length(self) -> f32 {
-        match self {
-            BgAnchor::Start(v) => v,
-            BgAnchor::End(_) | BgAnchor::Percent(_) => 0.0,
-        }
-    }
-
     /// Where the tile's start edge lands, given the box's and the tile's extent on this axis.
     #[must_use]
     pub fn resolve(self, box_extent: f32, tile_extent: f32) -> f32 {
@@ -676,6 +665,10 @@ fn resolve_bg_position(group: &[BgTok]) -> (BgAnchor, BgAnchor) {
     // Whether the last keyword was an edge one, and which axis/edge it named, so a length after it
     // becomes an offset from that edge.
     let mut pending_edge: Option<(bool, bool)> = None;
+    // A leading `center` claims a component without naming an axis, and the two-value form then
+    // means it took the horizontal one: `center 4px` is x = center, y = 4px. Without this the
+    // length filled the still-empty horizontal slot and the tile moved along the wrong axis.
+    let mut center_took_x = false;
 
     for tok in group {
         match tok {
@@ -703,7 +696,11 @@ fn resolve_bg_position(group: &[BgTok]) -> (BgAnchor, BgAnchor) {
                         pending_edge = Some((vertical, from_end));
                     }
                     (None, "center") => {
-                        // Which axis it means depends on the other keywords, so it waits.
+                        // Which axis it means depends on what follows, so it waits - but a length
+                        // after it is the *other* axis.
+                        if x.is_none() && y.is_none() {
+                            center_took_x = true;
+                        }
                         components += 1;
                         pending_edge = None;
                     }
@@ -728,7 +725,7 @@ fn resolve_bg_position(group: &[BgTok]) -> (BgAnchor, BgAnchor) {
                     })
                 }
                 None => {
-                    if x.is_none() {
+                    if x.is_none() && !center_took_x {
                         x = Some(BgAnchor::Start(*v));
                     } else if y.is_none() {
                         y = Some(BgAnchor::Start(*v));
@@ -738,7 +735,7 @@ fn resolve_bg_position(group: &[BgTok]) -> (BgAnchor, BgAnchor) {
             },
             BgTok::Pct(p) => {
                 pending_edge = None;
-                if x.is_none() {
+                if x.is_none() && !center_took_x {
                     x = Some(BgAnchor::Percent(*p));
                 } else if y.is_none() {
                     y = Some(BgAnchor::Percent(*p));
@@ -861,7 +858,10 @@ pub trait PipelineDocument: Send + Sync {
     /// `background-image` gradient layers in source order (first listed paints on top), each
     /// carrying its resolved tiling (`None` tiling = fill the box). Empty for solid/image
     /// backgrounds.
-    fn background_layers(&self, _id: NodeId) -> Vec<Gradient> {
+    ///
+    /// `box_size` is the painting area the layers are positioned against; an edge or percentage
+    /// `background-position` cannot be resolved without it.
+    fn background_layers(&self, _id: NodeId, _box_size: (f32, f32)) -> Vec<Gradient> {
         Vec::new()
     }
 
@@ -1688,7 +1688,7 @@ where
         None
     }
 
-    fn background_layers(&self, id: NodeId) -> Vec<Gradient> {
+    fn background_layers(&self, id: NodeId, box_size: (f32, f32)) -> Vec<Gradient> {
         // Read the layers from the pseudo-element's own map, never the owner's.
         let arc = if is_pseudo_id(u64::from(id)) {
             let (owner, role) = decode_pseudo(id);
@@ -1736,12 +1736,12 @@ where
             if tw <= 0.0 || th <= 0.0 {
                 continue;
             }
-            // A gradient's tile phase is resolved here, with no box to measure against, so only
-            // the length form can be honoured - as it always has been. An edge or percentage
-            // position on a gradient falls back to the origin.
+            // Resolved against the painting area, as `compute_bg_tiling` does for raster images:
+            // `right`, `center` and a percentage all mean a distance that depends on how much
+            // wider the box is than the tile.
             let position = pick(&pos_groups, i)
                 .map(|j| resolve_bg_position(&pos_groups[j]))
-                .map(|(x, y)| (x.as_length(), y.as_length()))
+                .map(|(x, y)| (x.resolve(box_size.0, tw), y.resolve(box_size.1, th)))
                 .unwrap_or((0.0, 0.0));
             let repeat = pick(&rep_groups, i)
                 .map(|j| resolve_bg_repeat(&rep_groups[j]))
@@ -2049,6 +2049,25 @@ mod bg_position_tests {
     }
 
     /// `right 10px` is an offset *from the right edge*, not a position 10px from the left.
+    /// `center 4px` is the two-value form: the `center` is the horizontal value and the length is
+    /// the vertical one. Letting the length take the first empty slot moved the tile sideways.
+    #[test]
+    fn a_leading_center_takes_the_horizontal_axis() {
+        assert_eq!(
+            resolve_bg_position(&[kw("center"), BgTok::Len(4.0)]),
+            (BgAnchor::Percent(50.0), BgAnchor::Start(4.0))
+        );
+        assert_eq!(
+            resolve_bg_position(&[kw("center"), BgTok::Pct(25.0)]),
+            (BgAnchor::Percent(50.0), BgAnchor::Percent(25.0))
+        );
+        // A trailing `center` still means the vertical axis.
+        assert_eq!(
+            resolve_bg_position(&[BgTok::Len(4.0), kw("center")]),
+            (BgAnchor::Start(4.0), BgAnchor::Percent(50.0))
+        );
+    }
+
     #[test]
     fn an_edge_keyword_swallows_the_length_after_it() {
         assert_eq!(

--- a/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
+++ b/crates/gosub_render_pipeline/src/common/document/pipeline_doc.rs
@@ -535,9 +535,8 @@ fn property_gradient_layers<S: CssSystem>(p: &S::Property) -> Vec<LinearGradient
 enum BgTok {
     /// A `<length>` in px (bare `0` included).
     Len(f32),
-    /// A `<percentage>` (0..100). The value is retained for future box-relative resolution;
-    /// today a percentage size/position falls back to "fill box" / zero offset.
-    #[allow(dead_code)]
+    /// A `<percentage>` (0..100). A percentage *size* still falls back to "fill the box"; a
+    /// percentage *position* is resolved against the box at paint time.
     Pct(f32),
     /// A keyword (`cover`, `center`, `no-repeat`, …), lowercased.
     Kw(String),
@@ -622,20 +621,158 @@ fn resolve_bg_size(group: &[BgTok]) -> Option<(f32, f32)> {
     }
 }
 
-/// `background-position` group → (x, y) px phase offset. Percentages and edge keywords need the
-/// box size, so they resolve to 0 for now; px offsets are exact.
-fn resolve_bg_position(group: &[BgTok]) -> (f32, f32) {
-    let lens: Vec<f32> = group
-        .iter()
-        .filter_map(|t| match t {
-            BgTok::Len(v) => Some(*v),
-            _ => None,
-        })
-        .collect();
-    match lens.as_slice() {
-        [x] => (*x, 0.0),
-        [x, y, ..] => (*x, *y),
-        _ => (0.0, 0.0),
+/// One axis of `background-position`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BgAnchor {
+    /// A length in px from the box's start edge (left / top).
+    Start(f32),
+    /// A length in px from the box's end edge - `right`, `bottom`, and the three-value forms
+    /// `right 10px` / `bottom 1em`.
+    End(f32),
+    /// A percentage: that point of the image is aligned with the same point of the box, so `50%`
+    /// centres it and `100%` puts its far edge on the box's far edge.
+    Percent(f32),
+}
+
+impl BgAnchor {
+    /// The px offset this anchor carries on its own, for callers with no box to resolve against.
+    /// `Start` is exact; an edge or percentage anchor has no meaning without the box, and falls
+    /// back to the origin.
+    #[must_use]
+    pub fn as_length(self) -> f32 {
+        match self {
+            BgAnchor::Start(v) => v,
+            BgAnchor::End(_) | BgAnchor::Percent(_) => 0.0,
+        }
+    }
+
+    /// Where the tile's start edge lands, given the box's and the tile's extent on this axis.
+    #[must_use]
+    pub fn resolve(self, box_extent: f32, tile_extent: f32) -> f32 {
+        match self {
+            BgAnchor::Start(v) => v,
+            BgAnchor::End(v) => box_extent - tile_extent - v,
+            BgAnchor::Percent(p) => (box_extent - tile_extent) * p / 100.0,
+        }
+    }
+}
+
+/// `background-position` group → one [`BgAnchor`] per axis.
+///
+/// The two-keyword form may be written in either order - `center right` means the same as
+/// `right center` - so the axis a keyword belongs to is decided by the keyword, not by where it
+/// sits in the list. Reading the first value as the horizontal one put Wikipedia's external-link
+/// icon, which is positioned `center right`, in the middle of every link instead of after it.
+///
+/// Also handles the three-value edge-offset form (`right 10px`) and the one-value form, whose
+/// missing axis is `center` rather than the start edge.
+fn resolve_bg_position(group: &[BgTok]) -> (BgAnchor, BgAnchor) {
+    let mut x: Option<BgAnchor> = None;
+    let mut y: Option<BgAnchor> = None;
+    // How many position components were written, so the one-value form can default its other axis
+    // to `center`. A length that an edge keyword swallows (`right 10px`) is part of that keyword's
+    // component, not one of its own.
+    let mut components = 0usize;
+    // Whether the last keyword was an edge one, and which axis/edge it named, so a length after it
+    // becomes an offset from that edge.
+    let mut pending_edge: Option<(bool, bool)> = None;
+
+    for tok in group {
+        match tok {
+            BgTok::Kw(k) => {
+                let edge = match k.as_str() {
+                    "left" => Some((false, false)),
+                    "right" => Some((false, true)),
+                    "top" => Some((true, false)),
+                    "bottom" => Some((true, true)),
+                    _ => None,
+                };
+                match (edge, k.as_str()) {
+                    (Some((vertical, from_end)), _) => {
+                        let anchor = if from_end {
+                            BgAnchor::End(0.0)
+                        } else {
+                            BgAnchor::Start(0.0)
+                        };
+                        if vertical {
+                            y = Some(anchor);
+                        } else {
+                            x = Some(anchor);
+                        }
+                        components += 1;
+                        pending_edge = Some((vertical, from_end));
+                    }
+                    (None, "center") => {
+                        // Which axis it means depends on the other keywords, so it waits.
+                        components += 1;
+                        pending_edge = None;
+                    }
+                    // Not a position keyword at all (a `background` shorthand carries
+                    // `no-repeat`, `cover`, … in the same list).
+                    (None, _) => pending_edge = None,
+                }
+            }
+            BgTok::Len(v) => match pending_edge.take() {
+                Some((true, from_end)) => {
+                    y = Some(if from_end {
+                        BgAnchor::End(*v)
+                    } else {
+                        BgAnchor::Start(*v)
+                    })
+                }
+                Some((false, from_end)) => {
+                    x = Some(if from_end {
+                        BgAnchor::End(*v)
+                    } else {
+                        BgAnchor::Start(*v)
+                    })
+                }
+                None => {
+                    if x.is_none() {
+                        x = Some(BgAnchor::Start(*v));
+                    } else if y.is_none() {
+                        y = Some(BgAnchor::Start(*v));
+                    }
+                    components += 1;
+                }
+            },
+            BgTok::Pct(p) => {
+                pending_edge = None;
+                if x.is_none() {
+                    x = Some(BgAnchor::Percent(*p));
+                } else if y.is_none() {
+                    y = Some(BgAnchor::Percent(*p));
+                }
+                components += 1;
+            }
+        }
+    }
+
+    // Whatever no component claimed is `center`: that is what a lone `center` means on the axis it
+    // did not name, and what the one-value form means for its missing axis.
+    let centered = BgAnchor::Percent(50.0);
+    match (x, y) {
+        (Some(x), Some(y)) => (x, y),
+        (Some(x), None) => (x, centered),
+        (None, Some(y)) => (centered, y),
+        // No component at all is the initial value, `0% 0%`.
+        (None, None) if components == 0 => (BgAnchor::Start(0.0), BgAnchor::Start(0.0)),
+        (None, None) => (centered, centered),
+    }
+}
+
+/// Whether a keyword names a place in `background-position`, as opposed to the repeat and size
+/// keywords that share the `background` shorthand's token list.
+fn is_position_keyword(k: &str) -> bool {
+    matches!(k, "left" | "right" | "top" | "bottom" | "center")
+}
+
+/// Whether a token could be part of a `<bg-position>`, used to tell a `background-position`
+/// declaration that says something from one that only carries junk.
+fn is_position_token(t: &BgTok) -> bool {
+    match t {
+        BgTok::Kw(k) => is_position_keyword(k),
+        BgTok::Len(_) | BgTok::Pct(_) => true,
     }
 }
 
@@ -684,10 +821,9 @@ pub enum BgSize {
 pub struct BgImageLayout {
     /// Whether the tile repeats on the x / y axis (`background-repeat`; default repeat both).
     pub repeat: (bool, bool),
-    /// Tile origin offset from the box origin, in px (`background-position`, length form).
-    pub position: (f32, f32),
-    /// Per-axis `center` keyword (`background-position: center`) - resolved against the box at paint.
-    pub center: (bool, bool),
+    /// Where the tile is anchored on each axis (`background-position`), resolved against the box
+    /// at paint time since edges and percentages need to know how big it is.
+    pub position: (BgAnchor, BgAnchor),
     /// Resolved `background-size`.
     pub size: BgSize,
 }
@@ -696,8 +832,7 @@ impl Default for BgImageLayout {
     fn default() -> Self {
         BgImageLayout {
             repeat: (true, true),
-            position: (0.0, 0.0),
-            center: (false, false),
+            position: (BgAnchor::Start(0.0), BgAnchor::Start(0.0)),
             size: BgSize::Auto,
         }
     }
@@ -1601,8 +1736,12 @@ where
             if tw <= 0.0 || th <= 0.0 {
                 continue;
             }
+            // A gradient's tile phase is resolved here, with no box to measure against, so only
+            // the length form can be honoured - as it always has been. An edge or percentage
+            // position on a gradient falls back to the origin.
             let position = pick(&pos_groups, i)
                 .map(|j| resolve_bg_position(&pos_groups[j]))
+                .map(|(x, y)| (x.as_length(), y.as_length()))
                 .unwrap_or((0.0, 0.0));
             let repeat = pick(&rep_groups, i)
                 .map(|j| resolve_bg_repeat(&rep_groups[j]))
@@ -1625,7 +1764,7 @@ where
         // / contain`) and then the longhands are usually empty, so scan both.
         let mut keywords: Vec<String> = Vec::new();
         let mut explicit_size: Option<(f32, f32)> = None;
-        let mut position: Option<(f32, f32)> = None;
+        let mut position: Option<(BgAnchor, BgAnchor)> = None;
 
         let mut scan = |key: &str, read_size: bool, read_pos: bool| {
             let Some(p) = <_ as CssPropertyMap<C::CssSystem>>::get(map, key) else {
@@ -1638,11 +1777,8 @@ where
             if read_size && explicit_size.is_none() {
                 explicit_size = resolve_bg_size(group);
             }
-            if read_pos && position.is_none() {
-                let pos = resolve_bg_position(group);
-                if pos != (0.0, 0.0) {
-                    position = Some(pos);
-                }
+            if read_pos && position.is_none() && group.iter().any(is_position_token) {
+                position = Some(resolve_bg_position(group));
             }
             for t in group {
                 if let BgTok::Kw(k) = t {
@@ -1673,19 +1809,18 @@ where
             None if has("contain") => BgSize::Contain,
             None => BgSize::Auto,
         };
-        // A length `background-position` wins; otherwise a bare `center` centers both axes.
-        let (position, center) = match position {
-            Some(pos) => (pos, (false, false)),
-            None if has("center") => ((0.0, 0.0), (true, true)),
-            None => ((0.0, 0.0), (false, false)),
-        };
+        // `background-position` from the longhand wins; otherwise the shorthand's own keywords
+        // (`background: url(x) no-repeat center`) are read as a position.
+        let position = position.unwrap_or_else(|| {
+            let group: Vec<BgTok> = keywords
+                .iter()
+                .filter(|k| is_position_keyword(k))
+                .map(|k| BgTok::Kw(k.clone()))
+                .collect();
+            resolve_bg_position(&group)
+        });
 
-        BgImageLayout {
-            repeat,
-            position,
-            center,
-            size,
-        }
+        BgImageLayout { repeat, position, size }
     }
 
     fn clear_style_cache(&self) {
@@ -1872,5 +2007,88 @@ fn css_system_color(name: &str) -> Option<(u8, u8, u8, u8)> {
         "window" | "appworkspace" | "scrollbar" | "background" | "menu" => Some((240, 240, 240, 255)),
         "windowtext" | "menutext" | "infotext" | "inactivecaptiontext" => Some((0, 0, 0, 255)),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod bg_position_tests {
+    use super::{resolve_bg_position, BgAnchor, BgTok};
+
+    fn kw(k: &str) -> BgTok {
+        BgTok::Kw(k.to_string())
+    }
+
+    /// The two-keyword form may be written in either order, so `center right` has to mean the same
+    /// as `right center`. Taking the first value as the horizontal one put Wikipedia's
+    /// external-link icon in the middle of every link.
+    #[test]
+    fn keyword_pairs_are_read_in_either_order() {
+        let right_middle = (BgAnchor::End(0.0), BgAnchor::Percent(50.0));
+        assert_eq!(resolve_bg_position(&[kw("right"), kw("center")]), right_middle);
+        assert_eq!(resolve_bg_position(&[kw("center"), kw("right")]), right_middle);
+
+        let middle_top = (BgAnchor::Percent(50.0), BgAnchor::Start(0.0));
+        assert_eq!(resolve_bg_position(&[kw("center"), kw("top")]), middle_top);
+        assert_eq!(resolve_bg_position(&[kw("top"), kw("center")]), middle_top);
+    }
+
+    #[test]
+    fn one_value_centres_the_other_axis() {
+        assert_eq!(
+            resolve_bg_position(&[kw("right")]),
+            (BgAnchor::End(0.0), BgAnchor::Percent(50.0))
+        );
+        assert_eq!(
+            resolve_bg_position(&[kw("center")]),
+            (BgAnchor::Percent(50.0), BgAnchor::Percent(50.0))
+        );
+        assert_eq!(
+            resolve_bg_position(&[BgTok::Len(20.0)]),
+            (BgAnchor::Start(20.0), BgAnchor::Percent(50.0))
+        );
+    }
+
+    /// `right 10px` is an offset *from the right edge*, not a position 10px from the left.
+    #[test]
+    fn an_edge_keyword_swallows_the_length_after_it() {
+        assert_eq!(
+            resolve_bg_position(&[kw("right"), BgTok::Len(10.0), kw("bottom"), BgTok::Len(4.0)]),
+            (BgAnchor::End(10.0), BgAnchor::End(4.0))
+        );
+    }
+
+    #[test]
+    fn lengths_and_percentages_fill_the_axes_in_order() {
+        assert_eq!(
+            resolve_bg_position(&[BgTok::Len(5.0), BgTok::Len(9.0)]),
+            (BgAnchor::Start(5.0), BgAnchor::Start(9.0))
+        );
+        assert_eq!(
+            resolve_bg_position(&[BgTok::Pct(50.0), BgTok::Pct(100.0)]),
+            (BgAnchor::Percent(50.0), BgAnchor::Percent(100.0))
+        );
+    }
+
+    /// The keywords of a `background` shorthand arrive in the same list as the position ones.
+    #[test]
+    fn non_position_keywords_are_ignored() {
+        assert_eq!(
+            resolve_bg_position(&[kw("no-repeat"), kw("right"), kw("cover")]),
+            (BgAnchor::End(0.0), BgAnchor::Percent(50.0))
+        );
+        assert_eq!(
+            resolve_bg_position(&[kw("no-repeat")]),
+            (BgAnchor::Start(0.0), BgAnchor::Start(0.0))
+        );
+    }
+
+    /// An anchor only becomes a pixel offset once the box and the tile are known.
+    #[test]
+    fn anchors_resolve_against_the_box() {
+        assert_eq!(BgAnchor::Start(12.0).resolve(300.0, 20.0), 12.0);
+        assert_eq!(BgAnchor::End(0.0).resolve(300.0, 20.0), 280.0);
+        assert_eq!(BgAnchor::End(10.0).resolve(300.0, 20.0), 270.0);
+        assert_eq!(BgAnchor::Percent(50.0).resolve(300.0, 20.0), 140.0);
+        assert_eq!(BgAnchor::Percent(100.0).resolve(300.0, 20.0), 280.0);
     }
 }

--- a/crates/gosub_render_pipeline/src/common/document/style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/style.rs
@@ -291,6 +291,7 @@ pub enum StyleProperty {
     GridAutoColumns,
     GridArea,
     GridTemplateAreas,
+    CaptionSide,
     FontStyle,
     WhiteSpace,
     TextDecorationLine,
@@ -391,6 +392,7 @@ impl StyleProperty {
             StyleProperty::Clear => 79,
             StyleProperty::GridArea => 80,
             StyleProperty::GridTemplateAreas => 81,
+            StyleProperty::CaptionSide => 82,
         }
     }
 
@@ -950,6 +952,12 @@ static PROPERTIES: &[PropertyMeta] = &[
         inherited: false,
         initial_kind: InitialKind::Keyword("none"),
     },
+    // 82 caption-side - inherited, so a caption picks it up from the table it belongs to
+    PropertyMeta {
+        name: "caption-side",
+        inherited: true,
+        initial_kind: InitialKind::Keyword("top"),
+    },
 ];
 
 // ── NodeStyle - replaces StylePropertyList ────────────────────────────────────
@@ -1093,6 +1101,7 @@ fn from_id(id: u8) -> Option<StyleProperty> {
         79 => Some(StyleProperty::Clear),
         80 => Some(StyleProperty::GridArea),
         81 => Some(StyleProperty::GridTemplateAreas),
+        82 => Some(StyleProperty::CaptionSide),
         _ => None,
     }
 }

--- a/crates/gosub_render_pipeline/src/common/document/style.rs
+++ b/crates/gosub_render_pipeline/src/common/document/style.rs
@@ -289,6 +289,8 @@ pub enum StyleProperty {
     GridTemplateColumns,
     GridAutoRows,
     GridAutoColumns,
+    GridArea,
+    GridTemplateAreas,
     FontStyle,
     WhiteSpace,
     TextDecorationLine,
@@ -387,6 +389,8 @@ impl StyleProperty {
             StyleProperty::MixBlendMode => 77,
             StyleProperty::Float => 78,
             StyleProperty::Clear => 79,
+            StyleProperty::GridArea => 80,
+            StyleProperty::GridTemplateAreas => 81,
         }
     }
 
@@ -933,6 +937,19 @@ static PROPERTIES: &[PropertyMeta] = &[
         inherited: false,
         initial_kind: InitialKind::Keyword("none"),
     },
+    // 80 grid-area - the shorthand, kept whole: a single named area (`grid-area: content`) is
+    // the form that matters, and it is resolved against the container's `grid-template-areas`.
+    PropertyMeta {
+        name: "grid-area",
+        inherited: false,
+        initial_kind: InitialKind::Keyword("auto"),
+    },
+    // 81 grid-template-areas
+    PropertyMeta {
+        name: "grid-template-areas",
+        inherited: false,
+        initial_kind: InitialKind::Keyword("none"),
+    },
 ];
 
 // ── NodeStyle - replaces StylePropertyList ────────────────────────────────────
@@ -1074,6 +1091,8 @@ fn from_id(id: u8) -> Option<StyleProperty> {
         77 => Some(StyleProperty::MixBlendMode),
         78 => Some(StyleProperty::Float),
         79 => Some(StyleProperty::Clear),
+        80 => Some(StyleProperty::GridArea),
+        81 => Some(StyleProperty::GridTemplateAreas),
         _ => None,
     }
 }

--- a/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
+++ b/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
@@ -9,8 +9,8 @@ use taffy::prelude::{
 };
 use taffy::{
     AlignContent, AlignItems, AlignSelf, BoxSizing, Dimension, Display, FlexDirection, FlexWrap, GridAutoFlow,
-    GridPlacement, GridTemplateComponent, LengthPercentage, LengthPercentageAuto, Line, Overflow, Point, Position,
-    Rect, Size, Style, TextAlign, TrackSizingFunction,
+    GridPlacement, GridTemplateArea, GridTemplateComponent, LengthPercentage, LengthPercentageAuto, Line, Overflow,
+    Point, Position, Rect, Size, Style, TextAlign, TrackSizingFunction,
 };
 
 /// Converts CSS properties from a `PipelineDocument` node into a Taffy `Style`.
@@ -105,8 +105,16 @@ impl<'a> CssTaffyConverter<'a> {
         ts.grid_auto_rows = self.get_grid_auto(StyleProperty::GridAutoRows, ts.grid_auto_rows);
         ts.grid_auto_columns = self.get_grid_auto(StyleProperty::GridAutoColumns, ts.grid_auto_columns);
         ts.grid_auto_flow = self.get_grid_auto_flow(ts.grid_auto_flow);
+        ts.grid_template_areas = self.get_grid_areas(ts.grid_template_areas);
         ts.grid_row = self.get_grid_line(StyleProperty::GridRow, ts.grid_row);
         ts.grid_column = self.get_grid_line(StyleProperty::GridColumn, ts.grid_column);
+        // `grid-area` is the shorthand for both axes. The CSS engine does not expand it into
+        // longhands, so it is read here and applied after them - an element that sets both gets
+        // the shorthand, which is the common case (`grid-area: content` with no `grid-row`).
+        if let Some((row, column)) = self.get_grid_area() {
+            ts.grid_row = row;
+            ts.grid_column = column;
+        }
 
         // Adjust display for table and inline elements.
         match self.get_own(&StyleProperty::Display) {
@@ -475,6 +483,30 @@ impl<'a> CssTaffyConverter<'a> {
         }
     }
 
+    /// `grid-template-areas`, as the rectangle each area name covers.
+    fn get_grid_areas(&self, default: Vec<GridTemplateArea<String>>) -> Vec<GridTemplateArea<String>> {
+        match self.get_own(&StyleProperty::GridTemplateAreas) {
+            Some(Value::Keyword(id)) => {
+                let s = lookup(id);
+                match s.as_str() {
+                    "none" | "" => Vec::new(),
+                    _ => parse_grid_areas(s.as_str()),
+                }
+            }
+            _ => default,
+        }
+    }
+
+    /// `grid-area`, as `(grid-row, grid-column)`. `None` when the property is not set, so the
+    /// longhands the caller already resolved are kept.
+    fn get_grid_area(&self) -> Option<(Line<GridPlacement>, Line<GridPlacement>)> {
+        let Some(Value::Keyword(id)) = self.get_own(&StyleProperty::GridArea) else {
+            return None;
+        };
+        let s = lookup(id);
+        parse_grid_area(s.as_str())
+    }
+
     fn get_grid_auto(&self, prop: StyleProperty, default: Vec<TrackSizingFunction>) -> Vec<TrackSizingFunction> {
         match self.get_own(&prop) {
             Some(Value::Keyword(id)) => {
@@ -639,14 +671,203 @@ fn parse_single_placement(s: &str) -> GridPlacement {
         return GridPlacement::Auto;
     }
     if let Some(rest) = s.strip_prefix("span ") {
-        if let Ok(n) = rest.trim().parse::<u16>() {
+        let rest = rest.trim();
+        if let Ok(n) = rest.parse::<u16>() {
             return span(n);
+        }
+        // `span <name>` - span until the next line with that name.
+        if is_custom_ident(rest) {
+            return GridPlacement::NamedSpan(rest.to_string(), 1);
         }
     }
     if let Ok(n) = s.parse::<i16>() {
         return GridPlacement::from_line_index(n);
     }
+    // A bare identifier is a named line. `grid-area: content` names an *area*, whose implicit
+    // `content-start` / `content-end` lines taffy derives from `grid-template-areas`, so the
+    // same placement covers both spellings.
+    if is_custom_ident(s) {
+        return GridPlacement::NamedLine(s.to_string(), 1);
+    }
     GridPlacement::Auto
+}
+
+/// A CSS `<custom-ident>`: letters, digits, `-` and `_`, not starting with a digit. Used to tell
+/// a named grid line from a keyword or a malformed token.
+fn is_custom_ident(s: &str) -> bool {
+    !s.is_empty()
+        && !s.starts_with(|c: char| c.is_ascii_digit())
+        && s.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+}
+
+/// Parse `grid-area` into `(grid-row, grid-column)`.
+///
+/// The shorthand is `<row-start> / <column-start> / <row-end> / <column-end>`, and any part
+/// left out is copied from its opposite when that is a custom ident (so `grid-area: content`
+/// places the item across the whole `content` area).
+fn parse_grid_area(s: &str) -> Option<(Line<GridPlacement>, Line<GridPlacement>)> {
+    let s = s.trim();
+    if s.is_empty() || s == "auto" || s == "none" {
+        return None;
+    }
+    let parts: Vec<&str> = s.split('/').map(str::trim).collect();
+    let placement = |i: usize| parts.get(i).map_or(GridPlacement::Auto, |p| parse_single_placement(p));
+
+    // An omitted end line repeats the start when the start is a name, and is `auto` otherwise -
+    // css-grid-2 §8.4. The same rule gives the column axis its value when only one part is given.
+    let mirror = |from: &GridPlacement, i: usize| match parts.get(i) {
+        Some(part) => parse_single_placement(part),
+        None => match from {
+            GridPlacement::NamedLine(name, idx) => GridPlacement::NamedLine(name.clone(), *idx),
+            _ => GridPlacement::Auto,
+        },
+    };
+
+    let row_start = placement(0);
+    let column_start = mirror(&row_start, 1);
+    let row_end = mirror(&row_start, 2);
+    let column_end = mirror(&column_start, 3);
+
+    Some((
+        Line {
+            start: row_start,
+            end: row_end,
+        },
+        Line {
+            start: column_start,
+            end: column_end,
+        },
+    ))
+}
+
+/// Parse `grid-template-areas` - one row per line, cells separated by whitespace - into the
+/// rectangle each name covers, in taffy's 1-based grid line coordinates.
+///
+/// `.` (or any run of dots) is a null cell and names no area. A name that does not form a
+/// rectangle is not rejected the way css-grid-2 requires; it gets its bounding box, which keeps
+/// a typo from dropping the whole shell.
+fn parse_grid_areas(s: &str) -> Vec<GridTemplateArea<String>> {
+    // Preserve document order so a page's areas keep a stable order in the output.
+    let mut order: Vec<&str> = Vec::new();
+    let mut bounds: std::collections::HashMap<&str, (u16, u16, u16, u16)> = std::collections::HashMap::new();
+
+    for (row, line) in s.lines().enumerate() {
+        for (column, cell) in line.split_whitespace().enumerate() {
+            if cell.chars().all(|c| c == '.') {
+                continue;
+            }
+            let (row, column) = (row as u16, column as u16);
+            match bounds.get_mut(cell) {
+                Some((row_start, row_end, column_start, column_end)) => {
+                    *row_start = (*row_start).min(row);
+                    *row_end = (*row_end).max(row);
+                    *column_start = (*column_start).min(column);
+                    *column_end = (*column_end).max(column);
+                }
+                None => {
+                    order.push(cell);
+                    bounds.insert(cell, (row, row, column, column));
+                }
+            }
+        }
+    }
+
+    order
+        .into_iter()
+        .filter_map(|name| {
+            let (row_start, row_end, column_start, column_end) = *bounds.get(name)?;
+            // Cell indices are 0-based; grid lines are 1-based and an area ends on the line
+            // *after* its last cell.
+            Some(GridTemplateArea {
+                name: name.to_string(),
+                row_start: row_start + 1,
+                row_end: row_end + 2,
+                column_start: column_start + 1,
+                column_end: column_end + 2,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod grid_area_tests {
+    use super::{parse_grid_area, parse_grid_areas};
+    use taffy::{GridPlacement, GridTemplateArea};
+
+    fn area(name: &str, rows: (u16, u16), columns: (u16, u16)) -> GridTemplateArea<String> {
+        GridTemplateArea {
+            name: name.to_string(),
+            row_start: rows.0,
+            row_end: rows.1,
+            column_start: columns.0,
+            column_end: columns.1,
+        }
+    }
+
+    #[test]
+    fn areas_become_line_rectangles() {
+        // Wikipedia's Vector-2022 page shell. Grid lines are 1-based and an area ends on the
+        // line after its last cell, so a single cell in the first row spans lines 1 to 2.
+        let parsed = parse_grid_areas("siteNotice siteNotice\ncolumnStart pageContent\nfooter footer");
+        assert_eq!(
+            parsed,
+            vec![
+                area("siteNotice", (1, 2), (1, 3)),
+                area("columnStart", (2, 3), (1, 2)),
+                area("pageContent", (2, 3), (2, 3)),
+                area("footer", (3, 4), (1, 3)),
+            ]
+        );
+    }
+
+    #[test]
+    fn an_area_spanning_rows_keeps_one_rectangle() {
+        let parsed = parse_grid_areas("side head\nside body");
+        assert_eq!(
+            parsed,
+            vec![
+                area("side", (1, 3), (1, 2)),
+                area("head", (1, 2), (2, 3)),
+                area("body", (2, 3), (2, 3)),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_dot_cell_names_no_area() {
+        let parsed = parse_grid_areas("titlebar .\ntitlebar columnEnd");
+        assert_eq!(
+            parsed,
+            vec![area("titlebar", (1, 3), (1, 2)), area("columnEnd", (2, 3), (2, 3))]
+        );
+    }
+
+    #[test]
+    fn a_single_name_places_the_item_across_the_whole_area() {
+        let (row, column) = parse_grid_area("columnStart").expect("a name is a placement");
+        let named = |name: &str| GridPlacement::NamedLine(name.to_string(), 1);
+        assert_eq!((row.start, row.end), (named("columnStart"), named("columnStart")));
+        assert_eq!((column.start, column.end), (named("columnStart"), named("columnStart")));
+    }
+
+    #[test]
+    fn the_slash_form_fills_each_axis() {
+        let (row, column) = parse_grid_area("2 / 1 / 4 / 3").expect("line numbers are a placement");
+        assert_eq!(
+            (row.start, row.end),
+            (GridPlacement::Line(2.into()), GridPlacement::Line(4.into()))
+        );
+        assert_eq!(
+            (column.start, column.end),
+            (GridPlacement::Line(1.into()), GridPlacement::Line(3.into()))
+        );
+    }
+
+    #[test]
+    fn auto_is_not_a_placement() {
+        assert!(parse_grid_area("auto").is_none());
+        assert!(parse_grid_area("").is_none());
+    }
 }
 
 #[cfg(test)]

--- a/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
+++ b/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
@@ -516,14 +516,13 @@ impl<'a> CssTaffyConverter<'a> {
         }
     }
 
-    /// `grid-area`, as `(grid-row, grid-column)`. `None` when the property is not set, so the
+    /// `grid-area`, as `(grid-row, grid-column)`. `None` only when the property is not set, so the
     /// longhands the caller already resolved are kept.
     fn get_grid_area(&self) -> Option<(Line<GridPlacement>, Line<GridPlacement>)> {
         let Some(Value::Keyword(id)) = self.get_own(&StyleProperty::GridArea) else {
             return None;
         };
-        let s = lookup(id);
-        parse_grid_area(s.as_str())
+        Some(declared_grid_area(lookup(id).as_str()))
     }
 
     fn get_grid_auto(&self, prop: StyleProperty, default: Vec<TrackSizingFunction>) -> Vec<TrackSizingFunction> {
@@ -751,6 +750,20 @@ fn is_custom_ident(s: &str) -> bool {
         && s.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_')
 }
 
+/// The placement a *declared* `grid-area` means.
+///
+/// `parse_grid_area` returns `None` for `auto` and `none`, which is right for "this names no
+/// area" - but a declaration that says `auto` is the author resetting both axes, not saying
+/// nothing. Treating the two the same left an earlier `grid-row` standing through a later
+/// `grid-area: auto`.
+fn declared_grid_area(s: &str) -> (Line<GridPlacement>, Line<GridPlacement>) {
+    let auto = || Line {
+        start: GridPlacement::Auto,
+        end: GridPlacement::Auto,
+    };
+    parse_grid_area(s).unwrap_or_else(|| (auto(), auto()))
+}
+
 /// Parse `grid-area` into `(grid-row, grid-column)`.
 ///
 /// The shorthand is `<row-start> / <column-start> / <row-end> / <column-end>`, and any part
@@ -969,7 +982,7 @@ mod grid_template_tests {
 
 #[cfg(test)]
 mod grid_placement_tests {
-    use super::{parse_single_placement, split_index_and_name};
+    use super::{declared_grid_area, parse_single_placement, split_index_and_name};
     use taffy::prelude::TaffyGridLine;
     use taffy::GridPlacement;
 
@@ -999,6 +1012,24 @@ mod grid_placement_tests {
             GridPlacement::NamedLine("content".to_string(), 1)
         );
         assert_eq!(parse_single_placement("span 2"), GridPlacement::Span(2));
+    }
+
+    /// A declared `grid-area: auto` resets both axes. Reading it as "says nothing" let an earlier
+    /// `grid-row` survive a later reset.
+    #[test]
+    fn a_declared_grid_area_of_auto_resets_both_axes() {
+        for reset in ["auto", "none", ""] {
+            let (row, column) = declared_grid_area(reset);
+            assert_eq!(row.start, GridPlacement::Auto, "{reset:?} row start");
+            assert_eq!(row.end, GridPlacement::Auto, "{reset:?} row end");
+            assert_eq!(column.start, GridPlacement::Auto, "{reset:?} column start");
+            assert_eq!(column.end, GridPlacement::Auto, "{reset:?} column end");
+        }
+
+        // A real area still places the item across it.
+        let (row, column) = declared_grid_area("content");
+        assert_eq!(row.start, GridPlacement::NamedLine("content".to_string(), 1));
+        assert_eq!(column.end, GridPlacement::NamedLine("content".to_string(), 1));
     }
 
     #[test]

--- a/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
+++ b/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
@@ -134,16 +134,14 @@ impl<'a> CssTaffyConverter<'a> {
                 // put Wikipedia's infobox image caption in a narrow strip beside the picture
                 // instead of underneath it.
                 ts.flex_direction = FlexDirection::Column;
-                // The cell's own `text-align` positions its line boxes. They are shrink-to-fit
-                // items of a flex column, so the axis that moves them across the cell is the
-                // *cross* axis - `align_items`, not `justify_content`, which only arranges words
-                // inside a line box that already hugs them. Wikipedia's infobox section headers
-                // are `text-align: center` and came out flush left for want of this.
-                ts.align_items = match self.doc.get_style(self.node_id, &StyleProperty::TextAlign) {
-                    Value::TextAlign(CssTextAlign::Center) => Some(AlignItems::CENTER),
-                    Value::TextAlign(CssTextAlign::End | CssTextAlign::Right) => Some(AlignItems::FLEX_END),
-                    _ => Some(AlignItems::FLEX_START),
-                };
+                // `align_items` is deliberately left at taffy's default (stretch). A line box must
+                // be as wide as the cell for the text inside it to be measured against a definite
+                // width - that is the only thing that makes it wrap. Setting `align_items` here to
+                // carry the cell's `text-align` (an earlier attempt at centring header cells) made
+                // every line box shrink-to-fit instead, so text measured at unlimited width and ran
+                // past the cell rather than wrapping inside it. The cell's `text-align` reaches its
+                // line boxes as `justify_content` on the anonymous container - see
+                // `line_box_justify` - which positions the run *within* a full-width line box.
                 ts.flex_grow = 1.0;
             }
             Some(Value::Display(CssDisplay::TableFooterGroup)) => {

--- a/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
+++ b/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
@@ -134,6 +134,16 @@ impl<'a> CssTaffyConverter<'a> {
                 // put Wikipedia's infobox image caption in a narrow strip beside the picture
                 // instead of underneath it.
                 ts.flex_direction = FlexDirection::Column;
+                // The cell's own `text-align` positions its line boxes. They are shrink-to-fit
+                // items of a flex column, so the axis that moves them across the cell is the
+                // *cross* axis - `align_items`, not `justify_content`, which only arranges words
+                // inside a line box that already hugs them. Wikipedia's infobox section headers
+                // are `text-align: center` and came out flush left for want of this.
+                ts.align_items = match self.doc.get_style(self.node_id, &StyleProperty::TextAlign) {
+                    Value::TextAlign(CssTextAlign::Center) => Some(AlignItems::CENTER),
+                    Value::TextAlign(CssTextAlign::End | CssTextAlign::Right) => Some(AlignItems::FLEX_END),
+                    _ => Some(AlignItems::FLEX_START),
+                };
                 ts.flex_grow = 1.0;
             }
             Some(Value::Display(CssDisplay::TableFooterGroup)) => {

--- a/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
+++ b/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
@@ -111,6 +111,11 @@ impl<'a> CssTaffyConverter<'a> {
         // `grid-area` is the shorthand for both axes. The CSS engine does not expand it into
         // longhands, so it is read here and applied after them - an element that sets both gets
         // the shorthand, which is the common case (`grid-area: content` with no `grid-row`).
+        //
+        // KNOWN LIMIT: that makes the shorthand win regardless of source order, so a later
+        // `grid-row: 2` after `grid-area: content` is ignored. Computed styles reach this point
+        // with no record of the order they were declared in; fixing it properly means expanding
+        // `grid-area` into its four longhands in the cascade, where the order still exists.
         if let Some((row, column)) = self.get_grid_area() {
             ts.grid_row = row;
             ts.grid_column = column;
@@ -693,9 +698,17 @@ fn parse_single_placement(s: &str) -> GridPlacement {
         if is_custom_ident(rest) {
             return GridPlacement::NamedSpan(rest.to_string(), 1);
         }
+        // `span 2 main` - span until the *second* line with that name.
+        if let Some((n, name)) = split_index_and_name(rest) {
+            return GridPlacement::NamedSpan(name.to_string(), n.unsigned_abs());
+        }
     }
     if let Ok(n) = s.parse::<i16>() {
         return GridPlacement::from_line_index(n);
+    }
+    // `<integer> && <custom-ident>` - the nth line with that name, written in either order.
+    if let Some((n, name)) = split_index_and_name(s) {
+        return GridPlacement::NamedLine(name.to_string(), n);
     }
     // A bare identifier is a named line. `grid-area: content` names an *area*, whose implicit
     // `content-start` / `content-end` lines taffy derives from `grid-template-areas`, so the
@@ -704,6 +717,26 @@ fn parse_single_placement(s: &str) -> GridPlacement {
         return GridPlacement::NamedLine(s.to_string(), 1);
     }
     GridPlacement::Auto
+}
+
+/// `<integer> && <custom-ident>`, in either order: `2 main-end` and `main-end 2` both name the
+/// second line called `main-end`. Without this the whole value fell through to `auto`, so an item
+/// placed on a repeated line was laid out wherever auto-placement happened to put it.
+///
+/// A zero index is not a line (css-grid-2 forbids it), and `1` is what taffy treats an unqualified
+/// name as, so both are left to the plain `<custom-ident>` path above.
+fn split_index_and_name(s: &str) -> Option<(i16, &str)> {
+    let (first, rest) = s.split_once(char::is_whitespace)?;
+    let second = rest.trim();
+    if second.is_empty() || second.contains(char::is_whitespace) {
+        return None;
+    }
+    let pair = match (first.parse::<i16>(), second.parse::<i16>()) {
+        (Ok(n), Err(_)) => (n, second),
+        (Err(_), Ok(n)) => (n, first),
+        _ => return None,
+    };
+    (pair.0 != 0 && is_custom_ident(pair.1)).then_some(pair)
 }
 
 /// A CSS `<custom-ident>`: letters, digits, `-` and `_`, not starting with a digit. Used to tell
@@ -927,5 +960,50 @@ mod grid_template_tests {
         assert!(parse_grid_template("repeat(auto-fill, 1fr)").is_none());
         // Garbage token -> None
         assert!(parse_grid_template("bogus").is_none());
+    }
+}
+
+#[cfg(test)]
+mod grid_placement_tests {
+    use super::{parse_single_placement, split_index_and_name};
+    use taffy::prelude::TaffyGridLine;
+    use taffy::GridPlacement;
+
+    #[test]
+    fn an_integer_qualified_name_picks_that_line() {
+        assert_eq!(
+            parse_single_placement("2 main-end"),
+            GridPlacement::NamedLine("main-end".to_string(), 2)
+        );
+        // css-grid-2 writes the integer and the name in either order.
+        assert_eq!(
+            parse_single_placement("main-end 2"),
+            GridPlacement::NamedLine("main-end".to_string(), 2)
+        );
+        assert_eq!(
+            parse_single_placement("span 2 main"),
+            GridPlacement::NamedSpan("main".to_string(), 2)
+        );
+    }
+
+    #[test]
+    fn the_plain_forms_are_unchanged() {
+        assert_eq!(parse_single_placement("auto"), GridPlacement::Auto);
+        assert_eq!(parse_single_placement("3"), GridPlacement::from_line_index(3));
+        assert_eq!(
+            parse_single_placement("content"),
+            GridPlacement::NamedLine("content".to_string(), 1)
+        );
+        assert_eq!(parse_single_placement("span 2"), GridPlacement::Span(2));
+    }
+
+    #[test]
+    fn a_value_that_is_neither_is_still_auto() {
+        assert_eq!(parse_single_placement("2 3"), GridPlacement::Auto);
+        assert_eq!(parse_single_placement("a b"), GridPlacement::Auto);
+        // A zero line index does not exist, so the value is not a named line either.
+        assert_eq!(parse_single_placement("0 main"), GridPlacement::Auto);
+        assert_eq!(parse_single_placement("2 main end"), GridPlacement::Auto);
+        assert_eq!(split_index_and_name("2"), None);
     }
 }

--- a/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
+++ b/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
@@ -698,9 +698,13 @@ fn parse_single_placement(s: &str) -> GridPlacement {
         if is_custom_ident(rest) {
             return GridPlacement::NamedSpan(rest.to_string(), 1);
         }
-        // `span 2 main` - span until the *second* line with that name.
+        // `span 2 main` - span until the *second* line with that name. A span counts forward
+        // only, so a negative integer is not a span at all and the value is invalid; a negative
+        // *line* index is fine and stays so below.
         if let Some((n, name)) = split_index_and_name(rest) {
-            return GridPlacement::NamedSpan(name.to_string(), n.unsigned_abs());
+            if n > 0 {
+                return GridPlacement::NamedSpan(name.to_string(), n as u16);
+            }
         }
     }
     if let Ok(n) = s.parse::<i16>() {
@@ -1004,6 +1008,13 @@ mod grid_placement_tests {
         // A zero line index does not exist, so the value is not a named line either.
         assert_eq!(parse_single_placement("0 main"), GridPlacement::Auto);
         assert_eq!(parse_single_placement("2 main end"), GridPlacement::Auto);
+        // A span counts forward, so a negative one is not a span - but a negative *line* index
+        // counts from the end of the grid and is perfectly good.
+        assert_eq!(parse_single_placement("span -2 main"), GridPlacement::Auto);
+        assert_eq!(
+            parse_single_placement("-2 main"),
+            GridPlacement::NamedLine("main".to_string(), -2)
+        );
         assert_eq!(split_index_and_name("2"), None);
     }
 }

--- a/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
+++ b/crates/gosub_render_pipeline/src/layouter/css_taffy_converter.rs
@@ -128,6 +128,12 @@ impl<'a> CssTaffyConverter<'a> {
             }
             Some(Value::Display(CssDisplay::TableCell)) => {
                 ts.display = Display::Flex;
+                // A cell is a block container: its block-level children stack, as do the anonymous
+                // containers the inline layout emits for line boxes. Taffy's default direction is
+                // `Row`, so a cell holding more than one block laid them out side by side - which
+                // put Wikipedia's infobox image caption in a narrow strip beside the picture
+                // instead of underneath it.
+                ts.flex_direction = FlexDirection::Column;
                 ts.flex_grow = 1.0;
             }
             Some(Value::Display(CssDisplay::TableFooterGroup)) => {

--- a/crates/gosub_render_pipeline/src/layouter/float.rs
+++ b/crates/gosub_render_pipeline/src/layouter/float.rs
@@ -10,7 +10,7 @@
 //! as it fits at its current vertical offset, never above the top of an earlier float in the same
 //! block, and drops below the floats already there when it does not fit beside them.
 //!
-//! Text flows around a float rather than under it: [`line_box_insets`] turns the placed floats
+//! Text flows around a float rather than under it: [`resolve_bands_in_document_order`] turns the placed floats
 //! into per-block insets that the layouter's second pass applies to its line boxes. A float's
 //! position is only known after layout, so the insets are derived from the first pass and fed
 //! back into a second one. The block itself keeps its full width - it is the line boxes that
@@ -26,7 +26,7 @@ use crate::common::document::pipeline_doc::PipelineDocument;
 use crate::common::document::style::{lookup, StyleProperty, Value};
 use crate::common::geo::Rect;
 use crate::layouter::{ElementContext, LayoutElementId, LayoutTree};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 /// Which edge a float is pinned to.
@@ -593,63 +593,206 @@ fn bands_for_block(content: Rect, floats: &[(Rect, FloatSide)]) -> Option<Vec<Fl
     Some(bands)
 }
 
-/// The bands of every block whose line boxes a float shortens, keyed by DOM node.
+/// How tall `block` becomes once its line boxes follow `bands`.
 ///
-/// Blocks that no float reaches are absent, and a block whose bands are all full width is left
-/// out too - there is nothing for the inline layout to do differently.
-pub fn line_box_insets(layout_tree: &LayoutTree, placed: &[PlacedFloat]) -> HashMap<DomNodeId, Vec<FloatBand>> {
-    let mut insets: HashMap<DomNodeId, Vec<FloatBand>> = HashMap::new();
-    if placed.is_empty() {
-        return insets;
+/// This is what lets the float resolution run as a single forward sweep instead of a fixed-point
+/// iteration. Narrowing a block's lines makes it taller, which moves every float below it, which
+/// changes *their* bands - so a sweep has to know the new height at the moment it decides the
+/// bands, before it has laid anything out again. The widths it needs are already known: the
+/// baseline pass measured every word box, and packing those widths into the bands is the same
+/// greedy fill the inline layout will perform.
+///
+/// `None` when the block holds nothing measurable, in which case the caller keeps its height.
+pub fn predict_banded_height(layout_tree: &LayoutTree, block: LayoutElementId, bands: &[FloatBand]) -> Option<f64> {
+    let el = layout_tree.arena.get(&block)?;
+
+    // Word widths and the line height, in document order, from the baseline layout.
+    let mut widths: Vec<f64> = Vec::new();
+    let mut line_height = 0.0_f64;
+    for child in &el.children {
+        let Some(child) = layout_tree.arena.get(child) else {
+            continue;
+        };
+        match &child.context {
+            ElementContext::Text(text) => {
+                if line_height <= 0.0 {
+                    line_height = text.font_info.line_height;
+                }
+                widths.push(child.box_model.border_box.width);
+            }
+            // A replaced element on the line takes its own width; anything else contributes
+            // whatever box the baseline gave it.
+            _ => widths.push(child.box_model.border_box.width),
+        }
+    }
+    if widths.is_empty() || line_height <= 0.0 {
+        return None;
     }
 
-    for (&block_id, block) in layout_tree.arena.iter() {
-        // Only blocks that actually hold text need bands; a wrapper contributes nothing and
-        // would double-count against its children.
-        if !has_inline_content(layout_tree, block_id) {
+    Some(stacked_height(&widths, line_height, bands))
+}
+
+/// Pack `widths` into `bands` as whole lines and report the height that takes.
+///
+/// The greedy fill the inline layout performs, over the word widths a previous layout measured:
+/// words go onto a line until the next will not fit, and when a band has no room for another line
+/// the tail it leaves is skipped, because a line that would still touch the float starts below it.
+fn stacked_height(widths: &[f64], line_height: f64, bands: &[FloatBand]) -> f64 {
+    let mut height = 0.0_f64;
+    let mut index = 0usize;
+    let mut used_in_band = 0.0_f64;
+    let mut line_used = 0.0_f64;
+
+    for &width in widths {
+        let band = bands[index.min(bands.len().saturating_sub(1))];
+        if line_used > 0.0 && line_used + width > f64::from(band.line_width) {
+            // Close the line and charge it to the band.
+            height += line_height;
+            used_in_band += line_height;
+            line_used = 0.0;
+
+            // Out of room for another whole line? Step to the next band, skipping the tail.
+            if let Some(band_height) = band.height {
+                if used_in_band + line_height > f64::from(band_height) {
+                    height += (f64::from(band_height) - used_in_band).max(0.0);
+                    used_in_band = 0.0;
+                    if index + 1 < bands.len() {
+                        index += 1;
+                    }
+                }
+            }
+        }
+        line_used += width;
+    }
+    // The line left open at the end still occupies one line box.
+    if line_used > 0.0 {
+        height += line_height;
+    }
+    height
+}
+
+/// Resolve every block's float bands in one forward sweep, in document order.
+///
+/// The iterative version of this measured bands from a finished layout and fed them into the next
+/// one, which cannot settle: narrowing a block makes it taller, a float of fixed height then meets
+/// fewer blocks, those blocks lose their bands and are short again. On the Wikipedia article the
+/// banded-block count cycled 133 -> 100 -> 92 -> 133 forever, so *where you stopped* decided the
+/// page.
+///
+/// A browser has no such problem because it lays out in document order and places each float as it
+/// meets it: a line box only ever sees floats above it, and information flows one way. This does
+/// the same. Walking top to bottom, each block's bands come from the floats already placed, and
+/// the height it will have once banded is predicted (see [`predict_banded_height`]) so that
+/// everything below it - floats included - is offset by the growth before its own turn comes.
+/// Nothing later can change an earlier answer, so one sweep is the answer.
+pub fn resolve_bands_in_document_order(
+    layout_tree: &LayoutTree,
+    placed: &[PlacedFloat],
+) -> HashMap<DomNodeId, Vec<FloatBand>> {
+    let mut bands: HashMap<DomNodeId, Vec<FloatBand>> = HashMap::new();
+    if placed.is_empty() {
+        return bands;
+    }
+
+    // Floats by the box they were placed against, so the sweep can pick them up when it reaches
+    // them rather than looking at all of them for every block.
+    let by_id: HashMap<LayoutElementId, &PlacedFloat> = placed.iter().map(|f| (f.layout_id, f)).collect();
+
+    // Floats seen so far, with their positions corrected for the growth of everything above them.
+    // The id is kept so a float can be excluded from the blocks it contains.
+    let mut seen: Vec<(LayoutElementId, Rect, FloatSide)> = Vec::new();
+    // Growth accumulated from blocks that got taller once banded. Everything below moves by it.
+    let mut shift = 0.0_f64;
+
+    let mut stack = vec![layout_tree.root_id];
+    let mut order: Vec<LayoutElementId> = Vec::new();
+    while let Some(id) = stack.pop() {
+        order.push(id);
+        if let Some(el) = layout_tree.arena.get(&id) {
+            stack.extend(el.children.iter().rev().copied());
+        }
+    }
+
+    let mut added: HashSet<LayoutElementId> = HashSet::new();
+    for id in &order {
+        let id = *id;
+        let Some(el) = layout_tree.arena.get(&id) else {
+            continue;
+        };
+
+        if let Some(float) = by_id.get(&id) {
+            // A float takes the shift of the content above it, then joins the context so every
+            // block after it is measured against where it actually ends up.
+            if added.insert(id) {
+                let mut rect = float.rect;
+                rect.y += shift;
+                seen.push((id, rect, float.side));
+            }
             continue;
         }
 
-        let content = block.box_model.content_box;
+        if !has_inline_content(layout_tree, id) {
+            continue;
+        }
+
+        // A float *inside* this block shortens this block's own line boxes - it sits at the top of
+        // its container's content, so document order reaching the container first must not hide
+        // it. Written as `<p><span class="thumb">…</span>text…</p>`, which is how a figure beside
+        // a paragraph is usually marked up, the float is a descendant of the very block it
+        // displaces.
+        for (float_id, float) in &by_id {
+            if added.contains(float_id) || !is_ancestor(layout_tree, id, *float_id) {
+                continue;
+            }
+            added.insert(*float_id);
+            let mut rect = float.rect;
+            rect.y += shift;
+            seen.push((*float_id, rect, float.side));
+        }
+        let mut content = el.box_model.content_box;
         if content.width <= 0.0 || content.height <= 0.0 {
             continue;
         }
-        let block_top = content.y;
-        let block_bottom = content.y + content.height;
-        let block_left = content.x;
-        let block_right = content.x + content.width;
+        content.y += shift;
 
-        // Floats that reach this block at all. A float never displaces its own contents, nor the
-        // contents of anything inside it.
-        let relevant: Vec<&PlacedFloat> = placed
+        // Only floats that are already placed can affect this block - that is the whole point.
+        let relevant: Vec<(Rect, FloatSide)> = seen
             .iter()
-            .filter(|float| {
-                if float.layout_id == block_id || is_ancestor(layout_tree, float.layout_id, block_id) {
+            .filter(|(float_id, rect, _)| {
+                // A float never displaces its own contents. Without this the infobox - itself a
+                // float - banded every paragraph inside it against its own edges, and its caption
+                // came out one character per line.
+                if *float_id == id || is_ancestor(layout_tree, *float_id, id) {
                     return false;
                 }
-                let r = float.rect;
-                r.y < block_bottom && r.y + r.height > block_top && r.x < block_right && r.x + r.width > block_left
+                rect.y < content.y + content.height
+                    && rect.y + rect.height > content.y
+                    && rect.x < content.x + content.width
+                    && rect.x + rect.width > content.x
             })
+            .map(|(_, rect, side)| (*rect, *side))
             .collect();
         if relevant.is_empty() {
             continue;
         }
-
-        let bands = bands_for_block(
-            content,
-            &relevant
-                .iter()
-                .map(|float| (float.rect, float.side))
-                .collect::<Vec<_>>(),
-        );
-        let Some(bands) = bands else {
+        let Some(block_bands) = bands_for_block(content, &relevant) else {
             continue;
         };
 
-        insets.insert(block.dom_node_id, bands);
+        if let Some(height) = predict_banded_height(layout_tree, id, &block_bands) {
+            shift += (height - content.height).max(0.0);
+        }
+        bands.insert(el.dom_node_id, block_bands);
     }
 
-    insets
+    if std::env::var("GOSUB_DEBUG_FLOAT_BANDS").is_ok() {
+        eprintln!(
+            "float bands: {} placed floats, {} blocks banded in one document-order sweep",
+            placed.len(),
+            bands.len()
+        );
+    }
+    bands
 }
 
 /// Whether `node` holds inline content directly (text, or an inline box), meaning it is the block
@@ -697,6 +840,66 @@ mod tests {
     /// A 600x100 block at the origin, the shape most of the band tests use.
     fn block() -> Rect {
         rect(0.0, 0.0, 600.0, 100.0)
+    }
+
+    fn open(line_width: f32) -> FloatBand {
+        FloatBand {
+            left_inset: 0.0,
+            line_width,
+            height: None,
+        }
+    }
+
+    fn narrow(line_width: f32, height: f32) -> FloatBand {
+        FloatBand {
+            left_inset: 0.0,
+            line_width,
+            height: Some(height),
+        }
+    }
+
+    #[test]
+    fn height_without_a_float_is_just_the_lines() {
+        // Six 50px words at a 100px width: two per line, three lines.
+        let widths = vec![50.0; 6];
+        assert_eq!(stacked_height(&widths, 20.0, &[open(100.0)]), 60.0);
+    }
+
+    #[test]
+    fn a_narrower_band_makes_the_block_taller() {
+        // The same words at half the width take twice as many lines. This is the number the
+        // document-order sweep needs *before* it lays anything out: it is what moves every float
+        // below this block, and getting it after the fact is what made the old iteration cycle.
+        let widths = vec![50.0; 6];
+        let tall = stacked_height(&widths, 20.0, &[open(50.0)]);
+        let short = stacked_height(&widths, 20.0, &[open(100.0)]);
+        assert!(tall > short, "{tall} vs {short}");
+        assert_eq!(tall, 120.0);
+    }
+
+    #[test]
+    fn text_widens_again_below_the_float() {
+        // 40px of band holds two 20px lines at the narrow width; the rest runs at full width.
+        // Four words fit two-to-a-line while narrow, then three-to-a-line after.
+        let widths = vec![50.0; 10];
+        let banded = stacked_height(&widths, 20.0, &[narrow(100.0, 40.0), open(200.0)]);
+        let narrow_throughout = stacked_height(&widths, 20.0, &[open(100.0)]);
+        assert!(banded < narrow_throughout, "{banded} vs {narrow_throughout}");
+    }
+
+    #[test]
+    fn a_bands_unused_tail_is_skipped() {
+        // One 50px word in a band 100px tall: the line takes 20px and the remaining 80px are
+        // skipped, because the next line would still be beside the float.
+        let widths = vec![50.0, 50.0, 50.0];
+        // Two words fill the 50px-wide band's single line, the third starts below the band.
+        let height = stacked_height(&widths, 20.0, &[narrow(60.0, 25.0), open(200.0)]);
+        assert!(height >= 45.0, "the tail of the first band must be skipped: {height}");
+    }
+
+    #[test]
+    fn an_empty_run_has_no_height() {
+        assert_eq!(stacked_height(&[], 20.0, &[open(100.0)]), 0.0);
     }
 
     #[test]

--- a/crates/gosub_render_pipeline/src/layouter/float.rs
+++ b/crates/gosub_render_pipeline/src/layouter/float.rs
@@ -1014,9 +1014,22 @@ mod tests {
     }
 
     #[test]
-    fn a_float_that_misses_the_block_horizontally_gives_no_bands() {
-        // Nothing overlaps, so every band would be full width and there is nothing to say.
+    fn a_block_with_no_floats_gives_no_bands() {
+        // Every band would be full width, so there is nothing to say.
         assert!(bands_for_block(block(), &[]).is_none());
+    }
+
+    #[test]
+    fn a_float_that_misses_the_block_horizontally_gives_no_bands() {
+        // The 600px block runs 0..600; this float sits entirely to the right of it, so it narrows
+        // no line in the block and the block is left unbanded rather than banded at full width.
+        let away = vec![(rect(700.0, 0.0, 100.0, 50.0), FloatSide::Right)];
+        assert!(bands_for_block(block(), &away).is_none());
+
+        // The same float moved back over the block's right edge does produce bands, which is what
+        // makes the case above about the horizontal test and not about floats in general.
+        let overlapping = vec![(rect(500.0, 0.0, 100.0, 50.0), FloatSide::Right)];
+        assert!(bands_for_block(block(), &overlapping).is_some());
     }
 
     #[test]

--- a/crates/gosub_render_pipeline/src/layouter/float.rs
+++ b/crates/gosub_render_pipeline/src/layouter/float.rs
@@ -731,7 +731,7 @@ pub fn resolve_bands_in_document_order(
             continue;
         }
 
-        if !has_inline_content(layout_tree, id) {
+        if !holds_line_boxes(layout_tree, id) {
             continue;
         }
 
@@ -793,6 +793,31 @@ pub fn resolve_bands_in_document_order(
         );
     }
     bands
+}
+
+/// Whether `node` is a block container holding inline content, i.e. whether it has line boxes of
+/// its own for a float to shorten.
+///
+/// The block-container half matters as much as the inline-content half. An `<a>` or `<span>` has
+/// text children, so a check for inline content alone calls it a block - and then every inline
+/// element inside a float got banded against the float containing it, which for a float that
+/// enclosed them produced a band of zero width. On the Wikipedia article **52 of the 60 bands were
+/// this**, all of them inside the infobox. An inline box has no line boxes; it sits on its
+/// parent's.
+fn holds_line_boxes(layout_tree: &LayoutTree, node: LayoutElementId) -> bool {
+    if !has_inline_content(layout_tree, node) {
+        return false;
+    }
+    let Some(el) = layout_tree.arena.get(&node) else {
+        return false;
+    };
+    !matches!(
+        layout_tree
+            .render_tree
+            .doc
+            .get_style(el.dom_node_id, &StyleProperty::Display),
+        Value::Display(crate::common::document::style::Display::Inline)
+    )
 }
 
 /// Whether `node` holds inline content directly (text, or an inline box), meaning it is the block

--- a/crates/gosub_render_pipeline/src/layouter/float.rs
+++ b/crates/gosub_render_pipeline/src/layouter/float.rs
@@ -484,14 +484,127 @@ fn shift_following_siblings(layout_tree: &mut LayoutTree, id: LayoutElementId, d
 /// whole: every line box in it clears the float, not only the lines actually beside it. Lines that
 /// hang below the float's bottom therefore stay narrower than CSS requires - correcting that needs
 /// the text split at the float's bottom edge, which the atomic text boxes do not currently allow.
-pub fn line_box_insets(layout_tree: &LayoutTree, placed: &[PlacedFloat]) -> HashMap<DomNodeId, (f32, f32)> {
-    let mut insets: HashMap<DomNodeId, (f32, f32)> = HashMap::new();
+/// One horizontal band of a block: the line-box geometry that holds over a range of its height.
+///
+/// A block crossed by a float is not one shape - it is narrow beside the float and full width
+/// below it - so a single inset per block cannot describe it. Bands give the inline layout the
+/// geometry line by line: it fills a band, then moves to the next.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FloatBand {
+    /// Left edge of the line boxes, relative to the block's content box.
+    pub left_inset: f32,
+    /// Width available to the line boxes in this band.
+    pub line_width: f32,
+    /// How tall the band is. `None` on the last band, which runs to the bottom of the block and
+    /// so holds however many lines are left.
+    pub height: Option<f32>,
+}
+
+/// Split a block's height into bands at the edges of the floats that reach it.
+///
+/// `None` when every band would be the full width, which means there is nothing for the inline
+/// layout to do differently. The returned list always ends with an open-ended band: past the
+/// lowest float the block is full width again and may run on for any number of lines.
+fn bands_for_block(content: Rect, floats: &[(Rect, FloatSide)]) -> Option<Vec<FloatBand>> {
+    let block_top = content.y;
+    let block_bottom = content.y + content.height;
+    let block_left = content.x;
+    let block_right = content.x + content.width;
+
+    // Deliberately *not* clipped to the block's current height: that height came from a pass laid
+    // out with no insets at all, so it is the very thing the bands are about to change. Clipping
+    // to it collapsed the common case - a float taller than the block it starts in - into one
+    // narrow band that then applied to every line, however far the text ran on.
+    let lowest = floats
+        .iter()
+        .map(|(r, _)| r.y + r.height)
+        .fold(block_top, f64::max)
+        .max(block_bottom);
+
+    let mut edges: Vec<f64> = vec![block_top, lowest];
+    for (r, _) in floats {
+        for edge in [r.y, r.y + r.height] {
+            if edge > block_top && edge < lowest {
+                edges.push(edge);
+            }
+        }
+    }
+    edges.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    edges.dedup();
+
+    let mut bands: Vec<FloatBand> = Vec::new();
+    for pair in edges.windows(2) {
+        let (top, bottom) = (pair[0], pair[1]);
+        if bottom - top <= 0.0 {
+            continue;
+        }
+        // A float applies to a band when it covers the band, which the midpoint decides: the
+        // boundaries are exactly the float edges, so none starts or stops part-way through one.
+        let mid = (top + bottom) / 2.0;
+        let mut left_inset: f64 = 0.0;
+        let mut right_inset: f64 = 0.0;
+        for (r, side) in floats {
+            if r.y > mid || r.y + r.height <= mid {
+                continue;
+            }
+            match side {
+                FloatSide::Left => left_inset = left_inset.max(r.x + r.width - block_left),
+                FloatSide::Right => right_inset = right_inset.max(block_right - r.x),
+            }
+        }
+        let left_inset = left_inset.clamp(0.0, content.width);
+        let right_inset = right_inset.clamp(0.0, content.width);
+        let band = FloatBand {
+            left_inset: left_inset as f32,
+            line_width: (content.width - left_inset - right_inset).max(0.0) as f32,
+            height: Some((bottom - top) as f32),
+        };
+        // Merge with the previous band when the geometry is unchanged, so a paragraph beside two
+        // stacked floats of the same width is one band, not two.
+        match bands.last_mut() {
+            Some(prev) if prev.left_inset == band.left_inset && prev.line_width == band.line_width => {
+                if let (Some(h), Some(add)) = (prev.height, band.height) {
+                    prev.height = Some(h + add);
+                }
+            }
+            _ => bands.push(band),
+        }
+    }
+
+    // Nothing to say when every band is the full width.
+    if !bands
+        .iter()
+        .any(|b| b.left_inset > 0.0 || b.line_width < content.width as f32)
+    {
+        return None;
+    }
+
+    let tail = FloatBand {
+        left_inset: 0.0,
+        line_width: content.width as f32,
+        height: None,
+    };
+    match bands.last_mut() {
+        Some(last) if last.left_inset == tail.left_inset && last.line_width == tail.line_width => {
+            last.height = None;
+        }
+        _ => bands.push(tail),
+    }
+    Some(bands)
+}
+
+/// The bands of every block whose line boxes a float shortens, keyed by DOM node.
+///
+/// Blocks that no float reaches are absent, and a block whose bands are all full width is left
+/// out too - there is nothing for the inline layout to do differently.
+pub fn line_box_insets(layout_tree: &LayoutTree, placed: &[PlacedFloat]) -> HashMap<DomNodeId, Vec<FloatBand>> {
+    let mut insets: HashMap<DomNodeId, Vec<FloatBand>> = HashMap::new();
     if placed.is_empty() {
         return insets;
     }
 
     for (&block_id, block) in layout_tree.arena.iter() {
-        // Only blocks that actually hold text need an inset; a wrapper contributes nothing and
+        // Only blocks that actually hold text need bands; a wrapper contributes nothing and
         // would double-count against its children.
         if !has_inline_content(layout_tree, block_id) {
             continue;
@@ -506,65 +619,38 @@ pub fn line_box_insets(layout_tree: &LayoutTree, placed: &[PlacedFloat]) -> Hash
         let block_left = content.x;
         let block_right = content.x + content.width;
 
-        let mut left_inset: f64 = 0.0;
-        let mut right_inset: f64 = 0.0;
-        let mut float_cover: f64 = 0.0;
-
-        for float in placed {
-            // A float never displaces its own contents, nor the contents of anything inside it.
-            if float.layout_id == block_id || is_ancestor(layout_tree, float.layout_id, block_id) {
-                continue;
-            }
-            let r = float.rect;
-            let overlaps_vertically = r.y < block_bottom && r.y + r.height > block_top;
-            let overlaps_horizontally = r.x < block_right && r.x + r.width > block_left;
-            if !overlaps_vertically || !overlaps_horizontally {
-                continue;
-            }
-            float_cover = float_cover.max((r.y + r.height).min(block_bottom) - r.y.max(block_top));
-            match float.side {
-                FloatSide::Left => left_inset = left_inset.max(r.x + r.width - block_left),
-                FloatSide::Right => right_inset = right_inset.max(block_right - r.x),
-            }
-        }
-
-        if left_inset <= 0.0 && right_inset <= 0.0 {
+        // Floats that reach this block at all. A float never displaces its own contents, nor the
+        // contents of anything inside it.
+        let relevant: Vec<&PlacedFloat> = placed
+            .iter()
+            .filter(|float| {
+                if float.layout_id == block_id || is_ancestor(layout_tree, float.layout_id, block_id) {
+                    return false;
+                }
+                let r = float.rect;
+                r.y < block_bottom && r.y + r.height > block_top && r.x < block_right && r.x + r.width > block_left
+            })
+            .collect();
+        if relevant.is_empty() {
             continue;
         }
 
-        // One inset has to stand in for every line in the block, so only take it where it is
-        // close to what per-line shortening would produce. Two guards bound the error:
-        //
-        // The float must cover most of the block. The inset is exact when the float spans the
-        // whole block and drifts as more lines hang below it, so a float clipping the corner of a
-        // long block is left alone rather than narrowing all of it.
-        if float_cover < content.height * MIN_FLOAT_COVERAGE {
+        let bands = bands_for_block(
+            content,
+            &relevant
+                .iter()
+                .map(|float| (float.rect, float.side))
+                .collect::<Vec<_>>(),
+        );
+        let Some(bands) = bands else {
             continue;
-        }
+        };
 
-        // Enough width has to survive to be worth using. CSS puts a line that cannot fit beside a
-        // float *below* it, which this model cannot express - it can only narrow. Squeezing text
-        // into the sliver left by a near-full-width float would wrap it a word at a time and grow
-        // the page enormously, so leave those lines full width instead.
-        let line_width = content.width - left_inset - right_inset;
-        if line_width < content.width * MIN_LINE_BOX_FRACTION {
-            continue;
-        }
-
-        // Hand the caller the resolved line-box width rather than just the insets: an auto width
-        // would have to be resolved against the block again, and the block's own width is already
-        // known from this pass.
-        insets.insert(block.dom_node_id, (left_inset as f32, line_width as f32));
+        insets.insert(block.dom_node_id, bands);
     }
 
     insets
 }
-
-/// How much of a block's height a float must cover before the block's line boxes are inset.
-const MIN_FLOAT_COVERAGE: f64 = 0.6;
-
-/// How much of a block's width must survive the inset for it to be applied at all.
-const MIN_LINE_BOX_FRACTION: f64 = 0.4;
 
 /// Whether `node` holds inline content directly (text, or an inline box), meaning it is the block
 /// whose line boxes a neighbouring float shortens.
@@ -602,6 +688,107 @@ mod tests {
             bottom,
             inner_edge,
         }
+    }
+
+    fn rect(x: f64, y: f64, width: f64, height: f64) -> Rect {
+        Rect::new(x, y, width, height)
+    }
+
+    /// A 600x100 block at the origin, the shape most of the band tests use.
+    fn block() -> Rect {
+        rect(0.0, 0.0, 600.0, 100.0)
+    }
+
+    #[test]
+    fn a_float_shorter_than_the_block_gives_two_bands() {
+        let bands = bands_for_block(block(), &[(rect(400.0, 0.0, 200.0, 40.0), FloatSide::Right)])
+            .expect("the float narrows the block");
+        assert_eq!(
+            bands,
+            vec![
+                FloatBand {
+                    left_inset: 0.0,
+                    line_width: 400.0,
+                    height: Some(40.0)
+                },
+                FloatBand {
+                    left_inset: 0.0,
+                    line_width: 600.0,
+                    height: None
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn a_float_taller_than_the_block_still_ends() {
+        // The block's height came from a pass with no insets, so it is *shorter* than the text
+        // will be once the bands apply. Clipping the bands to it made the narrow band open-ended
+        // and every line of the paragraph narrow, however far it ran past the float.
+        let bands = bands_for_block(block(), &[(rect(400.0, 0.0, 200.0, 260.0), FloatSide::Right)])
+            .expect("the float narrows the block");
+        assert_eq!(bands.len(), 2, "{bands:?}");
+        assert_eq!(bands[0].height, Some(260.0));
+        assert_eq!(bands[0].line_width, 400.0);
+        assert_eq!(bands[1].height, None);
+        assert_eq!(bands[1].line_width, 600.0);
+    }
+
+    #[test]
+    fn a_left_float_indents_rather_than_narrowing_only() {
+        let bands = bands_for_block(block(), &[(rect(0.0, 0.0, 150.0, 40.0), FloatSide::Left)])
+            .expect("the float indents the block");
+        assert_eq!(bands[0].left_inset, 150.0);
+        assert_eq!(bands[0].line_width, 450.0);
+        assert_eq!(bands[1].left_inset, 0.0);
+    }
+
+    #[test]
+    fn floats_on_both_sides_narrow_from_both() {
+        let bands = bands_for_block(
+            block(),
+            &[
+                (rect(0.0, 0.0, 100.0, 40.0), FloatSide::Left),
+                (rect(500.0, 0.0, 100.0, 40.0), FloatSide::Right),
+            ],
+        )
+        .expect("both floats apply");
+        assert_eq!(bands[0].left_inset, 100.0);
+        assert_eq!(bands[0].line_width, 400.0);
+    }
+
+    #[test]
+    fn stacked_floats_of_one_width_are_a_single_band() {
+        // Two thumbnails down the same margin should read as one narrow band, not two identical
+        // ones - the cursor charges lines against band heights, so splitting them would place a
+        // line break at the seam between the floats.
+        let bands = bands_for_block(
+            block(),
+            &[
+                (rect(400.0, 0.0, 200.0, 40.0), FloatSide::Right),
+                (rect(400.0, 40.0, 200.0, 40.0), FloatSide::Right),
+            ],
+        )
+        .expect("the floats narrow the block");
+        assert_eq!(bands.len(), 2, "{bands:?}");
+        assert_eq!(bands[0].height, Some(80.0));
+        assert_eq!(bands[0].line_width, 400.0);
+    }
+
+    #[test]
+    fn a_float_starting_below_the_top_leaves_a_full_width_band_above_it() {
+        let bands = bands_for_block(block(), &[(rect(400.0, 30.0, 200.0, 40.0), FloatSide::Right)])
+            .expect("the float narrows the block");
+        assert_eq!(bands.len(), 3, "{bands:?}");
+        assert_eq!((bands[0].line_width, bands[0].height), (600.0, Some(30.0)));
+        assert_eq!((bands[1].line_width, bands[1].height), (400.0, Some(40.0)));
+        assert_eq!((bands[2].line_width, bands[2].height), (600.0, None));
+    }
+
+    #[test]
+    fn a_float_that_misses_the_block_horizontally_gives_no_bands() {
+        // Nothing overlaps, so every band would be full width and there is nothing to say.
+        assert!(bands_for_block(block(), &[]).is_none());
     }
 
     #[test]

--- a/crates/gosub_render_pipeline/src/layouter/float.rs
+++ b/crates/gosub_render_pipeline/src/layouter/float.rs
@@ -217,7 +217,10 @@ fn place_floats_in(
 
     // Classify once: a container with no floats and no `clear` costs only these lookups.
     enum Role {
-        Float(FloatSide),
+        /// Side, plus the `clear` flags - `clear` applies to a float as much as to an in-flow
+        /// box (CSS 2.1 §9.5.2), and it is what stacks a column of floated figures down one
+        /// margin instead of letting them sit side by side.
+        Float(FloatSide, bool, bool),
         InFlow(bool, bool),
         OutOfFlow,
     }
@@ -229,15 +232,15 @@ fn place_floats_in(
             if position_is_out_of_flow(doc, dom_id) {
                 return Some((child_id, Role::OutOfFlow));
             }
+            let (clear_left, clear_right) = clear_sides(doc, dom_id);
             if let Some(side) = float_side(doc, dom_id) {
-                return Some((child_id, Role::Float(side)));
+                return Some((child_id, Role::Float(side, clear_left, clear_right)));
             }
-            let (l, r) = clear_sides(doc, dom_id);
-            Some((child_id, Role::InFlow(l, r)))
+            Some((child_id, Role::InFlow(clear_left, clear_right)))
         })
         .collect();
 
-    if !roles.iter().any(|(_, r)| matches!(r, Role::Float(_))) {
+    if !roles.iter().any(|(_, r)| matches!(r, Role::Float(..))) {
         return None;
     }
     let mut ctx = FloatContext::default();
@@ -252,8 +255,8 @@ fn place_floats_in(
     // Document order matters: a float is placed against the floats before it, and a cleared box
     // drops below exactly the floats that precede it.
     for (child_id, role) in roles {
-        let (child_id, side) = match role {
-            Role::Float(side) => (child_id, side),
+        let (child_id, side, clear_left, clear_right) = match role {
+            Role::Float(side, clear_left, clear_right) => (child_id, side, clear_left, clear_right),
             Role::OutOfFlow => continue,
             Role::InFlow(clear_left, clear_right) => {
                 if clear_left || clear_right {
@@ -276,6 +279,23 @@ fn place_floats_in(
         // A float never rises above the top of its containing block, nor above the flow position
         // it was reached at.
         let mut y = flow_y.max(content.y);
+
+        // `clear` on the float itself drops it below every earlier float on the cleared side,
+        // before the fitting walk gets a chance to tuck it into a gap beside one. Wikipedia's
+        // thumbnails are `float: right; clear: right`, which is what puts them in a single
+        // column down the right margin rather than three abreast across the text.
+        if clear_left || clear_right {
+            let mut barrier = f64::NEG_INFINITY;
+            if clear_left {
+                barrier = ctx.left.iter().map(|b| b.bottom).fold(barrier, f64::max);
+            }
+            if clear_right {
+                barrier = ctx.right.iter().map(|b| b.bottom).fold(barrier, f64::max);
+            }
+            if barrier.is_finite() {
+                y = y.max(barrier);
+            }
+        }
 
         // Walk down until the float fits between the bands already at that offset, or until no
         // float extends further and it has to go below all of them.

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -40,7 +40,7 @@ pub struct PipelineTableTree<'a> {
     min_content_cache: HashMap<DomNodeId, f32>,
     /// Cell widths the previous pass settled on and the layouter pinned on the taffy boxes.
     /// Empty on the first pass.
-    pinned: &'a HashMap<DomNodeId, SettledSize>,
+    pinned: &'a HashMap<DomNodeId, f32>,
 }
 
 impl<'a> PipelineTableTree<'a> {
@@ -49,7 +49,7 @@ impl<'a> PipelineTableTree<'a> {
         layout_tree: &'a mut LayoutTree,
         dom_to_layout: &'a HashMap<DomNodeId, LayoutElementId>,
         font_system: Arc<Mutex<dyn FontSystem>>,
-        pinned: &'a HashMap<DomNodeId, SettledSize>,
+        pinned: &'a HashMap<DomNodeId, f32>,
     ) -> Self {
         Self {
             doc,
@@ -405,8 +405,8 @@ impl TableTree for PipelineTableTree<'_> {
         // narrower column from its own previous answer. The contents were then laid out a few
         // pixels wider than the cell they ended up in, which is what still clipped the last of the
         // table headers.
-        if let Some(pinned) = self.pinned.get(&id) {
-            return pinned.width;
+        if let Some(&pinned) = self.pinned.get(&id) {
+            return pinned;
         }
         if let Some(&layout_id) = self.dom_to_layout.get(&id) {
             if let Some(element) = self.layout_tree.arena.get(&layout_id) {
@@ -420,21 +420,10 @@ impl TableTree for PipelineTableTree<'_> {
     }
 }
 
-/// A box size the column algorithm settled on, to be pinned on the taffy box next pass.
-///
-/// Cells carry a width only - their height is the row's, which taffy derives from the cells
-/// themselves. A table carries both: its height is the one thing taffy cannot arrive at on its own,
-/// because border-spacing and the row-height rules are lattice's, not taffy's.
-#[derive(Clone, Copy, Debug)]
-pub struct SettledSize {
-    pub width: f32,
-    pub height: Option<f32>,
-}
-
-/// What a table pass accumulates as it goes: the sizes to pin on the next pass, and how much
-/// taller lattice made each table than the box taffy sized everything around it against.
+/// What a table pass accumulates as it goes: the border-box widths to pin on the next pass, and
+/// how much taller lattice made each table than the box taffy sized everything around it against.
 struct TablePassOutput {
-    settled: HashMap<DomNodeId, SettledSize>,
+    settled: HashMap<DomNodeId, f32>,
     growth: HashMap<LayoutElementId, f64>,
 }
 
@@ -443,7 +432,7 @@ struct TablePassOutput {
 #[derive(Clone, Copy)]
 pub struct TablePassInputs<'a> {
     pub font_system: &'a Arc<Mutex<dyn FontSystem>>,
-    pub pinned: &'a HashMap<DomNodeId, SettledSize>,
+    pub pinned: &'a HashMap<DomNodeId, f32>,
 }
 
 /// Post-process all `display: table` nodes in the layout tree after the
@@ -452,7 +441,7 @@ pub fn post_process_tables(
     layout_tree: &mut LayoutTree,
     dom_to_layout: &HashMap<DomNodeId, LayoutElementId>,
     inputs: TablePassInputs<'_>,
-) -> HashMap<DomNodeId, SettledSize> {
+) -> HashMap<DomNodeId, f32> {
     // Clone the doc Arc up front so we don't hold a borrow on layout_tree
     // when we later pass it mutably to PipelineTableTree.
     let doc: Arc<dyn PipelineDocument> = Arc::clone(&layout_tree.render_tree.doc);
@@ -526,7 +515,7 @@ fn lay_out_one_table(
     table_layout_id: LayoutElementId,
     out: &mut TablePassOutput,
     inputs: TablePassInputs<'_>,
-) -> Option<SettledSize> {
+) -> Option<f32> {
     // Use the parent element's content width as available_width. For nested
     // tables the parent is a table cell whose box model was already updated
     // by the outer table's apply_positions call, giving us the correct width.
@@ -560,29 +549,30 @@ fn lay_out_one_table(
             if table_width <= 0.0 && table_height <= 0.0 {
                 return None;
             }
-            out.settled.extend(
-                tree.cell_widths
-                    .drain()
-                    .map(|(id, width)| (id, SettledSize { width, height: None })),
-            );
+            out.settled.extend(tree.cell_widths.drain());
             tree.apply_positions(table_dom_id);
             // Write back both dimensions so deeply-nested tables can read the
             // correct width from this table's box model via their parent lookup.
             if let Some(el) = layout_tree.arena.get_mut(&table_layout_id) {
                 let bb = el.box_model.border_box;
+                // A table whose rows all measure zero - every cell empty, no spacing, no borders,
+                // no padding - would collapse the box taffy had already sized. The width is still
+                // the column algorithm's to decide, so only the height falls back.
+                let height = if table_height > 0.0 {
+                    table_height as f64
+                } else {
+                    bb.height
+                };
                 // What the box grows by here is what the surrounding blocks were never told about.
-                *out.growth.entry(table_layout_id).or_insert(0.0) += table_height as f64 - bb.height;
+                *out.growth.entry(table_layout_id).or_insert(0.0) += height - bb.height;
                 el.box_model = BoxModel::new(
-                    Rect::new(bb.x, bb.y, table_width as f64, table_height as f64),
+                    Rect::new(bb.x, bb.y, table_width as f64, height),
                     el.box_model.padding,
                     el.box_model.border,
                     el.box_model.margin,
                 );
             }
-            Some(SettledSize {
-                width: table_width,
-                height: Some(table_height),
-            })
+            Some(table_width)
         }
         Err(e) => {
             log::warn!("lattice: table layout failed for node {:?}: {:?}", table_dom_id, e);

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -83,10 +83,18 @@ impl<'a> PipelineTableTree<'a> {
         match &el.context {
             ElementContext::Text(text_ctx) => {
                 let (text, font_info) = (text_ctx.text.clone(), text_ctx.font_info.clone());
-                text.split_ascii_whitespace()
-                    .map(|word| {
+                // `white-space: nowrap` removes every break opportunity, so the whole run is the
+                // unbreakable width. Reporting its longest word let a column be sized under text
+                // that cannot wrap into it.
+                let unbreakable: Box<dyn Iterator<Item = &str>> = if text_ctx.no_wrap {
+                    Box::new(std::iter::once(text.as_str()))
+                } else {
+                    Box::new(text.split_ascii_whitespace())
+                };
+                unbreakable
+                    .map(|run| {
                         measure_str_cached(
-                            word,
+                            run,
                             &font_info,
                             MAX_CONTENT_WIDTH,
                             &self.font_system,

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -6,7 +6,11 @@ use crate::common::document::style::{Display, StyleProperty, Unit, Value};
 use crate::common::geo::{Coordinate, Rect};
 use crate::layouter::box_model::{BoxModel, Edges};
 use crate::layouter::float::float_side;
+use crate::layouter::taffy::MAX_CONTENT_WIDTH;
+use crate::layouter::text::get_text_layout;
 use crate::layouter::{ElementContext, LayoutElementId, LayoutElementNode, LayoutTree};
+use gosub_interface::font_system::FontSystem;
+use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -26,6 +30,17 @@ pub struct PipelineTableTree<'a> {
     /// then takes its max-content width and runs past the cell. Feeding the settled width back is
     /// the same trick already used for the table's own width.
     cell_widths: HashMap<DomNodeId, f32>,
+    /// The font system the layouter measured with, so a cell's min-content width can be asked of
+    /// the same shaper. A column may not be narrower than its widest unbreakable word, and that
+    /// width is not recoverable from the laid-out boxes: a text box reports the width it *was*
+    /// given, not the width it needs.
+    font_system: Arc<Mutex<dyn FontSystem>>,
+    /// Memo for `cell_min_content_width`, which is asked once per cell per lattice run and would
+    /// otherwise re-shape every word of every table on the page each time.
+    min_content_cache: HashMap<DomNodeId, f32>,
+    /// Cell widths the previous pass settled on and the layouter pinned on the taffy boxes.
+    /// Empty on the first pass.
+    pinned: &'a HashMap<DomNodeId, f32>,
 }
 
 impl<'a> PipelineTableTree<'a> {
@@ -33,6 +48,8 @@ impl<'a> PipelineTableTree<'a> {
         doc: &'a dyn PipelineDocument,
         layout_tree: &'a mut LayoutTree,
         dom_to_layout: &'a HashMap<DomNodeId, LayoutElementId>,
+        font_system: Arc<Mutex<dyn FontSystem>>,
+        pinned: &'a HashMap<DomNodeId, f32>,
     ) -> Self {
         Self {
             doc,
@@ -40,6 +57,41 @@ impl<'a> PipelineTableTree<'a> {
             dom_to_layout,
             pending: HashMap::new(),
             cell_widths: HashMap::new(),
+            font_system,
+            min_content_cache: HashMap::new(),
+            pinned,
+        }
+    }
+
+    /// Widest unbreakable run of content in a layout subtree - its min-content width.
+    ///
+    /// Text contributes its longest word, measured unconstrained: that is the narrowest a text box
+    /// can be without the shaper breaking inside a word. A replaced element contributes its whole
+    /// border-box width, since an image has no break opportunities at all. The laid-out boxes
+    /// cannot answer this - a text box carries the width it was allotted, which may be anything
+    /// from one word to the whole run - so the words are re-measured through the same font system
+    /// the layouter used.
+    fn subtree_min_content_width(&mut self, id: LayoutElementId) -> f32 {
+        let Some(el) = self.layout_tree.arena.get(&id) else {
+            return 0.0;
+        };
+        match &el.context {
+            ElementContext::Text(text_ctx) => {
+                let (text, font_info) = (text_ctx.text.clone(), text_ctx.font_info.clone());
+                let mut fs = self.font_system.lock();
+                text.split_ascii_whitespace()
+                    .filter_map(|word| get_text_layout(word, &font_info, MAX_CONTENT_WIDTH, &mut *fs).ok())
+                    .map(|d| d.width as f32)
+                    .fold(0.0_f32, f32::max)
+            }
+            ElementContext::Image(_) | ElementContext::Svg(_) => el.box_model.border_box.width as f32,
+            ElementContext::None => {
+                let children = el.children.clone();
+                children
+                    .into_iter()
+                    .map(|cid| self.subtree_min_content_width(cid))
+                    .fold(0.0_f32, f32::max)
+            }
         }
     }
 
@@ -326,7 +378,36 @@ impl TableTree for PipelineTableTree<'_> {
             .unwrap_or(0.0)
     }
 
+    fn cell_min_content_width(&mut self, id: DomNodeId) -> f32 {
+        if let Some(&cached) = self.min_content_cache.get(&id) {
+            return cached;
+        }
+        let width = match self.dom_to_layout.get(&id).copied() {
+            Some(layout_id) => {
+                let pad = self
+                    .layout_tree
+                    .arena
+                    .get(&layout_id)
+                    .map(|el| (el.box_model.padding.left + el.box_model.padding.right) as f32)
+                    .unwrap_or(0.0);
+                self.subtree_min_content_width(layout_id) + pad
+            }
+            None => 0.0,
+        };
+        self.min_content_cache.insert(id, width);
+        width
+    }
+
     fn cell_content_width(&self, id: DomNodeId) -> f32 {
+        // Once a width has been pinned, that *is* this cell's settled width - report it rather
+        // than re-measuring. The pin makes taffy lay the contents out at the column width, so a
+        // fresh measurement comes back as "whatever it was given" and the algorithm re-derives a
+        // narrower column from its own previous answer. The contents were then laid out a few
+        // pixels wider than the cell they ended up in, which is what still clipped the last of the
+        // table headers.
+        if let Some(&pinned) = self.pinned.get(&id) {
+            return pinned;
+        }
         if let Some(&layout_id) = self.dom_to_layout.get(&id) {
             if let Some(element) = self.layout_tree.arena.get(&layout_id) {
                 // Include the cell's own horizontal padding so the column is wide enough to hold
@@ -339,11 +420,20 @@ impl TableTree for PipelineTableTree<'_> {
     }
 }
 
+/// What a table pass needs beyond the trees themselves: the shaper to ask for min-content widths,
+/// and the cell widths the previous pass settled on (empty on the first pass).
+#[derive(Clone, Copy)]
+pub struct TablePassInputs<'a> {
+    pub font_system: &'a Arc<Mutex<dyn FontSystem>>,
+    pub pinned: &'a HashMap<DomNodeId, f32>,
+}
+
 /// Post-process all `display: table` nodes in the layout tree after the
 /// Taffy first pass. Correct positions are written back via `gosub_lattice`.
 pub fn post_process_tables(
     layout_tree: &mut LayoutTree,
     dom_to_layout: &HashMap<DomNodeId, LayoutElementId>,
+    inputs: TablePassInputs<'_>,
 ) -> HashMap<DomNodeId, f32> {
     // Clone the doc Arc up front so we don't hold a borrow on layout_tree
     // when we later pass it mutably to PipelineTableTree.
@@ -380,6 +470,7 @@ pub fn post_process_tables(
                 table_dom_id,
                 table_layout_id,
                 &mut widths,
+                inputs,
             ) {
                 widths.insert(table_dom_id, width);
             }
@@ -397,6 +488,7 @@ fn lay_out_one_table(
     table_dom_id: DomNodeId,
     table_layout_id: LayoutElementId,
     widths: &mut HashMap<DomNodeId, f32>,
+    inputs: TablePassInputs<'_>,
 ) -> Option<f32> {
     // Use the parent element's content width as available_width. For nested
     // tables the parent is a table cell whose box model was already updated
@@ -415,7 +507,13 @@ fn lay_out_one_table(
                 .unwrap_or(0.0)
         });
 
-    let mut tree = PipelineTableTree::new(doc, layout_tree, dom_to_layout);
+    let mut tree = PipelineTableTree::new(
+        doc,
+        layout_tree,
+        dom_to_layout,
+        Arc::clone(inputs.font_system),
+        inputs.pinned,
+    );
 
     match gosub_lattice::compute_table_layout(&mut tree, table_dom_id, available_width, None) {
         Ok((table_width, table_height)) => {

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -6,13 +6,13 @@ use crate::common::document::style::{Display, StyleProperty, Unit, Value};
 use crate::common::geo::{Coordinate, Rect};
 use crate::layouter::box_model::{BoxModel, Edges};
 use crate::layouter::float::float_side;
-use crate::layouter::taffy::MAX_CONTENT_WIDTH;
-use crate::layouter::text::get_text_layout;
+use crate::layouter::taffy::{measure_str_cached, MeasureKey, MAX_CONTENT_WIDTH};
 use crate::layouter::{ElementContext, LayoutElementId, LayoutElementNode, LayoutTree};
 use gosub_interface::font_system::FontSystem;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
+use taffy::geometry::Size;
 
 /// Adapter that bridges `gosub_lattice`'s `TableTree` with the render pipeline's
 /// `LayoutTree`/`PipelineDocument`. Layout results are staged in `pending` and
@@ -35,9 +35,12 @@ pub struct PipelineTableTree<'a> {
     /// width is not recoverable from the laid-out boxes: a text box reports the width it *was*
     /// given, not the width it needs.
     font_system: Arc<Mutex<dyn FontSystem>>,
-    /// Memo for `cell_min_content_width`, which is asked once per cell per lattice run and would
-    /// otherwise re-shape every word of every table on the page each time.
+    /// Memo for `cell_min_content_width`. Per-cell, and so per lattice run: it folds in the
+    /// replaced elements' laid-out widths, which change once cell widths are pinned. The *text*
+    /// measurements underneath it are cached for the whole pass, in `measure_cache`.
     min_content_cache: HashMap<DomNodeId, f32>,
+    /// The layouter's measurement cache, shared with taffy's own text measurement.
+    measure_cache: &'a mut HashMap<MeasureKey, Size<f32>>,
     /// Cell widths the previous pass settled on and the layouter pinned on the taffy boxes.
     /// Empty on the first pass.
     pinned: &'a HashMap<DomNodeId, f32>,
@@ -50,6 +53,7 @@ impl<'a> PipelineTableTree<'a> {
         dom_to_layout: &'a HashMap<DomNodeId, LayoutElementId>,
         font_system: Arc<Mutex<dyn FontSystem>>,
         pinned: &'a HashMap<DomNodeId, f32>,
+        measure_cache: &'a mut HashMap<MeasureKey, Size<f32>>,
     ) -> Self {
         Self {
             doc,
@@ -59,6 +63,7 @@ impl<'a> PipelineTableTree<'a> {
             cell_widths: HashMap::new(),
             font_system,
             min_content_cache: HashMap::new(),
+            measure_cache,
             pinned,
         }
     }
@@ -78,10 +83,17 @@ impl<'a> PipelineTableTree<'a> {
         match &el.context {
             ElementContext::Text(text_ctx) => {
                 let (text, font_info) = (text_ctx.text.clone(), text_ctx.font_info.clone());
-                let mut fs = self.font_system.lock();
                 text.split_ascii_whitespace()
-                    .filter_map(|word| get_text_layout(word, &font_info, MAX_CONTENT_WIDTH, &mut *fs).ok())
-                    .map(|d| d.width as f32)
+                    .map(|word| {
+                        measure_str_cached(
+                            word,
+                            &font_info,
+                            MAX_CONTENT_WIDTH,
+                            &self.font_system,
+                            self.measure_cache,
+                        )
+                        .width
+                    })
                     .fold(0.0_f32, f32::max)
             }
             ElementContext::Image(_) | ElementContext::Svg(_) => el.box_model.border_box.width as f32,
@@ -428,11 +440,16 @@ struct TablePassOutput {
 }
 
 /// What a table pass needs beyond the trees themselves: the shaper to ask for min-content widths,
-/// and the cell widths the previous pass settled on (empty on the first pass).
-#[derive(Clone, Copy)]
+/// the cell widths the previous pass settled on (empty on the first pass), and the layouter's own
+/// measurement cache.
+///
+/// The cache is the layouter's, not the table pass's: lattice runs twice per taffy pass and shapes
+/// every word of every cell each time, on top of the shaping taffy already did for the same words
+/// at the same width. Sharing one cache makes all of that a single shaping per distinct word.
 pub struct TablePassInputs<'a> {
     pub font_system: &'a Arc<Mutex<dyn FontSystem>>,
     pub pinned: &'a HashMap<DomNodeId, f32>,
+    pub measure_cache: &'a mut HashMap<MeasureKey, Size<f32>>,
 }
 
 /// Post-process all `display: table` nodes in the layout tree after the
@@ -440,7 +457,7 @@ pub struct TablePassInputs<'a> {
 pub fn post_process_tables(
     layout_tree: &mut LayoutTree,
     dom_to_layout: &HashMap<DomNodeId, LayoutElementId>,
-    inputs: TablePassInputs<'_>,
+    inputs: &mut TablePassInputs<'_>,
 ) -> HashMap<DomNodeId, f32> {
     // Clone the doc Arc up front so we don't hold a borrow on layout_tree
     // when we later pass it mutably to PipelineTableTree.
@@ -514,7 +531,7 @@ fn lay_out_one_table(
     table_dom_id: DomNodeId,
     table_layout_id: LayoutElementId,
     out: &mut TablePassOutput,
-    inputs: TablePassInputs<'_>,
+    inputs: &mut TablePassInputs<'_>,
 ) -> Option<f32> {
     // Use the parent element's content width as available_width. For nested
     // tables the parent is a table cell whose box model was already updated
@@ -539,6 +556,7 @@ fn lay_out_one_table(
         dom_to_layout,
         Arc::clone(inputs.font_system),
         inputs.pinned,
+        inputs.measure_cache,
     );
 
     match gosub_lattice::compute_table_layout(&mut tree, table_dom_id, available_width, None) {

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -20,6 +20,12 @@ pub struct PipelineTableTree<'a> {
     dom_to_layout: &'a HashMap<DomNodeId, LayoutElementId>,
     /// Relative CellLayouts written by `compute_table_layout`.
     pending: HashMap<DomNodeId, CellLayout>,
+    /// Border-box width the column algorithm gave each cell, harvested for the layouter to pin on
+    /// the next pass. Taffy sizes a cell by flex before the columns are known, so its width is
+    /// indefinite and the anonymous line boxes inside it have nothing to wrap against - the text
+    /// then takes its max-content width and runs past the cell. Feeding the settled width back is
+    /// the same trick already used for the table's own width.
+    cell_widths: HashMap<DomNodeId, f32>,
 }
 
 impl<'a> PipelineTableTree<'a> {
@@ -33,6 +39,7 @@ impl<'a> PipelineTableTree<'a> {
             layout_tree,
             dom_to_layout,
             pending: HashMap::new(),
+            cell_widths: HashMap::new(),
         }
     }
 
@@ -256,6 +263,9 @@ impl TableTree for PipelineTableTree<'_> {
     }
 
     fn set_layout(&mut self, id: DomNodeId, layout: CellLayout) {
+        if self.table_role(id) == TableRole::Cell {
+            self.cell_widths.insert(id, layout.size.width);
+        }
         self.pending.insert(id, layout);
     }
 
@@ -348,7 +358,14 @@ pub fn post_process_tables(
             table_nodes.iter().rev().copied().collect()
         };
         for (table_dom_id, table_layout_id) in order {
-            if let Some(width) = lay_out_one_table(&*doc, layout_tree, dom_to_layout, table_dom_id, table_layout_id) {
+            if let Some(width) = lay_out_one_table(
+                &*doc,
+                layout_tree,
+                dom_to_layout,
+                table_dom_id,
+                table_layout_id,
+                &mut widths,
+            ) {
                 widths.insert(table_dom_id, width);
             }
         }
@@ -364,6 +381,7 @@ fn lay_out_one_table(
     dom_to_layout: &HashMap<DomNodeId, LayoutElementId>,
     table_dom_id: DomNodeId,
     table_layout_id: LayoutElementId,
+    widths: &mut HashMap<DomNodeId, f32>,
 ) -> Option<f32> {
     // Use the parent element's content width as available_width. For nested
     // tables the parent is a table cell whose box model was already updated
@@ -392,6 +410,7 @@ fn lay_out_one_table(
             if table_width <= 0.0 && table_height <= 0.0 {
                 return None;
             }
+            widths.extend(tree.cell_widths.drain());
             tree.apply_positions(table_dom_id);
             // Write back both dimensions so deeply-nested tables can read the
             // correct width from this table's box model via their parent lookup.

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -78,73 +78,59 @@ impl<'a> PipelineTableTree<'a> {
             self.doc,
             table_dom_id,
             table_abs,
-            Coordinate::ZERO,
             &pending,
             self.dom_to_layout,
-            &mut self.layout_tree.arena,
+            self.layout_tree,
         );
     }
 }
 
+/// Walks the DOM under `id` looking for nodes lattice gave a position to, and moves each one -
+/// with everything laid out inside it - to where lattice put it.
+///
+/// The move is done on the *layout* tree, not by walking the DOM again. A text node is laid out
+/// as one box per word and `dom_to_layout` deliberately holds none of them (its comment says so:
+/// one text node, many word boxes, one slot), and inline content sits under anonymous wrappers
+/// that have no DOM node at all. Translating what the DOM walk could reach therefore left every
+/// caption's and cell's text behind at its old position while the box moved out from under it.
+/// `shift_subtree` moves the whole layout subtree, which is exactly the set of boxes that should
+/// travel with the node.
 fn apply_recursive(
     doc: &dyn PipelineDocument,
     id: DomNodeId,
     parent_abs: Coordinate,
-    // Translation to apply to non-pending children. For nodes inside a
-    // lattice-repositioned cell this is (new_cell_abs - old_cell_abs).
-    offset: Coordinate,
     pending: &HashMap<DomNodeId, CellLayout>,
     dom_to_layout: &HashMap<DomNodeId, LayoutElementId>,
-    arena: &mut HashMap<LayoutElementId, LayoutElementNode>,
+    layout_tree: &mut LayoutTree,
 ) {
     for child_id in doc.children(id) {
-        match pending.get(&child_id) {
-            None => {
-                // Non-table-structure node: shift it by the accumulated translation
-                // so it stays correctly positioned relative to its parent cell.
-                if let Some(&layout_id) = dom_to_layout.get(&child_id) {
-                    if let Some(element) = arena.get_mut(&layout_id) {
-                        translate_box_model(&mut element.box_model, offset);
-                    }
-                }
-                apply_recursive(doc, child_id, parent_abs, offset, pending, dom_to_layout, arena);
+        let Some(cell_layout) = pending.get(&child_id) else {
+            // Not positioned by lattice: an ancestor's shift has already carried it along, so
+            // only keep looking for positioned nodes deeper down.
+            apply_recursive(doc, child_id, parent_abs, pending, dom_to_layout, layout_tree);
+            continue;
+        };
+
+        let abs = Coordinate::new(
+            parent_abs.x + cell_layout.position.x as f64,
+            parent_abs.y + cell_layout.position.y as f64,
+        );
+
+        if let Some(&layout_id) = dom_to_layout.get(&child_id) {
+            // Read the old origin before moving, so the subtree travels by the same delta.
+            // A descendant that lattice positions too is shifted here and then set absolutely by
+            // its own turn below, which lands it in the same place either way.
+            if let Some(element) = layout_tree.arena.get(&layout_id) {
+                let old = element.box_model.border_box;
+                layout_tree.shift_subtree(layout_id, abs.x - old.x, abs.y - old.y);
             }
-            Some(cell_layout) => {
-                let abs = Coordinate::new(
-                    parent_abs.x + cell_layout.position.x as f64,
-                    parent_abs.y + cell_layout.position.y as f64,
-                );
-                // Read old position before overwriting so we can compute the
-                // translation needed for non-pending children of this cell.
-                let old_abs = dom_to_layout
-                    .get(&child_id)
-                    .and_then(|&lid| arena.get(&lid))
-                    .map(|el| Coordinate::new(el.box_model.border_box.x, el.box_model.border_box.y))
-                    .unwrap_or(abs);
-                if let Some(&layout_id) = dom_to_layout.get(&child_id) {
-                    if let Some(element) = arena.get_mut(&layout_id) {
-                        element.box_model = cell_layout_to_box_model(cell_layout, abs);
-                    }
-                }
-                let child_offset = Coordinate::new(abs.x - old_abs.x, abs.y - old_abs.y);
-                apply_recursive(doc, child_id, abs, child_offset, pending, dom_to_layout, arena);
+            if let Some(element) = layout_tree.arena.get_mut(&layout_id) {
+                element.box_model = cell_layout_to_box_model(cell_layout, abs);
             }
         }
-    }
-}
 
-fn translate_box_model(bm: &mut BoxModel, offset: Coordinate) {
-    if offset.x == 0.0 && offset.y == 0.0 {
-        return;
+        apply_recursive(doc, child_id, abs, pending, dom_to_layout, layout_tree);
     }
-    bm.border_box.x += offset.x;
-    bm.border_box.y += offset.y;
-    bm.padding_box.x += offset.x;
-    bm.padding_box.y += offset.y;
-    bm.content_box.x += offset.x;
-    bm.content_box.y += offset.y;
-    bm.margin_box.x += offset.x;
-    bm.margin_box.y += offset.y;
 }
 
 fn cell_layout_to_box_model(layout: &CellLayout, abs: Coordinate) -> BoxModel {

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -202,7 +202,22 @@ impl TableTree for PipelineTableTree<'_> {
     type NodeId = DomNodeId;
 
     fn children(&self, id: DomNodeId) -> Vec<DomNodeId> {
-        self.doc.children(id)
+        // Whitespace between table-internal boxes is discarded (CSS 2.1 §17.2.1). The newline and
+        // indentation between two `<tr>`s is a text node like any other, and since a run of
+        // non-table children is wrapped in an anonymous cell, keeping them invented a row made of
+        // nothing but indentation - which then became the first row the column scan found, so the
+        // real cells' widths were never measured and every column fell back to an equal share.
+        self.doc
+            .children(id)
+            .into_iter()
+            .filter(|child| match self.doc.get_node_by_id(*child) {
+                Some(node) => match &node.node_type {
+                    NodeType::Text(text) => !text.trim_matches(|c: char| c.is_ascii_whitespace()).is_empty(),
+                    _ => true,
+                },
+                None => true,
+            })
+            .collect()
     }
 
     fn table_role(&self, id: DomNodeId) -> TableRole {

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -40,7 +40,7 @@ pub struct PipelineTableTree<'a> {
     min_content_cache: HashMap<DomNodeId, f32>,
     /// Cell widths the previous pass settled on and the layouter pinned on the taffy boxes.
     /// Empty on the first pass.
-    pinned: &'a HashMap<DomNodeId, f32>,
+    pinned: &'a HashMap<DomNodeId, SettledSize>,
 }
 
 impl<'a> PipelineTableTree<'a> {
@@ -49,7 +49,7 @@ impl<'a> PipelineTableTree<'a> {
         layout_tree: &'a mut LayoutTree,
         dom_to_layout: &'a HashMap<DomNodeId, LayoutElementId>,
         font_system: Arc<Mutex<dyn FontSystem>>,
-        pinned: &'a HashMap<DomNodeId, f32>,
+        pinned: &'a HashMap<DomNodeId, SettledSize>,
     ) -> Self {
         Self {
             doc,
@@ -405,8 +405,8 @@ impl TableTree for PipelineTableTree<'_> {
         // narrower column from its own previous answer. The contents were then laid out a few
         // pixels wider than the cell they ended up in, which is what still clipped the last of the
         // table headers.
-        if let Some(&pinned) = self.pinned.get(&id) {
-            return pinned;
+        if let Some(pinned) = self.pinned.get(&id) {
+            return pinned.width;
         }
         if let Some(&layout_id) = self.dom_to_layout.get(&id) {
             if let Some(element) = self.layout_tree.arena.get(&layout_id) {
@@ -420,12 +420,30 @@ impl TableTree for PipelineTableTree<'_> {
     }
 }
 
+/// A box size the column algorithm settled on, to be pinned on the taffy box next pass.
+///
+/// Cells carry a width only - their height is the row's, which taffy derives from the cells
+/// themselves. A table carries both: its height is the one thing taffy cannot arrive at on its own,
+/// because border-spacing and the row-height rules are lattice's, not taffy's.
+#[derive(Clone, Copy, Debug)]
+pub struct SettledSize {
+    pub width: f32,
+    pub height: Option<f32>,
+}
+
+/// What a table pass accumulates as it goes: the sizes to pin on the next pass, and how much
+/// taller lattice made each table than the box taffy sized everything around it against.
+struct TablePassOutput {
+    settled: HashMap<DomNodeId, SettledSize>,
+    growth: HashMap<LayoutElementId, f64>,
+}
+
 /// What a table pass needs beyond the trees themselves: the shaper to ask for min-content widths,
 /// and the cell widths the previous pass settled on (empty on the first pass).
 #[derive(Clone, Copy)]
 pub struct TablePassInputs<'a> {
     pub font_system: &'a Arc<Mutex<dyn FontSystem>>,
-    pub pinned: &'a HashMap<DomNodeId, f32>,
+    pub pinned: &'a HashMap<DomNodeId, SettledSize>,
 }
 
 /// Post-process all `display: table` nodes in the layout tree after the
@@ -434,7 +452,7 @@ pub fn post_process_tables(
     layout_tree: &mut LayoutTree,
     dom_to_layout: &HashMap<DomNodeId, LayoutElementId>,
     inputs: TablePassInputs<'_>,
-) -> HashMap<DomNodeId, f32> {
+) -> HashMap<DomNodeId, SettledSize> {
     // Clone the doc Arc up front so we don't hold a borrow on layout_tree
     // when we later pass it mutably to PipelineTableTree.
     let doc: Arc<dyn PipelineDocument> = Arc::clone(&layout_tree.render_tree.doc);
@@ -455,7 +473,10 @@ pub fn post_process_tables(
     // post-order (inner→outer): each table is re-laid-out *after* the tables nested inside its
     // cells, so an outer cell's height now reflects its nested table's true height - height
     // flows bottom-up. A single reverse pass propagates through any table-nesting depth.
-    let mut widths: HashMap<DomNodeId, f32> = HashMap::new();
+    let mut out = TablePassOutput {
+        settled: HashMap::new(),
+        growth: HashMap::new(),
+    };
     for pass in 0..2 {
         let order: Vec<(DomNodeId, LayoutElementId)> = if pass == 0 {
             table_nodes.clone()
@@ -463,20 +484,36 @@ pub fn post_process_tables(
             table_nodes.iter().rev().copied().collect()
         };
         for (table_dom_id, table_layout_id) in order {
-            if let Some(width) = lay_out_one_table(
+            if let Some(size) = lay_out_one_table(
                 &*doc,
                 layout_tree,
                 dom_to_layout,
                 table_dom_id,
                 table_layout_id,
-                &mut widths,
+                &mut out,
                 inputs,
             ) {
-                widths.insert(table_dom_id, width);
+                out.settled.insert(table_dom_id, size);
             }
         }
     }
-    widths
+
+    // Every table has its settled height by now; the blocks around them have not heard about it.
+    // Innermost first, so an outer table absorbs a nested one's growth as part of its own.
+    for (table_dom_id, table_layout_id) in table_nodes.iter().rev() {
+        // A float or an absolutely positioned box is out of flow: what follows it in the source is
+        // laid out beside or behind it, not after it, so its height must not push anything down.
+        // Wikipedia's infobox and its thumbnails are floated tables, and absorbing their growth
+        // shoved the whole article body 400px down the page.
+        if float_side(&*doc, *table_dom_id).is_some() || is_out_of_flow(&*doc, *table_dom_id) {
+            continue;
+        }
+        if let Some(&delta) = out.growth.get(table_layout_id) {
+            absorb_table_growth(&*doc, layout_tree, *table_layout_id, delta);
+        }
+    }
+
+    out.settled
 }
 
 /// Run lattice for a single table node and write the computed cell positions and the table's
@@ -487,9 +524,9 @@ fn lay_out_one_table(
     dom_to_layout: &HashMap<DomNodeId, LayoutElementId>,
     table_dom_id: DomNodeId,
     table_layout_id: LayoutElementId,
-    widths: &mut HashMap<DomNodeId, f32>,
+    out: &mut TablePassOutput,
     inputs: TablePassInputs<'_>,
-) -> Option<f32> {
+) -> Option<SettledSize> {
     // Use the parent element's content width as available_width. For nested
     // tables the parent is a table cell whose box model was already updated
     // by the outer table's apply_positions call, giving us the correct width.
@@ -523,12 +560,18 @@ fn lay_out_one_table(
             if table_width <= 0.0 && table_height <= 0.0 {
                 return None;
             }
-            widths.extend(tree.cell_widths.drain());
+            out.settled.extend(
+                tree.cell_widths
+                    .drain()
+                    .map(|(id, width)| (id, SettledSize { width, height: None })),
+            );
             tree.apply_positions(table_dom_id);
             // Write back both dimensions so deeply-nested tables can read the
             // correct width from this table's box model via their parent lookup.
             if let Some(el) = layout_tree.arena.get_mut(&table_layout_id) {
                 let bb = el.box_model.border_box;
+                // What the box grows by here is what the surrounding blocks were never told about.
+                *out.growth.entry(table_layout_id).or_insert(0.0) += table_height as f64 - bb.height;
                 el.box_model = BoxModel::new(
                     Rect::new(bb.x, bb.y, table_width as f64, table_height as f64),
                     el.box_model.padding,
@@ -536,12 +579,144 @@ fn lay_out_one_table(
                     el.box_model.margin,
                 );
             }
-            Some(table_width)
+            Some(SettledSize {
+                width: table_width,
+                height: Some(table_height),
+            })
         }
         Err(e) => {
             log::warn!("lattice: table layout failed for node {:?}: {:?}", table_dom_id, e);
             None
         }
+    }
+}
+
+/// Whether a sibling has to travel with a box that just grew.
+///
+/// `child_bottom` is where the grown box now ends and `delta` how much of that is new, so
+/// `child_bottom - delta` is the edge everything around it was laid out against. Only what starts
+/// at or after that edge was placed *after* the box and has to move; a sibling laid out beside it
+/// (a flex row, a float, the hatnote above a table) starts earlier and stays where it is. The 1px
+/// slack absorbs the rounding between a box's bottom and the next box's top.
+fn sits_below(sibling_top: f64, child_bottom: f64, delta: f64) -> bool {
+    sibling_top >= child_bottom - delta - 1.0
+}
+
+/// Whether a box is taken out of the normal flow by `position: absolute` or `fixed`.
+fn is_out_of_flow(doc: &dyn PipelineDocument, id: DomNodeId) -> bool {
+    matches!(
+        doc.get_style(id, &StyleProperty::Position),
+        Value::Keyword(kw) if matches!(crate::common::document::style::lookup(kw).as_str(), "absolute" | "fixed")
+    )
+}
+
+/// Push a table's settled height out into the ordinary blocks around it.
+///
+/// A table's height is lattice's to decide - border-spacing and the row-height rules are not
+/// taffy's, and a nested table's height is only known after it has been laid out - so the box ends
+/// up `delta` taller than the one taffy sized everything around it against. Whatever was laid out
+/// below it stayed where it was: that is what printed Wikipedia's "This section is an excerpt
+/// from" line across the last row of the table above it.
+///
+/// The walk goes up from the table. At each level whatever sat below the box that grew moves down
+/// by `delta`, and the parent grows by however much its children now overrun it - which becomes
+/// the `delta` for the level above. It stops when a parent turns out to have had room to spare
+/// (nothing outside it moved, so nothing outside it needs to know), at a box lattice owns - a
+/// cell, row or table, whose height the table pass propagates itself - and at a box whose height
+/// the author fixed, where overflowing is what the page asked for.
+fn absorb_table_growth(
+    doc: &dyn PipelineDocument,
+    layout_tree: &mut LayoutTree,
+    table_layout_id: LayoutElementId,
+    delta: f64,
+) {
+    let mut child = table_layout_id;
+    let mut delta = delta;
+    loop {
+        if delta <= 0.5 {
+            return;
+        }
+        let Some(node) = layout_tree.arena.get(&child) else {
+            return;
+        };
+        let child_bottom = node.box_model.margin_box.y + node.box_model.margin_box.height;
+        let Some(parent_id) = node.parent else {
+            return;
+        };
+        let Some(parent) = layout_tree.arena.get(&parent_id) else {
+            return;
+        };
+
+        let parent_dom_id = parent.dom_node_id;
+        let siblings = parent.children.clone();
+
+        // Inside a table, heights belong to the table pass.
+        if !matches!(
+            doc.get_own_style(parent_dom_id, &StyleProperty::Display),
+            None | Some(Value::Display(
+                Display::Block
+                    | Display::InlineBlock
+                    | Display::Flex
+                    | Display::InlineFlex
+                    | Display::Grid
+                    | Display::InlineGrid
+            ))
+        ) {
+            return;
+        }
+
+        for sibling in siblings {
+            if sibling == child {
+                continue;
+            }
+            let below = layout_tree
+                .arena
+                .get(&sibling)
+                .is_some_and(|s| sits_below(s.box_model.margin_box.y, child_bottom, delta));
+            if below {
+                layout_tree.shift_subtree(sibling, 0.0, delta);
+            }
+        }
+
+        // An explicit height means the author chose to clip or overflow: the siblings inside have
+        // moved, but the box itself does not grow and nothing outside it shifts.
+        if matches!(
+            doc.get_style(parent_dom_id, &StyleProperty::Height),
+            Value::Unit(h, Unit::Px | Unit::Percent) if h > 0.0
+        ) {
+            return;
+        }
+
+        let Some(parent) = layout_tree.arena.get(&parent_id) else {
+            return;
+        };
+        let content = parent.box_model.content_box;
+        let children_bottom = parent
+            .children
+            .iter()
+            .filter_map(|cid| layout_tree.arena.get(cid))
+            .map(|c| c.box_model.margin_box.y + c.box_model.margin_box.height)
+            .fold(f64::NEG_INFINITY, f64::max);
+        let grow = children_bottom - (content.y + content.height);
+        if !grow.is_finite() || grow <= 0.5 {
+            // The parent had room to spare, so its own box is unchanged and the walk ends here.
+            return;
+        }
+
+        if let Some(parent) = layout_tree.arena.get_mut(&parent_id) {
+            let bm = &mut parent.box_model;
+            for rect in [
+                &mut bm.content_box,
+                &mut bm.padding_box,
+                &mut bm.border_box,
+                &mut bm.margin_box,
+            ] {
+                rect.height += grow;
+            }
+        }
+
+        child = parent_id;
+        delta = grow;
     }
 }
 
@@ -562,5 +737,36 @@ fn collect_tables_preorder(
     }
     for child in doc.children(id) {
         collect_tables_preorder(doc, child, dom_to_layout, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sits_below;
+
+    // The rule that decides what travels with a table that grew. Getting it wrong is what shoved
+    // the article body down the page when the floated infobox's height was absorbed.
+    #[test]
+    fn only_what_was_laid_out_after_the_box_moves() {
+        // A 100px-tall box that grew by 20: everything was laid out against a bottom of 80.
+        let (bottom, delta) = (100.0, 20.0);
+
+        assert!(sits_below(80.0, bottom, delta), "the block that followed it moves");
+        assert!(sits_below(400.0, bottom, delta), "and so does everything after that");
+        assert!(
+            !sits_below(0.0, bottom, delta),
+            "a sibling beside it - a flex row, a float - stays where it is"
+        );
+        assert!(!sits_below(40.0, bottom, delta), "so does one that overlaps it");
+    }
+
+    #[test]
+    fn a_pixel_of_slack_at_the_boundary() {
+        // Box bottoms and the next box's top do not land on exactly the same fraction.
+        assert!(
+            sits_below(79.4, 100.0, 20.0),
+            "just above the edge still counts as after"
+        );
+        assert!(!sits_below(78.5, 100.0, 20.0), "but not a whole pixel above it");
     }
 }

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -5,6 +5,7 @@ use crate::common::document::pipeline_doc::PipelineDocument;
 use crate::common::document::style::{Display, StyleProperty, Unit, Value};
 use crate::common::geo::{Coordinate, Rect};
 use crate::layouter::box_model::{BoxModel, Edges};
+use crate::layouter::float::float_side;
 use crate::layouter::{ElementContext, LayoutElementId, LayoutElementNode, LayoutTree};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -184,12 +185,23 @@ fn intrinsic_content_width(el: &LayoutElementNode, arena: &HashMap<LayoutElement
         // the image *including its own CSS border* (the bare `dimension` omits it). Images are
         // never stretched to the cell width, so the border box is the true intrinsic width.
         ElementContext::Image(_) | ElementContext::Svg(_) => el.box_model.border_box.width as f32,
-        ElementContext::None => el
-            .children
-            .iter()
-            .filter_map(|&cid| arena.get(&cid))
-            .map(|child| intrinsic_content_width(child, arena))
-            .fold(0.0f32, f32::max),
+        ElementContext::None => {
+            let from_children = el
+                .children
+                .iter()
+                .filter_map(|&cid| arena.get(&cid))
+                .map(|child| intrinsic_content_width(child, arena))
+                .fold(0.0f32, f32::max);
+            if from_children > 0.0 {
+                return from_children;
+            }
+            // Nothing measurable underneath: an inline box's children are laid out inside an
+            // anonymous wrapper that has no `LayoutElementNode`, so the walk bottoms out at
+            // zero even though the box itself was measured. Wikipedia thumbnails hit this - the
+            // image sits inside an `<a>`, so the cell reported no width at all and the table
+            // collapsed to its border-spacing.
+            el.box_model.border_box.width as f32
+        }
     }
 }
 
@@ -278,6 +290,31 @@ impl TableTree for PipelineTableTree<'_> {
         0.0
     }
 
+    fn table_shrink_to_fit(&self, id: DomNodeId) -> bool {
+        // A float is always shrink-to-fit, and it is the case that matters here: Wikipedia
+        // thumbnails are `figure { display: table; float: right }`, and stretching them to the
+        // article column's width is what pushed their captions across the text.
+        float_side(self.doc, id).is_some()
+    }
+
+    fn caption_at_bottom(&self, id: DomNodeId) -> bool {
+        matches!(
+            self.doc.get_style(id, &StyleProperty::CaptionSide),
+            Value::Keyword(kw) if crate::common::document::style::lookup(kw) == "bottom"
+        )
+    }
+
+    fn caption_height(&mut self, id: DomNodeId, _width: f32) -> f32 {
+        // Measured, not re-laid-out: the caption's height comes from the taffy pass, as cell
+        // heights do. The layouter re-runs that pass with the table's computed width pinned on
+        // the box, so by the second pass the measurement is the one taken at `width`.
+        self.dom_to_layout
+            .get(&id)
+            .and_then(|layout_id| self.layout_tree.arena.get(layout_id))
+            .map(|el| el.box_model.margin_box.height as f32)
+            .unwrap_or(0.0)
+    }
+
     fn cell_content_width(&self, id: DomNodeId) -> f32 {
         if let Some(&layout_id) = self.dom_to_layout.get(&id) {
             if let Some(element) = self.layout_tree.arena.get(&layout_id) {
@@ -293,7 +330,10 @@ impl TableTree for PipelineTableTree<'_> {
 
 /// Post-process all `display: table` nodes in the layout tree after the
 /// Taffy first pass. Correct positions are written back via `gosub_lattice`.
-pub fn post_process_tables(layout_tree: &mut LayoutTree, dom_to_layout: &HashMap<DomNodeId, LayoutElementId>) {
+pub fn post_process_tables(
+    layout_tree: &mut LayoutTree,
+    dom_to_layout: &HashMap<DomNodeId, LayoutElementId>,
+) -> HashMap<DomNodeId, f32> {
     // Clone the doc Arc up front so we don't hold a borrow on layout_tree
     // when we later pass it mutably to PipelineTableTree.
     let doc: Arc<dyn PipelineDocument> = Arc::clone(&layout_tree.render_tree.doc);
@@ -314,6 +354,7 @@ pub fn post_process_tables(layout_tree: &mut LayoutTree, dom_to_layout: &HashMap
     // post-order (inner→outer): each table is re-laid-out *after* the tables nested inside its
     // cells, so an outer cell's height now reflects its nested table's true height - height
     // flows bottom-up. A single reverse pass propagates through any table-nesting depth.
+    let mut widths: HashMap<DomNodeId, f32> = HashMap::new();
     for pass in 0..2 {
         let order: Vec<(DomNodeId, LayoutElementId)> = if pass == 0 {
             table_nodes.clone()
@@ -321,9 +362,12 @@ pub fn post_process_tables(layout_tree: &mut LayoutTree, dom_to_layout: &HashMap
             table_nodes.iter().rev().copied().collect()
         };
         for (table_dom_id, table_layout_id) in order {
-            lay_out_one_table(&*doc, layout_tree, dom_to_layout, table_dom_id, table_layout_id);
+            if let Some(width) = lay_out_one_table(&*doc, layout_tree, dom_to_layout, table_dom_id, table_layout_id) {
+                widths.insert(table_dom_id, width);
+            }
         }
     }
+    widths
 }
 
 /// Run lattice for a single table node and write the computed cell positions and the table's
@@ -334,7 +378,7 @@ fn lay_out_one_table(
     dom_to_layout: &HashMap<DomNodeId, LayoutElementId>,
     table_dom_id: DomNodeId,
     table_layout_id: LayoutElementId,
-) {
+) -> Option<f32> {
     // Use the parent element's content width as available_width. For nested
     // tables the parent is a table cell whose box model was already updated
     // by the outer table's apply_positions call, giving us the correct width.
@@ -356,6 +400,12 @@ fn lay_out_one_table(
 
     match gosub_lattice::compute_table_layout(&mut tree, table_dom_id, available_width, None) {
         Ok((table_width, table_height)) => {
+            // A table with no columns computes to 0x0 - honest for its own model, but it would
+            // erase a box taffy had already sized and leave the children painting outside a
+            // collapsed parent. Keep what taffy produced instead.
+            if table_width <= 0.0 && table_height <= 0.0 {
+                return None;
+            }
             tree.apply_positions(table_dom_id);
             // Write back both dimensions so deeply-nested tables can read the
             // correct width from this table's box model via their parent lookup.
@@ -368,9 +418,11 @@ fn lay_out_one_table(
                     el.box_model.margin,
                 );
             }
+            Some(table_width)
         }
         Err(e) => {
             log::warn!("lattice: table layout failed for node {:?}: {:?}", table_dom_id, e);
+            None
         }
     }
 }
@@ -385,8 +437,7 @@ fn collect_tables_preorder(
     if matches!(
         doc.get_own_style(id, &StyleProperty::Display),
         Some(Value::Display(Display::Table))
-    ) && has_table_structure(doc, id)
-    {
+    ) {
         if let Some(&layout_id) = dom_to_layout.get(&id) {
             out.push((id, layout_id));
         }
@@ -394,42 +445,4 @@ fn collect_tables_preorder(
     for child in doc.children(id) {
         collect_tables_preorder(doc, child, dom_to_layout, out);
     }
-}
-
-/// Whether a `display: table` box actually contains rows or cells.
-///
-/// A caption does not count: it is placed beside the row box rather than being one, so a table
-/// holding only a caption and ordinary content still needs the anonymous row and cell. Wikipedia
-/// thumbnails are exactly that shape - `figure { display: table }` wrapping a link, an image and
-/// a `figcaption { display: table-caption }`.
-///
-/// CSS wraps a table box's non-table children in anonymous table-row and table-cell boxes, so a
-/// `display: table` element holding ordinary content is a one-cell table sized to that content.
-/// The table layouter models rows and cells that exist in the DOM and has no way to invent them,
-/// so it reports such a box as 0x0 - and that zero was written back over the size taffy had
-/// already computed, leaving the children to paint outside a collapsed parent. Wikipedia styles
-/// every thumbnail that way (`figure[typeof~='mw:File/Thumb'] { display: table; float: right }`),
-/// which put each caption outside the content column.
-///
-/// Leaving those boxes to taffy is not the anonymous-box algorithm, but it is the same answer for
-/// the single-cell case that occurs in practice, and a great deal closer than zero.
-fn has_table_structure(doc: &dyn PipelineDocument, table_id: DomNodeId) -> bool {
-    fn walk(doc: &dyn PipelineDocument, id: DomNodeId, is_root: bool) -> bool {
-        if !is_root {
-            match doc.get_own_style(id, &StyleProperty::Display) {
-                Some(Value::Display(
-                    Display::TableRow
-                    | Display::TableCell
-                    | Display::TableRowGroup
-                    | Display::TableHeaderGroup
-                    | Display::TableFooterGroup,
-                )) => return true,
-                // A nested table brings its own structure; it is collected in its own right.
-                Some(Value::Display(Display::Table)) => return false,
-                _ => {}
-            }
-        }
-        doc.children(id).into_iter().any(|child| walk(doc, child, false))
-    }
-    walk(doc, table_id, true)
 }

--- a/crates/gosub_render_pipeline/src/layouter/table.rs
+++ b/crates/gosub_render_pipeline/src/layouter/table.rs
@@ -385,7 +385,8 @@ fn collect_tables_preorder(
     if matches!(
         doc.get_own_style(id, &StyleProperty::Display),
         Some(Value::Display(Display::Table))
-    ) {
+    ) && has_table_structure(doc, id)
+    {
         if let Some(&layout_id) = dom_to_layout.get(&id) {
             out.push((id, layout_id));
         }
@@ -393,4 +394,42 @@ fn collect_tables_preorder(
     for child in doc.children(id) {
         collect_tables_preorder(doc, child, dom_to_layout, out);
     }
+}
+
+/// Whether a `display: table` box actually contains rows or cells.
+///
+/// A caption does not count: it is placed beside the row box rather than being one, so a table
+/// holding only a caption and ordinary content still needs the anonymous row and cell. Wikipedia
+/// thumbnails are exactly that shape - `figure { display: table }` wrapping a link, an image and
+/// a `figcaption { display: table-caption }`.
+///
+/// CSS wraps a table box's non-table children in anonymous table-row and table-cell boxes, so a
+/// `display: table` element holding ordinary content is a one-cell table sized to that content.
+/// The table layouter models rows and cells that exist in the DOM and has no way to invent them,
+/// so it reports such a box as 0x0 - and that zero was written back over the size taffy had
+/// already computed, leaving the children to paint outside a collapsed parent. Wikipedia styles
+/// every thumbnail that way (`figure[typeof~='mw:File/Thumb'] { display: table; float: right }`),
+/// which put each caption outside the content column.
+///
+/// Leaving those boxes to taffy is not the anonymous-box algorithm, but it is the same answer for
+/// the single-cell case that occurs in practice, and a great deal closer than zero.
+fn has_table_structure(doc: &dyn PipelineDocument, table_id: DomNodeId) -> bool {
+    fn walk(doc: &dyn PipelineDocument, id: DomNodeId, is_root: bool) -> bool {
+        if !is_root {
+            match doc.get_own_style(id, &StyleProperty::Display) {
+                Some(Value::Display(
+                    Display::TableRow
+                    | Display::TableCell
+                    | Display::TableRowGroup
+                    | Display::TableHeaderGroup
+                    | Display::TableFooterGroup,
+                )) => return true,
+                // A nested table brings its own structure; it is collected in its own right.
+                Some(Value::Display(Display::Table)) => return false,
+                _ => {}
+            }
+        }
+        doc.children(id).into_iter().any(|child| walk(doc, child, false))
+    }
+    walk(doc, table_id, true)
 }

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -58,7 +58,7 @@ const DEFAULT_FONT_SIZE: f64 = 16.0;
 
 /// Width an inline item is measured at to get its natural size. Large enough that nothing wraps;
 /// `f64::MAX` overflows inside the text stack, as the measure callback already notes.
-const MAX_CONTENT_WIDTH: f64 = 1_000_000_000.0;
+pub(crate) const MAX_CONTENT_WIDTH: f64 = 1_000_000_000.0;
 
 /// Whether an inline item is a run of whitespace, which is what the word splitter emits between
 /// words and what CSS drops at a line break.
@@ -660,66 +660,23 @@ impl TaffyLayouter {
                     Some(TaffyContext::Text(text_ctx)) => {
                         let max_width = if text_ctx.no_wrap {
                             // white-space: nowrap - measure at unlimited width so text never wraps
-                            1_000_000_000.0_f64
+                            MAX_CONTENT_WIDTH
                         } else {
                             match v_as.width {
                                 AvailableSpace::Definite(width) => width as f64,
-                                AvailableSpace::MaxContent => 1_000_000_000.0, // f64::MAX doesn't work. Seems some kind of overflow. Same goes for f32::MAX
-                                AvailableSpace::MinContent => 0.0,
-                            }
-                        };
-
-                        let cache_key: MeasureKey = (
-                            text_ctx.text.clone(),
-                            text_ctx.font_info.family.clone(),
-                            (text_ctx.font_info.size as f32).to_bits(),
-                            (text_ctx.font_info.line_height as f32).to_bits(),
-                            text_ctx.font_info.weight,
-                            (max_width as f32).to_bits(),
-                            (text_ctx.font_info.letter_spacing as f32).to_bits(),
-                        );
-                        if let Some(&cached) = measure_cache.get(&cache_key) {
-                            return cached;
-                        }
-
-                        // Measure through the shared font system. The lock is released
-                        // immediately after the call so other callers (e.g. the
-                        // rasterizer) can interleave without contention.
-                        let text_layout = {
-                            let mut fs = font_system.lock();
-                            get_text_layout(text_ctx.text.as_str(), &text_ctx.font_info, max_width, &mut *fs)
-                        };
-                        match text_layout {
-                            Ok(text_layout) => {
-                                // Ceil width to the nearest CSS pixel. Parley returns a fractional
-                                // f64 width; when taffy truncates to f32 and feeds that back as
-                                // available_width, parley re-measures with slightly less space than
-                                // the text requires and wraps. Ceiling ensures allocated width ≥
-                                // natural text width, preventing spurious wrapping at the boundary.
-                                let mut width = text_layout.width.ceil() as f32;
-
-                                // Parley strips trailing whitespace (including NBSP) from the line-box
-                                // advance width. When we appended U+00A0 as a trailing-space marker
-                                // for a text node that ended with whitespace, that NBSP is never
-                                // counted by parley, so taffy under-allocates and pango clips it.
-                                // Detect the marker and add the missing space width manually.
-                                // Whitespace-only nodes ("\u{00A0}") have their width fixed explicitly
-                                // in the taffy style, so the measure callback is not invoked for them.
-                                if text_ctx.text.ends_with('\u{00A0}') && text_ctx.text != "\u{00A0}" {
-                                    width += (text_ctx.font_info.size * 0.3) as f32;
+                                AvailableSpace::MaxContent => MAX_CONTENT_WIDTH,
+                                // Min-content is the widest *word*, not the widest character.
+                                // Laying the text out at zero width asks the shaper to break
+                                // inside words, so taffy believed a text box could be as narrow
+                                // as one grapheme - which is how a table header squeezed by the
+                                // column algorithm came out as "Windo/ws".
+                                AvailableSpace::MinContent => {
+                                    min_content_width(text_ctx, &font_system, &mut measure_cache)
                                 }
-
-                                let result = Size {
-                                    width,
-                                    // Ceil height so the layout height matches the integer-pixel surface
-                                    // that pango creates (prevents descenders from overflowing the box).
-                                    height: text_layout.height.ceil() as f32,
-                                };
-                                measure_cache.insert(cache_key, result);
-                                result
                             }
-                            Err(_) => Size::ZERO,
-                        }
+                        };
+
+                        measure_text_cached(text_ctx, max_width, &font_system, &mut measure_cache)
                     }
                     // Replaced elements: honour whichever dimension CSS has constrained and
                     // derive the other from the intrinsic aspect ratio, so e.g. an
@@ -745,7 +702,16 @@ impl TaffyLayouter {
         let root_id = layout_tree.root_id;
         let root_width = layout_tree.root_dimension.width;
         self.populate_boxmodel(layout_tree, root_id, Coordinate::ZERO, root_width);
-        let table_widths = post_process_tables(layout_tree, &self.dom_to_layout_mapping);
+        let pinned = std::mem::take(&mut self.table_widths);
+        let table_widths = post_process_tables(
+            layout_tree,
+            &self.dom_to_layout_mapping,
+            crate::layouter::table::TablePassInputs {
+                font_system: &self.font_system,
+                pinned: &pinned,
+            },
+        );
+        self.table_widths = pinned;
         // After tables: a float inside a table cell must be placed against the cell's final
         // position, which lattice only fixes during the table pass.
         let placed = post_process_floats(layout_tree);
@@ -1613,6 +1579,12 @@ impl TaffyLayouter {
                 // width and then drags the table out to match.
                 if let Some(&width) = self.table_widths.get(&dom_node.node_id) {
                     taffy_style.size.width = Dimension::from_length(width);
+                    // The column algorithm works in border-box widths, so the pin has to be read
+                    // as one whatever the element's own `box-sizing` says. Left at the CSS default
+                    // of `content-box` the box came out padding-and-border wider than its column,
+                    // and a centred or right-aligned run was positioned against that wider line
+                    // box - which is how a navbox header ended up printed across its own edge.
+                    taffy_style.box_sizing = taffy::BoxSizing::BorderBox;
                     // A cell is a flex item with `flex_grow: 1`, which would stretch it back to
                     // an equal share of its row and undo the pin. It only shows up in a row that
                     // does not span every column - the dialect table's second header row holds
@@ -1997,6 +1969,97 @@ fn to_absolute_url(uri: &str, base_uri: &str) -> String {
         // Base URL unusable (e.g. empty for an inline document) - fall back to the raw reference.
         Err(_) => uri.to_string(),
     }
+}
+
+/// Measure `text_ctx`'s text at `max_width`, going through `cache` so a repeated
+/// (text, font, width) triple is shaped once.
+///
+/// This is the body the measure callback used to hold inline; it became a function when
+/// min-content measurement needed to call it once per word as well.
+fn measure_text_cached(
+    text_ctx: &crate::layouter::ElementContextText,
+    max_width: f64,
+    font_system: &Arc<Mutex<dyn FontSystem>>,
+    cache: &mut HashMap<MeasureKey, Size<f32>>,
+) -> Size<f32> {
+    measure_str_cached(&text_ctx.text, &text_ctx.font_info, max_width, font_system, cache)
+}
+
+/// The same measurement for a bare string, so a single word can be measured with the
+/// surrounding node's font.
+fn measure_str_cached(
+    text: &str,
+    font_info: &crate::common::font::FontInfo,
+    max_width: f64,
+    font_system: &Arc<Mutex<dyn FontSystem>>,
+    cache: &mut HashMap<MeasureKey, Size<f32>>,
+) -> Size<f32> {
+    let cache_key: MeasureKey = (
+        text.to_string(),
+        font_info.family.clone(),
+        (font_info.size as f32).to_bits(),
+        (font_info.line_height as f32).to_bits(),
+        font_info.weight,
+        (max_width as f32).to_bits(),
+        (font_info.letter_spacing as f32).to_bits(),
+    );
+    if let Some(&cached) = cache.get(&cache_key) {
+        return cached;
+    }
+
+    // Measure through the shared font system. The lock is released immediately after the call
+    // so other callers (e.g. the rasterizer) can interleave without contention.
+    let text_layout = {
+        let mut fs = font_system.lock();
+        get_text_layout(text, font_info, max_width, &mut *fs)
+    };
+    let Ok(text_layout) = text_layout else {
+        return Size::ZERO;
+    };
+
+    // Ceil width to the nearest CSS pixel. Parley returns a fractional f64 width; when taffy
+    // truncates to f32 and feeds that back as available_width, parley re-measures with slightly
+    // less space than the text requires and wraps. Ceiling ensures allocated width >= natural
+    // text width, preventing spurious wrapping at the boundary.
+    let mut width = text_layout.width.ceil() as f32;
+
+    // Parley strips trailing whitespace (including NBSP) from the line-box advance width. When we
+    // appended U+00A0 as a trailing-space marker for a text node that ended with whitespace, that
+    // NBSP is never counted by parley, so taffy under-allocates and pango clips it. Detect the
+    // marker and add the missing space width manually. Whitespace-only nodes have their width
+    // fixed explicitly in the taffy style, so the measure callback is not invoked for them.
+    if text.ends_with('\u{00A0}') && text != "\u{00A0}" {
+        width += (font_info.size * 0.3) as f32;
+    }
+
+    let result = Size {
+        width,
+        // Ceil height so the layout height matches the integer-pixel surface that pango creates
+        // (prevents descenders from overflowing the box).
+        height: text_layout.height.ceil() as f32,
+    };
+    cache.insert(cache_key, result);
+    result
+}
+
+/// The CSS min-content width of a text node under `overflow-wrap: normal`: the width of its
+/// widest unbreakable run, i.e. its longest word.
+///
+/// Shapers break inside a word when the space on offer is narrower than the word itself, so
+/// measuring at width zero reports roughly one grapheme and tells taffy the box may be that
+/// narrow. Every word is measured unconstrained instead and the widest wins. NBSP is not a break
+/// opportunity, so splitting on ASCII whitespace is the right split - it keeps `A\u{00A0}B`
+/// together, as CSS requires.
+fn min_content_width(
+    text_ctx: &crate::layouter::ElementContextText,
+    font_system: &Arc<Mutex<dyn FontSystem>>,
+    cache: &mut HashMap<MeasureKey, Size<f32>>,
+) -> f64 {
+    text_ctx
+        .text
+        .split_ascii_whitespace()
+        .map(|word| measure_str_cached(word, &text_ctx.font_info, MAX_CONTENT_WIDTH, font_system, cache).width as f64)
+        .fold(0.0_f64, f64::max)
 }
 
 /// Measure a replaced element (image / SVG) honouring any dimension CSS has already

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -155,6 +155,12 @@ pub struct TaffyLayouter {
     /// block, in CSS pixels. Empty on the first layout pass, since a float's position is not known
     /// until that pass has run; filled in from its result for the second.
     float_insets: HashMap<DomNodeId, (f32, f32)>,
+    /// Width each `display: table` box settled on in the previous pass, pinned onto the box when
+    /// the tree is rebuilt. A table's width comes out of the column algorithm, which runs after
+    /// taffy - so on the first pass taffy laid the contents out at the wrong width, and anything
+    /// that wraps (most visibly a caption) wrapped to it. Replaying the width lets that content
+    /// be measured at the width it will actually have.
+    table_widths: HashMap<DomNodeId, f32>,
     /// Taffy insets for absolutely positioned boxes that stretch between opposing insets,
     /// rebased from their CSS containing block onto the parent taffy measures from. Empty on the
     /// first pass - a box's containing block is only known once the page has been laid out - and
@@ -273,6 +279,7 @@ impl TaffyLayouter {
             measure_cache: HashMap::new(),
             dom_to_layout_mapping: HashMap::new(),
             float_insets: HashMap::new(),
+            table_widths: HashMap::new(),
             abspos_insets: HashMap::new(),
         }
     }
@@ -325,20 +332,23 @@ impl CanLayout for TaffyLayouter {
         // needs neither - most of them - pays for one pass.
         self.float_insets.clear();
         self.abspos_insets.clear();
-        let (mut layout_tree, placed, stretched) = self.layout_pass(render_tree, root_id, viewport);
+        self.table_widths.clear();
+        let (mut layout_tree, placed, stretched, table_widths) = self.layout_pass(render_tree, root_id, viewport);
 
         let insets = line_box_insets(&layout_tree, &placed);
-        if insets.is_empty() && stretched.is_empty() {
+        if insets.is_empty() && stretched.is_empty() && table_widths.is_empty() {
             dump_layout_to_json(&layout_tree);
             return layout_tree;
         }
 
         self.float_insets = insets;
         self.abspos_insets = stretched;
-        let (layout_tree_2, _, _) = self.layout_pass(layout_tree.render_tree, root_id, viewport);
+        self.table_widths = table_widths;
+        let (layout_tree_2, _, _, _) = self.layout_pass(layout_tree.render_tree, root_id, viewport);
         layout_tree = layout_tree_2;
         self.float_insets.clear();
         self.abspos_insets.clear();
+        self.table_widths.clear();
         dump_layout_to_json(&layout_tree);
         layout_tree
     }
@@ -412,11 +422,12 @@ impl TaffyLayouter {
         LayoutTree,
         Vec<crate::layouter::float::PlacedFloat>,
         HashMap<DomNodeId, RebasedInsets>,
+        HashMap<DomNodeId, f32>,
     ) {
         let mut layout_tree = self.generate_tree(render_tree, root_id);
 
-        let (placed, stretched) = self.compute_and_populate(&mut layout_tree, viewport);
-        (layout_tree, placed, stretched)
+        let (placed, stretched, table_widths) = self.compute_and_populate(&mut layout_tree, viewport);
+        (layout_tree, placed, stretched, table_widths)
     }
 }
 
@@ -450,6 +461,7 @@ impl TaffyLayouter {
     ) -> (
         Vec<crate::layouter::float::PlacedFloat>,
         HashMap<DomNodeId, RebasedInsets>,
+        HashMap<DomNodeId, f32>,
     ) {
         // // Compute the layout based on the viewport
         let size = match viewport {
@@ -552,7 +564,7 @@ impl TaffyLayouter {
         {
             log::error!("Failed to compute taffy layout: {:?}", e);
             self.measure_cache = measure_cache;
-            return (Vec::new(), HashMap::new());
+            return (Vec::new(), HashMap::new(), HashMap::new());
         }
         self.measure_cache = measure_cache;
 
@@ -562,7 +574,7 @@ impl TaffyLayouter {
         let root_id = layout_tree.root_id;
         let root_width = layout_tree.root_dimension.width;
         self.populate_boxmodel(layout_tree, root_id, Coordinate::ZERO, root_width);
-        post_process_tables(layout_tree, &self.dom_to_layout_mapping);
+        let table_widths = post_process_tables(layout_tree, &self.dom_to_layout_mapping);
         // After tables: a float inside a table cell must be placed against the cell's final
         // position, which lattice only fixes during the table pass.
         let placed = post_process_floats(layout_tree);
@@ -584,7 +596,7 @@ impl TaffyLayouter {
         let icb = viewport.unwrap_or(layout_tree.root_dimension);
         let stretched = post_process_abspos(layout_tree, icb);
 
-        (placed, stretched)
+        (placed, stretched, table_widths)
     }
 
     fn populate_boxmodel(
@@ -1179,6 +1191,15 @@ impl TaffyLayouter {
             NodeType::Element(data) => {
                 let conv = CssTaffyConverter::new(dom_node.node_id, &*layout_tree.render_tree.doc);
                 taffy_style = conv.convert(false);
+
+                // Second pass only: pin the width the column algorithm settled on, so the
+                // contents are measured at the width the table will actually have. A caption is
+                // the visible case - it is laid out across the finished table, so on the first
+                // pass (where taffy sizes the box from its own contents) it wraps to the wrong
+                // width and then drags the table out to match.
+                if let Some(&width) = self.table_widths.get(&dom_node.node_id) {
+                    taffy_style.size.width = Dimension::from_length(width);
+                }
 
                 // Second pass only: replace the CSS insets of an absolutely positioned box that
                 // stretches between opposing insets with ones rebased onto its parent, so taffy

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -1847,6 +1847,8 @@ impl TaffyLayouter {
                     // collapsible whitespace, so a node holding just an `&nbsp;` came out 0 wide -
                     // and since Parsoid gives every entity its own element, Wikipedia's
                     // `Designed<span>&nbsp;</span>by` rendered as "Designedby".
+                    // A provisional width; the real one is measured below, once the font is
+                    // known. This stands in if that measurement comes back empty.
                     let space_width = (font_size * 0.3) as f32;
                     taffy_style.size.width = Dimension::from_length(space_width);
                     taffy_style.flex_shrink = 0.0;
@@ -1893,6 +1895,24 @@ impl TaffyLayouter {
                     underline: text_decoration.contains("underline"),
                     line_through: text_decoration.contains("line-through"),
                 };
+
+                // The gap between two words of a mixed inline run is one of these whitespace
+                // boxes, so a width a fifth too wide reads as loose spacing across a whole
+                // paragraph. Measure it rather than estimating: the text is a non-breaking space
+                // by now, which - unlike a plain one - parley will not trim away, so its advance
+                // at max-content is the font's real space width.
+                if whitespace_only {
+                    let measured = {
+                        let mut font_system = self.font_system.lock();
+                        get_text_layout(&text, &font_info, MAX_CONTENT_WIDTH, &mut *font_system)
+                            .ok()
+                            .map(|d| d.width as f32)
+                            .filter(|w| *w > 0.0)
+                    };
+                    if let Some(width) = measured {
+                        taffy_style.size.width = Dimension::from_length(width);
+                    }
+                }
 
                 taffy_context = Some(TaffyContext::text(
                     text.as_str(),

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -329,6 +329,7 @@ impl CanLayout for TaffyLayouter {
 
         let insets = line_box_insets(&layout_tree, &placed);
         if insets.is_empty() && stretched.is_empty() {
+            dump_layout_to_json(&layout_tree);
             return layout_tree;
         }
 
@@ -338,7 +339,64 @@ impl CanLayout for TaffyLayouter {
         layout_tree = layout_tree_2;
         self.float_insets.clear();
         self.abspos_insets.clear();
+        dump_layout_to_json(&layout_tree);
         layout_tree
+    }
+}
+
+/// Writes the settled box geometry of every element to the JSON file named by `GOSUB_DUMP_LAYOUT`,
+/// the layout counterpart of `GOSUB_DUMP_CSS`. Off unless the variable is set.
+///
+/// Each entry carries the element's tag, `id`/`class`, tree depth and border box, in document
+/// order - enough to see which boxes ended up on top of each other, which is not recoverable
+/// from a screenshot.
+fn dump_layout_to_json(layout_tree: &LayoutTree) {
+    let Ok(path) = std::env::var("GOSUB_DUMP_LAYOUT") else {
+        return;
+    };
+
+    let doc = &layout_tree.render_tree.doc;
+    let mut entries: Vec<serde_json::Value> = Vec::new();
+    let mut stack = vec![(layout_tree.root_id, 0usize)];
+    while let Some((id, depth)) = stack.pop() {
+        let Some(el) = layout_tree.arena.get(&id) else {
+            continue;
+        };
+        // Children are pushed in reverse so the walk emits them in document order.
+        stack.extend(el.children.iter().rev().map(|child| (*child, depth + 1)));
+
+        let (tag, id_attr, class_attr) = match doc.get_node_by_id(el.dom_node_id) {
+            Some(Node {
+                node_type: NodeType::Element(element),
+                ..
+            }) => (
+                element.tag_name.clone(),
+                element.attributes.get("id").cloned().unwrap_or_default(),
+                element.attributes.get("class").cloned().unwrap_or_default(),
+            ),
+            _ => continue,
+        };
+
+        let b = el.box_model.border_box;
+        entries.push(serde_json::json!({
+            "depth": depth,
+            "node_id": u64::from(el.dom_node_id),
+            "tag": tag,
+            "id": id_attr,
+            "class": class_attr,
+            "x": b.x,
+            "y": b.y,
+            "w": b.width,
+            "h": b.height,
+        }));
+    }
+
+    match serde_json::to_string_pretty(&entries) {
+        Ok(json) => match std::fs::write(&path, json) {
+            Ok(()) => log::info!("Layout dump written to {path} ({} elements)", entries.len()),
+            Err(e) => log::error!("Failed to write layout dump to {path}: {e}"),
+        },
+        Err(e) => log::error!("Failed to serialize layout dump: {e}"),
     }
 }
 

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -1260,6 +1260,20 @@ impl TaffyLayouter {
         // stacks its children puts every word on a line of its own. Only the table boxes are
         // excluded, rather than asking the CSS display outright: *inline* elements are mapped onto
         // flex containers as well - 12000 of them on this page - and must keep what they have.
+        // An inline box does not start a line - it continues its parent's - so whitespace at its
+        // start is only leading whitespace if the line itself is empty, which this element cannot
+        // know. Dropping it regardless lost the space in
+        // `1964<span>;</span><span> </span>62 years ago`, which rendered as "1964;62 years ago":
+        // Parsoid gives every entity its own element, so a single space routinely arrives as the
+        // whole content of one. A block container *does* start a line, and there the trim is right.
+        let starts_a_line = !matches!(
+            layout_tree
+                .render_tree
+                .doc
+                .get_style(dom_node.node_id, &StyleProperty::Display),
+            Value::Display(CssDisplay::Inline)
+        );
+
         let parent_is_flex_or_grid = matches!(taffy_style.display, Display::Flex | Display::Grid)
             && !matches!(
                 layout_tree
@@ -1367,10 +1381,11 @@ impl TaffyLayouter {
                 // Still discard pure-whitespace text nodes; they carry no visual content.
                 if let NodeType::Text(text) = &child_node.node_type {
                     if is_collapsible_whitespace(text) {
-                        // Drop leading whitespace (before any inline sibling). Keep inter-element
-                        // whitespace - it collapses to a single space in extract_taffy_data and
-                        // visually separates adjacent inline elements (e.g. between </span><span>).
-                        if current_inline_group.is_empty() {
+                        // Drop leading whitespace (before any inline sibling) of a box that
+                        // starts a line. Keep inter-element whitespace - it collapses to a single
+                        // space in extract_taffy_data and visually separates adjacent inline
+                        // elements (e.g. between </span><span>).
+                        if current_inline_group.is_empty() && starts_a_line {
                             continue;
                         }
                     }
@@ -1409,10 +1424,11 @@ impl TaffyLayouter {
                     // as leading whitespace. Parsoid gives every entity its own element, which is
                     // how Wikipedia's `Designed<span>&nbsp;</span>by` lost its space entirely.
                     if is_collapsible_whitespace(text) {
-                        // Drop leading whitespace (before any inline sibling). Keep inter-element
-                        // whitespace - it collapses to a single space in extract_taffy_data and
-                        // visually separates adjacent inline elements (e.g. between </span><span>).
-                        if current_inline_group.is_empty() {
+                        // Drop leading whitespace (before any inline sibling) of a box that
+                        // starts a line. Keep inter-element whitespace - it collapses to a single
+                        // space in extract_taffy_data and visually separates adjacent inline
+                        // elements (e.g. between </span><span>).
+                        if current_inline_group.is_empty() && starts_a_line {
                             continue;
                         }
                         true
@@ -2179,5 +2195,34 @@ mod whitespace_tests {
         // And on its own it is a word, not a separator that vanishes.
         assert_eq!(split_collapsible_whitespace(NBSP).collect::<Vec<_>>(), [NBSP]);
         assert!(split_collapsible_whitespace("   ").next().is_none());
+    }
+}
+
+#[cfg(test)]
+mod leading_whitespace_tests {
+    use crate::common::document::style::Display as CssDisplay;
+
+    /// The rule the two call sites share, stated on its own: only a box that starts a line may
+    /// trim whitespace at its start.
+    fn starts_a_line(display: CssDisplay) -> bool {
+        !matches!(display, CssDisplay::Inline)
+    }
+
+    #[test]
+    fn a_block_starts_a_line_and_may_trim() {
+        assert!(starts_a_line(CssDisplay::Block));
+        assert!(starts_a_line(CssDisplay::TableCell));
+        // An inline-block establishes its own formatting context, so its leading whitespace does
+        // go - unlike an inline box, which merely continues the line it is on.
+        assert!(starts_a_line(CssDisplay::InlineBlock));
+    }
+
+    #[test]
+    fn an_inline_box_continues_a_line_and_must_not_trim() {
+        // `1964<span>;</span><span> </span>62` - Parsoid gives every entity its own element, so a
+        // lone space routinely *is* the whole content of one. Trimming it per element rather than
+        // per line box rendered that as "1964;62", and cost every space between the tokens of a
+        // syntax-highlighted code block, where each token is its own span.
+        assert!(!starts_a_line(CssDisplay::Inline));
     }
 }

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -11,7 +11,7 @@ use crate::common::media::{Media, MediaId, MediaRequest, MediaType};
 use crate::layouter::abspos::{post_process_abspos, RebasedInsets};
 use crate::layouter::box_model::Edges;
 use crate::layouter::css_taffy_converter::CssTaffyConverter;
-use crate::layouter::float::{line_box_insets, post_process_floats};
+use crate::layouter::float::{float_side, line_box_insets, position_is_out_of_flow, post_process_floats, FloatBand};
 use crate::layouter::table::post_process_tables;
 use crate::layouter::text::get_text_layout;
 use crate::layouter::{
@@ -29,6 +29,133 @@ use taffy::prelude::*;
 use taffy::NodeId as TaffyNodeId;
 
 const DEFAULT_FONT_SIZE: f64 = 16.0;
+
+/// How many times the page may be laid out before the float bands are taken as settled. Two is
+/// the old behaviour (measure, then apply); the third lets a paragraph that grew taller under its
+/// new line widths move the floats below it and be re-measured against where they ended up.
+const MAX_LAYOUT_PASSES: usize = 3;
+
+/// Width an inline item is measured at to get its natural size. Large enough that nothing wraps;
+/// `f64::MAX` overflows inside the text stack, as the measure callback already notes.
+const MAX_CONTENT_WIDTH: f64 = 1_000_000_000.0;
+
+/// Whether an inline item is a run of whitespace, which is what the word splitter emits between
+/// words and what CSS drops at a line break.
+fn is_whitespace_item(layout_tree: &LayoutTree, id: &LayoutElementId) -> bool {
+    match layout_tree.arena.get(id).map(|el| &el.context) {
+        Some(ElementContext::Text(text)) => !text.text.is_empty() && text.text.chars().all(char::is_whitespace),
+        _ => false,
+    }
+}
+
+/// Length of `items` with any trailing whitespace items removed.
+fn trim_trailing_whitespace(layout_tree: &LayoutTree, items: &[(LayoutElementId, TaffyNodeId)]) -> usize {
+    let mut end = items.len();
+    while end > 0 && is_whitespace_item(layout_tree, &items[end - 1].0) {
+        end -= 1;
+    }
+    end
+}
+
+/// `items` with any leading whitespace items dropped.
+fn skip_leading_whitespace<'a>(
+    layout_tree: &LayoutTree,
+    items: &'a [(LayoutElementId, TaffyNodeId)],
+) -> &'a [(LayoutElementId, TaffyNodeId)] {
+    let mut start = 0;
+    while start < items.len() && is_whitespace_item(layout_tree, &items[start].0) {
+        start += 1;
+    }
+    &items[start..]
+}
+
+/// Where one line box goes: which band it sits in, and how far below the previous one it starts.
+#[derive(Debug, Clone, Copy)]
+struct LinePlacement {
+    band: FloatBand,
+    offset_top: f32,
+}
+
+/// Walks a block's float bands as its line boxes are emitted, remembering how much of the current
+/// band is already spoken for. One cursor covers a whole block, so a `<br>` in the middle of a
+/// paragraph keeps its place in the band list rather than starting over.
+struct BandCursor {
+    bands: Vec<FloatBand>,
+    index: usize,
+    /// Height consumed in the band at `index`.
+    used: f32,
+    /// Height left unused when the previous band was left behind, to be added above the next
+    /// container. A band 4.8 lines tall holds 4 whole lines; the fifth must start *below* the
+    /// float rather than in the sliver left over, which is what CSS does with a line box that
+    /// would otherwise intersect one.
+    pending_offset: f32,
+}
+
+impl BandCursor {
+    fn new(bands: &[FloatBand]) -> Self {
+        Self {
+            bands: bands.to_vec(),
+            index: 0,
+            used: 0.0,
+            pending_offset: 0.0,
+        }
+    }
+
+    /// The geometry for the next line box: the current band, plus any gap owed above it.
+    fn placement(&mut self) -> LinePlacement {
+        LinePlacement {
+            band: self.current(),
+            offset_top: std::mem::take(&mut self.pending_offset),
+        }
+    }
+
+    fn current(&self) -> FloatBand {
+        self.bands[self.index.min(self.bands.len() - 1)]
+    }
+
+    /// Line boxes of `line_height` still free in the current band. The last band is open-ended,
+    /// so everything left goes there.
+    fn lines_left(&self, line_height: f32) -> usize {
+        let band = self.current();
+        let Some(height) = band.height else {
+            return usize::MAX;
+        };
+        if line_height <= 0.0 {
+            return usize::MAX;
+        }
+        (((height - self.used) / line_height).floor().max(0.0)) as usize
+    }
+
+    /// Charge `lines` line boxes of `line_height` to the current band, moving on when it fills.
+    fn take_lines(&mut self, lines: usize, line_height: f32) {
+        let Some(height) = self.current().height else {
+            return;
+        };
+        self.used += lines as f32 * line_height.max(0.0);
+        if self.used >= height {
+            self.advance();
+        }
+    }
+
+    /// Move to the next band. Returns false when this was already the last one.
+    fn advance(&mut self) -> bool {
+        if self.index + 1 >= self.bands.len() {
+            return false;
+        }
+        if let Some(height) = self.current().height {
+            self.pending_offset += (height - self.used).max(0.0);
+        }
+        self.index += 1;
+        self.used = 0.0;
+        true
+    }
+
+    /// Give up on band-by-band placement: everything else goes in the final, open-ended band.
+    fn exhaust(&mut self) {
+        while self.advance() {}
+    }
+}
+
 const DEFAULT_FONT_FAMILY: &str = "sans-serif";
 
 /// Parse an HTML presentational length attribute (e.g. `<img width="80">`) into pixels.
@@ -154,7 +281,7 @@ pub struct TaffyLayouter {
     /// Per-block `(left inset, line width)` line-box geometry that clears the floats beside that
     /// block, in CSS pixels. Empty on the first layout pass, since a float's position is not known
     /// until that pass has run; filled in from its result for the second.
-    float_insets: HashMap<DomNodeId, (f32, f32)>,
+    float_insets: HashMap<DomNodeId, Vec<FloatBand>>,
     /// Width each `display: table` box settled on in the previous pass, pinned onto the box when
     /// the tree is rebuilt. A table's width comes out of the column algorithm, which runs after
     /// taffy - so on the first pass taffy laid the contents out at the wrong width, and anything
@@ -341,11 +468,32 @@ impl CanLayout for TaffyLayouter {
             return layout_tree;
         }
 
-        self.float_insets = insets;
-        self.abspos_insets = stretched;
-        self.table_widths = table_widths;
-        let (layout_tree_2, _, _, _) = self.layout_pass(layout_tree.render_tree, root_id, viewport);
-        layout_tree = layout_tree_2;
+        // Float bands are read off one layout and applied to the next, but applying them changes
+        // the very geometry they were measured from: narrower line boxes make a paragraph taller,
+        // which moves everything below it and so moves the floats. One extra pass leaves a
+        // paragraph flowing at the width its *previous*, shorter self needed. Re-measure and go
+        // again until the bands stop moving, with a hard cap so a layout that oscillates between
+        // two answers still terminates rather than looping.
+        let mut insets = insets;
+        let mut stretched = stretched;
+        let mut table_widths = table_widths;
+        for _ in 0..MAX_LAYOUT_PASSES - 1 {
+            self.float_insets.clone_from(&insets);
+            self.abspos_insets.clone_from(&stretched);
+            self.table_widths.clone_from(&table_widths);
+            let (next_tree, placed, next_stretched, next_widths) =
+                self.layout_pass(layout_tree.render_tree, root_id, viewport);
+            layout_tree = next_tree;
+
+            let next_insets = line_box_insets(&layout_tree, &placed);
+            let settled = next_insets == insets && next_stretched == stretched && next_widths == table_widths;
+            insets = next_insets;
+            stretched = next_stretched;
+            table_widths = next_widths;
+            if settled {
+                break;
+            }
+        }
         self.float_insets.clear();
         self.abspos_insets.clear();
         self.table_widths.clear();
@@ -717,6 +865,7 @@ impl TaffyLayouter {
     // vertically - that is how a `<br>` becomes a line break.
     fn process_inlines(
         &mut self,
+        layout_tree: &LayoutTree,
         current_inline_group: &[InlineEntry],
         element_node: &mut LayoutElementNode,
         leaf_id: TaffyNodeId,
@@ -728,6 +877,13 @@ impl TaffyLayouter {
             return;
         }
 
+        // Line boxes beside a float are shorter than the ones below it, and the anonymous
+        // container *is* the line box here, so a block crossed by a float needs one container per
+        // band rather than one for the whole block. `cursor` carries the position in that band
+        // list across the whole block, including over `<br>` boundaries.
+        let bands = self.float_insets.get(&element_node.dom_node_id).cloned();
+        let mut cursor = bands.as_ref().map(|bands| BandCursor::new(bands));
+
         // Split the run into line boxes at `<br>` boundaries. An empty segment (consecutive `<br>`s
         // or a leading `<br>`) still emits a line box of the break's line-height, so runs of `<br>`
         // produce blank lines rather than collapsing.
@@ -737,16 +893,162 @@ impl TaffyLayouter {
                 InlineEntry::Item(id, taffy) => segment.push((*id, *taffy)),
                 InlineEntry::Break(lh) => {
                     if segment.is_empty() {
-                        self.emit_line(&[], Some(*lh), element_node, leaf_id, justify);
+                        let placement = cursor.as_mut().map(BandCursor::placement);
+                        if let Some(c) = cursor.as_mut() {
+                            c.take_lines(1, *lh as f32);
+                        }
+                        self.emit_line(&[], Some(*lh), element_node, leaf_id, justify, placement);
                     } else {
-                        self.emit_line(&segment, None, element_node, leaf_id, justify);
+                        self.emit_banded(layout_tree, &segment, element_node, leaf_id, justify, cursor.as_mut());
                         segment.clear();
+                        // The break itself ends the line the segment left open.
+                        if let Some(c) = cursor.as_mut() {
+                            c.take_lines(1, *lh as f32);
+                        }
                     }
                 }
             }
         }
         if !segment.is_empty() {
-            self.emit_line(&segment, None, element_node, leaf_id, justify);
+            self.emit_banded(layout_tree, &segment, element_node, leaf_id, justify, cursor.as_mut());
+        }
+    }
+
+    /// Emit one run of inline items, split across the float bands it flows through.
+    ///
+    /// Without bands this is a single container, exactly as before. With them, the items are
+    /// packed into lines at each band's width until that band is full, and what is left starts a
+    /// new container in the next band - which is how text runs narrow beside a float and then
+    /// returns to full width underneath it.
+    fn emit_banded(
+        &mut self,
+        layout_tree: &LayoutTree,
+        items: &[(LayoutElementId, TaffyNodeId)],
+        element_node: &mut LayoutElementNode,
+        leaf_id: TaffyNodeId,
+        justify: Option<taffy::JustifyContent>,
+        cursor: Option<&mut BandCursor>,
+    ) {
+        let Some(cursor) = cursor else {
+            self.emit_line(items, None, element_node, leaf_id, justify, None);
+            return;
+        };
+
+        let line_height = self.inline_line_height(layout_tree, items);
+        let mut rest = items;
+        while !rest.is_empty() {
+            let band = cursor.current();
+            // Measuring every item lets the split match where taffy will actually wrap. If any
+            // item cannot be measured the split would be guesswork, so the whole run goes into
+            // one container at the current band's width instead.
+            let capacity = cursor.lines_left(line_height);
+            let Some((taken, lines)) = self.fill_band(layout_tree, rest, band, capacity) else {
+                let placement = cursor.placement();
+                cursor.exhaust();
+                self.emit_line(rest, None, element_node, leaf_id, justify, Some(placement));
+                return;
+            };
+            if taken == 0 {
+                // Nothing fits this band - a float leaves it too narrow for even one item - so
+                // drop to the next one rather than emitting an empty container. CSS puts a line
+                // that cannot fit beside a float below it, which is exactly this.
+                if !cursor.advance() {
+                    self.emit_line(rest, None, element_node, leaf_id, justify, Some(cursor.placement()));
+                    return;
+                }
+                continue;
+            }
+            // A space that falls at a band boundary is a line break's worth of whitespace, which
+            // CSS collapses away. Keeping it also risked a blank line: a trailing space pushed
+            // past the band's width wraps to a line of its own in that container.
+            let chunk_end = trim_trailing_whitespace(layout_tree, &rest[..taken]);
+            let placement = cursor.placement();
+            self.emit_line(
+                &rest[..chunk_end],
+                None,
+                element_node,
+                leaf_id,
+                justify,
+                Some(placement),
+            );
+            cursor.take_lines(lines, line_height);
+            rest = skip_leading_whitespace(layout_tree, &rest[taken..]);
+        }
+    }
+
+    /// The line height to charge each line of `items` against a band's height. Taken from the
+    /// first text item, which is what decides the line box's height in practice.
+    fn inline_line_height(&self, layout_tree: &LayoutTree, items: &[(LayoutElementId, TaffyNodeId)]) -> f32 {
+        for (id, _) in items {
+            if let Some(el) = layout_tree.arena.get(id) {
+                if let ElementContext::Text(text) = &el.context {
+                    if text.font_info.line_height > 0.0 {
+                        return text.font_info.line_height as f32;
+                    }
+                }
+            }
+        }
+        DEFAULT_FONT_SIZE as f32
+    }
+
+    /// How many leading items of `rest` fit in `band` within `max_lines` line boxes, and how many
+    /// lines they take. `None` when an item's width cannot be measured.
+    fn fill_band(
+        &mut self,
+        layout_tree: &LayoutTree,
+        rest: &[(LayoutElementId, TaffyNodeId)],
+        band: FloatBand,
+        max_lines: usize,
+    ) -> Option<(usize, usize)> {
+        if max_lines == 0 {
+            return Some((0, 0));
+        }
+        let width = band.line_width as f64;
+        let mut lines = 1usize;
+        let mut used = 0.0_f64;
+        for (i, (id, _)) in rest.iter().enumerate() {
+            let item_width = self.inline_item_width(layout_tree, id)?;
+            // The first item on a line always goes on it, however wide: a word longer than the
+            // line overflows rather than vanishing, which is what taffy does too.
+            if used > 0.0 && used + item_width > width {
+                if lines == max_lines {
+                    return Some((i, lines));
+                }
+                lines += 1;
+                used = 0.0;
+            }
+            used += item_width;
+        }
+        Some((rest.len(), lines))
+    }
+
+    /// Natural width of one inline item, measured the same way taffy will measure it.
+    fn inline_item_width(&mut self, layout_tree: &LayoutTree, id: &LayoutElementId) -> Option<f64> {
+        match &layout_tree.arena.get(id)?.context {
+            ElementContext::Text(text) => {
+                let font_info = text.font_info.clone();
+                let content = text.text.clone();
+                let mut font_system = self.font_system.lock();
+                get_text_layout(&content, &font_info, MAX_CONTENT_WIDTH, &mut *font_system)
+                    .ok()
+                    .map(|d| d.width)
+            }
+            ElementContext::Image(image) => Some(image.dimension.width),
+            ElementContext::Svg(svg) => Some(svg.dimension.width),
+            ElementContext::None => {
+                // A float or an absolutely positioned box is in the inline run only because that
+                // is where it was written; it is out of flow and takes no room on the line. The
+                // float that *causes* the bands is usually the first item in the very run being
+                // split, so counting it would be wrong twice over.
+                let dom_id = layout_tree.arena.get(id)?.dom_node_id;
+                let doc = &layout_tree.render_tree.doc;
+                if position_is_out_of_flow(&**doc, dom_id) || float_side(&**doc, dom_id).is_some() {
+                    return Some(0.0);
+                }
+                // Anything else with no context - an inline-block, say - has no measurable width
+                // until taffy runs, so the caller falls back rather than guessing.
+                None
+            }
         }
     }
 
@@ -760,11 +1062,8 @@ impl TaffyLayouter {
         element_node: &mut LayoutElementNode,
         leaf_id: TaffyNodeId,
         justify: Option<taffy::JustifyContent>,
+        placement: Option<LinePlacement>,
     ) {
-        // Line boxes - not the block itself - are what a float shortens, and the anonymous
-        // container *is* the line box here, so the inset goes on its margins. The block keeps its
-        // full width, so its background and borders still span the float, as CSS requires.
-        let float_inset = self.float_insets.get(&element_node.dom_node_id).copied();
         // All inline elements (even a single one) are wrapped in an anonymous flex container.
         // This ensures the text measure function always receives AvailableSpace::Definite from
         // the flex algorithm, preventing single-child text nodes from getting MaxContent width
@@ -790,9 +1089,15 @@ impl TaffyLayouter {
             },
             ..Default::default()
         };
-        if let Some((inset_left, line_width)) = float_inset {
-            style.margin.left = LengthPercentageAuto::length(inset_left);
-            style.size.width = Dimension::from_length(line_width);
+        // Line boxes - not the block itself - are what a float shortens, and the anonymous
+        // container *is* the line box here, so the inset goes on its margins. The block keeps its
+        // full width, so its background and borders still span the float, as CSS requires.
+        if let Some(placement) = placement {
+            style.margin.left = LengthPercentageAuto::length(placement.band.left_inset);
+            style.size.width = Dimension::from_length(placement.band.line_width);
+            if placement.offset_top > 0.0 {
+                style.margin.top = LengthPercentageAuto::length(placement.offset_top);
+            }
         }
         if items.is_empty() {
             match empty_line_height {
@@ -1090,7 +1395,13 @@ impl TaffyLayouter {
 
             // Strip trailing whitespace before flushing, then flush.
             current_inline_group.truncate(current_inline_group.len().saturating_sub(trailing_ws_count));
-            self.process_inlines(&current_inline_group, &mut element_node, leaf_id, line_justify);
+            self.process_inlines(
+                layout_tree,
+                &current_inline_group,
+                &mut element_node,
+                leaf_id,
+                line_justify,
+            );
             current_inline_group = Vec::new();
             trailing_ws_count = 0;
 
@@ -1102,7 +1413,13 @@ impl TaffyLayouter {
 
         // Strip trailing whitespace and deal with any remaining inline elements
         current_inline_group.truncate(current_inline_group.len().saturating_sub(trailing_ws_count));
-        self.process_inlines(&current_inline_group, &mut element_node, leaf_id, line_justify);
+        self.process_inlines(
+            layout_tree,
+            &current_inline_group,
+            &mut element_node,
+            leaf_id,
+            line_justify,
+        );
 
         // The layout-tree is the structure handed to the rest of the pipeline; taffy stays
         // internal to this layouter so other layout engines can be swapped in.
@@ -1698,5 +2015,72 @@ mod tests {
         );
         let data = "data:image/png;base64,iVBORw0KGgo=";
         assert!(to_absolute_url(data, "http://h/page.html").starts_with("data:image/png;base64,"));
+    }
+}
+
+#[cfg(test)]
+mod band_cursor_tests {
+    use super::{BandCursor, FloatBand};
+
+    fn bands() -> Vec<FloatBand> {
+        vec![
+            FloatBand {
+                left_inset: 0.0,
+                line_width: 400.0,
+                height: Some(100.0),
+            },
+            FloatBand {
+                left_inset: 0.0,
+                line_width: 600.0,
+                height: None,
+            },
+        ]
+    }
+
+    #[test]
+    fn a_band_holds_as_many_whole_lines_as_it_has_room_for() {
+        let cursor = BandCursor::new(&bands());
+        assert_eq!(cursor.lines_left(20.0), 5);
+        // 4.5 lines' worth of room holds four whole ones; the fifth would cross the float.
+        assert_eq!(cursor.lines_left(22.0), 4);
+    }
+
+    #[test]
+    fn the_last_band_is_open_ended() {
+        let mut cursor = BandCursor::new(&bands());
+        cursor.take_lines(5, 20.0);
+        assert_eq!(cursor.current().line_width, 600.0);
+        assert_eq!(cursor.lines_left(20.0), usize::MAX);
+    }
+
+    #[test]
+    fn the_unused_tail_of_a_band_is_owed_to_the_next_line() {
+        // 100px of band at 22px per line: four lines fit and 12px are left over. The next line
+        // must start below the float, not in the sliver - CSS moves a line box that would
+        // intersect a float down until it clears.
+        let mut cursor = BandCursor::new(&bands());
+        assert_eq!(cursor.placement().offset_top, 0.0);
+        cursor.take_lines(4, 22.0);
+        assert!(cursor.advance() || cursor.current().height.is_none());
+        let placement = cursor.placement();
+        assert_eq!(placement.band.line_width, 600.0);
+        assert_eq!(placement.offset_top, 12.0);
+        // Only owed once.
+        assert_eq!(cursor.placement().offset_top, 0.0);
+    }
+
+    #[test]
+    fn filling_a_band_exactly_advances_without_a_gap() {
+        let mut cursor = BandCursor::new(&bands());
+        cursor.take_lines(5, 20.0);
+        assert_eq!(cursor.placement().offset_top, 0.0);
+    }
+
+    #[test]
+    fn exhausting_jumps_to_the_open_ended_band() {
+        let mut cursor = BandCursor::new(&bands());
+        cursor.exhaust();
+        assert_eq!(cursor.current().line_width, 600.0);
+        assert!(cursor.current().height.is_none());
     }
 }

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -125,6 +125,10 @@ struct BandCursor {
     /// float rather than in the sliver left over, which is what CSS does with a line box that
     /// would otherwise intersect one.
     pending_offset: f32,
+    /// How much taller than the run the line that *closes* it is - a `<br>` with a bigger
+    /// line-height than the text before it. Charged with that last line rather than after it, so
+    /// a run that exactly fills a band cannot push the extra into the next one.
+    closing_extra: f32,
 }
 
 impl BandCursor {
@@ -134,6 +138,7 @@ impl BandCursor {
             index: 0,
             used: 0.0,
             pending_offset: 0.0,
+            closing_extra: 0.0,
         }
     }
 
@@ -164,25 +169,29 @@ impl BandCursor {
 
     /// Charge `lines` line boxes of `line_height` to the current band, moving on when it fills.
     fn take_lines(&mut self, lines: usize, line_height: f32) {
+        self.take_lines_tall_last(lines, line_height, 0.0);
+    }
+
+    /// Declare that the run about to be emitted is closed by a line `extra` taller than the run's
+    /// own lines - a `<br>` with a bigger line-height. Consumed by the last chunk the run is split
+    /// into.
+    fn set_closing_extra(&mut self, extra: f32) {
+        self.closing_extra = extra.max(0.0);
+    }
+
+    /// Charge `lines` line boxes of `line_height`, the last of them `tail_extra` taller.
+    ///
+    /// The tail has to be part of the same charge, not a second one: a run that exactly fills its
+    /// band advances the cursor the moment it is charged, and anything added afterwards lands in
+    /// the *next* band - or is dropped entirely when that band is open-ended, which left the
+    /// content after a tall `<br>` starting too high.
+    fn take_lines_tall_last(&mut self, lines: usize, line_height: f32, tail_extra: f32) {
         let Some(height) = self.current().height else {
             return;
         };
-        self.used += lines as f32 * line_height.max(0.0);
+        self.used += lines as f32 * line_height.max(0.0) + tail_extra.max(0.0);
         if self.used >= height {
             self.advance();
-        }
-    }
-
-    /// Raise the line just charged from `charged` to `line_height` when something taller ends it.
-    ///
-    /// A `<br>` after text closes the line the text is on; it does not add one. `emit_banded` has
-    /// already charged that line - `fill_band` counts the partly-filled last line too - so
-    /// charging a whole line again for the break pushed later content past a finite band early.
-    /// Only a `<br>` with a taller line-height than the run it follows adds anything at all.
-    fn raise_last_line(&mut self, charged: f32, line_height: f32) {
-        let extra = line_height - charged;
-        if extra > 0.0 {
-            self.take_lines(1, extra);
         }
     }
 
@@ -916,9 +925,13 @@ impl TaffyLayouter {
                         }
                         self.emit_line(&[], Some(*lh), element_node, leaf_id, line_style, placement);
                     } else {
-                        // The height `emit_banded` will charge each of the segment's lines at,
-                        // including the one the break is about to close.
+                        // The break ends the line the segment leaves open rather than adding one,
+                        // so it only makes that line taller - and that has to be charged *with*
+                        // the line, before the cursor decides the band is full.
                         let charged = self.inline_line_height(layout_tree, &segment);
+                        if let Some(c) = cursor.as_mut() {
+                            c.set_closing_extra(*lh as f32 - charged);
+                        }
                         self.emit_banded(
                             layout_tree,
                             &segment,
@@ -928,10 +941,6 @@ impl TaffyLayouter {
                             cursor.as_mut(),
                         );
                         segment.clear();
-                        // The break ends the line the segment left open rather than adding one.
-                        if let Some(c) = cursor.as_mut() {
-                            c.raise_last_line(charged, *lh as f32);
-                        }
                     }
                 }
             }
@@ -969,6 +978,8 @@ impl TaffyLayouter {
         };
 
         let line_height = self.inline_line_height(layout_tree, items);
+        // Taken up front so an early return cannot leak it into the next run.
+        let closing_extra = std::mem::take(&mut cursor.closing_extra);
         let mut rest = items;
         while !rest.is_empty() {
             let band = cursor.current();
@@ -1005,8 +1016,11 @@ impl TaffyLayouter {
                 line_style,
                 Some(placement),
             );
-            cursor.take_lines(lines, line_height);
-            rest = skip_leading_whitespace(layout_tree, &rest[taken..]);
+            // The line that closes the whole run is the last line of its last chunk.
+            let remaining = skip_leading_whitespace(layout_tree, &rest[taken..]);
+            let tail = if remaining.is_empty() { closing_extra } else { 0.0 };
+            cursor.take_lines_tall_last(lines, line_height, tail);
+            rest = remaining;
         }
     }
 
@@ -2223,14 +2237,46 @@ mod tests {
         assert_eq!(cursor.lines_left(20.0), 3);
 
         // One line of text, then a break of the same line-height: one line used, two left.
-        cursor.take_lines(1, 20.0);
-        cursor.raise_last_line(20.0, 20.0);
+        cursor.set_closing_extra(0.0);
+        cursor.take_lines_tall_last(1, 20.0, 0.0);
         assert_eq!(cursor.lines_left(20.0), 2, "the break must not take a line of its own");
 
         // A break taller than the run it ends does make that line taller.
-        cursor.take_lines(1, 20.0);
-        cursor.raise_last_line(20.0, 30.0);
-        assert_eq!(cursor.lines_left(20.0), 0, "20 + 30 of 60 leaves less than a line");
+        cursor.take_lines_tall_last(1, 20.0, 10.0);
+        assert_eq!(
+            cursor.lines_left(20.0),
+            0,
+            "20 + 30 of 60 leaves 10px, less than a line"
+        );
+    }
+
+    /// The tall closing line has to be charged *with* the run, not after it. A run that exactly
+    /// fills its band advances the cursor as it is charged, so an afterwards-correction landed in
+    /// the next band - stealing capacity from it, or vanishing when it was open-ended.
+    #[test]
+    fn a_tall_break_at_an_exact_band_fill_does_not_spill_into_the_next_band() {
+        use super::{BandCursor, FloatBand};
+
+        let narrow = FloatBand {
+            left_inset: 0.0,
+            line_width: 400.0,
+            height: Some(60.0),
+        };
+        let below = FloatBand {
+            height: Some(40.0),
+            ..narrow
+        };
+
+        let mut cursor = BandCursor::new(&[narrow, below]);
+        // Three 20px lines fill the 60px band exactly, and the run is closed by a 10px-taller
+        // break.
+        cursor.take_lines_tall_last(3, 20.0, 10.0);
+
+        assert_eq!(
+            cursor.lines_left(20.0),
+            2,
+            "the next band keeps its whole 40px: the closing line belongs to the band above it"
+        );
     }
 
     #[test]

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -204,7 +204,7 @@ fn parse_px_attr(v: &str) -> Option<f32> {
 
 // Cache key: (text, font_family, size_bits, line_height_bits, weight, max_width_bits,
 // letter_spacing_bits). Floats are stored as their bit pattern so the tuple is Hash + Eq.
-type MeasureKey = (String, String, u32, u32, i32, u32, u32);
+pub(crate) type MeasureKey = (String, String, u32, u32, i32, u32, u32);
 
 /// CSS `text-align` on a block, as `justify_content` for the anonymous flex containers holding its
 /// line boxes. A line box *is* that container, so this is what positions a run too short to fill it
@@ -706,9 +706,10 @@ impl TaffyLayouter {
         let table_widths = post_process_tables(
             layout_tree,
             &self.dom_to_layout_mapping,
-            crate::layouter::table::TablePassInputs {
+            &mut crate::layouter::table::TablePassInputs {
                 font_system: &self.font_system,
                 pinned: &pinned,
+                measure_cache: &mut self.measure_cache,
             },
         );
         self.table_widths = pinned;
@@ -1043,12 +1044,21 @@ impl TaffyLayouter {
     fn inline_item_width(&mut self, layout_tree: &LayoutTree, id: &LayoutElementId) -> Option<f64> {
         match &layout_tree.arena.get(id)?.context {
             ElementContext::Text(text) => {
+                // Through the shared cache, not the font system directly: `fill_band` asks for
+                // every inline item in a block, and taffy has already shaped most of them at this
+                // same width through `measure_text_cached`. Shaping them again is the whole cost
+                // of banding a block on a page with thousands of word boxes.
                 let font_info = text.font_info.clone();
                 let content = text.text.clone();
-                let mut font_system = self.font_system.lock();
-                get_text_layout(&content, &font_info, MAX_CONTENT_WIDTH, &mut *font_system)
-                    .ok()
-                    .map(|d| d.width)
+                let width = measure_str_cached(
+                    &content,
+                    &font_info,
+                    MAX_CONTENT_WIDTH,
+                    &self.font_system,
+                    &mut self.measure_cache,
+                )
+                .width;
+                Some(width as f64)
             }
             ElementContext::Image(image) => Some(image.dimension.width),
             ElementContext::Svg(svg) => Some(svg.dimension.width),
@@ -1988,7 +1998,7 @@ fn measure_text_cached(
 
 /// The same measurement for a bare string, so a single word can be measured with the
 /// surrounding node's font.
-fn measure_str_cached(
+pub(crate) fn measure_str_cached(
     text: &str,
     font_info: &crate::common::font::FontInfo,
     max_width: f64,

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -11,7 +11,9 @@ use crate::common::media::{Media, MediaId, MediaRequest, MediaType};
 use crate::layouter::abspos::{post_process_abspos, RebasedInsets};
 use crate::layouter::box_model::Edges;
 use crate::layouter::css_taffy_converter::CssTaffyConverter;
-use crate::layouter::float::{float_side, line_box_insets, position_is_out_of_flow, post_process_floats, FloatBand};
+use crate::layouter::float::{
+    float_side, position_is_out_of_flow, post_process_floats, resolve_bands_in_document_order, FloatBand,
+};
 use crate::layouter::table::post_process_tables;
 use crate::layouter::text::get_text_layout;
 use crate::layouter::{
@@ -28,12 +30,30 @@ use std::sync::Arc;
 use taffy::prelude::*;
 use taffy::NodeId as TaffyNodeId;
 
-const DEFAULT_FONT_SIZE: f64 = 16.0;
+/// Whether a text node is nothing but the whitespace CSS collapses.
+///
+/// Deliberately ASCII: `str::trim` and `char::is_whitespace` use the Unicode set, which counts
+/// U+00A0 and the other fixed-width spaces. Those are content - they exist to be kept - so a node
+/// holding only an `&nbsp;` must not be mistaken for source indentation and dropped. Parsoid wraps
+/// every entity in its own element, so that mistake cost Wikipedia's infoboxes every one of their
+/// non-breaking spaces: "Designedby", "Firstappeared", "May1, 1964".
+fn is_collapsible_whitespace(text: &str) -> bool {
+    text.trim_matches(|c: char| c.is_ascii_whitespace()).is_empty()
+}
 
-/// How many times the page may be laid out before the float bands are taken as settled. Two is
-/// the old behaviour (measure, then apply); the third lets a paragraph that grew taller under its
-/// new line widths move the floats below it and be re-measured against where they ended up.
-const MAX_LAYOUT_PASSES: usize = 3;
+/// Split text on the whitespace CSS actually collapses.
+///
+/// CSS `white-space` processing operates on spaces, tabs and newlines - not on every character
+/// Unicode marks as white space. `str::split_whitespace` uses the Unicode set, which includes
+/// U+00A0 NO-BREAK SPACE, so a text node holding only an `&nbsp;` split into *no* words at all and
+/// was dropped. Parsoid wraps every entity in its own element, so Wikipedia's
+/// `Designed<span typeof="mw:Entity">&nbsp;</span>by` rendered as "Designedby", and the same for
+/// "First appeared", "May 1, 1964" and "; 62 years ago".
+fn split_collapsible_whitespace(text: &str) -> impl Iterator<Item = &str> {
+    text.split(|c: char| c.is_ascii_whitespace()).filter(|s| !s.is_empty())
+}
+
+const DEFAULT_FONT_SIZE: f64 = 16.0;
 
 /// Width an inline item is measured at to get its natural size. Large enough that nothing wraps;
 /// `f64::MAX` overflows inside the text stack, as the measure callback already notes.
@@ -43,7 +63,11 @@ const MAX_CONTENT_WIDTH: f64 = 1_000_000_000.0;
 /// words and what CSS drops at a line break.
 fn is_whitespace_item(layout_tree: &LayoutTree, id: &LayoutElementId) -> bool {
     match layout_tree.arena.get(id).map(|el| &el.context) {
-        Some(ElementContext::Text(text)) => !text.text.is_empty() && text.text.chars().all(char::is_whitespace),
+        // `is_ascii_whitespace`, not `is_whitespace`: an `&nbsp;` is a character to render, not
+        // a break opportunity, so it must not be dropped at a band boundary.
+        Some(ElementContext::Text(text)) => {
+            !text.text.is_empty() && text.text.chars().all(|c: char| c.is_ascii_whitespace())
+        }
         _ => false,
     }
 }
@@ -462,38 +486,20 @@ impl CanLayout for TaffyLayouter {
         self.table_widths.clear();
         let (mut layout_tree, placed, stretched, table_widths) = self.layout_pass(render_tree, root_id, viewport);
 
-        let insets = line_box_insets(&layout_tree, &placed);
+        // Float bands are resolved in document order from this one baseline layout rather than by
+        // laying the page out over and over until the answer stops moving - which it did not: see
+        // `resolve_bands_in_document_order`. Two passes total, always.
+        let insets = resolve_bands_in_document_order(&layout_tree, &placed);
         if insets.is_empty() && stretched.is_empty() && table_widths.is_empty() {
             dump_layout_to_json(&layout_tree);
             return layout_tree;
         }
 
-        // Float bands are read off one layout and applied to the next, but applying them changes
-        // the very geometry they were measured from: narrower line boxes make a paragraph taller,
-        // which moves everything below it and so moves the floats. One extra pass leaves a
-        // paragraph flowing at the width its *previous*, shorter self needed. Re-measure and go
-        // again until the bands stop moving, with a hard cap so a layout that oscillates between
-        // two answers still terminates rather than looping.
-        let mut insets = insets;
-        let mut stretched = stretched;
-        let mut table_widths = table_widths;
-        for _ in 0..MAX_LAYOUT_PASSES - 1 {
-            self.float_insets.clone_from(&insets);
-            self.abspos_insets.clone_from(&stretched);
-            self.table_widths.clone_from(&table_widths);
-            let (next_tree, placed, next_stretched, next_widths) =
-                self.layout_pass(layout_tree.render_tree, root_id, viewport);
-            layout_tree = next_tree;
-
-            let next_insets = line_box_insets(&layout_tree, &placed);
-            let settled = next_insets == insets && next_stretched == stretched && next_widths == table_widths;
-            insets = next_insets;
-            stretched = next_stretched;
-            table_widths = next_widths;
-            if settled {
-                break;
-            }
-        }
+        self.float_insets = insets;
+        self.abspos_insets = stretched;
+        self.table_widths = table_widths;
+        let (final_tree, _, _, _) = self.layout_pass(layout_tree.render_tree, root_id, viewport);
+        layout_tree = final_tree;
         self.float_insets.clear();
         self.abspos_insets.clear();
         self.table_widths.clear();
@@ -523,6 +529,8 @@ fn dump_layout_to_json(layout_tree: &LayoutTree) {
         // Children are pushed in reverse so the walk emits them in document order.
         stack.extend(el.children.iter().rev().map(|child| (*child, depth + 1)));
 
+        // Text boxes are included as `#text` with their content: a box that is the wrong size
+        // because its *text* went missing is invisible in an element-only dump.
         let (tag, id_attr, class_attr) = match doc.get_node_by_id(el.dom_node_id) {
             Some(Node {
                 node_type: NodeType::Element(element),
@@ -532,7 +540,10 @@ fn dump_layout_to_json(layout_tree: &LayoutTree) {
                 element.attributes.get("id").cloned().unwrap_or_default(),
                 element.attributes.get("class").cloned().unwrap_or_default(),
             ),
-            _ => continue,
+            _ => match &el.context {
+                ElementContext::Text(text) => ("#text".to_string(), String::new(), text.text.clone()),
+                _ => continue,
+            },
         };
 
         let b = el.box_model.border_box;
@@ -1147,7 +1158,9 @@ impl TaffyLayouter {
             (
                 full.starts_with(|c: char| c.is_ascii_whitespace()),
                 full.ends_with(|c: char| c.is_ascii_whitespace()),
-                full.split_whitespace().map(str::to_string).collect::<Vec<_>>(),
+                split_collapsible_whitespace(full)
+                    .map(str::to_string)
+                    .collect::<Vec<_>>(),
             )
         };
         if words.is_empty() {
@@ -1310,7 +1323,7 @@ impl TaffyLayouter {
             // Whitespace-only nodes fall through to the normal NBSP-separator path below.
             if has_inline_element_child {
                 if let NodeType::Text(text) = &child_node.node_type {
-                    if !text.trim().is_empty() {
+                    if !is_collapsible_whitespace(text) {
                         self.push_text_words(layout_tree, &child_node, *child_id, &mut current_inline_group);
                         trailing_ws_count = 0;
                         continue;
@@ -1328,7 +1341,7 @@ impl TaffyLayouter {
             if parent_is_flex_or_grid {
                 // Still discard pure-whitespace text nodes; they carry no visual content.
                 if let NodeType::Text(text) = &child_node.node_type {
-                    if text.trim().is_empty() {
+                    if is_collapsible_whitespace(text) {
                         // Drop leading whitespace (before any inline sibling). Keep inter-element
                         // whitespace - it collapses to a single space in extract_taffy_data and
                         // visually separates adjacent inline elements (e.g. between </span><span>).
@@ -1366,7 +1379,11 @@ impl TaffyLayouter {
                     continue;
                 }
                 let is_ws = if let NodeType::Text(text) = &child_node.node_type {
-                    if text.trim().is_empty() {
+                    // ASCII, not `str::trim`: `trim` uses the Unicode whitespace set, so a text
+                    // node holding only an `&nbsp;` looked like source formatting and was skipped
+                    // as leading whitespace. Parsoid gives every entity its own element, which is
+                    // how Wikipedia's `Designed<span>&nbsp;</span>by` lost its space entirely.
+                    if is_collapsible_whitespace(text) {
                         // Drop leading whitespace (before any inline sibling). Keep inter-element
                         // whitespace - it collapses to a single space in extract_taffy_data and
                         // visually separates adjacent inline elements (e.g. between </span><span>).
@@ -1758,13 +1775,18 @@ impl TaffyLayouter {
                 // pango would render as a blank first line if left untouched.
                 // Whitespace-only source nodes (e.g. "\n  " between </span><span>) collapse
                 // to a single space so they produce an inter-element gap when kept.
-                let is_whitespace_only = !text.is_empty() && text.chars().all(|c: char| c.is_ascii_whitespace());
+                // Two different "all whitespace" questions. *Collapsible* whitespace (spaces,
+                // tabs, newlines) is source formatting that collapses to one space. Whitespace
+                // that CSS does not collapse - U+00A0 and the other fixed-width spaces - is
+                // content, and the node must keep exactly what it says.
+                let collapsible_only = !text.is_empty() && text.chars().all(|c: char| c.is_ascii_whitespace());
+                let whitespace_only = !text.is_empty() && text.chars().all(char::is_whitespace);
                 // Preserve one leading/trailing inter-element gap as NBSP (non-breaking) so
                 // pango does not wrap at the boundary space, while still rendering a visible gap.
                 let had_leading_space = text.starts_with(|c: char| c.is_ascii_whitespace());
                 let had_trailing_space = text.ends_with(|c: char| c.is_ascii_whitespace());
-                let mut text: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
-                if !is_whitespace_only {
+                let mut text: String = split_collapsible_whitespace(text).collect::<Vec<_>>().join(" ");
+                if !collapsible_only {
                     if had_leading_space && !text.is_empty() {
                         text.insert(0, '\u{00A0}');
                     }
@@ -1772,13 +1794,18 @@ impl TaffyLayouter {
                         text.push('\u{00A0}');
                     }
                 }
-                if is_whitespace_only {
+                if collapsible_only {
                     // Inter-element whitespace (e.g. between </span><span>). Collapse to a single
-                    // NBSP so the text context is non-empty. We bypass parley measurement entirely
-                    // by setting an explicit taffy width (~0.3em), because parley returns 0 for
-                    // spaces when called with MinContent (max_advance=0), causing the flex item to
-                    // collapse. flex_shrink=0 prevents the space from being squeezed away.
+                    // NBSP so the text context is non-empty and pango does not wrap at it.
                     text = "\u{00A0}".to_string();
+                }
+                if whitespace_only {
+                    // Parley measures a run of only whitespace as 0 wide when called with
+                    // MinContent (max_advance=0), which collapses the flex item to nothing, so the
+                    // width is set explicitly and `flex_shrink` pinned. This used to apply only to
+                    // collapsible whitespace, so a node holding just an `&nbsp;` came out 0 wide -
+                    // and since Parsoid gives every entity its own element, Wikipedia's
+                    // `Designed<span>&nbsp;</span>by` rendered as "Designedby".
                     let space_width = (font_size * 0.3) as f32;
                     taffy_style.size.width = Dimension::from_length(space_width);
                     taffy_style.flex_shrink = 0.0;
@@ -2082,5 +2109,50 @@ mod band_cursor_tests {
         cursor.exhaust();
         assert_eq!(cursor.current().line_width, 600.0);
         assert!(cursor.current().height.is_none());
+    }
+}
+
+#[cfg(test)]
+mod whitespace_tests {
+    use super::{is_collapsible_whitespace, split_collapsible_whitespace};
+
+    const NBSP: &str = "\u{a0}";
+
+    #[test]
+    fn source_formatting_is_collapsible() {
+        assert!(is_collapsible_whitespace(" "));
+        assert!(is_collapsible_whitespace("\n    "));
+        assert!(is_collapsible_whitespace("\t\r\n"));
+        assert!(is_collapsible_whitespace(""));
+    }
+
+    #[test]
+    fn a_non_breaking_space_is_content() {
+        // The bug in one line: `str::trim` and `char::is_whitespace` use the Unicode set, which
+        // counts U+00A0, so a text node holding only an `&nbsp;` was discarded as indentation.
+        // Parsoid gives every entity its own element, so Wikipedia's
+        // `Designed<span>&nbsp;</span>by` lost its space and read "Designedby".
+        assert!(!is_collapsible_whitespace(NBSP));
+        assert!(!is_collapsible_whitespace(&format!(" {NBSP} ")));
+        // The other fixed-width spaces are content too.
+        assert!(!is_collapsible_whitespace("\u{2009}"));
+        assert!(!is_collapsible_whitespace("\u{2007}"));
+    }
+
+    #[test]
+    fn words_split_on_collapsible_whitespace_only() {
+        assert_eq!(
+            split_collapsible_whitespace("a b\n c").collect::<Vec<_>>(),
+            ["a", "b", "c"]
+        );
+        // An nbsp binds its neighbours into one word - that is what it is for.
+        let joined = format!("May{NBSP}1,");
+        assert_eq!(
+            split_collapsible_whitespace(&joined).collect::<Vec<_>>(),
+            [joined.as_str()]
+        );
+        // And on its own it is a word, not a separator that vanishes.
+        assert_eq!(split_collapsible_whitespace(NBSP).collect::<Vec<_>>(), [NBSP]);
+        assert!(split_collapsible_whitespace("   ").next().is_none());
     }
 }

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -173,6 +173,19 @@ impl BandCursor {
         }
     }
 
+    /// Raise the line just charged from `charged` to `line_height` when something taller ends it.
+    ///
+    /// A `<br>` after text closes the line the text is on; it does not add one. `emit_banded` has
+    /// already charged that line - `fill_band` counts the partly-filled last line too - so
+    /// charging a whole line again for the break pushed later content past a finite band early.
+    /// Only a `<br>` with a taller line-height than the run it follows adds anything at all.
+    fn raise_last_line(&mut self, charged: f32, line_height: f32) {
+        let extra = line_height - charged;
+        if extra > 0.0 {
+            self.take_lines(1, extra);
+        }
+    }
+
     /// Move to the next band. Returns false when this was already the last one.
     fn advance(&mut self) -> bool {
         if self.index + 1 >= self.bands.len() {
@@ -903,6 +916,9 @@ impl TaffyLayouter {
                         }
                         self.emit_line(&[], Some(*lh), element_node, leaf_id, line_style, placement);
                     } else {
+                        // The height `emit_banded` will charge each of the segment's lines at,
+                        // including the one the break is about to close.
+                        let charged = self.inline_line_height(layout_tree, &segment);
                         self.emit_banded(
                             layout_tree,
                             &segment,
@@ -912,9 +928,9 @@ impl TaffyLayouter {
                             cursor.as_mut(),
                         );
                         segment.clear();
-                        // The break itself ends the line the segment left open.
+                        // The break ends the line the segment left open rather than adding one.
                         if let Some(c) = cursor.as_mut() {
-                            c.take_lines(1, *lh as f32);
+                            c.raise_last_line(charged, *lh as f32);
                         }
                     }
                 }
@@ -2188,6 +2204,33 @@ mod tests {
             apply_text_transform("Working".to_string(), Value::Number(1.0)),
             "Working"
         );
+    }
+
+    /// A `<br>` after text closes the line the text is on. Charging a whole line for it as well
+    /// pushed later content below a finite float band before the band was actually full.
+    #[test]
+    fn a_break_after_text_does_not_consume_a_second_line() {
+        use super::{BandCursor, FloatBand};
+
+        // A band exactly three 20px lines tall, beside a float.
+        let band = FloatBand {
+            left_inset: 0.0,
+            line_width: 400.0,
+            height: Some(60.0),
+        };
+
+        let mut cursor = BandCursor::new(&[band, FloatBand { height: None, ..band }]);
+        assert_eq!(cursor.lines_left(20.0), 3);
+
+        // One line of text, then a break of the same line-height: one line used, two left.
+        cursor.take_lines(1, 20.0);
+        cursor.raise_last_line(20.0, 20.0);
+        assert_eq!(cursor.lines_left(20.0), 2, "the break must not take a line of its own");
+
+        // A break taller than the run it ends does make that line taller.
+        cursor.take_lines(1, 20.0);
+        cursor.raise_last_line(20.0, 30.0);
+        assert_eq!(cursor.lines_left(20.0), 0, "20 + 30 of 60 leaves less than a line");
     }
 
     #[test]

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -323,7 +323,7 @@ pub struct TaffyLayouter {
     /// taffy - so on the first pass taffy laid the contents out at the wrong width, and anything
     /// that wraps (most visibly a caption) wrapped to it. Replaying the width lets that content
     /// be measured at the width it will actually have.
-    table_widths: HashMap<DomNodeId, crate::layouter::table::SettledSize>,
+    table_widths: HashMap<DomNodeId, f32>,
     /// Taffy insets for absolutely positioned boxes that stretch between opposing insets,
     /// rebased from their CSS containing block onto the parent taffy measures from. Empty on the
     /// first pass - a box's containing block is only known once the page has been laid out - and
@@ -593,7 +593,7 @@ impl TaffyLayouter {
         LayoutTree,
         Vec<crate::layouter::float::PlacedFloat>,
         HashMap<DomNodeId, RebasedInsets>,
-        HashMap<DomNodeId, crate::layouter::table::SettledSize>,
+        HashMap<DomNodeId, f32>,
     ) {
         let mut layout_tree = self.generate_tree(render_tree, root_id);
 
@@ -632,7 +632,7 @@ impl TaffyLayouter {
     ) -> (
         Vec<crate::layouter::float::PlacedFloat>,
         HashMap<DomNodeId, RebasedInsets>,
-        HashMap<DomNodeId, crate::layouter::table::SettledSize>,
+        HashMap<DomNodeId, f32>,
     ) {
         // // Compute the layout based on the viewport
         let size = match viewport {
@@ -1577,8 +1577,8 @@ impl TaffyLayouter {
                 // the visible case - it is laid out across the finished table, so on the first
                 // pass (where taffy sizes the box from its own contents) it wraps to the wrong
                 // width and then drags the table out to match.
-                if let Some(&settled) = self.table_widths.get(&dom_node.node_id) {
-                    taffy_style.size.width = Dimension::from_length(settled.width);
+                if let Some(&width) = self.table_widths.get(&dom_node.node_id) {
+                    taffy_style.size.width = Dimension::from_length(width);
 
                     // The column algorithm works in border-box widths, so the pin has to be read
                     // as one whatever the element's own `box-sizing` says. Left at the CSS default

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -94,6 +94,17 @@ fn skip_leading_whitespace<'a>(
     &items[start..]
 }
 
+/// How a block wants its line boxes laid out, beyond where they sit.
+#[derive(Debug, Clone, Copy)]
+struct LineStyle {
+    /// The block's `text-align`, which positions runs that do not fill the line box.
+    justify: Option<taffy::JustifyContent>,
+    /// The block is a table cell: a flex column, where the axis that moves a line box across the
+    /// cell is the cross axis. Its `align_items` does that, and an `align_self` on the line box
+    /// would override it, so inside a cell the line box sets none.
+    cell_aligned: bool,
+}
+
 /// Where one line box goes: which band it sits in, and how far below the previous one it starts.
 #[derive(Debug, Clone, Copy)]
 struct LinePlacement {
@@ -893,6 +904,20 @@ impl TaffyLayouter {
         // container *is* the line box here, so a block crossed by a float needs one container per
         // band rather than one for the whole block. `cursor` carries the position in that band
         // list across the whole block, including over `<br>` boundaries.
+        // A table cell is a flex column, so the axis that moves a line box across the cell is the
+        // cross axis - the cell's `align_items`, set from its `text-align`. An `align_self` on the
+        // line box would override that, so inside a cell it is left off. Wikipedia's infobox
+        // section headers are `text-align: center` and came out flush left for want of this.
+        let line_style = LineStyle {
+            justify,
+            cell_aligned: matches!(
+                layout_tree
+                    .render_tree
+                    .doc
+                    .get_style(element_node.dom_node_id, &StyleProperty::Display),
+                Value::Display(CssDisplay::TableCell)
+            ),
+        };
         let bands = self.float_insets.get(&element_node.dom_node_id).cloned();
         let mut cursor = bands.as_ref().map(|bands| BandCursor::new(bands));
 
@@ -909,9 +934,16 @@ impl TaffyLayouter {
                         if let Some(c) = cursor.as_mut() {
                             c.take_lines(1, *lh as f32);
                         }
-                        self.emit_line(&[], Some(*lh), element_node, leaf_id, justify, placement);
+                        self.emit_line(&[], Some(*lh), element_node, leaf_id, line_style, placement);
                     } else {
-                        self.emit_banded(layout_tree, &segment, element_node, leaf_id, justify, cursor.as_mut());
+                        self.emit_banded(
+                            layout_tree,
+                            &segment,
+                            element_node,
+                            leaf_id,
+                            line_style,
+                            cursor.as_mut(),
+                        );
                         segment.clear();
                         // The break itself ends the line the segment left open.
                         if let Some(c) = cursor.as_mut() {
@@ -922,7 +954,14 @@ impl TaffyLayouter {
             }
         }
         if !segment.is_empty() {
-            self.emit_banded(layout_tree, &segment, element_node, leaf_id, justify, cursor.as_mut());
+            self.emit_banded(
+                layout_tree,
+                &segment,
+                element_node,
+                leaf_id,
+                line_style,
+                cursor.as_mut(),
+            );
         }
     }
 
@@ -938,11 +977,11 @@ impl TaffyLayouter {
         items: &[(LayoutElementId, TaffyNodeId)],
         element_node: &mut LayoutElementNode,
         leaf_id: TaffyNodeId,
-        justify: Option<taffy::JustifyContent>,
+        line_style: LineStyle,
         cursor: Option<&mut BandCursor>,
     ) {
         let Some(cursor) = cursor else {
-            self.emit_line(items, None, element_node, leaf_id, justify, None);
+            self.emit_line(items, None, element_node, leaf_id, line_style, None);
             return;
         };
 
@@ -957,7 +996,7 @@ impl TaffyLayouter {
             let Some((taken, lines)) = self.fill_band(layout_tree, rest, band, capacity) else {
                 let placement = cursor.placement();
                 cursor.exhaust();
-                self.emit_line(rest, None, element_node, leaf_id, justify, Some(placement));
+                self.emit_line(rest, None, element_node, leaf_id, line_style, Some(placement));
                 return;
             };
             if taken == 0 {
@@ -965,7 +1004,7 @@ impl TaffyLayouter {
                 // drop to the next one rather than emitting an empty container. CSS puts a line
                 // that cannot fit beside a float below it, which is exactly this.
                 if !cursor.advance() {
-                    self.emit_line(rest, None, element_node, leaf_id, justify, Some(cursor.placement()));
+                    self.emit_line(rest, None, element_node, leaf_id, line_style, Some(cursor.placement()));
                     return;
                 }
                 continue;
@@ -980,7 +1019,7 @@ impl TaffyLayouter {
                 None,
                 element_node,
                 leaf_id,
-                justify,
+                line_style,
                 Some(placement),
             );
             cursor.take_lines(lines, line_height);
@@ -1073,7 +1112,7 @@ impl TaffyLayouter {
         empty_line_height: Option<f64>,
         element_node: &mut LayoutElementNode,
         leaf_id: TaffyNodeId,
-        justify: Option<taffy::JustifyContent>,
+        line_style: LineStyle,
         placement: Option<LinePlacement>,
     ) {
         // All inline elements (even a single one) are wrapped in an anonymous flex container.
@@ -1085,8 +1124,8 @@ impl TaffyLayouter {
             flex_direction: FlexDirection::Row,
             flex_wrap: FlexWrap::Wrap,
             // The block's `text-align`: positions runs that don't fill the line box.
-            justify_content: justify,
-            align_self: Some(AlignSelf::FLEX_START),
+            justify_content: line_style.justify,
+            align_self: (!line_style.cell_aligned).then_some(AlignSelf::FLEX_START),
             // FlexStart ensures multi-row intrinsic height = sum of all row heights.
             // Taffy's default (None = Stretch) fails to include wrapped rows in the
             // container's auto height, causing rows beyond the first to overflow.
@@ -1574,6 +1613,14 @@ impl TaffyLayouter {
                 // width and then drags the table out to match.
                 if let Some(&width) = self.table_widths.get(&dom_node.node_id) {
                     taffy_style.size.width = Dimension::from_length(width);
+                    // A cell is a flex item with `flex_grow: 1`, which would stretch it back to
+                    // an equal share of its row and undo the pin. It only shows up in a row that
+                    // does not span every column - the dialect table's second header row holds
+                    // two cells under a `colspan=2` title, and they grew to half the table each,
+                    // leaving their centred text far to the right of the cells lattice then
+                    // moved into place.
+                    taffy_style.flex_grow = 0.0;
+                    taffy_style.flex_shrink = 0.0;
                 }
 
                 // Second pass only: replace the CSS insets of an absolutely positioned box that

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -323,7 +323,7 @@ pub struct TaffyLayouter {
     /// taffy - so on the first pass taffy laid the contents out at the wrong width, and anything
     /// that wraps (most visibly a caption) wrapped to it. Replaying the width lets that content
     /// be measured at the width it will actually have.
-    table_widths: HashMap<DomNodeId, f32>,
+    table_widths: HashMap<DomNodeId, crate::layouter::table::SettledSize>,
     /// Taffy insets for absolutely positioned boxes that stretch between opposing insets,
     /// rebased from their CSS containing block onto the parent taffy measures from. Empty on the
     /// first pass - a box's containing block is only known once the page has been laid out - and
@@ -593,7 +593,7 @@ impl TaffyLayouter {
         LayoutTree,
         Vec<crate::layouter::float::PlacedFloat>,
         HashMap<DomNodeId, RebasedInsets>,
-        HashMap<DomNodeId, f32>,
+        HashMap<DomNodeId, crate::layouter::table::SettledSize>,
     ) {
         let mut layout_tree = self.generate_tree(render_tree, root_id);
 
@@ -632,7 +632,7 @@ impl TaffyLayouter {
     ) -> (
         Vec<crate::layouter::float::PlacedFloat>,
         HashMap<DomNodeId, RebasedInsets>,
-        HashMap<DomNodeId, f32>,
+        HashMap<DomNodeId, crate::layouter::table::SettledSize>,
     ) {
         // // Compute the layout based on the viewport
         let size = match viewport {
@@ -1577,8 +1577,9 @@ impl TaffyLayouter {
                 // the visible case - it is laid out across the finished table, so on the first
                 // pass (where taffy sizes the box from its own contents) it wraps to the wrong
                 // width and then drags the table out to match.
-                if let Some(&width) = self.table_widths.get(&dom_node.node_id) {
-                    taffy_style.size.width = Dimension::from_length(width);
+                if let Some(&settled) = self.table_widths.get(&dom_node.node_id) {
+                    taffy_style.size.width = Dimension::from_length(settled.width);
+
                     // The column algorithm works in border-box widths, so the pin has to be read
                     // as one whatever the element's own `box-sizing` says. Left at the CSS default
                     // of `content-box` the box came out padding-and-border wider than its column,

--- a/crates/gosub_render_pipeline/src/layouter/taffy.rs
+++ b/crates/gosub_render_pipeline/src/layouter/taffy.rs
@@ -2,6 +2,7 @@ use cow_utils::CowUtils;
 
 use crate::common::document::node::{Node, NodeId as DomNodeId, NodeType};
 use crate::common::document::pipeline_doc::BgSize;
+use crate::common::document::style::Display as CssDisplay;
 use crate::common::document::style::{lookup, FontWeight, StyleProperty, TextAlign, Unit, Value};
 use crate::common::font::{FontAlignment, FontInfo};
 use crate::common::geo;
@@ -1250,7 +1251,31 @@ impl TaffyLayouter {
         // Flex and grid containers are formatting contexts where ALL children - inline or block -
         // are direct layout participants. Wrapping inline children in an anonymous flex container
         // would insert an extra level that breaks the parent's `gap`, `align-items`, etc.
-        let parent_is_flex_or_grid = matches!(taffy_style.display, Display::Flex | Display::Grid);
+        // Flex and grid containers are formatting contexts where ALL children - inline or block -
+        // are direct layout participants. Wrapping inline children in an anonymous flex container
+        // would insert an extra level that breaks the parent's `gap`, `align-items`, etc.
+        //
+        // The table displays are mapped onto taffy flex containers too, but a cell is a block
+        // container and its inline content still belongs in line boxes - without that, a cell that
+        // stacks its children puts every word on a line of its own. Only the table boxes are
+        // excluded, rather than asking the CSS display outright: *inline* elements are mapped onto
+        // flex containers as well - 12000 of them on this page - and must keep what they have.
+        let parent_is_flex_or_grid = matches!(taffy_style.display, Display::Flex | Display::Grid)
+            && !matches!(
+                layout_tree
+                    .render_tree
+                    .doc
+                    .get_style(dom_node.node_id, &StyleProperty::Display),
+                Value::Display(
+                    CssDisplay::Table
+                        | CssDisplay::TableCaption
+                        | CssDisplay::TableCell
+                        | CssDisplay::TableFooterGroup
+                        | CssDisplay::TableHeaderGroup
+                        | CssDisplay::TableRow
+                        | CssDisplay::TableRowGroup
+                )
+            );
 
         // The context will be moved to the taffy tree, so we need to convert it before that happens.
         let element_context = match taffy_context {

--- a/crates/gosub_render_pipeline/src/painter.rs
+++ b/crates/gosub_render_pipeline/src/painter.rs
@@ -630,16 +630,8 @@ fn compute_bg_tiling(natural: (f32, f32), layout: &BgImageLayout, box_w: f32, bo
         return None;
     }
 
-    let px = if layout.center.0 {
-        (box_w - tw) / 2.0
-    } else {
-        layout.position.0
-    };
-    let py = if layout.center.1 {
-        (box_h - th) / 2.0
-    } else {
-        layout.position.1
-    };
+    let px = layout.position.0.resolve(box_w, tw);
+    let py = layout.position.1.resolve(box_h, th);
 
     Some(Tiling {
         tile_size: (tw, th),

--- a/crates/gosub_render_pipeline/src/painter.rs
+++ b/crates/gosub_render_pipeline/src/painter.rs
@@ -213,9 +213,9 @@ impl Painter {
     ///
     /// A lone non-tiled gradient becomes the base brush directly, so border/radius decorate the
     /// same rect. Multiple or tiled layers instead stack as separate rects over `background-color`.
-    fn background_fill(&self, node_id: NodeId) -> (Brush, Vec<Gradient>) {
+    fn background_fill(&self, node_id: NodeId, box_size: (f32, f32)) -> (Brush, Vec<Gradient>) {
         let doc = &self.layer_list.layout_tree.render_tree.doc;
-        let layers = doc.background_layers(node_id);
+        let layers = doc.background_layers(node_id, box_size);
         let color = self.get_brush(
             node_id,
             &StyleProperty::BackgroundColor,
@@ -431,7 +431,8 @@ impl Painter {
 
                 // CSS paints background-color behind the (possibly transparent) replaced content,
                 // e.g. a transparent PNG on `<img style="background:#3a7">` shows green through.
-                let (bg_brush, _) = self.background_fill(dom_node_id);
+                let (bg_brush, _) =
+                    self.background_fill(dom_node_id, (border_box.width as f32, border_box.height as f32));
                 if !matches!(&bg_brush, Brush::Solid(c) if c.a() == 0.0) {
                     let bg_r = Rectangle::new(border_box)
                         .with_background(bg_brush)
@@ -476,8 +477,9 @@ impl Painter {
                 }
             }
             ElementContext::None => {
-                let (brush, overlay_layers) = self.background_fill(dom_node_id);
                 let border_box = layout_element.box_model.border_box;
+                let (brush, overlay_layers) =
+                    self.background_fill(dom_node_id, (border_box.width as f32, border_box.height as f32));
                 let r = Rectangle::new(border_box)
                     .with_background(brush)
                     .with_blend_mode(self.mix_blend_mode(dom_node_id));

--- a/crates/gosub_render_pipeline/src/tests.rs
+++ b/crates/gosub_render_pipeline/src/tests.rs
@@ -374,6 +374,66 @@ mod rendertree_from_engine {
         );
     }
 
+    // `font-size` written as a percentage or a keyword could not be turned into pixels, so
+    // `font_size_px` fell back to its 16px default and the element rendered at full body size.
+    // Every `<sup>` on Wikipedia is `font-size: 80%`, which is why every reference marker came out
+    // as large as the text around it.
+    #[test]
+    fn font_size_resolves_percentages_and_keywords() {
+        use crate::common::document::pipeline_doc::PipelineDocument;
+        use crate::common::document::style::{StyleProperty, Unit, Value};
+
+        let html = r#"
+            <html><head><style>
+                body { font-size: 20px; }
+                #pct { font-size: 80%; }
+                #smaller { font-size: smaller; }
+                #larger { font-size: larger; }
+                #abs { font-size: small; }
+                #outer { font-size: 50%; }
+                #nested { font-size: 50%; }
+            </style></head>
+            <body>
+                <p id="pct">a</p>
+                <p id="smaller">b</p>
+                <p id="larger">c</p>
+                <p id="abs">d</p>
+                <p id="outer"><span id="nested">e</span></p>
+            </body></html>
+        "#;
+
+        let mut doc = html_compile::<Config>(html);
+        let ua = Css3System::load_default_useragent_stylesheet();
+        doc.add_stylesheet(ua);
+        let adapter = GosubDocumentAdapter::<Config>::new(Arc::new(doc));
+        let root = adapter.doc.root();
+
+        let size_of = |id: &str| match adapter.get_style(
+            find_node_by_id_attr(&adapter.doc, root, id).expect("find the element"),
+            &StyleProperty::FontSize,
+        ) {
+            Value::Unit(px, Unit::Px) => px,
+            other => panic!("font-size for #{id} should resolve to px, got {other:?}"),
+        };
+
+        // Against the parent's 20px.
+        assert!((size_of("pct") - 16.0).abs() < 0.01, "80% of 20px");
+        assert!(
+            (size_of("smaller") - 20.0 / 1.2).abs() < 0.01,
+            "one step down from 20px"
+        );
+        assert!((size_of("larger") - 20.0 * 1.2).abs() < 0.01, "one step up from 20px");
+        // An absolute keyword ignores the parent and takes its place on the CSS scale.
+        assert!((size_of("abs") - 13.0).abs() < 0.01, "`small` is 13px");
+        // Percentages compound down the tree: 50% of 50% of 20px.
+        assert!(
+            (size_of("nested") - 5.0).abs() < 0.01,
+            "nested percentages compound: got {} for #nested, {} for #outer",
+            size_of("nested"),
+            size_of("outer")
+        );
+    }
+
     // Covers the shorthand (the HN `.votearrow` case), the longhand, and an inline style.
     #[test]
     fn background_image_is_read_from_css() {

--- a/crates/gosub_render_pipeline/src/tests.rs
+++ b/crates/gosub_render_pipeline/src/tests.rs
@@ -319,6 +319,61 @@ mod rendertree_from_engine {
         None
     }
 
+    // A longhand declared after a shorthand must win, even though every longhand produced by
+    // expanding a shorthand is applied after all the directly declared ones. Before the cascade
+    // gained a document-order tiebreak, the expansion won every tie: `margin: 4px` beat a later
+    // `margin-left`, and Wikipedia's `grid-template` shorthand erased the `grid-template-areas`
+    // that a later rule set, collapsing the whole page shell into one grid cell.
+    #[test]
+    fn a_longhand_declared_after_a_shorthand_wins() {
+        use crate::common::document::pipeline_doc::PipelineDocument;
+        use crate::common::document::style::{lookup, StyleProperty, Unit, Value};
+
+        let html = r#"
+            <html>
+            <head>
+                <style>
+                    .same-rule { margin: 4px; margin-left: 80px; }
+                    .later-rule { margin: 4px; }
+                    .later-rule { margin-left: 80px; }
+                    .grid { display: grid; grid-template: min-content / 12rem 1fr; }
+                    .grid { grid-template-areas: 'head head' 'side body'; }
+                </style>
+            </head>
+            <body>
+                <div class="same-rule">a</div>
+                <div class="later-rule">b</div>
+                <div class="grid">c</div>
+            </body>
+            </html>
+        "#;
+
+        let mut doc = html_compile::<Config>(html);
+        let ua = Css3System::load_default_useragent_stylesheet();
+        doc.add_stylesheet(ua);
+        let adapter = GosubDocumentAdapter::<Config>::new(Arc::new(doc));
+        let root = adapter.doc.root();
+
+        for class in ["same-rule", "later-rule"] {
+            let id = find_node_by_class_dfs(&adapter.doc, root, class).expect("find the element");
+            assert_eq!(
+                adapter.get_style(id, &StyleProperty::MarginLeft),
+                Value::Unit(80.0, Unit::Px),
+                "the later `margin-left` should beat the `margin` shorthand on .{class}"
+            );
+        }
+
+        let grid = find_node_by_class_dfs(&adapter.doc, root, "grid").expect("find .grid");
+        let areas = match adapter.get_style(grid, &StyleProperty::GridTemplateAreas) {
+            Value::Keyword(k) => lookup(k),
+            other => panic!("expected the area rows, got {other:?}"),
+        };
+        assert_eq!(
+            areas, "head head\nside body",
+            "the later `grid-template-areas` should survive the `grid-template` shorthand"
+        );
+    }
+
     // Covers the shorthand (the HN `.votearrow` case), the longhand, and an inline style.
     #[test]
     fn background_image_is_read_from_css() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CSS grid template areas and grid-area placement.
  * Improved table captions, shrink-to-fit sizing, minimum-content widths, spanning cells, and anonymous table cells.
  * Added `calc()` support in media queries.
  * Improved CSS variable fallbacks, background positioning, and font-size resolution.

* **Bug Fixes**
  * Corrected color parsing failures and `transparent` handling.
  * Improved float clearing and text wrapping around floats.
  * Preserved Unicode whitespace as content.
  * Fixed cascade ordering, unknown at-rule descriptor parsing, and invalid media-query handling.
  * Improved font handling stability during concurrent layout operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->