### PR TITLE
Remove all reqwest dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,30 +1352,11 @@ dependencies = [
  "base64 0.22.1",
  "hkdf",
  "hmac",
- "percent-encoding",
  "rand 0.8.6",
  "sha2 0.10.9",
  "subtle",
  "time",
  "version_check",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
-dependencies = [
- "cookie",
- "document-features",
- "idna",
- "log",
- "publicsuffix",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
- "url",
 ]
 
 [[package]]
@@ -2731,11 +2712,12 @@ name = "generate_definitions"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "gosub-sonar",
  "regex",
- "reqwest",
  "serde",
  "serde_json",
  "sha1",
+ "url",
 ]
 
 [[package]]
@@ -3045,9 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "gosub-sonar"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49605ffd1e20a39b7b3b6901a5b57c82b1789b7345bbe61ae7368f1080bd0c55"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3132,7 +3112,6 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rand 0.10.2",
- "reqwest",
  "serde_json",
  "simple_logger",
  "test-case",
@@ -3231,7 +3210,6 @@ dependencies = [
  "r2d2_sqlite",
  "rand 0.10.2",
  "regex",
- "reqwest",
  "serde",
  "serde_json",
  "tempfile",
@@ -5796,16 +5774,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
-name = "publicsuffix"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
-dependencies = [
- "idna",
- "psl-types",
-]
-
-[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6233,8 +6201,6 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "cookie",
- "cookie_store",
  "encoding_rs",
  "futures-channel",
  "futures-core",
@@ -6255,8 +6221,6 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
- "serde",
- "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3028,6 +3028,8 @@ dependencies = [
 [[package]]
 name = "gosub-sonar"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41736cf18a0dabae8a606df004cbcbe0d0f1d0337d0d20bbf5745a3741a868bb"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,6 @@ pollster = "1.0.1"
 rand = "0.10.1"
 regex = "1.12.3"
 rquickjs = { version = "0.12.2", features = ["classes", "properties", "macro"] }
-reqwest = {version = "0.13.3", default-features = false}
 resvg = "0.48.1"
 serde = "1.0.228"
 serde_json = "1.0.150"
@@ -176,7 +175,6 @@ http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 tracing-log = { workspace = true }
-reqwest = { workspace = true, default-features = true, features = ["json", "rustls"] }
 serde_json = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true, features = ["v4", "macro-diagnostics"] }
@@ -212,7 +210,7 @@ gosub_v8 = { version = "0.1.1", path = "./crates/gosub_v8", features = [], regis
 gosub_webexecutor = { version = "0.1.1", path = "./crates/gosub_webexecutor", features = [], registry = "gosub" }
 gosub_config = { version = "0.1.1", path = "./crates/gosub_config", features = [], registry = "gosub" }
 gosub_jsapi = { version = "0.1.1", path = "./crates/gosub_jsapi", features = [], registry = "gosub" }
-gosub-sonar = "0.6.3"
+gosub-sonar = "0.7.0"
 futures = { workspace = true }
 cookie = { workspace = true, features = ["secure", "private"] }
 clap = { workspace = true, features = ["derive"] }

--- a/crates/gosub_css3/tools/generate_definitions/Cargo.toml
+++ b/crates/gosub_css3/tools/generate_definitions/Cargo.toml
@@ -14,8 +14,9 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+gosub-sonar = "0.7.0"
 regex = { workspace = true }
-reqwest = { workspace = true, features = ["blocking", "rustls"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha1 = "0.11"
+url = { workspace = true }

--- a/crates/gosub_css3/tools/generate_definitions/src/fetch.rs
+++ b/crates/gosub_css3/tools/generate_definitions/src/fetch.rs
@@ -1,0 +1,15 @@
+//! The one way this tool talks to the network.
+//!
+//! Everything HTTP in the workspace goes through gosub-sonar, this generator included. Sonar
+//! sets what a Gosub request looks like on the wire, the user agent included - GitHub's API
+//! refuses a request without one - and a tool with its own client would not pick up changes
+//! made there.
+
+use anyhow::{Context, Result};
+
+/// GET `url`, returning the body. Non-2xx responses are errors.
+pub fn get(url: &str) -> Result<Vec<u8>> {
+    let parsed = url::Url::parse(url).with_context(|| format!("invalid URL {url}"))?;
+    let body = gosub_sonar::sync_get(&parsed).with_context(|| format!("fetching {url}"))?;
+    Ok(body.to_vec())
+}

--- a/crates/gosub_css3/tools/generate_definitions/src/main.rs
+++ b/crates/gosub_css3/tools/generate_definitions/src/main.rs
@@ -2,6 +2,7 @@
 //! (`resources/definitions/`) by merging webref's spec grammars with MDN's
 //! property metadata. See README.md for the full data-flow description.
 
+mod fetch;
 mod mdn;
 mod types;
 mod webref;
@@ -97,12 +98,8 @@ fn main() -> Result<()> {
     // and many layers.
     let comma_list_idiom = Regex::new(r"(<[^>]+>)#\? , ")?;
 
-    let client = reqwest::blocking::Client::builder()
-        .user_agent("gosub-generate-definitions")
-        .build()?;
-
-    let webref_data = webref::get_webref_data(&client)?;
-    let mdn_data = mdn::get_mdn_data(&client)?;
+    let webref_data = webref::get_webref_data()?;
+    let mdn_data = mdn::get_mdn_data()?;
 
     let mut data = Data::default();
 
@@ -172,7 +169,7 @@ fn main() -> Result<()> {
     // not fully cover (e.g. outline-radius, single-animation-*). Add every
     // entry webref did not already define, so grammar references to them
     // resolve.
-    for (name, syntax) in mdn::get_mdn_syntaxes(&client)? {
+    for (name, syntax) in mdn::get_mdn_syntaxes()? {
         let key = format!("<{name}>");
         if syntax.is_empty() || defined_values.contains(&key) {
             continue;

--- a/crates/gosub_css3/tools/generate_definitions/src/mdn.rs
+++ b/crates/gosub_css3/tools/generate_definitions/src/mdn.rs
@@ -28,18 +28,16 @@ struct MdnSyntax {
     syntax: String,
 }
 
-pub fn get_mdn_data(client: &reqwest::blocking::Client) -> Result<BTreeMap<String, MdnItem>> {
-    let resp = client.get(MDN_PROPERTIES).send()?.error_for_status()?;
-    let body = resp.bytes()?;
+pub fn get_mdn_data() -> Result<BTreeMap<String, MdnItem>> {
+    let body = crate::fetch::get(MDN_PROPERTIES)?;
     serde_json::from_slice(&body).context("parsing MDN properties.json")
 }
 
 /// Returns MDN's value-type dictionary (css/syntaxes.json) as a map of type
 /// name (without angle brackets) to its grammar. webref does not fully cover
 /// these value types, so they are used to backfill value definitions.
-pub fn get_mdn_syntaxes(client: &reqwest::blocking::Client) -> Result<BTreeMap<String, String>> {
-    let resp = client.get(MDN_SYNTAXES).send()?.error_for_status()?;
-    let body = resp.bytes()?;
+pub fn get_mdn_syntaxes() -> Result<BTreeMap<String, String>> {
+    let body = crate::fetch::get(MDN_SYNTAXES)?;
     let raw: BTreeMap<String, MdnSyntax> = serde_json::from_slice(&body).context("parsing MDN syntaxes.json")?;
 
     Ok(raw.into_iter().map(|(name, item)| (name, item.syntax)).collect())

--- a/crates/gosub_css3/tools/generate_definitions/src/webref.rs
+++ b/crates/gosub_css3/tools/generate_definitions/src/webref.rs
@@ -103,8 +103,8 @@ struct ParseData {
     selectors: BTreeMap<String, Selector>,
 }
 
-pub fn get_webref_data(client: &reqwest::blocking::Client) -> Result<WebRefData> {
-    let files = get_webref_files(client)?;
+pub fn get_webref_data() -> Result<WebRefData> {
+    let files = get_webref_files()?;
 
     let mut pd = ParseData::default();
 
@@ -122,7 +122,7 @@ pub fn get_webref_data(client: &reqwest::blocking::Client) -> Result<WebRefData>
             continue;
         }
 
-        let content = download_file_content(client, file).with_context(|| format!("downloading {}", file.path))?;
+        let content = download_file_content(file).with_context(|| format!("downloading {}", file.path))?;
         decode_file_content(&content, &mut pd).with_context(|| format!("parsing {}", file.name))?;
     }
 
@@ -134,16 +134,15 @@ pub fn get_webref_data(client: &reqwest::blocking::Client) -> Result<WebRefData>
     })
 }
 
-fn get_webref_files(client: &reqwest::blocking::Client) -> Result<Vec<DirectoryListItem>> {
+fn get_webref_files() -> Result<Vec<DirectoryListItem>> {
     let url = format!("https://api.github.com/repos/{REPO}/contents/{LOCATION}?ref={BRANCH}");
-    let resp = client.get(&url).send()?.error_for_status()?;
-    let body = resp.bytes()?;
+    let body = crate::fetch::get(&url)?;
     serde_json::from_slice(&body).context("parsing webref directory listing")
 }
 
 /// Returns the file's content, from the local cache when it still matches the
 /// upstream git blob SHA, downloading and re-caching it otherwise.
-fn download_file_content(client: &reqwest::blocking::Client, file: &DirectoryListItem) -> Result<Vec<u8>> {
+fn download_file_content(file: &DirectoryListItem) -> Result<Vec<u8>> {
     let cache_path = Path::new(CACHE_DIR).join("specs").join(&file.name);
     if let Some(parent) = cache_path.parent() {
         fs::create_dir_all(parent)?;
@@ -160,8 +159,7 @@ fn download_file_content(client: &reqwest::blocking::Client, file: &DirectoryLis
         .download_url
         .as_deref()
         .context("listing entry has no download_url")?;
-    let resp = client.get(url).send()?.error_for_status()?;
-    let body = resp.bytes()?.to_vec();
+    let body = crate::fetch::get(url)?;
     fs::write(&cache_path, &body).with_context(|| format!("writing cache file {}", cache_path.display()))?;
 
     Ok(body)

--- a/crates/gosub_engine/Cargo.toml
+++ b/crates/gosub_engine/Cargo.toml
@@ -9,7 +9,7 @@ name = "gosub_engine"
 crate-type = ["rlib"]
 
 [dependencies]
-gosub-sonar = "0.6.3"
+gosub-sonar = "0.7.0"
 gosub_shared = { version = "0.1.1", path = "../gosub_shared" }
 gosub_config = { version = "0.1.1", path = "../gosub_config" }
 gosub_html5 = { version = "0.1.1", path = "../gosub_html5" }
@@ -18,7 +18,6 @@ gosub_interface = { version = "0.1.2", path = "../gosub_interface" }
 gosub_fontmanager = { version = "0.1.0", path = "../gosub_fontmanager", registry = "gosub" }
 gosub_render_pipeline = { version = "0.1.0", path = "../gosub_render_pipeline" }
 uuid = { workspace = true, features = ["v4", "serde"] }
-reqwest = { workspace = true, default-features = true, features = ["json", "gzip", "brotli", "deflate", "cookies", "rustls", "stream"] }
 tokio = { workspace = true, features = [
     "macros",
     "rt-multi-thread",

--- a/crates/gosub_engine/src/net/emitter/engine_event_emitter.rs
+++ b/crates/gosub_engine/src/net/emitter/engine_event_emitter.rs
@@ -6,6 +6,7 @@ use crate::net::events::NetEvent;
 use crate::net::req_ref_tracker::{RequestReference, REF_REGISTRY};
 use crate::net::types::{Initiator, NetError, ResourceKind};
 use crate::tab::TabId;
+use gosub_sonar::{TransportError, TransportErrorKind};
 use std::sync::Arc;
 
 /// Converts NetEvents into EngineEvents and send them over to the event_tx channel back to the UA
@@ -175,11 +176,11 @@ impl NetObserver for EngineEventEmitter {
                     url: url.to_string(),
                     status,
                     content_length: headers
-                        .get(reqwest::header::CONTENT_LENGTH)
+                        .get(http::header::CONTENT_LENGTH)
                         .and_then(|v| v.to_str().ok())
                         .and_then(|s| s.parse::<u64>().ok()),
                     content_type: headers
-                        .get(reqwest::header::CONTENT_TYPE)
+                        .get(http::header::CONTENT_TYPE)
                         .and_then(|v| v.to_str().ok())
                         .map(|s| s.to_string()),
                     headers: headers
@@ -300,36 +301,26 @@ fn classify(error: &anyhow::Error) -> FailureKind {
         NetError::Redirect(_) => FailureKind::Redirect,
         NetError::Cancelled(_) => FailureKind::Cancelled,
         NetError::Io(_) => FailureKind::Transfer,
-        // `Read` is the stack's catch-all: a `send()` that never got a connection is
-        // wrapped in it just as a body that died mid-stream is. The variant alone would
-        // report a dead host as a broken transfer, which sends you looking in the wrong
-        // place -- but the client's own error is one downcast further down.
-        NetError::Read(inner) => from_client(inner).unwrap_or(FailureKind::Transfer),
-        NetError::Other(inner) => from_client(inner).unwrap_or(FailureKind::Other),
-        NetError::Reqwest(e) => from_client_error(e),
+        // Sonar has already separated these. A `send()` that never got a connection and a
+        // body that stopped mid-stream are both transport failures, and reporting the first
+        // as a broken transfer sends you looking at the server when the problem is the
+        // address.
+        NetError::Transport(e) => from_transport(e),
+        NetError::Read(_) => FailureKind::Transfer,
+        NetError::Other(_) => FailureKind::Other,
     }
 }
 
-/// Find the HTTP client's own error somewhere in the chain and read it.
-fn from_client(error: &anyhow::Error) -> Option<FailureKind> {
-    let client = error.chain().find_map(|e| e.downcast_ref::<reqwest::Error>())?;
-    Some(from_client_error(client))
-}
-
-/// The client knows whether it never got a connection, ran out of time, or lost one part
-/// way -- which is the difference between "the host is unreachable", "nothing answered in
-/// time" and "the transfer died".
-fn from_client_error(error: &reqwest::Error) -> FailureKind {
-    if error.is_timeout() {
-        FailureKind::Timeout
-    } else if error.is_connect() {
-        FailureKind::Connect
-    } else if error.is_redirect() {
-        FailureKind::Redirect
-    } else if error.is_body() || error.is_decode() {
-        FailureKind::Transfer
-    } else {
-        FailureKind::Other
+/// Map a sonar transport failure onto the kind the shell reports.
+fn from_transport(error: &TransportError) -> FailureKind {
+    match error.kind {
+        TransportErrorKind::Connect => FailureKind::Connect,
+        TransportErrorKind::Timeout => FailureKind::Timeout,
+        TransportErrorKind::Redirect => FailureKind::Redirect,
+        TransportErrorKind::Body | TransportErrorKind::Decode => FailureKind::Transfer,
+        // `Request` and `Builder` mean nothing was sent, and whatever sonar learns to tell
+        // apart later lands here first. Neither says anything about the network.
+        _ => FailureKind::Other,
     }
 }
 
@@ -427,33 +418,35 @@ mod tests {
         assert_eq!(seen[0].0, FailureKind::Blocked);
     }
 
-    /// The case that made this worth doing: a host nothing is listening on comes back
-    /// wrapped in `Read`, the same variant a body that died mid-stream uses. Reported as
-    /// a broken transfer it sends you looking at the server; reported as a connection
-    /// failure it sends you at the address, which is where the problem is.
+    /// The case that made this worth doing: a host nothing is listening on and a body that
+    /// stopped mid-stream are both transport failures. Reported as a broken transfer the
+    /// first sends you looking at the server; reported as a connection failure it sends you
+    /// at the address, which is where the problem is. Sonar draws the line and tests it
+    /// against a real socket; this checks the engine keeps it.
     #[test]
     fn a_host_that_never_connects_is_not_reported_as_a_broken_transfer() {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        // Port 1 on loopback: nothing listens there, and nothing leaves the machine.
-        let client_error = runtime.block_on(async {
-            reqwest::Client::new()
-                .get("http://127.0.0.1:1/")
-                .send()
-                .await
-                .unwrap_err()
-        });
-        assert!(
-            client_error.is_connect(),
-            "expected a connect error, got {client_error:?}"
-        );
+        let connect = anyhow::Error::from(NetError::Transport(TransportError {
+            kind: TransportErrorKind::Connect,
+            message: "net.get_with_redirects request failed: connection refused".into(),
+        }));
+        assert_eq!(classify(&connect), FailureKind::Connect);
 
-        let err = anyhow::Error::from(NetError::Read(Arc::new(
-            anyhow::Error::from(client_error).context("net.get_with_redirects request failed"),
-        )));
-        assert_eq!(classify(&err), FailureKind::Connect);
+        let mid_body = anyhow::Error::from(NetError::Transport(TransportError {
+            kind: TransportErrorKind::Body,
+            message: "error reading a body from connection".into(),
+        }));
+        assert_eq!(classify(&mid_body), FailureKind::Transfer);
+    }
+
+    /// `TransportErrorKind` is non-exhaustive, so the catch-all arm gets whatever sonar
+    /// learns to tell apart next. It must not be reported as a kind the engine does know.
+    #[test]
+    fn an_unmapped_transport_kind_claims_nothing() {
+        let err = anyhow::Error::from(NetError::Transport(TransportError {
+            kind: TransportErrorKind::Builder,
+            message: "invalid header value".into(),
+        }));
+        assert_eq!(classify(&err), FailureKind::Other);
     }
 
     /// An error from somewhere other than the network stack says nothing about the

--- a/crates/gosub_engine/src/net/fetcher.rs
+++ b/crates/gosub_engine/src/net/fetcher.rs
@@ -29,10 +29,10 @@ pub fn fetcher_config_from(cfg: &gosub_config::Config) -> FetcherConfig {
         req_timeout: Duration::from_secs(cfg.get_uint("net.timeout.request_secs") as u64),
         read_idle_timeout: Duration::from_secs(cfg.get_uint("net.timeout.read_idle_secs") as u64),
         total_body_timeout: (body_secs > 0).then(|| Duration::from_secs(body_secs as u64)),
-        // Resolution has to go through a `DnsResolver` to be visible: reqwest's built-in
+        // Resolution has to go through a `DnsResolver` to be visible: the HTTP client's own
         // lookup happens below sonar's level and emits no event, so `net.dns` stays silent
         // without one. `SystemResolver` is `getaddrinfo` with no policy attached - the same
-        // resolution reqwest would do by itself - so this buys the timing and changes
+        // resolution the client would do by itself - so this buys the timing and changes
         // nothing else.
         //
         // It applies no SSRF or DNS-rebinding protection. Neither does the default it
@@ -180,8 +180,8 @@ mod dns_resolver_tests {
     use super::*;
     use crate::engine::settings_store::default_config;
 
-    /// `net.dns` timings only exist when resolution goes through a `DnsResolver`; reqwest's
-    /// built-in lookup is below sonar's level and emits nothing. Dropping the resolver from
+    /// `net.dns` timings only exist when resolution goes through a `DnsResolver`; the HTTP
+    /// client's built-in lookup is below sonar's level and emits nothing. Dropping it from
     /// the config would silence that namespace without breaking anything else, which is a
     /// hard failure to notice - hence this test.
     #[test]

--- a/crates/gosub_render_pipeline/Cargo.toml
+++ b/crates/gosub_render_pipeline/Cargo.toml
@@ -36,7 +36,7 @@ gosub_lattice = { version = "0.1.0", path = "../gosub_lattice", registry = "gosu
 [dev-dependencies]
 # For the examples only. The library itself fetches nothing: media reaches it through the
 # resource handoff, which is what keeps every request on the engine's one observed path.
-gosub-sonar = "0.6.3"
+gosub-sonar = "0.7.0"
 gosub_html5 = { path = "../gosub_html5", registry = "gosub" }
 gosub_css3 = { path = "../gosub_css3", registry = "gosub" }
 url = { workspace = true }

--- a/examples/metrics_cli.rs
+++ b/examples/metrics_cli.rs
@@ -81,8 +81,8 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn fetch(url: &str) -> anyhow::Result<String> {
-    let resp = reqwest::get(url).await?.text().await?;
-    Ok(resp)
+    let body = gosub_sonar::simple_get(&url::Url::parse(url)?).await?;
+    Ok(String::from_utf8(body.to_vec())?)
 }
 
 fn print_table(json: &str) {


### PR DESCRIPTION
All dependencies on reqwest have been removed and it will use sonar instead (0.7.0 mininum)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated networking across the application and supporting tools to use the shared HTTP client.
  - Improved handling and classification of connection, timeout, redirect, and transfer errors.
  - CSS definition generation continues to retrieve WebRef and MDN data, with clearer network error reporting.
  - Metrics tooling now processes downloaded response data consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->